### PR TITLE
fix(chat): don't collapse repeated card-launched chats in dedup

### DIFF
--- a/apps/screenpipe-app-tauri/lib/__tests__/chat-storage.test.ts
+++ b/apps/screenpipe-app-tauri/lib/__tests__/chat-storage.test.ts
@@ -364,6 +364,38 @@ function candidate(
   return { meta: meta(id, over), key, hasCompletedReply };
 }
 
+describe("conversationDedupKey", () => {
+  it("keys plain typed chats by their stripped opener", () => {
+    const key = conversationDedupKey({
+      kind: "chat",
+      messages: [{ role: "user", content: "export last 5 min of video" }],
+    });
+    expect(key).toBe("export last 5 min of video");
+  });
+
+  it("exempts templated starter/summary openers (they carry a displayContent)", () => {
+    // Two distinct launches of the same card produce identical text but are
+    // separate chats; a non-null key would collapse them on the next boot.
+    const conv = {
+      kind: "chat",
+      messages: [
+        {
+          role: "user",
+          displayContent: "\u2728 Day Recap \u2014 Today",
+          content:
+            "Analyze my screen and audio recordings from today.\n\nUser instructions: recap",
+        },
+      ],
+    };
+    expect(conversationDedupKey(conv)).toBeNull();
+  });
+
+  it("still returns null for pipe runs and empty chats", () => {
+    expect(conversationDedupKey({ kind: "pipe", messages: [{ role: "user", content: "x" }] })).toBeNull();
+    expect(conversationDedupKey({ kind: "chat", messages: [] })).toBeNull();
+  });
+});
+
 describe("dedupeConversationMetas", () => {
   it("collapses two copies of the same chat, keeping the one with a real reply", () => {
     const out = dedupeConversationMetas([

--- a/apps/screenpipe-app-tauri/lib/chat-dedup.ts
+++ b/apps/screenpipe-app-tauri/lib/chat-dedup.ts
@@ -77,9 +77,21 @@ export function conversationDedupKey(conv: DedupConvLike | null | undefined): st
   const firstUser = messages.find((m) => m?.role === "user");
   const display = typeof firstUser?.displayContent === "string" ? firstUser.displayContent : "";
   const content = typeof firstUser?.content === "string" ? firstUser.content : "";
-  const semantic = display.trim() || stripPromptPlumbing(content);
-  const cleaned = semantic.trim().toLowerCase().replace(/\s+/g, " ");
-  return cleaned ? cleaned.slice(0, 200) : null;
+  const stripped = stripPromptPlumbing(content);
+  const norm = (s: string) => s.trim().toLowerCase().replace(/\s+/g, " ");
+  const displayNorm = norm(display);
+  const strippedNorm = norm(stripped);
+  // Card openers set a title displayContent distinct from the injected body
+  // and share a fixed template across launches, so exempt them from dedup
+  // (typed message labels prefix their content and still dedup).
+  const isTemplatedCardOpener =
+    displayNorm.length > 0 &&
+    strippedNorm.length > 0 &&
+    displayNorm !== strippedNorm &&
+    !strippedNorm.startsWith(displayNorm);
+  if (isTemplatedCardOpener) return null;
+  const semantic = displayNorm || strippedNorm;
+  return semantic ? semantic.slice(0, 200) : null;
 }
 
 /** Stable identity for read-time duplicate collapsing.


### PR DESCRIPTION
- conversationDedupKey collapsed chats whose first message normalizes to the same text within a 30 minute window
- starter and summary cards inject a fixed prompt template, so every launch of the same card produced identical text and merged into one history row on the next app start (silent data loss)
- card openers (a title displayContent distinct from, and not a prefix of, the injected body) are now exempt from text-keyed dedup, like pipe runs already are
- typed messages keep deduping, including pasted-file chats whose label prefixes the content
- verified: bunx vitest run lib/__tests__/chat-storage.test.ts, 33 tests pass, including 3 new conversationDedupKey cases
