### PR TITLE
fix(macos): TCC status, enrollment, and Settings list recovery

### DIFF
--- a/apps/screenpipe-app-tauri/lib/utils/permission-flow.test.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/permission-flow.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
     return undefined;
   }),
   resetPermission: vi.fn(async () => ({ status: "ok" as const, data: null })),
+  requestPermission: vi.fn(async () => undefined),
   setWindowAlwaysOnTopNative: vi.fn(async () => ({
     status: "ok" as const,
     data: null,
@@ -47,7 +48,7 @@ vi.mock("@/lib/utils/tauri", () => ({
   commands: {
     resetPermission: mocks.resetPermission,
     setWindowAlwaysOnTopNative: mocks.setWindowAlwaysOnTopNative,
-    requestPermission: vi.fn(async () => undefined),
+    requestPermission: mocks.requestPermission,
     openPermissionSettings: vi.fn(async () => undefined),
     calendarAuthorize: vi.fn(async () => ({
       status: "ok" as const,
@@ -71,6 +72,8 @@ describe("permission flow TCC preparation", () => {
 
     expect(mocks.resetPermission).toHaveBeenCalledTimes(1);
     expect(mocks.resetPermission).toHaveBeenCalledWith("accessibility");
+    // After tccutil wipe, re-request so the app reappears in System Settings.
+    expect(mocks.requestPermission).toHaveBeenCalledWith("accessibility");
     expect(
       mocks.invoke.mock.calls.filter(([command]) =>
         String(command).endsWith("|start_flow"),

--- a/apps/screenpipe-app-tauri/lib/utils/permission-flow.test.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/permission-flow.test.ts
@@ -62,6 +62,15 @@ import { requestPermissionWithFlow } from "./permission-flow";
 describe("permission flow TCC preparation", () => {
   afterEach(() => {
     vi.clearAllTimers();
+    vi.clearAllMocks();
+    mocks.invoke.mockImplementation(async (command: string) => {
+      if (command.endsWith("|create")) return 1;
+      if (command.endsWith("|suggested_host_app_path")) {
+        return "/Applications/screenpipe.app";
+      }
+      if (command.endsWith("|authorization_state")) return "notGranted";
+      return undefined;
+    });
   });
 
   it("resets a stale permission once without revoking it on a repeat click", async () => {
@@ -72,12 +81,35 @@ describe("permission flow TCC preparation", () => {
 
     expect(mocks.resetPermission).toHaveBeenCalledTimes(1);
     expect(mocks.resetPermission).toHaveBeenCalledWith("accessibility");
-    // After tccutil wipe, re-request so the app reappears in System Settings.
-    expect(mocks.requestPermission).toHaveBeenCalledWith("accessibility");
+    // Reset must leave the TCC list empty for drag-to-grant. Re-requesting
+    // here would recreate a denied row and break the drop as a duplicate.
+    expect(mocks.requestPermission).not.toHaveBeenCalled();
     expect(
       mocks.invoke.mock.calls.filter(([command]) =>
         String(command).endsWith("|start_flow"),
       ),
     ).toHaveLength(2);
+  });
+
+  it("skips the drag panel when authorization is already granted", async () => {
+    vi.useFakeTimers();
+    mocks.invoke.mockImplementation(async (command: string) => {
+      if (command.endsWith("|create")) return 1;
+      if (command.endsWith("|suggested_host_app_path")) {
+        return "/Applications/screenpipe.app";
+      }
+      if (command.endsWith("|authorization_state")) return "granted";
+      return undefined;
+    });
+
+    await requestPermissionWithFlow("accessibility");
+
+    expect(mocks.resetPermission).not.toHaveBeenCalled();
+    expect(mocks.requestPermission).not.toHaveBeenCalled();
+    expect(
+      mocks.invoke.mock.calls.filter(([command]) =>
+        String(command).endsWith("|start_flow"),
+      ),
+    ).toHaveLength(0);
   });
 });

--- a/apps/screenpipe-app-tauri/lib/utils/permission-flow.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/permission-flow.ts
@@ -501,15 +501,11 @@ async function preparePermissionForDrag(
     const result = await commands.resetPermission(permission);
     if (result.status === "error") {
       state.preparedPermissions.delete(permission);
-    } else {
-      // tccutil wipe removes the app from the System Settings list. Re-request
-      // so TCC recreates a row (denied until the user toggles or finishes drag).
-      try {
-        await commands.requestPermission(permission);
-      } catch {
-        // Enrollment is best-effort; drag / Settings still work as fallback.
-      }
     }
+    // Do NOT call requestPermission here. Reset intentionally leaves the TCC
+    // list empty so drag-to-grant can add the app. Re-enrolling a denied row
+    // makes macOS reject the drop as a duplicate and also opens competing
+    // Settings/prompt UI before the drag panel.
   } catch {
     // Let a later click retry when tccutil itself failed to run.
     state.preparedPermissions.delete(permission);
@@ -586,6 +582,9 @@ export async function requestPermissionWithFlow(
   try {
     const flow = await getOrCreateFlow();
     await preparePermissionForDrag(permission, dragPermission);
+    // Prepare can race a user toggle / modal grant. Skip the drag UI if we
+    // are already authorized so we never open a redundant stuck panel.
+    if (await finishIfAlreadyGranted(permission, dragPermission)) return;
     // Start watching BEFORE the drag panel opens so a manual toggle in
     // system settings is detected while startFlow is still awaiting.
     watchUntilGrantedAndClose(permission, dragPermission);
@@ -603,11 +602,7 @@ export async function requestPermissionWithFlow(
     if (!state.flow && !state.activeWatch) return;
     // startFlow resolved — do an immediate grant check for the "already in
     // list, re-enabled via drag" case.
-    const postDragState = await authorizationState(dragPermission);
-    if (postDragState === PermissionAuthorizationState.Granted) {
-      await stopActiveFlow();
-      await reclaimScreenpipeWindow();
-    }
+    if (await finishIfAlreadyGranted(permission, dragPermission)) return;
     // Not yet granted — watcher keeps polling.
   } catch (error) {
     console.error("permission-flow failed, falling back:", error);
@@ -631,6 +626,7 @@ export async function openPermissionSettingsWithFlow(
   try {
     const flow = await getOrCreateFlow();
     await preparePermissionForDrag(permission, dragPermission);
+    if (await finishIfAlreadyGranted(permission, dragPermission)) return;
     watchUntilGrantedAndClose(permission, dragPermission);
     try {
       await flow.startFlow({
@@ -640,14 +636,23 @@ export async function openPermissionSettingsWithFlow(
       });
     } catch {}
     if (!state.flow && !state.activeWatch) return;
-    const postDragState = await authorizationState(dragPermission);
-    if (postDragState === PermissionAuthorizationState.Granted) {
-      await stopActiveFlow();
-      await reclaimScreenpipeWindow();
-    }
+    if (await finishIfAlreadyGranted(permission, dragPermission)) return;
   } catch (error) {
     console.error("permission-flow settings open failed, falling back:", error);
     await stopActiveFlow();
     await openNativePermissionSettings(permission);
   }
+}
+
+/** Close the flow when authorization is already granted. */
+async function finishIfAlreadyGranted(
+  permission: PermissionFlowPermission,
+  dragPermission: Permission,
+): Promise<boolean> {
+  const authState = await authorizationState(dragPermission).catch(() => null);
+  if (authState !== PermissionAuthorizationState.Granted) return false;
+  state.preparedPermissions.delete(permission);
+  await stopActiveFlow();
+  await reclaimScreenpipeWindow();
+  return true;
 }

--- a/apps/screenpipe-app-tauri/lib/utils/permission-flow.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/permission-flow.ts
@@ -501,6 +501,14 @@ async function preparePermissionForDrag(
     const result = await commands.resetPermission(permission);
     if (result.status === "error") {
       state.preparedPermissions.delete(permission);
+    } else {
+      // tccutil wipe removes the app from the System Settings list. Re-request
+      // so TCC recreates a row (denied until the user toggles or finishes drag).
+      try {
+        await commands.requestPermission(permission);
+      } catch {
+        // Enrollment is best-effort; drag / Settings still work as fallback.
+      }
     }
   } catch {
     // Let a later click retry when tccutil itself failed to run.

--- a/apps/screenpipe-app-tauri/src-tauri/Info.plist
+++ b/apps/screenpipe-app-tauri/src-tauri/Info.plist
@@ -4,6 +4,8 @@
 <dict>
     <key>NSMicrophoneUsageDescription</key>
     <string>This app requires microphone access to record audio.</string>
+    <key>NSAccessibilityUsageDescription</key>
+    <string>screenpipe needs Accessibility to read app and window context, meeting controls, and on-screen UI text for local AI context. Your data stays on-device.</string>
     <key>NSScreenCaptureUsageDescription</key>
     <string>This app requires screen capture access to record the screen.</string>
     <key>CGRequestScreenCaptureAccess</key>

--- a/apps/screenpipe-app-tauri/src-tauri/src/permissions.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/permissions.rs
@@ -479,17 +479,12 @@ pub async fn request_input_monitoring_permission() -> OSPermissionStatus {
         if screenpipe_a11y::check_input_monitoring() {
             return OSPermissionStatus::Granted;
         }
-        // Open the Input Monitoring pane first so when the OS prompt
-        // appears it's layered on top of the settings UI the user lands
-        // in if they dismiss the prompt. Matches the pattern used by
-        // request_permission for ScreenRecording above.
+        // Enroll first so System Settings shows a row, then open the pane.
+        let granted = screenpipe_a11y::request_input_monitoring();
         let _ = Command::new("open")
             .arg("x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent")
             .spawn();
-        // Triggers the native consent prompt the first time the process
-        // calls it. Subsequent calls are no-ops if denied — the user has
-        // to enable from System Settings, which we just opened.
-        if screenpipe_a11y::request_input_monitoring() {
+        if granted {
             OSPermissionStatus::Granted
         } else {
             OSPermissionStatus::Denied

--- a/apps/screenpipe-app-tauri/src-tauri/src/permissions.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/permissions.rs
@@ -113,9 +113,8 @@ pub async fn request_permission(app: tauri::AppHandle, permission: OSPermission)
                 open_permission_settings(OSPermission::Automation);
             }
             OSPermission::InputMonitoring => {
-                // Defer to the dedicated request flow (opens Settings + calls
-                // CGRequestListenEventAccess). No probe tap is created — the
-                // check reads from INPUT_MONITORING_GROUND_TRUTH or preflight.
+                // Defer to the dedicated request flow (enroll list row, open
+                // Settings, then CGRequestListenEventAccess for the prompt).
                 let _ = request_input_monitoring_permission().await;
             }
             OSPermission::Calendar => {
@@ -462,14 +461,9 @@ pub fn check_input_monitoring_permission_cmd() -> OSPermissionStatus {
 
 /// Request Input Monitoring permission (macOS only).
 ///
-/// Calls `cg_access::listen_request()` to trigger the system permission
-/// flow. On first call this either shows the native prompt (if NotDetermined)
-/// or silently no-ops (if already Denied — macOS doesn't re-prompt). For
-/// reliability we also open System Settings → Input Monitoring so the user
-/// can grant manually if the prompt didn't appear.
-///
-/// Returns the post-request permission status so the UI can update without
-/// waiting for the next poll.
+/// Enrolls a TCC list row, opens System Settings → Input Monitoring, then
+/// calls `CGRequestListenEventAccess` so the consent prompt layers on top of
+/// Settings. Returns the post-request status for an immediate UI update.
 #[tauri::command(async)]
 #[specta::specta]
 pub async fn request_input_monitoring_permission() -> OSPermissionStatus {
@@ -479,12 +473,14 @@ pub async fn request_input_monitoring_permission() -> OSPermissionStatus {
         if screenpipe_a11y::check_input_monitoring() {
             return OSPermissionStatus::Granted;
         }
-        // Enroll first so System Settings shows a row, then open the pane.
-        let granted = screenpipe_a11y::request_input_monitoring();
+        // Enroll a TCC list row first, open Settings, then prompt so the
+        // consent dialog layers on top of the Privacy pane (same pattern as
+        // Screen Recording: settings visible before the modal).
+        screenpipe_a11y::enroll_input_monitoring();
         let _ = Command::new("open")
             .arg("x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent")
             .spawn();
-        if granted {
+        if screenpipe_a11y::prompt_input_monitoring() {
             OSPermissionStatus::Granted
         } else {
             OSPermissionStatus::Denied

--- a/crates/screenpipe-a11y/src/lib.rs
+++ b/crates/screenpipe-a11y/src/lib.rs
@@ -76,7 +76,8 @@ pub use events::{
     WindowTreeSnapshot,
 };
 pub use platform::{
-    check_input_monitoring, request_input_monitoring, PermissionStatus, RecordingHandle, UiRecorder,
+    check_input_monitoring, enroll_input_monitoring, prompt_input_monitoring,
+    request_input_monitoring, PermissionStatus, RecordingHandle, UiRecorder,
 };
 
 /// Prelude for convenient imports

--- a/crates/screenpipe-a11y/src/platform/macos.rs
+++ b/crates/screenpipe-a11y/src/platform/macos.rs
@@ -357,27 +357,60 @@ pub fn check_input_monitoring() -> bool {
                 return true;
             }
             // Earlier tap succeeded, but TCC now denies (revoke/reset).
-            INPUT_MONITORING_GROUND_TRUTH.store(0, Ordering::SeqCst);
+            // Clear to unknown so a later System Settings toggle can recover
+            // via preflight without requiring a process relaunch.
+            INPUT_MONITORING_GROUND_TRUTH.store(-1, Ordering::SeqCst);
             return false;
         }
-        0 => return false,
+        0 => {
+            // Known denied from a failed real tap — still allow recovery when
+            // the user re-grants in System Settings (same cold-start preflight
+            // ghost-record risk as an unset cache).
+            if preflight {
+                INPUT_MONITORING_GROUND_TRUTH.store(-1, Ordering::SeqCst);
+                return true;
+            }
+            return false;
+        }
         _ => {}
     }
     preflight
 }
 
-/// Request Input Monitoring and enroll this process in the TCC list.
+/// Ensure this process appears under System Settings → Input Monitoring.
 ///
-/// Calls `CGRequestListenEventAccess`, then a short-lived `LISTEN_ONLY` tap
-/// create (never enabled / never on a run loop) so System Settings shows a row.
-pub fn request_input_monitoring() -> bool {
-    let _ = cg_access::listen_request();
+/// Creates a disposable LISTEN_ONLY tap (never enabled / never on a run loop)
+/// so tccd lists the app. Does not show the consent prompt.
+pub fn enroll_input_monitoring() {
     enroll_listen_event_via_tap();
+}
+
+/// Request Input Monitoring consent and enroll this process in the TCC list.
+///
+/// Enrolls first (list row), then calls `CGRequestListenEventAccess`. Prefer
+/// [`enroll_input_monitoring`] + open Settings + this prompt path when the
+/// host wants the OS prompt layered above System Settings.
+pub fn request_input_monitoring() -> bool {
+    enroll_listen_event_via_tap();
+    let _ = cg_access::listen_request();
+    check_input_monitoring()
+}
+
+/// Show the Input Monitoring consent prompt without opening System Settings.
+///
+/// Call after [`enroll_input_monitoring`] and after activating the Privacy
+/// pane so the prompt lands on top of Settings.
+pub fn prompt_input_monitoring() -> bool {
+    let _ = cg_access::listen_request();
     check_input_monitoring()
 }
 
 /// Create a disposable LISTEN_ONLY HID tap so tccd lists this app under
 /// Input Monitoring. Create + invalidate only; do not enable or attach.
+///
+/// Does not write `INPUT_MONITORING_GROUND_TRUTH` — that cache stays owned by
+/// real capture taps (KeyCastr ghost-keystroke rule). Status after enroll
+/// comes from preflight / a later real tap.
 fn enroll_listen_event_via_tap() {
     use std::ffi::c_void;
 
@@ -428,13 +461,12 @@ fn enroll_listen_event_via_tap() {
             std::ptr::null_mut(),
         );
         if tap.is_null() {
-            // Denied, but create still enrolls a list row. Do not cache denial.
+            // Denied, but create still enrolls a list row.
             return;
         }
         CGEventTapEnable(tap, false);
         CFMachPortInvalidate(tap);
         CFRelease(tap as *const c_void);
-        record_input_monitoring_truth(true);
     }
 }
 

--- a/crates/screenpipe-a11y/src/platform/macos.rs
+++ b/crates/screenpipe-a11y/src/platform/macos.rs
@@ -346,32 +346,96 @@ impl UiRecorder {
 ///
 /// Resolution order:
 ///   1. If a real capture tap has already run this process, return its cached
-///      ground truth — it cannot be fooled by stale ("ghost") TCC records and
-///      costs nothing. This is the common case while recording is active.
-///   2. Otherwise fall back to `CGPreflightListenEventAccess`. It can
-///      false-positive on ghost TCC records, but it never creates a tap and
-///      therefore never emits phantom keystrokes. The first real tap creation
-///      corrects the cache immediately afterwards.
+///      ground truth. A cached grant is re-checked against preflight so a
+///      mid-session revoke is not stuck showing granted until relaunch.
+///   2. Otherwise fall back to `CGPreflightListenEventAccess`.
 pub fn check_input_monitoring() -> bool {
+    let preflight = cg_access::listen_preflight();
     match INPUT_MONITORING_GROUND_TRUTH.load(Ordering::SeqCst) {
-        1 => return true,
+        1 => {
+            if preflight {
+                return true;
+            }
+            // Earlier tap succeeded, but TCC now denies (revoke/reset).
+            INPUT_MONITORING_GROUND_TRUTH.store(0, Ordering::SeqCst);
+            return false;
+        }
         0 => return false,
         _ => {}
     }
-    cg_access::listen_preflight()
+    preflight
 }
 
-/// Trigger the macOS Input Monitoring permission flow for the current
-/// process. Returns the resulting grant status. First call shows the
-/// native prompt (and registers the process in System Settings →
-/// Privacy & Security → Input Monitoring); subsequent calls return the
-/// current status without re-prompting.
+/// Request Input Monitoring and enroll this process in the TCC list.
 ///
-/// Like `check_input_monitoring`, this no longer creates a probe tap — it
-/// requests via the OS API and then reports the cached/preflight status.
+/// Calls `CGRequestListenEventAccess`, then a short-lived `LISTEN_ONLY` tap
+/// create (never enabled / never on a run loop) so System Settings shows a row.
 pub fn request_input_monitoring() -> bool {
-    let requested = cg_access::listen_request();
-    requested && check_input_monitoring()
+    let _ = cg_access::listen_request();
+    enroll_listen_event_via_tap();
+    check_input_monitoring()
+}
+
+/// Create a disposable LISTEN_ONLY HID tap so tccd lists this app under
+/// Input Monitoring. Create + invalidate only; do not enable or attach.
+fn enroll_listen_event_via_tap() {
+    use std::ffi::c_void;
+
+    type CGEventTapProxy = *mut c_void;
+    type CGEventRef = *mut c_void;
+    type CFMachPortRef = *mut c_void;
+
+    extern "C" fn noop_callback(
+        _proxy: CGEventTapProxy,
+        _event_type: u32,
+        event: CGEventRef,
+        _user_info: *mut c_void,
+    ) -> CGEventRef {
+        event
+    }
+
+    #[link(name = "CoreGraphics", kind = "framework")]
+    extern "C" {
+        fn CGEventTapCreate(
+            tap: u32,
+            place: u32,
+            options: u32,
+            events_of_interest: u64,
+            callback: extern "C" fn(CGEventTapProxy, u32, CGEventRef, *mut c_void) -> CGEventRef,
+            user_info: *mut c_void,
+        ) -> CFMachPortRef;
+        fn CGEventTapEnable(tap: CFMachPortRef, enable: bool);
+    }
+
+    #[link(name = "CoreFoundation", kind = "framework")]
+    extern "C" {
+        fn CFRelease(cf: *const c_void);
+        fn CFMachPortInvalidate(port: CFMachPortRef);
+    }
+
+    const K_CG_HID_EVENT_TAP: u32 = 0;
+    const K_CG_HEAD_INSERT_EVENT_TAP: u32 = 0;
+    const K_CG_EVENT_TAP_OPTION_LISTEN_ONLY: u32 = 1;
+    const K_CG_EVENT_KEY_DOWN: u64 = 10;
+
+    unsafe {
+        let tap = CGEventTapCreate(
+            K_CG_HID_EVENT_TAP,
+            K_CG_HEAD_INSERT_EVENT_TAP,
+            K_CG_EVENT_TAP_OPTION_LISTEN_ONLY,
+            1u64 << K_CG_EVENT_KEY_DOWN,
+            noop_callback,
+            std::ptr::null_mut(),
+        );
+        if tap.is_null() {
+            // Denied, but create still enrolls a list row. Do not cache denial.
+            return;
+        }
+        CGEventTapEnable(tap, false);
+        CFMachPortInvalidate(tap);
+        CFRelease(tap as *const c_void);
+        record_input_monitoring_truth(true);
+    }
 }
 
 // ============================================================================

--- a/crates/screenpipe-a11y/src/platform/mod.rs
+++ b/crates/screenpipe-a11y/src/platform/mod.rs
@@ -18,7 +18,8 @@ pub mod linux;
 // Re-export platform-specific types with common names
 #[cfg(target_os = "macos")]
 pub use macos::{
-    check_input_monitoring, request_input_monitoring, PermissionStatus, RecordingHandle, UiRecorder,
+    check_input_monitoring, enroll_input_monitoring, prompt_input_monitoring,
+    request_input_monitoring, PermissionStatus, RecordingHandle, UiRecorder,
 };
 
 #[cfg(target_os = "windows")]
@@ -33,6 +34,12 @@ pub use linux::{PermissionStatus, RecordingHandle, UiRecorder};
 // permission as always granted.
 #[cfg(not(target_os = "macos"))]
 pub fn check_input_monitoring() -> bool {
+    true
+}
+#[cfg(not(target_os = "macos"))]
+pub fn enroll_input_monitoring() {}
+#[cfg(not(target_os = "macos"))]
+pub fn prompt_input_monitoring() -> bool {
     true
 }
 #[cfg(not(target_os = "macos"))]

--- a/crates/screenpipe-core/src/permissions.rs
+++ b/crates/screenpipe-core/src/permissions.rs
@@ -285,21 +285,14 @@ pub fn check_accessibility() -> PermissionStatus {
 
 /// Live accessibility check for the onboarding/settings poll loop.
 ///
-/// `AXIsProcessTrusted()` caches its answer in-process (macOS 13+), so a grant
-/// made while the app is running keeps reading as denied until relaunch. The
-/// event-tap probe asks tccd at call time and catches that transition;
-/// `AXIsProcessTrusted()` stays as the cheap first-line check and covers the
-/// probe's own false negatives (LSBackgroundOnly helpers, dev-build signature
-/// churn).
+/// `AXIsProcessTrusted()` caches mid-session. The event-tap probe asks tccd
+/// now and is the live signal for grant and revoke.
 ///
-/// NOT side-effect-free: creating an active event tap while denied enrolls the
-/// app in the Accessibility pane and can surface the system prompt. Only call
-/// this from a context where the user is actively being asked for the
-/// permission (the onboarding/settings grant flow) — never from a passive
-/// launch-time gate.
+/// NOT side-effect-free: an active tap while denied can enroll/prompt. Only
+/// call while the user is actively granting, never from a launch-time gate.
 #[cfg(target_os = "macos")]
 pub fn check_accessibility_live() -> PermissionStatus {
-    if check_accessibility().is_granted() || macos_accessibility::event_tap_probe() {
+    if macos_accessibility::event_tap_probe() {
         PermissionStatus::Granted
     } else {
         PermissionStatus::Denied


### PR DESCRIPTION
## Summary
- Detect Accessibility revoke mid-session via live event-tap probe (stop false greens after `tccutil reset`)
- Enroll Input Monitoring with a disposable LISTEN_ONLY tap so the app appears in System Settings; prompt after Settings opens so the dialog layers on top
- Clear Input Monitoring ground-truth to unknown on revoke so a System Settings re-toggle is visible without relaunch
- Keep drag-prep `tccutil reset` from re-enrolling a denied row (empty list is required for drag-to-grant)
- Skip the drag panel when authorization is already granted
- Add `NSAccessibilityUsageDescription`

## Tradeoff
- `check_accessibility_live` is probe-only (no `AXIsProcessTrusted` OR). Fixes mid-session revoke false greens; probe false-negatives on some dev/unsigned builds can stall onboarding until skip. Named deliberately.

## Test plan
- [ ] grant Accessibility, `tccutil reset Accessibility`, stay in the running app, recheck live status: must flip denied without relaunch
- [ ] `tccutil reset ListenEvent`, request Input Monitoring: app appears under Privacy → Input Monitoring; consent prompt should appear above Settings
- [ ] revoke Input Monitoring then toggle it back on in System Settings (no Enable click): settings card / status should return to granted without relaunch
- [ ] Enable with drag/reset path: list starts empty after reset, drag drop is accepted (not rejected as duplicate)
- [ ] Enable when already granted: no redundant drag panel
- [ ] Confirm mic/screen still request normally