### PR TITLE
fix(macos): autostart via AppleScript so Login Items shows 'screenpipe'

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -953,8 +953,16 @@ async fn main() {
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_process::init())
+        // macOS: AppleScript binds the login item to the .app bundle path so
+        // System Settings -> Login Items displays the app's product name
+        // ("screenpipe") instead of grouping under the Developer ID team
+        // display name (which reads as an individual's name for individual
+        // Apple Developer accounts). See issue #3298.
+        // The legacy LaunchAgent plist is cleaned up in the setup() hook below
+        // via a one-shot migration so users don't end up with two autostart
+        // mechanisms firing in parallel.
         .plugin(tauri_plugin_autostart::init(
-            MacosLauncher::LaunchAgent,
+            MacosLauncher::AppleScript,
             None,
         ))
         // single-instance plugin uses zbus::blocking on Linux which panics
@@ -1867,6 +1875,82 @@ async fn main() {
 
             let is_autostart_enabled = store
                 .auto_start_enabled;
+
+            // macOS one-shot migration for issue #3298:
+            // previous builds used MacosLauncher::LaunchAgent which writes
+            // ~/Library/LaunchAgents/<productName>.plist. macOS groups
+            // freestanding signed LaunchAgents under the Developer ID team
+            // display name in System Settings -> Login Items, which for an
+            // individual Apple Developer account is a person's real name.
+            // We've switched to MacosLauncher::AppleScript so the login item
+            // gets bound to the .app bundle (and is displayed as "screenpipe").
+            // Delete any leftover legacy plist on first launch after this
+            // change, otherwise both autostart paths would fire in parallel
+            // on next boot (LaunchAgent + AppleScript = duplicate process).
+            #[cfg(target_os = "macos")]
+            {
+                const LOGIN_ITEM_MIGRATION_KEY: &str =
+                    "_loginItemAppleScriptMigrationApplied";
+
+                let already_migrated = store
+                    .extra
+                    .get(LOGIN_ITEM_MIGRATION_KEY)
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+
+                if !already_migrated {
+                    if let Ok(home) = std::env::var("HOME") {
+                        // The auto-launch crate writes the plist as
+                        // ~/Library/LaunchAgents/<app_name>.plist where
+                        // app_name is tauri's package_info().name (the
+                        // configured productName, e.g. "screenpipe",
+                        // "screenpipe beta", "screenpipe enterprise",
+                        // "screenpipe - Development"). Use the same source
+                        // here rather than hardcoding so beta/enterprise
+                        // builds also clean up their own legacy plists.
+                        let product_name = app.package_info().name.clone();
+                        let legacy_plist = std::path::PathBuf::from(&home)
+                            .join("Library")
+                            .join("LaunchAgents")
+                            .join(format!("{}.plist", product_name));
+
+                        if legacy_plist.exists() {
+                            match std::fs::remove_file(&legacy_plist) {
+                                Ok(()) => info!(
+                                    "removed legacy autostart LaunchAgent plist: {}",
+                                    legacy_plist.display()
+                                ),
+                                Err(e) => warn!(
+                                    "failed to remove legacy autostart plist {}: {}",
+                                    legacy_plist.display(),
+                                    e
+                                ),
+                            }
+                        } else {
+                            debug!(
+                                "no legacy autostart plist found at {}",
+                                legacy_plist.display()
+                            );
+                        }
+                    } else {
+                        warn!("HOME env var not set, skipping legacy autostart plist cleanup");
+                    }
+
+                    // Persist the flag so this only runs once per install.
+                    // We update both the in-memory copy and the on-disk store
+                    // so a re-read by other code sees the migrated state.
+                    store.extra.insert(
+                        LOGIN_ITEM_MIGRATION_KEY.to_string(),
+                        json!(true),
+                    );
+                    if let Err(e) = store.save(&app.handle()) {
+                        warn!(
+                            "failed to persist login item migration flag: {}",
+                            e
+                        );
+                    }
+                }
+            }
 
             if is_autostart_enabled {
                 let _ = autostart_manager.enable();


### PR DESCRIPTION
## Summary

- Switch `tauri-plugin-autostart` from `MacosLauncher::LaunchAgent` to `MacosLauncher::AppleScript` so macOS displays the login item under the app's product name instead of grouping it under the Apple Developer team display name.
- Add a one-shot migration on startup that deletes the legacy `~/Library/LaunchAgents/<productName>.plist` left over from the old launcher, guarded by a `_loginItemAppleScriptMigrationApplied` flag in the settings store so it only runs once.
- No behavior change for users who never enabled autostart, and no new dependencies.

## Why

`MacosLauncher::LaunchAgent` writes a freestanding signed plist under `~/Library/LaunchAgents/`. macOS groups freestanding signed launch agents in System Settings -> Login Items under the Developer ID team display name. For Apple Developer accounts registered as an individual, that string is a person's real name rather than "screenpipe". `MacosLauncher::AppleScript` binds the login item to the `.app` bundle path, so macOS shows the bundle's product name.

## Migration: what happens on first launch after this lands

- On macOS, before the existing `autostart_manager.enable()`/`disable()` call, the app checks `settings.extra._loginItemAppleScriptMigrationApplied`.
- If unset, the app removes `~/Library/LaunchAgents/<productName>.plist` (the path the `auto-launch` crate used to write — `productName` resolves to "screenpipe", "screenpipe beta", "screenpipe enterprise", or "screenpipe - Development" depending on build).
- The flag is then persisted via `SettingsStore::save` so the cleanup never runs again.
- The subsequent `autostart_manager.enable()` call re-registers autostart via AppleScript if the user still has it enabled in settings, preventing the LaunchAgent + AppleScript double-fire that would otherwise leave two autostart mechanisms active in parallel.
- Users who never enabled autostart: no plist exists, the removal is a no-op, only the flag gets written.

## Test plan

- [ ] Fresh install (no legacy plist): enable autostart in Settings, log out and log back in, confirm System Settings -> General -> Login Items & Extensions -> "Allow in the Background" shows "screenpipe" and no LaunchAgent plist appears under `~/Library/LaunchAgents/`.
- [ ] Upgrade path: with a legacy `~/Library/LaunchAgents/screenpipe.plist` present and autostart previously enabled, launch the new build; confirm the plist is gone, log shows `removed legacy autostart LaunchAgent plist: ...`, the login item entry shows "screenpipe", and only one screenpipe process spawns at next login.
- [ ] Idempotency: relaunch the app a second time after migration; log should not mention removing the plist again (flag already set), and `~/Library/LaunchAgents/` should remain clean.
- [ ] Autostart-off users: launch with autostart disabled and no legacy plist — flag still gets persisted, no warnings, no plist created.
- [ ] Beta / enterprise builds (productName "screenpipe beta" / "screenpipe enterprise"): same checks against their own legacy plist filenames.

Fixes #3298

🤖 Generated with [Claude Code](https://claude.com/claude-code)