### PR TITLE
fix(auth): retry first sign-in verification while account provisioning completes

### DIFF
--- a/apps/screenpipe-app-tauri/components/deeplink-handler.tsx
+++ b/apps/screenpipe-app-tauri/components/deeplink-handler.tsx
@@ -73,6 +73,31 @@ export function DeeplinkHandler() {
       }
     };
 
+    // A brand-new account may not exist server-side yet when the deep link
+    // arrives (the user row is provisioned asynchronously after the token is
+    // minted), so 404/5xx on first sign-in mean "not ready", not "rejected".
+    // Retry briefly before failing; 401/403 stay definitive and are rethrown.
+    const loadUserWithProvisioningRetry = async (apiKey: string) => {
+      const retryDelaysMs = [0, 2000, 5000, 10000];
+      for (let i = 0; i < retryDelaysMs.length; i++) {
+        if (retryDelaysMs[i] > 0) {
+          await new Promise((resolve) => setTimeout(resolve, retryDelaysMs[i]));
+        }
+        try {
+          await loadUser(apiKey);
+          return;
+        } catch (error) {
+          const status = (error as { status?: number }).status;
+          const retryable =
+            status === 404 || (typeof status === "number" && status >= 500);
+          if (!retryable || i === retryDelaysMs.length - 1) throw error;
+          console.warn(
+            `[deeplink] sign-in verify not ready (status ${status}), retrying...`,
+          );
+        }
+      }
+    };
+
     // Shared deep-link URL processor used by both the native plugin callback
     // and the custom Tauri event from single-instance handoff.
     const processDeepLinkUrl = async (url: string) => {
@@ -83,7 +108,7 @@ export function DeeplinkHandler() {
         const apiKey = parsedUrl.searchParams.get("api_key");
         if (apiKey) {
           try {
-            await loadUser(apiKey);
+            await loadUserWithProvisioningRetry(apiKey);
             toast({
               title: "logged in!",
               description: "you have been logged in",

--- a/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -1728,9 +1728,11 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
 				if (response.status === 401 || response.status === 403) {
 					await clearRejectedSession();
 				}
-				throw new Error(
+				const verifyError = new Error(
 					`failed to verify token: ${response.status} ${response.statusText} - ${body}`,
-				);
+				) as Error & { status?: number };
+				verifyError.status = response.status;
+				throw verifyError;
 			}
 
 			const data = await response.json();


### PR DESCRIPTION
### Description:
- the app treated a failed first sign-in as final: any 404/5xx from `/api/user` discarded the token with no retry, stranding new users whose account wasn't provisioned server-side yet
- the deep-link sign-in path now retries 404/5xx up to 4 times (~17s with backoff); 401/403 still clear the session immediately and never retry
- server half: screenpipe/website#694 (outage root cause), screenpipe/website#696 (retryable 503s)

Ref #5793
