### PR TITLE
perf(retention): add partial index on frames.elements_ref_frame_id

### DIFF
--- a/crates/screenpipe-db/src/migrations/20260411000000_add_elements_ref_frame_id_index.sql
+++ b/crates/screenpipe-db/src/migrations/20260411000000_add_elements_ref_frame_id_index.sql
@@ -1,0 +1,26 @@
+-- Partial index on frames.elements_ref_frame_id to eliminate the full
+-- table scan in the retention anchor-frame subquery.
+--
+-- The correlated subquery in delete_time_range_batch:
+--   SELECT DISTINCT f.id FROM frames f
+--   WHERE f.timestamp BETWEEN ?1 AND ?2
+--   AND EXISTS (SELECT 1 FROM frames ref
+--               WHERE ref.elements_ref_frame_id = f.id
+--               AND ref.timestamp NOT BETWEEN ?1 AND ?2)
+--
+-- falls back to a full scan of `frames` on the inner EXISTS without this
+-- index (elements_ref_frame_id was added in 20260318000000 without one).
+-- Measured 5m55s per 1-hour retention batch on a 33k-frame DB, making
+-- retention unusable on any non-trivial backlog.
+--
+-- With the index, the inner plan becomes:
+--   SEARCH ref USING INDEX idx_frames_elements_ref_frame_id (elements_ref_frame_id=?)
+-- and the same query runs in ~5ms.
+--
+-- Partial (WHERE elements_ref_frame_id IS NOT NULL) because only frames
+-- that reference a dedup anchor are relevant here. Storage cost is
+-- negligible -- single-digit MB/year for typical capture volume, and it
+-- is the smallest index on the frames table by a wide margin.
+CREATE INDEX IF NOT EXISTS idx_frames_elements_ref_frame_id
+    ON frames(elements_ref_frame_id)
+    WHERE elements_ref_frame_id IS NOT NULL;


### PR DESCRIPTION
## description

Add a partial index on `frames.elements_ref_frame_id` to eliminate the full table scan in the retention anchor-frame subquery.

The correlated subquery in `delete_time_range_batch` checks, for each frame in the batch range, whether any frame outside the range still references it as a dedup anchor:

```sql
SELECT DISTINCT f.id FROM frames f
WHERE f.timestamp BETWEEN ?1 AND ?2
AND EXISTS (
    SELECT 1 FROM frames ref
    WHERE ref.elements_ref_frame_id = f.id
    AND ref.timestamp NOT BETWEEN ?1 AND ?2
)
```

Without an index on `elements_ref_frame_id`, SQLite falls back to a full `frames` scan on every iteration:

```
QUERY PLAN
|--SEARCH f USING COVERING INDEX idx_frames_timestamp
`--CORRELATED SCALAR SUBQUERY 1
   `--SCAN ref
```

Measured 5m 55s per 1-hour retention batch on a 33k-frame DB, making retention unusable on any non-trivial backlog. Each batch runs inside `ImmediateTx`, so the slow query also holds the SQLite write lock the entire time and blocks new frame captures.

The column was added in migration `20260318000000_add_elements_ref_frame_id.sql` without an index, despite every other reference column on the `elements` table being indexed (`idx_elements_frame_id`, `idx_elements_parent_id`, `idx_elements_frame_source`, etc.). This looks like an omission rather than a design choice.

With the partial index added, the inner plan becomes:

```
SEARCH ref USING INDEX idx_frames_elements_ref_frame_id (elements_ref_frame_id=?)
```

and the same query drops to ~5ms -- roughly a 70,000x speedup on the batch's hot path. The index is partial (only non-NULL rows, which is roughly half of `frames` in practice) and is the smallest index on `frames` by a wide margin; storage cost is single-digit MB/year for typical capture volume and per-insert write amplification is negligible.

See #2929 for the full write-up with measurements and query plans.

related issue: #2929

## how to test

1. Build and run this branch in place of your current screenpipe binary. The new migration `20260411000000_add_elements_ref_frame_id_index.sql` will be applied automatically on startup.

2. Confirm the migration ran and the index exists:
   ```
   sqlite3 ~/.screenpipe/db.sqlite \
     "SELECT version, description FROM _sqlx_migrations WHERE version=20260411000000;"
   sqlite3 ~/.screenpipe/db.sqlite \
     "SELECT sql FROM sqlite_master WHERE name='idx_frames_elements_ref_frame_id';"
   ```

3. Check the query plan now uses the index:
   ```
   sqlite3 ~/.screenpipe/db.sqlite "EXPLAIN QUERY PLAN
   SELECT DISTINCT f.id FROM frames f
   WHERE f.timestamp BETWEEN '2026-03-01' AND '2026-03-02'
   AND EXISTS (SELECT 1 FROM frames ref
               WHERE ref.elements_ref_frame_id = f.id
               AND ref.timestamp NOT BETWEEN '2026-03-01' AND '2026-03-02');"
   ```
   The inner subquery should show `SEARCH ref USING INDEX idx_frames_elements_ref_frame_id` instead of `SCAN ref`.

4. If this PR is applied together with #2931 (the accessibility rollback fix), retention batches should now complete in seconds instead of minutes, and DB backlog from long-running installs actually drains.

## dependencies

This PR does not depend on #2931 to be correct -- the index is useful independently. But users will only see the retention speedup in practice after #2931 lands, since retention currently rolls back every batch without #2931.
