### PR TITLE
fix(meetings): force resolved language on local live transcription

### DIFF
--- a/crates/screenpipe-audio/src/meeting_streaming/selected_engine.rs
+++ b/crates/screenpipe-audio/src/meeting_streaming/selected_engine.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
 use chrono::{DateTime, Utc};
+use screenpipe_core::Language;
 use tokio::{
     sync::{mpsc, RwLock},
     task::JoinHandle,
@@ -73,7 +74,8 @@ async fn run_stream(
 ) -> Result<()> {
     // Bias the local live transcriber toward this meeting's keyterms (user
     // vocabulary + calendar attendee names) by seeding the session vocabulary.
-    let mut session = selected_engine_session(&engine_ref, &config.keyterms).await?;
+    let mut session =
+        selected_engine_session(&engine_ref, &config.keyterms, config.language.as_deref()).await?;
     let model = selected_engine_model(&session);
     let mut buffer = LiveChunkBuffer::default();
     let mut resampler: Option<StreamResampler> = None;
@@ -121,6 +123,7 @@ async fn run_stream(
 async fn selected_engine_session(
     engine_ref: &Arc<RwLock<Option<TranscriptionEngine>>>,
     keyterms: &[String],
+    language: Option<&str>,
 ) -> Result<TranscriptionSession> {
     let engine = engine_ref
         .read()
@@ -134,7 +137,18 @@ async fn selected_engine_session(
         ));
     }
 
-    engine.create_session_with_keyterms(keyterms)
+    let mut session = engine.create_session_with_keyterms(keyterms)?;
+
+    // Force the meeting's resolved language (parallel to the cloud/Deepgram live
+    // path, which passes `config.language`). Without this, the local Whisper live
+    // path auto-detects language per short chunk and mis-detects non-English
+    // speech — rendering e.g. Russian as Latin/Polish. Only apply when the user
+    // resolved a single language; empty/multi keeps auto-detection.
+    if let Some(forced) = language.and_then(|code| code.parse::<Language>().ok()) {
+        session.force_language(forced);
+    }
+
+    Ok(session)
 }
 
 fn selected_engine_model(session: &TranscriptionSession) -> Option<String> {

--- a/crates/screenpipe-audio/src/transcription/engine.rs
+++ b/crates/screenpipe-audio/src/transcription/engine.rs
@@ -579,6 +579,24 @@ pub enum TranscriptionSession {
 }
 
 impl TranscriptionSession {
+    /// Force a single transcription language on this session, overriding the
+    /// engine's configured language set. Used by the live meeting path to honor
+    /// the meeting's resolved language (`MeetingStreamingConfig.language`) so the
+    /// local transcriber does not fall back to per-chunk auto-detection — which
+    /// on short live chunks mis-detects non-English speech and emits the wrong
+    /// script (e.g. Russian rendered as Latin/Polish). No-op for engines that do
+    /// not carry a language set (Parakeet/Qwen3 auto-detect internally).
+    pub fn force_language(&mut self, language: Language) {
+        match self {
+            Self::Whisper { languages, .. }
+            | Self::Deepgram { languages, .. }
+            | Self::OpenAICompatible { languages, .. } => {
+                *languages = vec![language];
+            }
+            _ => {}
+        }
+    }
+
     pub async fn transcribe_detailed(
         &mut self,
         audio: &[f32],
@@ -921,5 +939,58 @@ mod merge_keyterms_tests {
     fn empty_extra_returns_base_unchanged() {
         let base = vec![v("Screenpipe")];
         assert_eq!(merge_keyterms(&base, &[]).len(), 1);
+    }
+}
+
+#[cfg(test)]
+mod force_language_tests {
+    use super::*;
+    use crate::transcription::deepgram::DeepgramTranscriptionConfig;
+
+    /// Regression for #5650: the live meeting path must be able to force the
+    /// meeting's resolved language onto a session so the local transcriber does
+    /// not auto-detect per short chunk (which garbles non-English into the wrong
+    /// script). Whisper shares this exact match arm; it is exercised here via the
+    /// Deepgram variant, which needs no model file to construct.
+    #[test]
+    fn force_language_overrides_language_set() {
+        let mut session = TranscriptionSession::Deepgram {
+            config: DeepgramTranscriptionConfig::direct("k".to_string()),
+            languages: vec![],
+            vocabulary: vec![],
+        };
+        session.force_language(Language::Russian);
+        match &session {
+            TranscriptionSession::Deepgram { languages, .. } => {
+                assert_eq!(languages.as_slice(), &[Language::Russian]);
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    /// Forcing must replace any previously-detected/multi set with exactly one
+    /// language, since downstream Whisper forcing only triggers on a single entry.
+    #[test]
+    fn force_language_replaces_multi_with_single() {
+        let mut session = TranscriptionSession::Deepgram {
+            config: DeepgramTranscriptionConfig::direct("k".to_string()),
+            languages: vec![Language::English, Language::German],
+            vocabulary: vec![],
+        };
+        session.force_language(Language::Russian);
+        match &session {
+            TranscriptionSession::Deepgram { languages, .. } => {
+                assert_eq!(languages.as_slice(), &[Language::Russian]);
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    /// Disabled sessions carry no language set; forcing must be a safe no-op.
+    #[test]
+    fn force_language_noop_on_disabled() {
+        let mut session = TranscriptionSession::Disabled;
+        session.force_language(Language::Russian);
+        assert!(matches!(session, TranscriptionSession::Disabled));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #5650.

When live meeting notes use the **local** transcription engine (`meetingLiveTranscriptionProvider = "selected-engine"`), the user's configured transcription language was ignored. The local Whisper live path ran per-chunk auto-detection and, on short 2–6 s live chunks, mis-detected non-English speech — rendering e.g. Russian in the wrong script (Latin/Polish-looking `ište, što ne všeš školu`, `naša celivaya cifra`).

The cloud/Deepgram live path already forces `config.language` (`deepgram_live.rs`), and the batch path forces it too. Only the local selected-engine live path didn't — it never read `MeetingStreamingConfig.language`.

## Changes

- Add `TranscriptionSession::force_language`, which overrides the session's language set to a single forced language (Whisper / Deepgram / OpenAI-compatible; no-op for engines that auto-detect internally).
- In `selected_engine_session`, apply `config.language` after creating the session — mirroring the cloud path. When the user resolved a single language it is forced; empty/multi keeps auto-detection.

## Test plan

- [x] `cargo test -p screenpipe-audio --lib force_language` (3 passed) — override, multi→single replacement, and no-op on Disabled.
- [x] `cargo test -p screenpipe-audio --lib meeting_streaming` (31 passed) — no regressions.
- [x] `cargo clippy -p screenpipe-audio --lib` — no new warnings.
