### PR TITLE
fix(chat): honest persistence for tool-only and interrupted turns

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat/standalone/message-content.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/message-content.tsx
@@ -1359,6 +1359,12 @@ export function MessageContent({
     const stoppedSummary = message.stoppedByUser && hasToolWorkGroup
       ? formatStoppedWorkDuration(message.workDurationMs)
       : undefined;
+    // A turn cut off by app quit / crash: tell the truth on the work
+    // summary instead of showing a normal "Worked for X" completion.
+    const interruptedSummary = message.interruptedByQuit && hasToolWorkGroup
+      ? "interrupted — app closed mid-task"
+      : undefined;
+    const workSummaryOverride = stoppedSummary || interruptedSummary;
     return (
       <div className="space-y-2 min-w-0 w-full overflow-hidden">
         {displayGroups.map((group) => {
@@ -1412,8 +1418,8 @@ export function MessageContent({
                 toolCalls={group.toolCalls}
                 defaultExpanded={false}
                 isGenerating={isGenerating && !message.workDurationMs}
-                preferSummaryOverride={Boolean(stoppedSummary)}
-                summaryOverride={stoppedSummary || (message.workDurationMs ? formatWorkDuration(message.workDurationMs) : undefined)}
+                preferSummaryOverride={Boolean(workSummaryOverride)}
+                summaryOverride={workSummaryOverride || (message.workDurationMs ? formatWorkDuration(message.workDurationMs) : undefined)}
                 workStartedAtMs={message.timestamp}
                 hideSummary={hideToolSummary}
                 forceCollapsed={forceCollapseTools}
@@ -1433,8 +1439,8 @@ export function MessageContent({
                 toolCalls={group.toolCalls}
                 defaultExpanded={false}
                 isGenerating={isGenerating && !message.workDurationMs}
-                preferSummaryOverride={Boolean(stoppedSummary)}
-                summaryOverride={stoppedSummary || formatWorkDuration(durationMs)}
+                preferSummaryOverride={Boolean(workSummaryOverride)}
+                summaryOverride={workSummaryOverride || formatWorkDuration(durationMs)}
                 workStartedAtMs={message.timestamp}
                 hideSummary={hideToolSummary}
                 forceCollapsed={forceCollapseTools}
@@ -1454,9 +1460,13 @@ export function MessageContent({
   // without displayContent — the displayContent case is handled above before
   // the contentBlocks path).
   // Strip raw "Error:" prefix that leaks from backend — show only the human part
-  const displayText = !isUser && message.content.startsWith("Error: ")
+  const rawText = !isUser && message.content.startsWith("Error: ")
     ? message.content.slice("Error: ".length)
     : message.content;
+  // "(tool result)" is a persistence placeholder given to tool-only messages so
+  // they are not stored empty. It is not user-facing text, so never render it as
+  // an assistant bubble (the tool activity itself renders from contentBlocks).
+  const displayText = rawText === "(tool result)" ? "" : rawText;
   const hasMeaningfulText = Boolean(displayText && displayText !== "Processing...");
 
   if (!isUser && !hasMeaningfulText && !attachmentsRow && !sourceFooter && !retryCta) {

--- a/apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts
+++ b/apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts
@@ -835,13 +835,15 @@ export function useChatConversations(opts: UseChatConversationsOpts) {
       // file size becomes a problem for power users we cap at the render
       // layer, never on disk.
       messages: msgs.map(m => {
-        // For tool-only responses, content may be empty but contentBlocks has the data.
+        // Tool-only responses have no text; content stays empty (the tool
+        // activity is preserved via contentBlocks) rather than a placeholder
+        // that would render as an assistant text bubble.
         let content = m.content;
         if (!content && m.contentBlocks?.length) {
           content = m.contentBlocks
             .filter((b: any) => b.type === "text")
             .map((b: any) => b.text)
-            .join("\n") || "(tool result)";
+            .join("\n");
         }
         // Persist contentBlocks so tool calls/results survive reload.
         // Strip isRunning (stale) and cap result length to keep file small.
@@ -1543,7 +1545,7 @@ export function useChatConversations(opts: UseChatConversationsOpts) {
           content = m.contentBlocks
             .filter((b: any) => b.type === "text")
             .map((b: any) => b.text)
-            .join("\n") || "(tool result)";
+            .join("\n");
         }
         const blocks = m.contentBlocks?.map((b: any) => {
           if (b.type === "tool") {

--- a/apps/screenpipe-app-tauri/lib/__tests__/pi-event-router.test.ts
+++ b/apps/screenpipe-app-tauri/lib/__tests__/pi-event-router.test.ts
@@ -480,3 +480,67 @@ describe("pi-event-router: agent_terminated", () => {
     );
   });
 });
+
+describe("pi-event-router: honest interruption on quit/crash", () => {
+  beforeEach(reset);
+
+  it("marks a still-running tool as interrupted when the process terminates mid-turn", async () => {
+    seed("A");
+    useChatStore.setState({ currentId: "B" });
+    await handlePiEvent(
+      piEvt("A", { type: "message_start", message: { role: "assistant" } }),
+    );
+    await handlePiEvent(
+      piEvt("A", {
+        type: "tool_execution_start",
+        toolCallId: "long-tool",
+        toolName: "Bash",
+        args: {},
+      } as unknown as AgentInnerEvent),
+    );
+
+    // Process dies before the tool ever completes.
+    handleTerminated({ sessionId: "A", source: "pi", exitCode: 1 });
+    await flushPendingSaves();
+
+    const saved = (saveConversationFile as any).mock.calls.at(-1)[0];
+    const assistant = saved.messages.find((m: any) => m.role === "assistant");
+    expect(assistant.interruptedByQuit).toBe(true);
+    const tool = assistant.contentBlocks.find((b: any) => b.type === "tool");
+    expect(tool.toolCall.isRunning).toBe(false);
+    expect(tool.toolCall.isError).toBe(true);
+    expect(tool.toolCall.result).toContain("interrupted");
+  });
+
+  it("does not flag a normally completed turn", async () => {
+    seed("A");
+    useChatStore.setState({ currentId: "B" });
+    await handlePiEvent(
+      piEvt("A", { type: "message_start", message: { role: "assistant" } }),
+    );
+    await handlePiEvent(
+      piEvt("A", {
+        type: "tool_execution_start",
+        toolCallId: "quick-tool",
+        toolName: "Read",
+        args: {},
+      } as unknown as AgentInnerEvent),
+    );
+    await handlePiEvent(
+      piEvt("A", {
+        type: "tool_execution_end",
+        toolCallId: "quick-tool",
+        toolName: "Read",
+        result: { content: [{ type: "text", text: "done" }] },
+      } as unknown as AgentInnerEvent),
+    );
+    await handlePiEvent(piEvt("A", { type: "agent_end" }));
+    await flushPendingSaves();
+
+    const saved = (saveConversationFile as any).mock.calls.at(-1)[0];
+    const assistant = saved.messages.find((m: any) => m.role === "assistant");
+    expect(assistant.interruptedByQuit).toBeUndefined();
+    const tool = assistant.contentBlocks.find((b: any) => b.type === "tool");
+    expect(tool.toolCall.isError).not.toBe(true);
+  });
+});

--- a/apps/screenpipe-app-tauri/lib/chat/types.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/types.ts
@@ -80,6 +80,10 @@ export interface Message {
   entrySource?: ChatEntrySource;
   /** Allowlisted home-card category. Never contains a title, prompt, or user-authored value. */
   entryCard?: ChatEntryCard;
+  /** The app quit while this assistant turn was still streaming; its
+   *  running tools never reported completion and are shown as interrupted
+   *  rather than silently marked done. */
+  interruptedByQuit?: boolean;
 }
 
 export type QueuedDisplayPayload = {

--- a/apps/screenpipe-app-tauri/lib/stores/pi-event-router.ts
+++ b/apps/screenpipe-app-tauri/lib/stores/pi-event-router.ts
@@ -195,29 +195,11 @@ export async function handlePiEvent(envelope: AgentEventEnvelope) {
   }
 
   const store = useChatStore.getState();
-  const existing = store.sessions[sid];
+  let existing = store.sessions[sid];
 
   const nextStatus = statusForEvent(inner);
   const snippet = previewSnippet(inner);
   const err = errorMessage(inner);
-
-  // Phase 3: accumulate full message-content state in the store for
-  // EVERY session (current + background). This is what makes it possible
-  // for the chat panel to switch back to a previously-backgrounded
-  // session and see live tokens that arrived while it was away — the
-  // router has been writing them to the store the whole time. The chat
-  // panel either reads the store directly or syncs its local state from
-  // the store on session switch.
-  //
-  // Pipe-watch sessions are written by `pipe-watch-writer` instead —
-  // pipe streams don't follow chat-shaped lifecycles (missing
-  // message_start between turns, terminal `agent_end` carrying the
-  // canonical messages array), and double-writing here would race
-  // against that writer. Status mirroring (the sidebar dot / preview)
-  // still happens below for both kinds.
-  if (existing?.kind !== "pipe-watch") {
-    applyEventToSessionContent(sid, inner);
-  }
 
   // Lazy-create on first event from a previously-unknown session id.
   // Handles the case where Pi was started outside the chat-storage flow
@@ -240,7 +222,26 @@ export async function handlePiEvent(envelope: AgentEventEnvelope) {
       ...(snippet ? { lastContentAt: now } : {}),
     });
     if (snippet) previewLastEmittedAt.set(sid, Date.now());
-    return;
+    existing = useChatStore.getState().sessions[sid];
+    if (!existing) return;
+  }
+
+  // Phase 3: accumulate full message-content state in the store for
+  // EVERY session (current + background). This is what makes it possible
+  // for the chat panel to switch back to a previously-backgrounded
+  // session and see live tokens that arrived while it was away — the
+  // router has been writing them to the store the whole time. The chat
+  // panel either reads the store directly or syncs its local state from
+  // the store on session switch.
+  //
+  // Pipe-watch sessions are written by `pipe-watch-writer` instead —
+  // pipe streams don't follow chat-shaped lifecycles (missing
+  // message_start between turns, terminal `agent_end` carrying the
+  // canonical messages array), and double-writing here would race
+  // against that writer. Status mirroring (the sidebar dot / preview)
+  // still happens below for both kinds.
+  if (existing.kind !== "pipe-watch") {
+    applyEventToSessionContent(sid, inner);
   }
 
   // Decide whether to write a preview update — throttled per session.
@@ -797,21 +798,34 @@ async function persistBackgroundSession(sid: string): Promise<void> {
         messages: messages.map((m: any) => {
           let content: string = m.content || "";
           if (!content && m.contentBlocks?.length) {
-            content =
-              m.contentBlocks
-                .filter((b: any) => b.type === "text")
-                .map((b: any) => b.text)
-                .join("\n") || "(tool result)";
+            // Tool-only messages have no text; leave content empty (the tool
+            // activity persists via contentBlocks) rather than a placeholder
+            // that would render as an assistant text bubble.
+            content = m.contentBlocks
+              .filter((b: any) => b.type === "text")
+              .map((b: any) => b.text)
+              .join("\n");
           }
+          // A tool still marked running at persist time never reported
+          // completion: the turn was cut off (crash or app quit), since a
+          // normal finish flips isRunning false via tool_execution_end
+          // before agent_end. Record it honestly instead of persisting it
+          // as silently done, and flag the message so the UI can say so.
+          let wasInterrupted = false;
           const blocks = m.contentBlocks?.map((b: any) => {
             if (b.type === "tool") {
-              const { isRunning: _isRunning, ...rest } = b.toolCall ?? {};
+              const { isRunning, ...rest } = b.toolCall ?? {};
+              const interrupted = isRunning === true;
+              if (interrupted) wasInterrupted = true;
               return {
                 type: "tool",
                 toolCall: {
                   ...rest,
                   isRunning: false,
-                  result: rest.result?.slice?.(0, 4000),
+                  isError: interrupted ? true : rest.isError,
+                  result: interrupted
+                    ? "interrupted — the app closed before this finished"
+                    : rest.result?.slice?.(0, 4000),
                 },
               };
             }
@@ -820,6 +834,7 @@ async function persistBackgroundSession(sid: string): Promise<void> {
             }
             return b;
           });
+          const interruptedByQuit = m.interruptedByQuit || wasInterrupted;
           return {
             id: m.id,
             role: m.role,
@@ -836,6 +851,7 @@ async function persistBackgroundSession(sid: string): Promise<void> {
             ...(m.steeredResponse ? { steeredResponse: true } : {}),
             ...(m.workDurationMs ? { workDurationMs: m.workDurationMs } : {}),
             ...(m.stoppedByUser ? { stoppedByUser: true } : {}),
+            ...(interruptedByQuit ? { interruptedByQuit: true } : {}),
           };
         }),
         createdAt: existing?.createdAt ?? Date.now(),


### PR DESCRIPTION
Two honesty fixes for how chat turns persist, plus a router fix. No ACP code.

- tool-only turns persisted a "(tool result)" placeholder that rendered as an empty assistant bubble; content now stays empty and the tool activity persists via contentBlocks
- a tool still marked running at persist time (app quit or crash mid-turn) was persisted as silently done; it is now flagged interruptedByQuit with isError, an interrupted result string, and an "interrupted" work summary instead of a fake "Worked for X"
- the router's lazy-create path upserted an unknown session and returned early, dropping that first event's content; it now upserts then falls through to content accumulation
- verified: bunx vitest run lib/__tests__/pi-event-router.test.ts, 23 tests pass, tsc clean
