### PR TITLE
fix(app): prevent Live View header status overlap

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -18,15 +18,15 @@ results and `cargo llvm-cov` data on top when judging release confidence.
 
 ### Tauri E2E
 
-- Mapped specs: 91
-- Declared test blocks: 255
-- Weighted coverage points: 197.7
+- Mapped specs: 92
+- Declared test blocks: 256
+- Weighted coverage points: 198.7
 
 | Platform | Specs | Declared tests | Weighted points | Layers | Features | Critical score |
 | --- | --- | --- | --- | --- | --- | --- |
-| windows | 73 | 227 | 184.2 | 15 | 77 | 91% |
-| macos | 87 | 218 | 168.5 | 17 | 79 | 89% |
-| linux | 63 | 187 | 154.0 | 14 | 72 | 88% |
+| windows | 74 | 228 | 185.2 | 15 | 77 | 91% |
+| macos | 88 | 219 | 169.5 | 17 | 79 | 89% |
+| linux | 64 | 188 | 155.0 | 14 | 72 | 88% |
 
 ### Core Engine
 

--- a/apps/screenpipe-app-tauri/components/settings/__tests__/brain-overview.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/brain-overview.test.tsx
@@ -723,6 +723,11 @@ describe("BrainOverview", () => {
     const row = await screen.findByTestId("overview-dashboard-row");
     expect(within(row).getByTestId("section-navigation")).toBeTruthy();
     expect(within(row).getByTestId("overview-dashboard-selector")).toBeTruthy();
+    const status = within(row).getByTestId("overview-data-status");
+    expect(status.className).toContain("basis-full");
+    expect(status.className).toContain("shrink-0");
+    expect(status.className).toContain("break-words");
+    expect(status.className).not.toContain("sm:basis-auto");
   });
 
   it("opens AI creation first and keeps blank manual creation available", async () => {

--- a/apps/screenpipe-app-tauri/components/settings/brain-overview.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/brain-overview.tsx
@@ -2374,7 +2374,7 @@ export function BrainOverview({
           />
           <p
             data-testid="overview-data-status"
-            className="basis-full pl-12 font-mono text-[9px] text-muted-foreground sm:basis-auto sm:pl-0"
+            className="min-w-0 basis-full shrink-0 whitespace-normal break-words pl-12 font-mono text-[9px] leading-4 text-muted-foreground sm:pl-0"
           >
             {onboardingColdStart
               ? "This view will appear when Screenpipe has enough real activity for your outcome."

--- a/apps/screenpipe-app-tauri/e2e/specs/brain-overview.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/brain-overview.spec.ts
@@ -568,6 +568,43 @@ describe("Brain Live Views", function () {
     expect((await statusText).toLowerCase()).toContain("updated");
     expect((await statusText).toLowerCase()).not.toMatch(/^updated /);
 
+    const headerLayout = await browser.execute(() => {
+      const switcher = document.querySelector(
+        "[data-testid='live-view-dashboard-switcher']",
+      );
+      const status = document.querySelector(
+        "[data-testid='overview-data-status']",
+      );
+      const row = document.querySelector(
+        "[data-testid='overview-dashboard-row']",
+      );
+      const controls = document.querySelector(
+        "[data-testid='overview-header-controls']",
+      );
+      if (!switcher || !status || !row || !controls) return null;
+      const switcherRect = switcher.getBoundingClientRect();
+      const statusRect = status.getBoundingClientRect();
+      const rowRect = row.getBoundingClientRect();
+      const controlsRect = controls.getBoundingClientRect();
+      return {
+        switcherBottom: switcherRect.bottom,
+        statusTop: statusRect.top,
+        statusRight: statusRect.right,
+        rowRight: rowRect.right,
+        controlsLeft: controlsRect.left,
+      };
+    });
+    expect(headerLayout).toBeTruthy();
+    expect(headerLayout!.statusTop).toBeGreaterThanOrEqual(
+      headerLayout!.switcherBottom,
+    );
+    expect(headerLayout!.statusRight).toBeLessThanOrEqual(
+      headerLayout!.rowRight,
+    );
+    expect(headerLayout!.rowRight).toBeLessThanOrEqual(
+      headerLayout!.controlsLeft,
+    );
+
     const cardText = (
       await waitForTestId("overview-card-tracked-work", 10_000)
     ).getText();


### PR DESCRIPTION
## summary

- keep the Live View freshness status on its own bounded header row
- allow long oldest/latest timestamps to wrap instead of painting across controls
- add component and rendered-geometry regressions for the reported overlap

## visual

```text
before
+--------+------------------+   status text crosses the controls   +-------------+
| views  | dashboard     ...|<------------------------------------>| Last 7 days |
+--------+------------------+                                      +-------------+

after
+--------+------------------+                                      +-------------+
| views  | dashboard     ...|                                      | Last 7 days |
+--------+------------------+                                      +-------------+
| 6 of 6 blocks ready · oldest ... · latest ...                                  |
+--------------------------------------------------------------------------------+
```

## verification

- `bunx vitest run --config vitest.config.ts components/settings/__tests__/brain-overview.test.tsx` — 57 passed
- `bun run typecheck` — passed
- `git diff --check` — passed
- native E2E was not run locally because this clean worktree has no prebuilt E2E app binary; the bounding-box regression is included for CI
