### PR TITLE
fix: invalidate persistent SCStream after screen unlock/wake on macOS

### DIFF
--- a/crates/screenpipe-engine/src/event_driven_capture.rs
+++ b/crates/screenpipe-engine/src/event_driven_capture.rs
@@ -334,6 +334,14 @@ pub async fn event_driven_capture_loop(
             continue;
         }
 
+        // After unlock or wake, invalidate persistent SCStream handles so
+        // the next capture picks up fresh frames instead of stale ones.
+        #[cfg(target_os = "macos")]
+        if screenpipe_screen::stream_invalidation::take() {
+            info!("invalidating persistent streams after unlock/wake for monitor {}", monitor_id);
+            screenpipe_screen::stream_invalidation::invalidate_streams();
+        }
+
         // Skip capture while DRM streaming content is focused
         if crate::drm_detector::drm_content_paused() {
             tokio::time::sleep(poll_interval).await;

--- a/crates/screenpipe-engine/src/sleep_monitor.rs
+++ b/crates/screenpipe-engine/src/sleep_monitor.rs
@@ -198,6 +198,10 @@ pub fn start_sleep_monitor() {
             let was_locked = SCREEN_IS_LOCKED.swap(false, Ordering::SeqCst);
             if was_locked {
                 // State change logged via safety-net poll below if needed.
+                // Request invalidation of persistent SCStream handles so
+                // the capture loop recreates them with fresh frames.
+                #[cfg(target_os = "macos")]
+                screenpipe_screen::stream_invalidation::request();
             }
         }
 
@@ -256,6 +260,8 @@ pub fn start_sleep_monitor() {
                 info!("Screen locked (CGSession safety-net poll)");
             } else {
                 info!("Screen unlocked (CGSession safety-net poll)");
+                #[cfg(target_os = "macos")]
+                screenpipe_screen::stream_invalidation::request();
             }
         }
     });
@@ -333,6 +339,11 @@ fn on_did_wake(handle: &tokio::runtime::Handle) {
         // CFNotification missed the unlock — we're fixing it here
     }
 
+    // Invalidate persistent SCStream handles so the capture loop
+    // recreates them with fresh frames after wake.
+    #[cfg(target_os = "macos")]
+    screenpipe_screen::stream_invalidation::request();
+
     // Spawn a task on the captured tokio runtime handle to check recording
     // health after a short delay. We can't use bare tokio::spawn() here
     // because this callback runs on an NSRunLoop thread, not a tokio thread.
@@ -345,6 +356,8 @@ fn on_did_wake(handle: &tokio::runtime::Handle) {
         let was_locked = SCREEN_IS_LOCKED.swap(locked, Ordering::SeqCst);
         if was_locked && !locked {
             info!("Screen unlocked after wake (CGSession safety-net cleared SCREEN_IS_LOCKED)");
+            #[cfg(target_os = "macos")]
+            screenpipe_screen::stream_invalidation::request();
         }
 
         // Check if recording is healthy

--- a/crates/screenpipe-screen/src/lib.rs
+++ b/crates/screenpipe-screen/src/lib.rs
@@ -29,3 +29,31 @@ pub use microsoft::perform_ocr_windows;
 pub use tesseract::perform_ocr_tesseract;
 pub mod browser_utils;
 pub mod snapshot_writer;
+
+/// Flag to request invalidation of persistent SCStream handles after screen
+/// unlock or wake. Set by `sleep_monitor` (CFNotification callback thread),
+/// consumed by the event-driven capture loop (tokio thread) so that the actual
+/// stream teardown happens in a safe context — not inside the C callback.
+#[cfg(target_os = "macos")]
+pub mod stream_invalidation {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    static NEEDS_INVALIDATION: AtomicBool = AtomicBool::new(false);
+
+    /// Request that all persistent SCStream handles be invalidated.
+    /// Safe to call from any thread (including CFNotification callbacks).
+    pub fn request() {
+        NEEDS_INVALIDATION.store(true, Ordering::SeqCst);
+    }
+
+    /// Check and clear the invalidation flag. If `true`, the caller should
+    /// call `invalidate_streams()` to tear down stale SCStream handles.
+    pub fn take() -> bool {
+        NEEDS_INVALIDATION.swap(false, Ordering::SeqCst)
+    }
+
+    /// Stop all persistent SCStream handles. The next capture call will
+    /// lazily recreate them with fresh frames.
+    pub fn invalidate_streams() {
+        sck_rs::stop_all_streams();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2678

After `cb413e1` introduced persistent `SCStream` per monitor via `sck-rs`, unlocking the screen no longer triggers stream recreation. The persistent stream keeps returning the last frame captured before lock (the lock screen), making all subsequent captures stale indefinitely. Only restarting screenpipe resolves it.

## Root Cause

The `sck-rs` update (`1561f06` → `c088aed`) added `stream_manager.rs` with a singleton `StreamManager` that maintains one persistent `SCStream` per display. When macOS locks the screen, the stream stops delivering new frames. After unlock, nobody calls `invalidate()` or `stop_all_streams()`, so `capture()` continues returning the stale lock screen frame from the buffer.

## Changes

- **`screenpipe-screen/src/lib.rs`**: Add `stream_invalidation` module with an `AtomicBool` flag. The flag bridges the unlock/wake detection (CFNotification callback thread) with the capture loop (tokio thread), avoiding unsafe Mutex operations inside C callbacks.
- **`screenpipe-engine/src/sleep_monitor.rs`**: Set the invalidation flag on all four unlock paths:
  1. `on_screen_unlocked` CFNotification callback
  2. CGSession safety-net poll (5s interval)
  3. `on_did_wake` immediate check
  4. `on_did_wake` delayed re-check (5s after wake)
- **`screenpipe-engine/src/event_driven_capture.rs`**: Consume the flag in the main capture loop and call `stop_all_streams()`, forcing lazy recreation on the next capture.

## Test Results (with fix applied)

### Before lock — normal capture working:
![fix_1_before_lock](https://github.com/user-attachments/assets/a764222a-98d9-43eb-b6cd-a0590d560600)
*(image: GitHub issue page captured correctly)*

### During lock — capture correctly skipped:
No JPG produced (the `screen_is_locked()` check correctly skips capture). Log shows:
```
Screen locked (CGSession safety-net poll)

```

### After unlock — capture recovers with fresh frames:
![fix_3_after_unlock](https://github.com/user-attachments/assets/f0751007-dd97-456b-8bc4-1512d365aafc)

After Touch ID unlock, I deliberately switched to a different app (Gemini browser) to verify the stream was truly recreated. The capture correctly picked up the new screen content — not a stale frame.

Log confirms invalidation triggered:
```
INFO screenpipe_engine::event_driven_capture: invalidating persistent streams after unlock/wake for monitor 2
```

OCR API also confirms the stream is delivering fresh frames — the app and text content changed after unlock, matching the actual screen:
```
# Before lock — Finder was focused:
18:00:15 app='Finder' text='Claude Code... Screen unlocked after wake...'

# After unlock — switched to Brave/Gemini, OCR correctly reflects this:
18:01:19 app='Brave Browser' text='Claude Code... cargo build --release...'
```

## Notes

Not entirely sure this is the most idiomatic approach for this codebase — happy to discuss alternatives. The fix is workable and tested on macOS Sequoia 15.6 with dual monitors and Touch ID unlock. The `stream_invalidation` flag pattern follows the existing style (similar to how DRM pause flags work).
