### PR TITLE
fix(ai): align Max and Ultra cost recovery

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -18,29 +18,29 @@ results and `cargo llvm-cov` data on top when judging release confidence.
 
 ### Tauri E2E
 
-- Mapped specs: 86
-- Declared test blocks: 245
-- Weighted coverage points: 187.7
+- Mapped specs: 88
+- Declared test blocks: 247
+- Weighted coverage points: 189.7
 
 | Platform | Specs | Declared tests | Weighted points | Layers | Features | Critical score |
 | --- | --- | --- | --- | --- | --- | --- |
-| windows | 69 | 218 | 175.2 | 15 | 72 | 90% |
-| macos | 82 | 208 | 158.5 | 17 | 74 | 88% |
-| linux | 59 | 178 | 145.0 | 13 | 67 | 87% |
+| windows | 71 | 220 | 177.2 | 15 | 74 | 91% |
+| macos | 84 | 210 | 160.5 | 17 | 76 | 89% |
+| linux | 61 | 180 | 147.0 | 14 | 69 | 88% |
 
 ### Core Engine
 
 - Mapped suites: 30
 - Mapped Rust files: 300
-- Active test blocks: 2807
+- Active test blocks: 2812
 - Ignored/manual test blocks: 133
-- Weighted coverage points: 2312.9
+- Weighted coverage points: 2317.3
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 27 | 2680 | 128 | 2254.6 | 21 | 11 | 100% |
-| macos | 27 | 2730 | 108 | 2264.1 | 22 | 11 | 100% |
-| linux | 23 | 2374 | 102 | 1976.9 | 20 | 11 | 100% |
+| windows | 27 | 2685 | 128 | 2259.0 | 21 | 11 | 100% |
+| macos | 27 | 2735 | 108 | 2268.5 | 22 | 11 | 100% |
+| linux | 23 | 2379 | 102 | 1981.3 | 20 | 11 | 100% |
 
 ## Refresh
 

--- a/apps/screenpipe-app-tauri/components/chat/standalone/upgrade-quota-banner.test.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/upgrade-quota-banner.test.tsx
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   blockedUpgrade: null as any,
   clearQuotaUpgrade: vi.fn(),
   openBusinessUpgradeSurface: vi.fn(),
+  openUrl: vi.fn(),
   routerPush: vi.fn(),
 }));
 
