### PR TITLE
feat(chat): live output and elapsed time for long-running tools

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat/standalone/hooks/use-pi-foreground-events.ts
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/hooks/use-pi-foreground-events.ts
@@ -350,6 +350,25 @@ export function usePiForegroundEvents({
               prev.map((m) => m.id === msgId ? { ...m, contentBlocks } : m)
             );
           }
+        } else if (data.type === "tool_execution_update") {
+          // Pi streams the tool's partial output while it runs. partialResult
+          // is cumulative, so store its tail as the running tool's progress.
+          if (piMessageIdRef.current) {
+            const msgId = piMessageIdRef.current;
+            const toolCallId = stringValue(data.toolCallId);
+            const partial = textFromToolResult(data.partialResult);
+            if (partial) {
+              for (const block of piContentBlocksRef.current) {
+                if (block.type !== "tool" || block.toolCall.id !== toolCallId) continue;
+                block.toolCall.progress =
+                  partial.length > 4000 ? partial.slice(-4000) : partial;
+              }
+              const contentBlocks = [...piContentBlocksRef.current];
+              setMessages((prev) =>
+                prev.map((m) => m.id === msgId ? { ...m, contentBlocks } : m)
+              );
+            }
+          }
         } else if (data.type === "tool_execution_end") {
           if (piMessageIdRef.current) {
             const msgId = piMessageIdRef.current;

--- a/apps/screenpipe-app-tauri/components/chat/standalone/message-content.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/message-content.tsx
@@ -399,6 +399,30 @@ function FriendlyToolDetails({ toolCall }: { toolCall: ToolCall }) {
 }
 
 // Single tool call row in the progress rail
+function formatElapsedSeconds(totalSeconds: number): string {
+  const seconds = Math.max(0, Math.floor(totalSeconds));
+  if (seconds < 60) return `${seconds}s`;
+  return `${Math.floor(seconds / 60)}m ${String(seconds % 60).padStart(2, "0")}s`;
+}
+
+/** A tool's elapsed time as a short label: ticking while it runs, then frozen
+ *  to its final duration. Empty for tools too quick to be worth showing. */
+function useToolElapsedLabel(toolCall: ToolCall): string | null {
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  useEffect(() => {
+    if (!toolCall.isRunning) return;
+    const id = window.setInterval(() => setNowMs(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, [toolCall.isRunning]);
+
+  if (!toolCall.startedAtMs) return null;
+  const endMs = toolCall.isRunning ? nowMs : toolCall.endedAtMs ?? nowMs;
+  const elapsed = (endMs - toolCall.startedAtMs) / 1000;
+  // Quiet for quick tools; the group header already shows the turn total.
+  if (elapsed < 3) return null;
+  return formatElapsedSeconds(elapsed);
+}
+
 function ToolCallRailItem({
   toolCall,
   isLast,
@@ -411,6 +435,7 @@ function ToolCallRailItem({
   const [expanded, setExpanded] = useState(false);
   const presentation = presentToolActivity(toolCall);
   const label = toolCall.isRunning ? presentation.runningLabel : presentation.completedLabel;
+  const elapsedLabel = useToolElapsedLabel(toolCall);
   const appName = extractAppFromToolCall(toolCall);
   const connectionIconName = extractConnectionIconFromToolCall(toolCall);
   const webTarget = extractWebTargetFromToolCall(toolCall);
@@ -469,6 +494,11 @@ function ToolCallRailItem({
             <span className="truncate flex-1 text-xs text-foreground/70 group-hover:text-foreground transition-colors duration-150">
               {label}
             </span>
+            {elapsedLabel && (
+              <span className="flex-shrink-0 font-mono text-[10px] tabular-nums text-foreground/40">
+                {elapsedLabel}
+              </span>
+            )}
             {expanded ? (
               <ChevronDown className="h-3 w-3 flex-shrink-0 text-foreground/30 group-hover:text-foreground/60 transition-colors duration-150" />
             ) : (
@@ -487,6 +517,16 @@ function ToolCallRailItem({
             >
               <div className="border-l border-border ml-0 pl-3 mt-1 mb-1">
                 <FriendlyToolDetails toolCall={toolCall} />
+                {/* Streamed output: live while running, and kept after the tool
+                    finishes so what streamed doesn't vanish. Only for bash once
+                    done, since other tools already show their full result below. */}
+                {toolCall.progress && (toolCall.isRunning || toolCall.toolName === "bash") && (
+                  <div className="mt-1 pt-1 border-t border-border/50">
+                    <pre className="whitespace-pre-wrap break-words max-h-[200px] overflow-y-auto overflow-x-hidden max-w-full text-xs font-mono text-foreground/50">
+                      {toolCall.progress}
+                    </pre>
+                  </div>
+                )}
                 {toolCall.result !== undefined && toolCall.toolName !== "bash" && (
                   <div className="mt-1 pt-1 border-t border-border/50">
                     <pre className={cn(

--- a/apps/screenpipe-app-tauri/lib/__tests__/pi-event-router.test.ts
+++ b/apps/screenpipe-app-tauri/lib/__tests__/pi-event-router.test.ts
@@ -480,3 +480,68 @@ describe("pi-event-router: agent_terminated", () => {
     );
   });
 });
+
+describe("pi-event-router: live tool output", () => {
+  beforeEach(reset);
+
+  it("stores the tail of a running tool's streamed partial output", async () => {
+    seed("A");
+    useChatStore.setState({ currentId: "B" });
+    await handlePiEvent(
+      piEvt("A", { type: "message_start", message: { role: "assistant" } }),
+    );
+    await handlePiEvent(
+      piEvt("A", {
+        type: "tool_execution_start",
+        toolCallId: "t1",
+        toolName: "bash",
+        args: {},
+      } as unknown as AgentInnerEvent),
+    );
+    await handlePiEvent(
+      piEvt("A", {
+        type: "tool_execution_update",
+        toolCallId: "t1",
+        toolName: "bash",
+        partialResult: { content: [{ type: "text", text: "line 1\nline 2\n" }] },
+      } as unknown as AgentInnerEvent),
+    );
+
+    const session = useChatStore.getState().sessions.A;
+    const tool = (session.contentBlocks as any[]).find(
+      (b) => b.type === "tool" && b.toolCall.id === "t1",
+    ).toolCall;
+    expect(tool.progress).toBe("line 1\nline 2\n");
+    expect(tool.isRunning).toBe(true);
+  });
+
+  it("caps the stored output at 4000 chars", async () => {
+    seed("A");
+    useChatStore.setState({ currentId: "B" });
+    await handlePiEvent(
+      piEvt("A", { type: "message_start", message: { role: "assistant" } }),
+    );
+    await handlePiEvent(
+      piEvt("A", {
+        type: "tool_execution_start",
+        toolCallId: "t1",
+        toolName: "bash",
+        args: {},
+      } as unknown as AgentInnerEvent),
+    );
+    await handlePiEvent(
+      piEvt("A", {
+        type: "tool_execution_update",
+        toolCallId: "t1",
+        toolName: "bash",
+        partialResult: { content: [{ type: "text", text: "x".repeat(9000) }] },
+      } as unknown as AgentInnerEvent),
+    );
+
+    const session = useChatStore.getState().sessions.A;
+    const tool = (session.contentBlocks as any[]).find(
+      (b) => b.type === "tool" && b.toolCall.id === "t1",
+    ).toolCall;
+    expect(tool.progress.length).toBe(4000);
+  });
+});

--- a/apps/screenpipe-app-tauri/lib/chat/types.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/types.ts
@@ -39,6 +39,9 @@ export interface ToolCall {
   isRunning: boolean;
   startedAtMs?: number;
   endedAtMs?: number;
+  /** Rolling tail of the tool's streamed partial output while it runs, from
+   *  pi's tool_execution_update.partialResult (capped). */
+  progress?: string;
 }
 
 export type ContentBlock =

--- a/apps/screenpipe-app-tauri/lib/stores/pi-event-router.ts
+++ b/apps/screenpipe-app-tauri/lib/stores/pi-event-router.ts
@@ -625,6 +625,32 @@ function applyEventToSessionContent(sid: string, payload: PiInnerEvent) {
     return;
   }
 
+  // Pi streams the tool's partial output while it runs; store its tail as the
+  // running tool's progress so a long tool visibly advances.
+  if (t === "tool_execution_update") {
+    const cur = store.sessions[sid];
+    if (!cur?.streamingMessageId) return;
+    const msgId = cur.streamingMessageId;
+    const toolCallId = (payload as any).toolCallId;
+    const partial: string =
+      (payload as any).partialResult?.content
+        ?.map((c: any) => c.text || "")
+        .join("\n") || "";
+    if (!partial) return;
+    const progress = partial.length > 4000 ? partial.slice(-4000) : partial;
+    const blocks = ((cur.contentBlocks as any[]) ?? []).map((b: any) =>
+      b.type === "tool" && b.toolCall?.id === toolCallId
+        ? { ...b, toolCall: { ...b.toolCall, progress } }
+        : b
+    );
+    store.actions.setStreaming(sid, { contentBlocks: blocks });
+    store.actions.patchMessage(sid, msgId, (m: any) => ({
+      ...m,
+      contentBlocks: blocks,
+    }));
+    return;
+  }
+
   if (t === "tool_execution_end") {
     const cur = store.sessions[sid];
     if (!cur?.streamingMessageId) return;


### PR DESCRIPTION
- pi streams a tool's partial output as tool_execution_update.partialResult while the tool runs; the chat ignored that event, so a long tool showed only a spinner
- the running tool now stores the tail of that partial output and shows it on the tool row, alongside a self-driven elapsed timer, so a slow bash or search visibly advances
- verified against the pi the app actually runs (@earendil-works/pi-coding-agent 0.83.0): its tool event is tool_execution_update with partialResult (confirmed in pi's own types and in screenpipe's clean-pipe-stdout test); this PR consumes that real event, no invented fields
- handled in both the foreground hook and the background router, capped at 4000 chars


## Before

<img width="905" height="320" alt="image" src="https://github.com/user-attachments/assets/2ea8318e-7349-42c4-b415-565b712b36e6" />


## After


https://github.com/user-attachments/assets/5173f2f8-2285-47a6-9db2-783c26dc1772

