### PR TITLE
fix(retention): remove DELETE on already-dropped accessibility table

### DIFF
--- a/crates/screenpipe-connect/src/remote_sync.rs
+++ b/crates/screenpipe-connect/src/remote_sync.rs
@@ -115,12 +115,6 @@ FROM audio_transcriptions
 WHERE transcription LIKE '%search%' ORDER BY timestamp DESC LIMIT 20;
 ```
 
-**accessibility** — Accessibility tree text (macOS)
-```sql
-SELECT timestamp, app_name, window_name, text_content
-FROM accessibility WHERE text_content LIKE '%search%' ORDER BY timestamp DESC;
-```
-
 **speakers** — Identified speakers
 ```sql
 SELECT s.id, s.name, COUNT(at.id) as utterances

--- a/crates/screenpipe-db/src/db.rs
+++ b/crates/screenpipe-db/src/db.rs
@@ -4535,14 +4535,8 @@ impl DatabaseManager {
         .await?;
         let audio_chunks_deleted = audio_chunks_result.rows_affected();
 
-        // 9. Delete accessibility records
-        let accessibility_result =
-            sqlx::query("DELETE FROM accessibility WHERE timestamp BETWEEN ?1 AND ?2")
-                .bind(&start_str)
-                .bind(&end_str)
-                .execute(&mut **tx.conn())
-                .await?;
-        let accessibility_deleted = accessibility_result.rows_affected();
+        // 9. accessibility table was dropped by migration 20260312000000
+        let accessibility_deleted: u64 = 0;
 
         // 10. Delete ui_events — triggers ui_events_fts delete
         let ui_events_result =
@@ -4727,14 +4721,8 @@ impl DatabaseManager {
         .await?;
         let audio_chunks_deleted = audio_chunks_result.rows_affected();
 
-        // 11. Delete accessibility records
-        let accessibility_result =
-            sqlx::query("DELETE FROM accessibility WHERE timestamp BETWEEN ?1 AND ?2")
-                .bind(&start_str)
-                .bind(&end_str)
-                .execute(&mut **tx.conn())
-                .await?;
-        let accessibility_deleted = accessibility_result.rows_affected();
+        // 11. accessibility table was dropped by migration 20260312000000
+        let accessibility_deleted: u64 = 0;
 
         // 12. Delete ui_events
         let ui_events_result =
@@ -4922,14 +4910,8 @@ impl DatabaseManager {
 
         // NO orphan audio_chunks cleanup here — done separately
 
-        // Delete accessibility records
-        let accessibility_result =
-            sqlx::query("DELETE FROM accessibility WHERE timestamp BETWEEN ?1 AND ?2")
-                .bind(&start_str)
-                .bind(&end_str)
-                .execute(&mut **tx.conn())
-                .await?;
-        let accessibility_deleted = accessibility_result.rows_affected();
+        // accessibility table was dropped by migration 20260312000000
+        let accessibility_deleted: u64 = 0;
 
         // Delete ui_events
         let ui_events_result =


### PR DESCRIPTION
## description

Revert commit 9889cc0 ("fix: add accessibility table cleanup to all delete paths") in `crates/screenpipe-db/src/db.rs`, and drop a stale `accessibility` example from the `SCREENPIPE_SKILL` reference string in `crates/screenpipe-connect/src/remote_sync.rs`.

The `accessibility` table was dropped by migration 20260312000000 eleven days before 9889cc0, but the commit misread the correct `accessibility table was dropped by migration` comment as stale and replaced the `let accessibility_deleted: u64 = 0` stubs with actual `DELETE FROM accessibility` statements against the no-longer-existing table. Every retention tick on every affected install has since failed with `no such table: accessibility`, rolling back the entire `ImmediateTx` and cleaning up nothing.

See #2928 for the full root cause write-up, log evidence, and impact analysis.

related issue: #2928

## how to test

Assumes a screenpipe install with the retention loop enabled (the default) and at least 14 days of capture data, so retention has something to delete.

1. Build and run this branch in place of your current screenpipe binary.
2. Trigger retention immediately instead of waiting 5.5 minutes for the first tick:
   ```
   curl -X POST http://localhost:3030/retention/run
   ```
3. Confirm the log shows successful batches like `retention: batch deleted frames=... ocr=... ...` with zero `no such table: accessibility` errors and zero `ImmediateTx dropped without commit` warnings.
4. Verify old data is actually being removed:
   ```
   sqlite3 ~/.screenpipe/db.sqlite \
     "SELECT MIN(timestamp), COUNT(*) FROM frames;"
   ```
   Run before and after retention. The oldest timestamp should advance toward `now - 14 days` and the frame count should decrease.

On a DB with a large accumulated backlog, the first retention run will take longer than expected because of two separately-tracked bottlenecks: #2929 (missing index on `frames.elements_ref_frame_id`) and #2930 (the `frames_ad` trigger cost after retention was added). Neither is required for this PR to demonstrate the revert works -- a single successfully-committed batch is sufficient.
