### PR TITLE
fix(linux): keep UI activity capture running without AT-SPI

### DIFF
--- a/crates/screenpipe-a11y/src/platform/linux.rs
+++ b/crates/screenpipe-a11y/src/platform/linux.rs
@@ -169,10 +169,9 @@ impl UiRecorder {
     ) -> Result<(RecordingHandle, Option<ActivityFeed>)> {
         let perms = self.check_permissions();
         if !perms.accessibility && !perms.input_monitoring {
-            anyhow::bail!(
-                "No permissions available. Need either:\n\
-                 - AT-SPI2 (accessibility): install at-spi2-core\n\
-                 - evdev (input monitoring): sudo usermod -aG input $USER"
+            warn!(
+                "AT-SPI2 and evdev input monitoring are unavailable; continuing with \
+                 compositor/X11 window tracking only"
             );
         }
 
@@ -228,21 +227,23 @@ impl UiRecorder {
 // Permission checks
 // ============================================================================
 
-/// Check if AT-SPI2 D-Bus service is available.
+/// Check whether this process can connect to the AT-SPI2 bus.
+///
+/// This deliberately reuses the tree walker's in-process zbus connection
+/// rather than shelling out to `dbus-send`. The previous command probe hid its
+/// stderr and reported every failure as a missing package, even when the
+/// AppImage simply lacked the graphical session's D-Bus environment.
 fn check_atspi_available() -> bool {
-    // Try to connect to the session bus and check if org.a11y.Bus exists
-    std::process::Command::new("dbus-send")
-        .args([
-            "--session",
-            "--dest=org.a11y.Bus",
-            "--type=method_call",
-            "--print-reply",
-            "/org/a11y/bus",
-            "org.a11y.Bus.GetAddress",
-        ])
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
+    match crate::tree::linux::check_atspi_bus_connection() {
+        Ok(()) => true,
+        Err(error) => {
+            warn!(
+                "AT-SPI2 is unavailable to this process: {error:#}. \
+                 Accessibility-tree capture is disabled, but window tracking can continue."
+            );
+            false
+        }
+    }
 }
 
 /// Check if the user can read evdev input devices.

--- a/crates/screenpipe-a11y/src/tree/linux.rs
+++ b/crates/screenpipe-a11y/src/tree/linux.rs
@@ -962,6 +962,15 @@ fn connect_to_atspi_bus() -> Result<Connection> {
     Ok(conn)
 }
 
+/// Verify that this process can open the AT-SPI2 bus.
+///
+/// The UI-event recorder uses this only to report AT-SPI availability. Keeping
+/// the probe beside the tree-walker connection code means both paths honor the
+/// same session-bus and `AT_SPI_BUS_ADDRESS` resolution rules.
+pub(crate) fn check_atspi_bus_connection() -> Result<()> {
+    connect_to_atspi_bus().map(|_| ())
+}
+
 /// Enable accessibility for Chromium/Electron apps.
 ///
 /// Chromium only builds its AT-SPI2 tree when it detects an AT is active:

--- a/crates/screenpipe-a11y/src/tree/mod.rs
+++ b/crates/screenpipe-a11y/src/tree/mod.rs
@@ -13,7 +13,7 @@
 mod app_version;
 mod electron_docs;
 #[cfg(target_os = "linux")]
-mod linux;
+pub(crate) mod linux;
 #[cfg(target_os = "linux")]
 mod linux_lines;
 #[cfg(target_os = "macos")]

--- a/crates/screenpipe-engine/src/ui_recorder.rs
+++ b/crates/screenpipe-engine/src/ui_recorder.rs
@@ -22,6 +22,13 @@ use crate::frame_linker_actor::{next_correlation_id, LinkerMessage, LinkerSender
 const UI_RECORDER_IDLE_RECV_TIMEOUT: Duration = Duration::from_secs(1);
 const UI_RECORDER_MIN_RECV_TIMEOUT: Duration = Duration::from_millis(1);
 
+// Linux app/window activity comes from compositor IPC or X11, not AT-SPI2.
+// AT-SPI remains required by the separate accessibility-tree walker.
+#[cfg(target_os = "linux")]
+const UI_EVENT_CAPTURE_REQUIRES_ACCESSIBILITY: bool = false;
+#[cfg(not(target_os = "linux"))]
+const UI_EVENT_CAPTURE_REQUIRES_ACCESSIBILITY: bool = true;
+
 /// A batched UI event plus an optional correlation id. Events that
 /// won't trigger a capture (Move, Idle, filtered-out targets) leave
 /// `correlation_id` as `None` — those rows stay `frame_id = NULL`.
@@ -701,7 +708,7 @@ pub async fn start_ui_recording(
             perms.accessibility, perms.input_monitoring
         );
     }
-    if !perms.accessibility {
+    if !perms.accessibility && UI_EVENT_CAPTURE_REQUIRES_ACCESSIBILITY {
         // The "accessibility" bit means different things per OS. macOS:
         // TCC grant for the app. Linux: AT-SPI2 client library present.
         // Windows: always true (no separate gate). Tailor the remediation
@@ -726,6 +733,13 @@ pub async fn start_ui_recording(
             task_handle: None,
             tree_walker_handle: None,
         });
+    }
+    #[cfg(target_os = "linux")]
+    if !perms.accessibility {
+        warn!(
+            "AT-SPI2 is unavailable to this process; continuing UI event recording with \
+             compositor/X11 window tracking. Accessibility-tree capture remains unavailable."
+        );
     }
     if !perms.input_monitoring {
         // On macOS this is a TCC gate (System Settings → Input Monitoring).
@@ -770,10 +784,8 @@ pub async fn start_ui_recording(
         }
     };
 
-    // app_events_running mirrors the recorder being up: the app observer
-    // thread is unconditionally spawned in start_internal whenever
-    // accessibility is granted (which it is, here — we'd have bailed
-    // otherwise).
+    // `start_internal` starts the platform's app/window observer whenever
+    // the recorder starts, including Linux's compositor/X11 fallback.
     set_ui_recorder_state(
         true,
         true,
@@ -1973,6 +1985,14 @@ mod scroll_burst_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_ui_event_capture_does_not_require_atspi() {
+        // Linux app/window events come from compositor IPC or X11. AT-SPI is
+        // required by the separate tree walker, not this recorder's startup.
+        assert!(!UI_EVENT_CAPTURE_REQUIRES_ACCESSIBILITY);
+    }
 
     #[test]
     fn window_focus_capture_is_always_enabled() {


### PR DESCRIPTION
## Summary

Fix Linux UI activity capture being disabled when the AT-SPI availability probe fails, even though the recorder's app/window event path is independent of AT-SPI.

- replace the `dbus-send` subprocess probe with the same in-process `zbus` connection used by the Linux tree walker;
- preserve AT-SPI as a requirement for accessibility-tree capture;
- let Linux UI recording start with its compositor/X11 window observer when AT-SPI or evdev is unavailable;
- add a Linux regression guard for the engine startup policy.

## Root cause

Linux support originally introduced AT-SPI tree walking and evdev UI input capture together (#2318). A later shared engine policy made Accessibility the hard startup requirement for macOS TCC behavior (#3485, #3898). On Linux that turned an AT-SPI probe failure into a full UI-recorder shutdown, even though Linux window activity is sourced from Hyprland/Sway IPC or X11/xdotool.

The old probe hid `dbus-send` failures, so an AppImage without the graphical session's D-Bus environment reported only a misleading package-install instruction. The new probe reports the actual in-process D-Bus failure.

## Behavior

```text
before
AT-SPI probe fails ──> UI recorder off ──> no ui_events

after
AT-SPI probe fails ──> tree capture unavailable (diagnostic logged)
                     └─> Linux compositor/X11 recorder starts ──> ui_events
```

## Validation

- `cargo fmt --check`
- `cargo test -p screenpipe-engine --lib ui_recorder` (50 passed)

The full `screenpipe-a11y` host suite ran 237 tests successfully but has one existing macOS clipboard failure (`test_get_clipboard_empty_returns_none`, NSPasteboard rejects an empty write), unrelated to this Linux-only change.

Linux cross-compilation could not run in this macOS workspace because `x86_64-linux-gnu-gcc` is unavailable; Docker is installed but its daemon is not running.

## Follow-up boundary

This does not add GNOME-specific Wayland foreground-window discovery. The current observer supports Hyprland, Sway, and X11/xdotool; if a GNOME Wayland customer still sees no activity after this fix, that needs separate backend support.