@@ -55,6 +56,7 @@ vi.mock("@/lib/utils/tauri", () => ({
 vi.mock("@/lib/upgrade-flow", () => ({
   openBusinessUpgradeSurface: mocks.openBusinessUpgradeSurface,
 }));
+vi.mock("@tauri-apps/plugin-shell", () => ({ open: mocks.openUrl }));
 
 describe("UpgradeQuotaBanner", () => {
   beforeEach(() => {
@@ -73,6 +75,8 @@ describe("UpgradeQuotaBanner", () => {
     mocks.clearQuotaUpgrade.mockReset();
     mocks.openBusinessUpgradeSurface.mockReset();
     mocks.openBusinessUpgradeSurface.mockResolvedValue(undefined);
+    mocks.openUrl.mockReset();
+    mocks.openUrl.mockResolvedValue(undefined);
     mocks.routerPush.mockReset();
   });
 
@@ -124,6 +128,7 @@ describe("UpgradeQuotaBanner", () => {
       requiredPlan: "business",
       upgradeUrl: "https://screenpi.pe/account/billing",
       resetsAt: "2026-08-02T00:00:00.000Z",
+      reason: "daily_cost_limit_exceeded",
     };
 
     render(<UpgradeQuotaBanner />);
@@ -151,6 +156,7 @@ describe("UpgradeQuotaBanner", () => {
       requiredPlan: "business",
       upgradeUrl: "https://screenpi.pe/account/billing",
       resetsAt: null,
+      reason: "daily_cost_limit_exceeded",
     };
     render(<UpgradeQuotaBanner />);
 
@@ -158,5 +164,38 @@ describe("UpgradeQuotaBanner", () => {
       screen.getByRole("button", { name: "dismiss AI usage notice" }),
     );
     expect(mocks.clearQuotaUpgrade).toHaveBeenCalledOnce();
+  });
+
+  it("opens the exact server-validated Max billing target", async () => {
+    mocks.blockedUpgrade = {
+      requiredPlan: "business_max",
+      upgradeUrl:
+        "https://screenpi.pe/account/billing?target_plan=pro_max&interval=month",
+      resetsAt: "2026-09-01T00:00:00.000Z",
+      reason: "monthly_cost_limit_exceeded",
+    };
+    render(<UpgradeQuotaBanner />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Upgrade to Max" }));
+    await waitFor(() =>
+      expect(mocks.openUrl).toHaveBeenCalledWith(
+        "https://screenpi.pe/account/billing?target_plan=pro_max&interval=month",
+      ),
+    );
+    expect(mocks.openBusinessUpgradeSurface).not.toHaveBeenCalled();
+  });
+
+  it("does not suggest reviewing pipes for a single oversized request", () => {
+    mocks.blockedUpgrade = {
+      requiredPlan: "business_max",
+      upgradeUrl:
+        "https://screenpi.pe/account/billing?target_plan=pro_max&interval=month",
+      resetsAt: null,
+      reason: "request_cost_limit_exceeded",
+    };
+    render(<UpgradeQuotaBanner />);
+
+    expect(screen.getByText(/request is too large/i)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Review pipes" })).toBeNull();
   });
 });

--- a/apps/screenpipe-app-tauri/components/chat/standalone/upgrade-quota-banner.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/upgrade-quota-banner.tsx
@@ -7,6 +7,7 @@ import { useState } from "react";
 import { X, Zap } from "lucide-react";
 import { useRouter } from "next/navigation";
 import posthog from "posthog-js";
+import { open as openUrl } from "@tauri-apps/plugin-shell";
 import { Button } from "@/components/ui/button";
 import { useUsageStatus, formatResetTime } from "@/lib/hooks/use-usage-status";
 import { useModelUpsellGating } from "@/lib/hooks/use-model-upsell-gating";
@@ -14,12 +15,10 @@ import { clearQuotaUpgrade, useQuotaUpgrade } from "@/lib/chat/quota-upgrade";
 import { openBusinessUpgradeSurface } from "@/lib/upgrade-flow";
 
 /**
- * At-the-cap upgrade prompt (the "intensity" lever). Appears in the composer
- * only when a non-Business user has spent their full daily premium-message
- * budget (`remaining <= 0`). Free models keep working, so this is a soft,
- * dismissible nudge — not a wall. One click opens the native Business offer so
- * price and billing cadence are reviewed before sign-in or checkout. Hidden for Business (`subscribed`) and BYOK users
- * (usage is null when the worker is bypassed).
+ * Recovery prompt for either proactive query exhaustion or a structured hosted
+ * AI cost-limit response. The proactive prompt stays hidden for paid and BYOK
+ * users. A server-selected cost recovery may also offer Business Max/Ultra and
+ * opens only the exact allow-listed billing target parsed by quota-errors.ts.
  *
  * To reproduce the exhausted state on demand without burning real quota, see
  * the dev force-flag in use-usage-status.tsx.
@@ -62,10 +61,18 @@ export function UpgradeQuotaBanner() {
     try {
       posthog.capture("desktop_upgrade_entry_clicked", {
         source,
+        required_plan: blockedUpgrade?.requiredPlan ?? "business",
       });
-      await openBusinessUpgradeSurface(source);
+      if (
+        blockedUpgrade &&
+        blockedUpgrade.requiredPlan !== "business"
+      ) {
+        await openUrl(blockedUpgrade.upgradeUrl);
+      } else {
+        await openBusinessUpgradeSurface(source);
+      }
     } catch (e) {
-      console.error("failed to open Business upgrade:", e);
+      console.error("failed to open hosted AI upgrade:", e);
     } finally {
       setBusy(false);
     }
@@ -79,9 +86,29 @@ export function UpgradeQuotaBanner() {
     router.push("/?section=pipes");
   };
 
-  const blockedTitle = resets
-    ? `Hosted AI paused until ${resets}`
-    : "Hosted AI is paused for today";
+  const blockedTitle = blockedUpgrade?.reason === "request_cost_limit_exceeded"
+    ? "This request is too large for hosted AI"
+    : blockedUpgrade?.reason === "trial_cost_limit_exceeded"
+      ? "Hosted AI trial allowance reached"
+      : resets
+        ? `Hosted AI paused until ${resets}`
+        : "Hosted AI allowance reached";
+  const blockedDescription = blockedUpgrade?.reason === "request_cost_limit_exceeded"
+    ? "Start a new chat or shorten the context. Local and own-key AI presets keep working."
+    : blockedUpgrade?.reason === "trial_cost_limit_exceeded"
+      ? "Local and own-key AI presets keep working. Upgrade for a larger hosted allowance."
+      : "Background pipes share this allowance. The website message allowance is separate. Local and own-key AI presets keep working.";
+  const upgradeLabel = blockedUpgrade?.requiredPlan === "business_max"
+    ? "Upgrade to Max"
+    : blockedUpgrade?.requiredPlan === "business_ultra"
+      ? "Upgrade to Ultra"
+      : blockedUpgrade
+        ? "Upgrade to Business"
+        : "View Business";
+  const canReviewPipes = blockedUpgrade && (
+    blockedUpgrade.reason === "daily_cost_limit_exceeded" ||
+    blockedUpgrade.reason === "monthly_cost_limit_exceeded"
+  );
 
   return (
     <div
@@ -101,18 +128,14 @@ export function UpgradeQuotaBanner() {
           </div>
           <div className="mt-0.5 text-muted-foreground">
             {blockedUpgrade ? (
-              <>
-                Background pipes share this budget. The website message
-                allowance is separate. Choose a local or own-key AI preset below
-                to keep working.
-              </>
+              <>{blockedDescription}</>
             ) : (
               <>Free models still work{resets ? ` · resets ${resets}` : ""}.</>
             )}
           </div>
         </div>
         <span className="flex shrink-0 items-center gap-1.5">
-          {blockedUpgrade && (
+          {canReviewPipes && (
             <Button
               size="sm"
               variant="ghost"
@@ -128,7 +151,7 @@ export function UpgradeQuotaBanner() {
             onClick={onUpgrade}
             disabled={busy}
           >
-            {blockedUpgrade ? "Upgrade to Business" : "View Business"}
+            {upgradeLabel}
           </Button>
           <button
             type="button"

--- a/apps/screenpipe-app-tauri/lib/chat/__tests__/quota-errors.test.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/__tests__/quota-errors.test.ts
@@ -27,6 +27,9 @@ describe("classifyQuotaError", () => {
     expect(classifyQuotaError("credits_exhausted")).toBe("daily");
     expect(classifyQuotaError("daily_limit_exceeded")).toBe("daily");
     expect(classifyQuotaError("daily_cost_limit_exceeded")).toBe("daily");
+    expect(classifyQuotaError("request_cost_limit_exceeded")).toBe("daily");
+    expect(classifyQuotaError("monthly_cost_limit_exceeded")).toBe("daily");
+    expect(classifyQuotaError("trial_cost_limit_exceeded")).toBe("daily");
     // case-insensitive
     expect(classifyQuotaError("DAILY_LIMIT_EXCEEDED")).toBe("daily");
   });
@@ -122,6 +125,38 @@ describe("buildDailyLimitMessage", () => {
       requiredPlan: "business",
       upgradeUrl: "https://screenpi.pe/account/billing",
       resetsAt: "2026-08-02T00:00:00.000Z",
+      reason: "daily_cost_limit_exceeded",
+    });
+  });
+
+  it("accepts only matching Max and Ultra billing targets", () => {
+    const max = JSON.stringify({
+      error: "monthly_cost_limit_exceeded",
+      required_plan: "business_max",
+      upgrade_url: "https://screenpi.pe/account/billing?target_plan=pro_max&interval=month",
+    });
+    expect(parseQuotaUpgradeAction(max)).toMatchObject({
+      requiredPlan: "business_max",
+      reason: "monthly_cost_limit_exceeded",
+    });
+    expect(parseQuotaUpgradeAction(max.replace("pro_max", "pro_ultra"))).toBeNull();
+    expect(
+      parseQuotaUpgradeAction(
+        max.replace("&interval=month", "&interval=month&redirect=https://example.com"),
+      ),
+    ).toBeNull();
+    expect(
+      parseQuotaUpgradeAction(max.replace("screenpi.pe", "screenpi.pe:8443")),
+    ).toBeNull();
+
+    const ultra = JSON.stringify({
+      error: "daily_cost_limit_exceeded",
+      required_plan: "business_ultra",
+      upgrade_url: "https://screenpipe.com/account/billing?target_plan=pro_ultra&interval=month",
+    });
+    expect(parseQuotaUpgradeAction(ultra)).toMatchObject({
+      requiredPlan: "business_ultra",
+      reason: "daily_cost_limit_exceeded",
     });
   });
 
@@ -147,8 +182,8 @@ describe("buildDailyLimitMessage", () => {
     ).toBeNull();
   });
 
-  it("does not invent an upgrade for Business Max or Ultra cost limits", () => {
-    for (const plan of ["business_max", "business_ultra"]) {
+  it("does not invent an upgrade above Ultra or for an absent server action", () => {
+    for (const plan of ["business_ultra", "enterprise"]) {
       const error = JSON.stringify({
         error: "daily_cost_limit_exceeded",
         plan,

--- a/apps/screenpipe-app-tauri/lib/chat/quota-errors.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/quota-errors.ts
@@ -5,16 +5,20 @@
 // Pure helpers for classifying and presenting AI quota / rate-limit errors.
 
 export type QuotaUpgradeAction = {
-  requiredPlan: "business";
+  requiredPlan: "business" | "business_max" | "business_ultra";
   upgradeUrl: string;
   resetsAt: string | null;
+  reason: CostLimitCode;
 };
 
 const COST_LIMIT_CODES = [
+  "request_cost_limit_exceeded",
   "daily_cost_limit_exceeded",
   "monthly_cost_limit_exceeded",
   "trial_cost_limit_exceeded",
 ] as const;
+
+export type CostLimitCode = (typeof COST_LIMIT_CODES)[number];
 
 function structuredString(errorStr: string, field: string): string | null {
   const normalized = errorStr.replace(/\\\"/g, '"');
@@ -30,20 +34,21 @@ function structuredString(errorStr: string, field: string): string | null {
  * Pi may wrap the JSON body in an HTTP error string, so this deliberately
  * extracts only the small allow-listed contract instead of trying to parse
  * arbitrary nested provider errors. The URL is accepted only for Screenpipe's
- * HTTPS billing page; the desktop still opens its native reviewed offer.
+ * HTTPS billing page. Business uses the native reviewed offer; power plans
+ * open the exact server-selected website target.
  */
 export function parseQuotaUpgradeAction(
   errorStr: string,
 ): QuotaUpgradeAction | null {
   const normalized = errorStr.toLowerCase();
-  if (!COST_LIMIT_CODES.some((code) => normalized.includes(code))) {
-    return null;
-  }
+  const reason = COST_LIMIT_CODES.find((code) => normalized.includes(code));
+  if (!reason) return null;
+  const requiredPlan = structuredString(errorStr, "required_plan")?.toLowerCase();
   if (
-    structuredString(errorStr, "required_plan")?.toLowerCase() !== "business"
-  ) {
-    return null;
-  }
+    requiredPlan !== "business" &&
+    requiredPlan !== "business_max" &&
+    requiredPlan !== "business_ultra"
+  ) return null;
 
   const upgradeUrl = structuredString(errorStr, "upgrade_url");
   if (!upgradeUrl) return null;
@@ -51,19 +56,39 @@ export function parseQuotaUpgradeAction(
     const url = new URL(upgradeUrl);
     if (
       url.protocol !== "https:" ||
+      url.username !== "" ||
+      url.password !== "" ||
+      url.port !== "" ||
+      url.hash !== "" ||
       !["screenpi.pe", "screenpipe.com"].includes(url.hostname) ||
       url.pathname !== "/account/billing"
     ) {
       return null;
+    }
+    const expectedTarget = requiredPlan === "business_max"
+      ? "pro_max"
+      : requiredPlan === "business_ultra"
+        ? "pro_ultra"
+        : null;
+    if (expectedTarget) {
+      const keys = [...url.searchParams.keys()].sort();
+      if (
+        keys.length !== 2 ||
+        keys[0] !== "interval" ||
+        keys[1] !== "target_plan" ||
+        url.searchParams.get("target_plan") !== expectedTarget ||
+        url.searchParams.get("interval") !== "month"
+      ) return null;
     }
   } catch {
     return null;
   }
 
   return {
-    requiredPlan: "business",
+    requiredPlan,
     upgradeUrl,
     resetsAt: structuredString(errorStr, "resets_at"),
+    reason,
   };
 }
 
@@ -75,7 +100,10 @@ export function buildDailyLimitMessage(errorStr: string): string {
     if (errorStr.includes("free_chat_turn_request_limit_exceeded")) {
       return "This free message reached its 8-step agent limit. Upgrade for longer agent runs, or switch your AI preset to your own provider.";
     }
-    const isCostLimit = errorStr.includes("daily_cost_limit_exceeded");
+    const normalized = errorStr.toLowerCase();
+    const costLimitCode = COST_LIMIT_CODES.find((code) =>
+      normalized.includes(code),
+    );
     const isRateLimit =
       errorStr.includes("rate limit") || errorStr.includes("Rate limit");
 
@@ -83,7 +111,7 @@ export function buildDailyLimitMessage(errorStr: string): string {
       return "This model is temporarily rate-limited. Try again in a few seconds, or switch to a different model.";
     }
 
-    if (isCostLimit) {
+    if (costLimitCode) {
       // Don't leak the raw dollar cap — that's our internal margin. Frame it
       // as an account-wide budget so the user understands why it fired even
       // when they "didn't use much" (background pipes consume it too).
@@ -92,7 +120,25 @@ export function buildDailyLimitMessage(errorStr: string): string {
         // The persistent recovery panel owns the explanation and actions. Keep
         // the transcript entry short so the same technical paragraph is not
         // repeated immediately above it.
+        if (costLimitCode === "request_cost_limit_exceeded") {
+          return "This conversation is too large for the hosted AI request allowance. Choose a recovery option below.";
+        }
+        if (costLimitCode === "trial_cost_limit_exceeded") {
+          return "This trial's hosted AI allowance is used. Choose a recovery option below.";
+        }
+        if (costLimitCode === "monthly_cost_limit_exceeded") {
+          return "This month's hosted AI allowance is used. Choose a recovery option below.";
+        }
         return "Hosted AI didn't run this request because today's account budget is reached. Choose a recovery option below.";
+      }
+      if (costLimitCode === "request_cost_limit_exceeded") {
+        return "This conversation is too large for the hosted AI request allowance. Start a new chat, shorten the context, or use a local model or your own provider key.";
+      }
+      if (costLimitCode === "trial_cost_limit_exceeded") {
+        return "This trial's hosted AI allowance is used. Switch to a local model or your own provider key to keep working.";
+      }
+      if (costLimitCode === "monthly_cost_limit_exceeded") {
+        return "This month's hosted AI allowance is used. Background pipes share this allowance. Switch to a local model or your own provider key to keep working.";
       }
       return "Hosted AI didn't run this request because today's account budget is reached. Background pipes share this budget. Switch to a local model or your own provider key to keep working.";
     }
@@ -125,7 +171,7 @@ export function classifyQuotaError(errorStr: string): QuotaErrorType {
     normalized.includes("free_chat_turn_request_limit_exceeded") ||
     normalized.includes("credits_exhausted") ||
     normalized.includes("daily_limit_exceeded") ||
-    normalized.includes("daily_cost_limit_exceeded");
+    COST_LIMIT_CODES.some((code) => normalized.includes(code));
   if (isDailyLimit) {
     return "daily";
   }

--- a/docs/coverage/CORE.md
+++ b/docs/coverage/CORE.md
@@ -9,10 +9,10 @@ confidence, and criticality.
 - Tracked crates: screenpipe-engine, screenpipe-db, screenpipe-audio, screenpipe-screen, screenpipe-a11y
 - Mapped suites: 30
 - Mapped Rust files: 300
-- Active test blocks: 2807
+- Active test blocks: 2812
 - Ignored/manual test blocks: 133
-- Declared test blocks: 2940
-- Weighted coverage points: 2312.9
+- Declared test blocks: 2945
+- Weighted coverage points: 2317.3
 
 Confidence weights: strong=1.0, partial=0.7, conditional=0.4, smoke=0.3.
 Criticality weights: high=1.0, medium=0.7, low=0.4.
@@ -23,16 +23,16 @@ are explicitly enabled in a runtime lane.
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 27 | 2680 | 128 | 2254.6 | 21 | 11 | 100% |
-| macos | 27 | 2730 | 108 | 2264.1 | 22 | 11 | 100% |
-| linux | 23 | 2374 | 102 | 1976.9 | 20 | 11 | 100% |
+| windows | 27 | 2685 | 128 | 2259.0 | 21 | 11 | 100% |
+| macos | 27 | 2735 | 108 | 2268.5 | 22 | 11 | 100% |
+| linux | 23 | 2379 | 102 | 1981.3 | 20 | 11 | 100% |
 
 ## Crate Summary
 
 | Crate | Suites | Integration files | Source unit files | Active tests | Ignored tests | Weighted points | Flows |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | screenpipe-engine | 9 | 18 | 94 | 1331 | 42 | 1024.6 | 10 |
-| screenpipe-db | 5 | 48 | 13 | 395 | 16 | 378.0 | 9 |
+| screenpipe-db | 5 | 48 | 13 | 400 | 16 | 382.4 | 9 |
 | screenpipe-audio | 6 | 23 | 47 | 523 | 39 | 453.9 | 5 |
 | screenpipe-screen | 6 | 9 | 18 | 229 | 9 | 210.6 | 4 |
 | screenpipe-a11y | 4 | 2 | 28 | 329 | 27 | 246.0 | 3 |
@@ -64,21 +64,21 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | audio | 7 suites / 618 active / 40 ignored / 548.9 pts | 7 suites / 618 active / 40 ignored / 548.9 pts | 6 suites / 550 active / 40 ignored / 501.3 pts |
 | audio-device | 2 suites / 193 active / 6 ignored / 172.6 pts | 2 suites / 193 active / 6 ignored / 172.6 pts | 1 suites / 125 active / 6 ignored / 125.0 pts |
 | configuration | 2 suites / 135 active / 3 ignored / 122.8 pts | 2 suites / 135 active / 3 ignored / 122.8 pts | 2 suites / 135 active / 3 ignored / 122.8 pts |
-| database | 4 suites / 294 active / 12 ignored / 277.0 pts | 4 suites / 294 active / 12 ignored / 277.0 pts | 4 suites / 294 active / 12 ignored / 277.0 pts |
+| database | 4 suites / 299 active / 12 ignored / 281.4 pts | 4 suites / 299 active / 12 ignored / 281.4 pts | 4 suites / 299 active / 12 ignored / 281.4 pts |
 | db-search | 2 suites / 105 active / 9 ignored / 105.0 pts | 2 suites / 105 active / 9 ignored / 105.0 pts | 2 suites / 105 active / 9 ignored / 105.0 pts |
 | engine-lifecycle | 4 suites / 184 active / 1 ignored / 159.6 pts | 4 suites / 184 active / 1 ignored / 159.6 pts | 3 suites / 178 active / 1 ignored / 157.9 pts |
 | local-api | 2 suites / 278 active / 9 ignored / 195.8 pts | 2 suites / 278 active / 9 ignored / 195.8 pts | 2 suites / 278 active / 9 ignored / 195.8 pts |
 | meeting | 6 suites / 1269 active / 15 ignored / 1036.8 pts | 6 suites / 1269 active / 15 ignored / 1036.8 pts | 4 suites / 998 active / 12 ignored / 786.2 pts |
 | ocr | 4 suites / 120 active / 7 ignored / 114.3 pts | 4 suites / 124 active / 7 ignored / 119.8 pts | 3 suites / 115 active / 6 ignored / 110.8 pts |
 | os-integration | 1 suites / 6 active / 0 ignored / 1.7 pts | 1 suites / 6 active / 0 ignored / 1.7 pts | - |
-| performance | 13 suites / 1289 active / 67 ignored / 1143.1 pts | 14 suites / 1383 active / 70 ignored / 1180.7 pts | 13 suites / 1289 active / 67 ignored / 1143.1 pts |
+| performance | 13 suites / 1294 active / 67 ignored / 1147.5 pts | 14 suites / 1388 active / 70 ignored / 1185.1 pts | 13 suites / 1294 active / 67 ignored / 1147.5 pts |
 | pipes | 1 suites / 432 active / 3 ignored / 302.4 pts | 1 suites / 432 active / 3 ignored / 302.4 pts | 1 suites / 432 active / 3 ignored / 302.4 pts |
 | privacy | 5 suites / 839 active / 36 ignored / 684.8 pts | 5 suites / 885 active / 16 ignored / 688.8 pts | 5 suites / 815 active / 14 ignored / 663.0 pts |
 | real-app | - | 1 suites / 94 active / 3 ignored / 37.6 pts | - |
 | speaker | 2 suites / 292 active / 5 ignored / 292.0 pts | 2 suites / 292 active / 5 ignored / 292.0 pts | 2 suites / 292 active / 5 ignored / 292.0 pts |
-| storage | 3 suites / 431 active / 29 ignored / 349.4 pts | 3 suites / 431 active / 29 ignored / 349.4 pts | 3 suites / 431 active / 29 ignored / 349.4 pts |
+| storage | 3 suites / 434 active / 29 ignored / 352.4 pts | 3 suites / 434 active / 29 ignored / 352.4 pts | 3 suites / 434 active / 29 ignored / 352.4 pts |
 | sync | 1 suites / 432 active / 3 ignored / 302.4 pts | 1 suites / 432 active / 3 ignored / 302.4 pts | 1 suites / 432 active / 3 ignored / 302.4 pts |
-| timeline | 4 suites / 843 active / 33 ignored / 690.6 pts | 4 suites / 843 active / 33 ignored / 690.6 pts | 4 suites / 843 active / 33 ignored / 690.6 pts |
+| timeline | 4 suites / 846 active / 33 ignored / 693.6 pts | 4 suites / 846 active / 33 ignored / 693.6 pts | 4 suites / 846 active / 33 ignored / 693.6 pts |
 | transcription | 5 suites / 604 active / 37 ignored / 473.1 pts | 5 suites / 604 active / 37 ignored / 473.1 pts | 5 suites / 604 active / 37 ignored / 473.1 pts |
 | ui-events | 4 suites / 667 active / 28 ignored / 510.8 pts | 3 suites / 619 active / 5 ignored / 477.2 pts | 3 suites / 619 active / 5 ignored / 477.2 pts |
 | vision-capture | 5 suites / 454 active / 32 ignored / 365.3 pts | 5 suites / 458 active / 32 ignored / 370.8 pts | 4 suites / 449 active / 31 ignored / 361.8 pts |
@@ -129,9 +129,9 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | audio-transcription-pipeline | screenpipe-audio | windows, macos, linux | audio, transcription, performance | audio-record-transcribe, meeting-live-notes, performance-liveness | high | partial | mixed | 13 | 91 | 7 | Batch deferral, cleanup, language detection, result normalization, and real recording/transcription tests. Hardware/model-heavy tests are ignored by default. |
 | db-accessibility-ui-events | screenpipe-db | windows, macos, linux | database, configuration, accessibility, ui-events, performance | settings-to-engine-config, accessibility-ui-events, performance-liveness | medium | partial | integration | 7 | 24 | 2 | Elements bulk insert, on-screen filtering, UI event batching, DB tier config, and ignored heavy-read real-DB probes. |
 | db-audio-meetings-speakers | screenpipe-db | windows, macos, linux | database, audio, meeting, speaker | audio-record-transcribe, audio-device-health, meeting-live-notes | high | strong | integration | 14 | 95 | 1 | Audio transcript dedupe, live meeting mirroring, open meeting invariants, liveness, and speaker reassignment coverage. |
-| db-runtime-reliability | screenpipe-db | windows, macos, linux | database, performance | performance-liveness | high | partial | mixed | 10 | 16 | 6 | SQLite hard-fault classification, failpoint VFS injection, query cancellation surviving dropped futures, close-severs-connections wedge regression, multi-pool WAL parity/corruption coverage, runtime version pinning, and manual WAL chaos plus memory-pressure probes (several ignored by default). |
+| db-runtime-reliability | screenpipe-db | windows, macos, linux | database, performance | performance-liveness | high | partial | mixed | 10 | 18 | 6 | SQLite hard-fault classification, failpoint VFS injection, query cancellation surviving dropped futures, close-severs-connections wedge regression, multi-pool WAL parity/corruption coverage, runtime version pinning, and manual WAL chaos plus memory-pressure probes (several ignored by default). |
 | db-search-indexing | screenpipe-db | windows, macos, linux | db-search, ocr, accessibility, performance | local-api-search, capture-ocr-pipeline, accessibility-ui-events, performance-liveness | high | strong | mixed | 13 | 101 | 4 | FTS, tokenizer, OCR snapshot search, query planning, ordering, accessibility search, and contention coverage. |
-| db-timeline-frames | screenpipe-db | windows, macos, linux | database, timeline, storage, performance | timeline-streaming, performance-liveness | high | strong | mixed | 17 | 159 | 3 | Frame/audio joins, timeline query shape, suggestions frames, write queue, DB primitives (src/db.rs split into src/db/ modules), feedback record upserts, media eviction anti-join regressions, SAF output registry, semantic storage, and timeline performance. |
+| db-timeline-frames | screenpipe-db | windows, macos, linux | database, timeline, storage, performance | timeline-streaming, performance-liveness | high | strong | mixed | 17 | 162 | 3 | Frame/audio joins, timeline query shape, suggestions frames, write queue, DB primitives (src/db.rs split into src/db/ modules), feedback record upserts, media eviction anti-join regressions, SAF output registry, semantic storage, and timeline performance. |
 | engine-api-routes | screenpipe-engine | windows, macos, linux | local-api, timeline, meeting, transcription | local-api-search, timeline-streaming, meeting-live-notes, audio-record-transcribe | high | partial | mixed | 26 | 274 | 4 | Route/unit coverage for search, health, streaming, meetings, time/timezone, and transcription. Legacy endpoint/websocket tests require local data and remain ignored. |
 | engine-capture-timeline | screenpipe-engine | windows, macos, linux | vision-capture, timeline, storage, performance | capture-ocr-pipeline, timeline-streaming, performance-liveness | high | partial | mixed | 23 | 234 | 26 | Covers capture trigger logic, frame/audio linking, hot cache, timeline refresh regressions, fragmented MP4 extraction, and HD-mode control. Several real-data tests are intentionally ignored by default. |
 | engine-config-lifecycle | screenpipe-engine | windows, macos, linux | configuration, engine-lifecycle, performance | settings-to-engine-config, engine-health-lifecycle, performance-liveness | high | strong | mixed | 11 | 111 | 1 | Fast logic coverage for the config bridge, tray health debounce, sleep/power policies, and queue backpressure. |
@@ -256,11 +256,11 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | db-accessibility-ui-events | screenpipe-db | src/db/elements.rs | source | 2 | 0 | 2 |
 | db-timeline-frames | screenpipe-db | src/db/feedback.rs | source | 1 | 0 | 1 |
 | db-timeline-frames | screenpipe-db | src/db/maintenance.rs | source | 3 | 1 | 4 |
-| db-timeline-frames | screenpipe-db | src/db/setup.rs | source | 1 | 0 | 1 |
+| db-timeline-frames | screenpipe-db | src/db/setup.rs | source | 4 | 0 | 4 |
 | db-timeline-frames | screenpipe-db | src/db/tests.rs | source | 31 | 1 | 32 |
 | db-timeline-frames | screenpipe-db | src/db/truncation_tests.rs | source | 1 | 0 | 1 |
-| db-runtime-reliability | screenpipe-db | src/failpoint_vfs.rs | source | 2 | 0 | 2 |
-| db-runtime-reliability | screenpipe-db | src/sqlite_error.rs | source | 4 | 0 | 4 |
+| db-runtime-reliability | screenpipe-db | src/failpoint_vfs.rs | source | 3 | 0 | 3 |
+| db-runtime-reliability | screenpipe-db | src/sqlite_error.rs | source | 5 | 0 | 5 |
 | db-search-indexing | screenpipe-db | src/text_normalizer.rs | source | 17 | 0 | 17 |
 | db-search-indexing | screenpipe-db | src/text_similarity.rs | source | 20 | 0 | 20 |
 | db-timeline-frames | screenpipe-db | src/types.rs | source | 3 | 0 | 3 |

--- a/packages/ai-gateway/src/index.ts
+++ b/packages/ai-gateway/src/index.ts
@@ -42,6 +42,7 @@ import {
 	reserveDailyCostCap,
 	withDailyCostSettlement,
 	getDailyUserCostForCap,
+	type DailyCostReservation,
 } from './services/cost-cap';
 import {
 	logReservedCost,
@@ -81,6 +82,26 @@ export { RateLimiter };
 type BoundedJsonRead =
 	| { ok: true; value: unknown; bytes: number }
 	| { ok: false; tooLarge: boolean };
+
+type RejectedCostReservation = Extract<DailyCostReservation, { allowed: false }>;
+
+/** Log only bounded policy dimensions; never identifiers, prompts, or controls. */
+function costReservationRejectionResponse(
+	route: string,
+	auth: AuthResult,
+	reservation: RejectedCostReservation,
+): Response {
+	console.warn('hosted AI admission rejected', {
+		gate: 'cost_reservation',
+		reason: reservation.reason,
+		route,
+		tier: auth.tier,
+		accountPlan: auth.accountPlan,
+		hostedAiTrial: auth.hostedAiTrial === true,
+		status: reservation.response.status,
+	});
+	return reservation.response;
+}
 
 /** Read at most maxBytes instead of trusting a spoofable Content-Length. */
 async function readBoundedJson(request: Request, maxBytes: number): Promise<BoundedJsonRead> {
@@ -148,6 +169,7 @@ async function handleMeteredTinfoilRequest(
 	subPath: '/v1/chat/completions' | '/v1/responses',
 ): Promise<Response> {
 	const model = 'gemma4-31b';
+	const route = new URL(request.url).pathname;
 	const reservation = await reserveDailyCostCap(
 		env,
 		auth.deviceId,
@@ -159,11 +181,13 @@ async function handleMeteredTinfoilRequest(
 		auth.accountPlan,
 		auth.hostedAiTrial === true,
 	);
-	if (!reservation.allowed) return reservation.response;
+	if (!reservation.allowed) {
+		return costReservationRejectionResponse(route, auth, reservation);
+	}
 	const attribution = reservedCostAttribution(
 		auth,
 		model,
-		`/v1/tinfoil${subPath}`,
+		route,
 		false,
 		{ provider: 'tinfoil' },
 	);
@@ -220,7 +244,9 @@ async function handleMeteredVoiceAiRequest(
 		auth.accountPlan,
 		auth.hostedAiTrial === true,
 	);
-	if (!reservation.allowed) return reservation.response;
+	if (!reservation.allowed) {
+		return costReservationRejectionResponse(endpoint, auth, reservation);
+	}
 	const attribution = reservedCostAttribution(auth, model, endpoint, false);
 	let response: Response;
 	try {
@@ -567,15 +593,8 @@ export async function handleRequest(request: Request, env: Env, ctx: ExecutionCo
 				authResult.hostedAiTrial === true,
 			);
 			if (!costReservation.allowed) {
-				console.warn('hosted AI admission rejected', {
-					gate: 'cost_reservation',
-					tier: authResult.tier,
-					accountPlan: authResult.accountPlan,
-					hostedAiTrial: authResult.hostedAiTrial === true,
-					status: costReservation.response.status,
-				});
 				if (freeChatLease) await releaseFreeChatLease(env, freeChatLease);
-				return costReservation.response;
+				return costReservationRejectionResponse('/v1/chat/completions', authResult, costReservation);
 			}
 			const dailyCostReservation = costReservation.reservation;
 
@@ -760,7 +779,9 @@ export async function handleRequest(request: Request, env: Env, ctx: ExecutionCo
 				authResult.accountPlan,
 				authResult.hostedAiTrial === true,
 			);
-			if (!costReservation.allowed) return costReservation.response;
+			if (!costReservation.allowed) {
+				return costReservationRejectionResponse('/v1/web-search', authResult, costReservation);
+			}
 			const attribution = reservedCostAttribution(
 				authResult,
 				'gemini-2.5-flash',
@@ -986,7 +1007,9 @@ export async function handleRequest(request: Request, env: Env, ctx: ExecutionCo
 				authResult.accountPlan,
 				authResult.hostedAiTrial === true,
 			);
-			if (!costReservation.allowed) return costReservation.response;
+			if (!costReservation.allowed) {
+				return costReservationRejectionResponse('/v1/messages', authResult, costReservation);
+			}
 			const attribution = reservedCostAttribution(
 				authResult,
 				parsedModel,
@@ -1134,7 +1157,9 @@ export async function handleRequest(request: Request, env: Env, ctx: ExecutionCo
 				authResult.accountPlan,
 				authResult.hostedAiTrial === true,
 			);
-			if (!costReservation.allowed) return costReservation.response;
+			if (!costReservation.allowed) {
+				return costReservationRejectionResponse('/anthropic/v1/messages', authResult, costReservation);
+			}
 			const attribution = reservedCostAttribution(
 				authResult,
 				ocModel,

--- a/packages/ai-gateway/src/services/cost-cap.ts
+++ b/packages/ai-gateway/src/services/cost-cap.ts
@@ -42,9 +42,23 @@ export type DailyCostHold = {
 
 export type DailyCostLane = 'interactive' | 'background';
 
+export type CostReservationRejectionReason =
+	| 'request_cost_limit'
+	| 'daily_cost_limit'
+	| 'trial_cost_limit'
+	| 'monthly_cost_limit'
+	| 'global_hourly_cost_limit'
+	| 'global_daily_cost_limit'
+	| 'capacity'
+	| 'cost_control_unavailable';
+
 export type DailyCostReservation =
 	| { allowed: true; reservation: DailyCostHold | null }
-	| { allowed: false; response: Response };
+	| {
+		allowed: false;
+		response: Response;
+		reason: CostReservationRejectionReason;
+	};
 
 function changed(result: D1Result<unknown>): boolean {
 	return Number(result.meta?.changes ?? 0) > 0;
@@ -127,6 +141,32 @@ export async function getDailyUserCostForCap(env: Env, deviceId: string): Promis
 	}
 }
 
+type CostCapacityUpgradePlan = 'basic' | 'business' | 'business_max' | 'business_ultra';
+
+function nextCostCapacityPlan(accountPlan: AccountPlan): CostCapacityUpgradePlan | null {
+	switch (accountPlan) {
+		case 'free': return 'basic';
+		case 'basic': return 'business';
+		case 'business': return 'business_max';
+		case 'business_max': return 'business_ultra';
+		default: return null;
+	}
+}
+
+function costCapacityUpgradeUrl(requiredPlan: CostCapacityUpgradePlan | null): string | null {
+	switch (requiredPlan) {
+		case 'business_max':
+			return 'https://screenpi.pe/account/billing?target_plan=pro_max&interval=month';
+		case 'business_ultra':
+			return 'https://screenpi.pe/account/billing?target_plan=pro_ultra&interval=month';
+		case 'basic':
+		case 'business':
+			return 'https://screenpi.pe/account/billing';
+		default:
+			return null;
+	}
+}
+
 function capResponse(accountPlan: AccountPlan, period: 'request' | 'day' | 'month' | 'trial'): Response {
 	const resetsAt = new Date();
 	if (period === 'month') {
@@ -135,7 +175,8 @@ function capResponse(accountPlan: AccountPlan, period: 'request' | 'day' | 'mont
 	} else {
 		resetsAt.setUTCHours(24, 0, 0, 0);
 	}
-	const canUpgrade = accountPlan === 'free' || accountPlan === 'basic';
+	const requiredPlan = nextCostCapacityPlan(accountPlan);
+	const upgradeUrl = costCapacityUpgradeUrl(requiredPlan);
 	return addCorsHeaders(createErrorResponse(429, JSON.stringify({
 		error: period === 'request'
 			? 'request_cost_limit_exceeded'
@@ -151,8 +192,8 @@ function capResponse(accountPlan: AccountPlan, period: 'request' | 'day' | 'mont
 				: `You've used your ${period === 'day' ? 'daily' : 'monthly'} hosted AI allowance. Background pipes share this allowance.`,
 		resets_at: period === 'request' || period === 'trial' ? null : resetsAt.toISOString(),
 		plan: accountPlan,
-		required_plan: canUpgrade ? (accountPlan === 'free' ? 'basic' : 'business') : null,
-		upgrade_url: canUpgrade ? 'https://screenpi.pe/account/billing' : null,
+		required_plan: requiredPlan,
+		upgrade_url: upgradeUrl,
 		can_buy_credits: false,
 		byok_supported: true,
 	})));
@@ -479,26 +520,38 @@ export async function reserveDailyCostCap(
 		const accountReservedMicroUsd = Math.max(0, Number(accountHolds?.reserved ?? 0));
 		const globalReservedMicroUsd = Math.max(0, Number(globalHolds?.reserved ?? 0));
 		let response: Response;
+		let reason: CostReservationRejectionReason;
 		if (reservedMicroUsd > requestCapMicroUsd) {
 			response = capResponse(accountPlan, 'request');
+			reason = 'request_cost_limit';
 		} else if (dailyCostMicroUsd + accountReservedMicroUsd + reservedMicroUsd > dailyCapMicroUsd) {
 			response = capResponse(accountPlan, 'day');
+			reason = 'daily_cost_limit';
 		} else if (monthlyCostMicroUsd + accountReservedMicroUsd + reservedMicroUsd > monthlyCapMicroUsd) {
 			response = capResponse(accountPlan, hostedAiTrial ? 'trial' : 'month');
+			reason = hostedAiTrial ? 'trial_cost_limit' : 'monthly_cost_limit';
 		} else if (globalHourlyCostMicroUsd + globalReservedMicroUsd + reservedMicroUsd > globalHourlyCapMicroUsd) {
 			response = globalCapResponse('hour');
+			reason = 'global_hourly_cost_limit';
 		} else if (globalDailyCostMicroUsd + globalReservedMicroUsd + reservedMicroUsd > globalDailyCapMicroUsd) {
 			response = globalCapResponse('day');
+			reason = 'global_daily_cost_limit';
 		} else {
 			response = capacityResponse(accountPlan, lane);
+			reason = 'capacity';
 		}
 		return {
 			allowed: false,
 			response,
+			reason,
 		};
 	} catch (error) {
 		console.error('daily cost reservation unavailable', error);
-		return { allowed: false, response: unavailableResponse() };
+		return {
+			allowed: false,
+			response: unavailableResponse(),
+			reason: 'cost_control_unavailable',
+		};
 	}
 }
 

--- a/packages/ai-gateway/src/services/hosted-ai-cost-controls.ts
+++ b/packages/ai-gateway/src/services/hosted-ai-cost-controls.ts
@@ -196,6 +196,18 @@ function requireHostedPlan(accountPlan: AccountPlan): HostedAiPlan {
 	return plan;
 }
 
+/**
+ * Max and Ultra are the same model-access product as Business with additional
+ * self-serve hosted-AI headroom. Scale the reviewed Business request/day/month
+ * controls together so no window becomes an accidental lower-plan bottleneck;
+ * global safety breakers remain unchanged.
+ */
+function powerPlanCostMultiplier(accountPlan: AccountPlan): number {
+	if (accountPlan === 'business_max') return 2;
+	if (accountPlan === 'business_ultra') return 4;
+	return 1;
+}
+
 export function getTranscriptionDailyCostCap(
 	accountPlan: AccountPlan,
 	env: HostedAiCostControlEnv,
@@ -253,11 +265,12 @@ export function resolveHostedAiTextCostLimits(
 		};
 	}
 	const plan = requireHostedPlan(accountPlan);
+	const multiplier = powerPlanCostMultiplier(accountPlan);
 	const windows = clampWindowsToIncludedAllowance(
 		accountPlan,
-		controls.request[plan],
-		controls.daily[plan],
-		controls.monthly[plan],
+		controls.request[plan] * multiplier,
+		controls.daily[plan] * multiplier,
+		controls.monthly[plan] * multiplier,
 	);
 	return {
 		...windows,

--- a/packages/ai-gateway/src/services/hosted-ai-policy.test.ts
+++ b/packages/ai-gateway/src/services/hosted-ai-policy.test.ts
@@ -65,8 +65,8 @@ describe('hosted AI model products', () => {
 		['free', 10, 0.1],
 		['basic', 150, 1.5],
 		['business', 400, 4],
-		['business_max', 400, 4],
-		['business_ultra', 400, 4],
+		['business_max', 800, 8],
+		['business_ultra', 1_600, 16],
 		['team', 400, 4],
 		['enterprise', 400, 4],
 	] as const)('keeps %s credits and provider-cost allowance aligned', (plan, credits, costUsd) => {

--- a/packages/ai-gateway/src/services/hosted-ai-policy.ts
+++ b/packages/ai-gateway/src/services/hosted-ai-policy.ts
@@ -77,10 +77,15 @@ export function getHostedAiAllowedModels(accountPlan: AccountPlan): readonly str
 
 /** Customer-facing credits advertised by the public plan contract. */
 export function getHostedAiIncludedCredits(accountPlan: AccountPlan): number {
-	switch (getHostedAiPlan(accountPlan)) {
+	switch (accountPlan) {
 		case 'free': return 10;
 		case 'basic': return 150;
-		case 'business': return 400;
+		case 'business_max': return 800;
+		case 'business_ultra': return 1_600;
+		case 'business':
+		case 'team':
+		case 'enterprise':
+			return 400;
 		default: return 0;
 	}
 }

--- a/packages/ai-gateway/src/test/cost-cap.unit.test.ts
+++ b/packages/ai-gateway/src/test/cost-cap.unit.test.ts
@@ -65,8 +65,12 @@ describe('enforceDailyCostCap', () => {
 		});
 	});
 
-	it('does not offer a false upgrade when Business, Max, or Ultra reaches its cost budget', async () => {
-		for (const plan of ['business', 'business_max', 'business_ultra'] as const) {
+	it('offers the next real power plan without inventing an upgrade above Ultra', async () => {
+		for (const [plan, requiredPlan, upgradeUrl] of [
+			['business', 'business_max', 'https://screenpi.pe/account/billing?target_plan=pro_max&interval=month'],
+			['business_max', 'business_ultra', 'https://screenpi.pe/account/billing?target_plan=pro_ultra&interval=month'],
+			['business_ultra', null, null],
+		] as const) {
 			const response = await enforceDailyCostCap(
 				dbEnv(200), 'dev', 'subscribed', 'gemini-3.5-flash', plan,
 			);
@@ -75,8 +79,8 @@ describe('enforceDailyCostCap', () => {
 			expect(JSON.parse(wireBody.error)).toMatchObject({
 				error: 'daily_cost_limit_exceeded',
 				plan,
-				required_plan: null,
-				upgrade_url: null,
+				required_plan: requiredPlan,
+				upgrade_url: upgradeUrl,
 				can_buy_credits: false,
 			});
 		}
@@ -138,6 +142,7 @@ describe('reserveDailyCostCap policy edges', () => {
 		expect(result.allowed).toBe(false);
 		if (!result.allowed) {
 			expect(result.response.status).toBe(503);
+			expect(result.reason).toBe('cost_control_unavailable');
 			expect(await result.response.text()).toContain('cost_control_unavailable');
 		}
 	});

--- a/packages/ai-gateway/src/test/hosted-ai-cost-controls.unit.test.ts
+++ b/packages/ai-gateway/src/test/hosted-ai-cost-controls.unit.test.ts
@@ -108,6 +108,34 @@ describe('private hosted AI cost controls', () => {
 		});
 	});
 
+	it('scales reviewed Business windows for Max and Ultra without widening global breakers', () => {
+		const env = privateCostControls({
+			MAX_REQUEST_FREE_TEXT_COST: '0.1',
+			MAX_REQUEST_BASIC_TEXT_COST: '0.25',
+			MAX_REQUEST_BUSINESS_TEXT_COST: '0.5',
+			MAX_DAILY_FREE_TEXT_COST: '0.25',
+			MAX_DAILY_BASIC_TEXT_COST: '0.5',
+			MAX_DAILY_BUSINESS_TEXT_COST: '1',
+			MAX_MONTHLY_FREE_TEXT_COST: '1',
+			MAX_MONTHLY_BASIC_TEXT_COST: '2',
+			MAX_MONTHLY_BUSINESS_TEXT_COST: '4',
+		});
+		expect(resolveHostedAiTextCostLimits('business_max', env)).toEqual({
+			request: 1,
+			daily: 2,
+			monthly: 8,
+			globalHourly: 401,
+			globalDaily: 402,
+		});
+		expect(resolveHostedAiTextCostLimits('business_ultra', env)).toEqual({
+			request: 2,
+			daily: 4,
+			monthly: 16,
+			globalHourly: 401,
+			globalDaily: 402,
+		});
+	});
+
 	it('fails closed for an unrecognized account plan', () => {
 		expect(() => getPlanDailyCostCap(
 			'unknown' as AccountPlan,


### PR DESCRIPTION
## Summary
- align public hosted-AI credits and private admission windows for Business Max and Ultra
- classify cost-reservation rejections with bounded, privacy-safe operational reasons
- return the next real upgrade target and stop desktop retries for non-retryable cost limits
- open only exact allow-listed Max/Ultra billing targets from the desktop recovery panel

## Validation
- gateway: 770 tests passed, including workerd/D1 concurrency coverage
- desktop Vitest: 2,052 tests passed
- desktop Bun tests: 230 passed
- desktop TypeScript: clean
- Wrangler production bundle dry-run: clean