### PR TITLE
feat(engine): Linux meeting detection via PipeWire audio-process sensor

### DIFF
--- a/crates/screenpipe-audio/Cargo.toml
+++ b/crates/screenpipe-audio/Cargo.toml
@@ -93,6 +93,8 @@ url = { workspace = true }
 [target.'cfg(target_os = "linux")'.dependencies]
 libpulse-binding = { version = "2.28", optional = true }
 libpulse-simple-binding = { version = "2.28", optional = true }
+# meeting_processes: SIGKILL of a timed-out snapshot tool's process group.
+libc = { workspace = true }
 # Bundle ONNX Runtime on Linux (same as macOS). load-dynamic was tried but
 # broke systems without a system-installed libonnxruntime.so (see #2506).
 ort = { workspace = true, features = ["download-binaries", "tls-native"] }

--- a/crates/screenpipe-audio/src/meeting_processes.rs
+++ b/crates/screenpipe-audio/src/meeting_processes.rs
@@ -708,27 +708,50 @@ mod platform {
 
     pub fn current_input_processes() -> AudioProcessSnapshot {
         let self_pid = std::process::id() as i32;
-        // pw-dump can be installed but failing (e.g. PipeWire not running on a
-        // plain PulseAudio system), so pactl is the fallback for BOTH the
-        // missing and the failed case, and both errors are preserved when
-        // neither tool produces a snapshot.
-        let pw = run_tool("pw-dump", &[]);
-        if let ToolResult::Output(json) = pw {
-            return snapshot_from(parse_pw_dump(&json, self_pid));
+        // pw-dump can be installed but unusable — failing to run (PipeWire not
+        // running on a plain PulseAudio system) or emitting output the parser
+        // rejects (contract drift) — so pactl is the fallback for every
+        // pw-dump outcome short of a parsed snapshot. Both errors are
+        // preserved when neither tool produces one.
+        let (pw_missing, pw_err) =
+            match attempt("pw-dump", &[], parse_pw_dump, self_pid) {
+                Ok(snapshot) => return snapshot,
+                Err(outcome) => outcome,
+            };
+        let (pactl_missing, pactl_err) = match attempt(
+            "pactl",
+            &["--format=json", "list", "source-outputs"],
+            parse_pactl_source_outputs,
+            self_pid,
+        ) {
+            Ok(snapshot) => return snapshot,
+            Err(outcome) => outcome,
+        };
+        if pw_missing && pactl_missing {
+            return AudioProcessSnapshot::unsupported("linux (neither pw-dump nor pactl found)");
         }
-        let pactl = run_tool("pactl", &["--format=json", "list", "source-outputs"]);
-        match (pw, pactl) {
-            (_, ToolResult::Output(json)) => {
-                snapshot_from(parse_pactl_source_outputs(&json, self_pid))
-            }
-            (ToolResult::Missing, ToolResult::Missing) => {
-                AudioProcessSnapshot::unsupported("linux (neither pw-dump nor pactl found)")
-            }
-            (pw, pactl) => failed_snapshot(&format!(
-                "pw-dump: {}; pactl: {}",
-                tool_error(pw),
-                tool_error(pactl)
-            )),
+        failed_snapshot(&format!("pw-dump: {pw_err}; pactl: {pactl_err}"))
+    }
+
+    /// Run one tool end-to-end. `Ok` is a usable snapshot; `Err` carries
+    /// (was_missing, error_description) for the combined failure report.
+    fn attempt(
+        bin: &str,
+        args: &[&str],
+        parse: fn(&str, i32) -> Result<Vec<AudioInputProcess>, String>,
+        self_pid: i32,
+    ) -> Result<AudioProcessSnapshot, (bool, String)> {
+        match run_tool(bin, args) {
+            ToolResult::Output(json) => match parse(&json, self_pid) {
+                Ok(processes) => Ok(AudioProcessSnapshot {
+                    supported: true,
+                    processes,
+                    error: None,
+                }),
+                Err(e) => Err((false, e)),
+            },
+            ToolResult::Missing => Err((true, "not found".to_string())),
+            ToolResult::Failed(e) => Err((false, e)),
         }
     }
 
@@ -738,88 +761,65 @@ mod platform {
         Failed(String),
     }
 
-    fn tool_error(result: ToolResult) -> String {
-        match result {
-            ToolResult::Output(_) => "ok".to_string(),
-            ToolResult::Missing => "not found".to_string(),
-            ToolResult::Failed(e) => e,
-        }
-    }
-
     fn run_tool(bin: &str, args: &[&str]) -> ToolResult {
-        use std::io::Read;
+        use std::os::unix::process::CommandExt;
         use std::process::Stdio;
-        use std::time::Instant;
+        use std::sync::mpsc;
 
-        let mut child = match Command::new(bin)
+        // The child gets its own process group so a timeout can SIGKILL the
+        // whole tree: killing only the direct child would leave a grandchild
+        // holding the pipe fds, and the collector thread below would stay
+        // blocked on them forever.
+        let child = match Command::new(bin)
             .args(args)
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
+            .process_group(0)
             .spawn()
         {
             Ok(child) => child,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => return ToolResult::Missing,
             Err(e) => return ToolResult::Failed(format!("failed to spawn {bin}: {e}")),
         };
+        let pgid = child.id() as i32;
 
-        // Drain stdout on a thread so a large dump can't deadlock the pipe
-        // while we poll for exit below.
-        let mut stdout = child.stdout.take().expect("stdout piped above");
-        let reader = std::thread::spawn(move || {
-            let mut buf = String::new();
-            let _ = stdout.read_to_string(&mut buf);
-            buf
+        // wait_with_output drains stdout AND stderr concurrently and reaps the
+        // child, so neither a large dump nor a chatty failure can deadlock the
+        // pipes. It runs on its own thread so this (synchronous, poll-path)
+        // caller can bound it with a channel timeout.
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(child.wait_with_output());
         });
 
-        let deadline = Instant::now() + TOOL_TIMEOUT;
-        let status = loop {
-            match child.try_wait() {
-                Ok(Some(status)) => break status,
-                Ok(None) if Instant::now() >= deadline => {
-                    let _ = child.kill();
-                    let _ = child.wait(); // reap; no zombie
-                    return ToolResult::Failed(format!(
-                        "{bin} timed out after {}s",
-                        TOOL_TIMEOUT.as_secs()
-                    ));
-                }
-                Ok(None) => std::thread::sleep(std::time::Duration::from_millis(20)),
-                Err(e) => {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    return ToolResult::Failed(format!("failed to wait on {bin}: {e}"));
-                }
+        let output = match rx.recv_timeout(TOOL_TIMEOUT) {
+            Ok(result) => result,
+            Err(_) => {
+                // SAFETY: plain kill(2) on the process group we created above;
+                // no memory safety concerns. Negative pid = whole group.
+                unsafe { libc::kill(-pgid, libc::SIGKILL) };
+                // The group is gone, so the pipes close and the collector
+                // thread finishes promptly — join it via the channel to avoid
+                // leaking a thread per timeout on this long-lived poll loop.
+                let _ = rx.recv_timeout(TOOL_TIMEOUT);
+                return ToolResult::Failed(format!(
+                    "{bin} timed out after {}s",
+                    TOOL_TIMEOUT.as_secs()
+                ));
             }
         };
 
-        let stdout = reader.join().unwrap_or_default();
-        if status.success() {
-            ToolResult::Output(stdout)
-        } else {
-            let mut stderr_buf = String::new();
-            if let Some(mut stderr) = child.stderr.take() {
-                let _ = stderr.read_to_string(&mut stderr_buf);
+        match output {
+            Ok(out) if out.status.success() => {
+                ToolResult::Output(String::from_utf8_lossy(&out.stdout).into_owned())
             }
-            ToolResult::Failed(format!(
-                "{bin} exited with {status}: {}",
-                stderr_buf.trim()
-            ))
-        }
-    }
-
-    fn snapshot_from(parsed: Result<Vec<AudioInputProcess>, String>) -> AudioProcessSnapshot {
-        match parsed {
-            Ok(processes) => AudioProcessSnapshot {
-                supported: true,
-                processes,
-                error: None,
-            },
-            Err(error) => AudioProcessSnapshot {
-                supported: true,
-                processes: Vec::new(),
-                error: Some(error),
-            },
+            Ok(out) => ToolResult::Failed(format!(
+                "{bin} exited with {}: {}",
+                out.status,
+                String::from_utf8_lossy(&out.stderr).trim()
+            )),
+            Err(e) => ToolResult::Failed(format!("failed to wait on {bin}: {e}")),
         }
     }
 

--- a/crates/screenpipe-audio/src/meeting_processes.rs
+++ b/crates/screenpipe-audio/src/meeting_processes.rs
@@ -684,7 +684,364 @@ mod platform {
     }
 }
 
-#[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+#[cfg(target_os = "linux")]
+mod platform {
+    //! Linux collector: PipeWire capture-stream clients via `pw-dump`, with a
+    //! `pactl` (PulseAudio / pipewire-pulse) fallback.
+    //!
+    //! Both tools emit JSON over a one-shot subprocess, so this stays
+    //! compositor- and distro-agnostic: any system running PipeWire (or plain
+    //! PulseAudio for the fallback) reports the same shape regardless of
+    //! Wayland/X11 or desktop environment. Graph-internal nodes (filter
+    //! chains, loopbacks) carry no `application.process.id` and are dropped —
+    //! only real client processes count as meeting evidence.
+    use super::{is_screenpipe_process, AudioInputProcess, AudioProcessSnapshot};
+    use std::collections::HashSet;
+    use std::process::Command;
+    use tracing::debug;
+
+    /// Upper bound on a snapshot subprocess. The collector runs synchronously
+    /// on the detector's poll path, so a wedged audio service must not be able
+    /// to stall meeting detection (or shutdown) behind a child that never
+    /// exits.
+    const TOOL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
+
+    pub fn current_input_processes() -> AudioProcessSnapshot {
+        let self_pid = std::process::id() as i32;
+        // pw-dump can be installed but failing (e.g. PipeWire not running on a
+        // plain PulseAudio system), so pactl is the fallback for BOTH the
+        // missing and the failed case, and both errors are preserved when
+        // neither tool produces a snapshot.
+        let pw = run_tool("pw-dump", &[]);
+        if let ToolResult::Output(json) = pw {
+            return snapshot_from(parse_pw_dump(&json, self_pid));
+        }
+        let pactl = run_tool("pactl", &["--format=json", "list", "source-outputs"]);
+        match (pw, pactl) {
+            (_, ToolResult::Output(json)) => {
+                snapshot_from(parse_pactl_source_outputs(&json, self_pid))
+            }
+            (ToolResult::Missing, ToolResult::Missing) => {
+                AudioProcessSnapshot::unsupported("linux (neither pw-dump nor pactl found)")
+            }
+            (pw, pactl) => failed_snapshot(&format!(
+                "pw-dump: {}; pactl: {}",
+                tool_error(pw),
+                tool_error(pactl)
+            )),
+        }
+    }
+
+    enum ToolResult {
+        Output(String),
+        Missing,
+        Failed(String),
+    }
+
+    fn tool_error(result: ToolResult) -> String {
+        match result {
+            ToolResult::Output(_) => "ok".to_string(),
+            ToolResult::Missing => "not found".to_string(),
+            ToolResult::Failed(e) => e,
+        }
+    }
+
+    fn run_tool(bin: &str, args: &[&str]) -> ToolResult {
+        use std::io::Read;
+        use std::process::Stdio;
+        use std::time::Instant;
+
+        let mut child = match Command::new(bin)
+            .args(args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+        {
+            Ok(child) => child,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return ToolResult::Missing,
+            Err(e) => return ToolResult::Failed(format!("failed to spawn {bin}: {e}")),
+        };
+
+        // Drain stdout on a thread so a large dump can't deadlock the pipe
+        // while we poll for exit below.
+        let mut stdout = child.stdout.take().expect("stdout piped above");
+        let reader = std::thread::spawn(move || {
+            let mut buf = String::new();
+            let _ = stdout.read_to_string(&mut buf);
+            buf
+        });
+
+        let deadline = Instant::now() + TOOL_TIMEOUT;
+        let status = loop {
+            match child.try_wait() {
+                Ok(Some(status)) => break status,
+                Ok(None) if Instant::now() >= deadline => {
+                    let _ = child.kill();
+                    let _ = child.wait(); // reap; no zombie
+                    return ToolResult::Failed(format!(
+                        "{bin} timed out after {}s",
+                        TOOL_TIMEOUT.as_secs()
+                    ));
+                }
+                Ok(None) => std::thread::sleep(std::time::Duration::from_millis(20)),
+                Err(e) => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return ToolResult::Failed(format!("failed to wait on {bin}: {e}"));
+                }
+            }
+        };
+
+        let stdout = reader.join().unwrap_or_default();
+        if status.success() {
+            ToolResult::Output(stdout)
+        } else {
+            let mut stderr_buf = String::new();
+            if let Some(mut stderr) = child.stderr.take() {
+                let _ = stderr.read_to_string(&mut stderr_buf);
+            }
+            ToolResult::Failed(format!(
+                "{bin} exited with {status}: {}",
+                stderr_buf.trim()
+            ))
+        }
+    }
+
+    fn snapshot_from(parsed: Result<Vec<AudioInputProcess>, String>) -> AudioProcessSnapshot {
+        match parsed {
+            Ok(processes) => AudioProcessSnapshot {
+                supported: true,
+                processes,
+                error: None,
+            },
+            Err(error) => AudioProcessSnapshot {
+                supported: true,
+                processes: Vec::new(),
+                error: Some(error),
+            },
+        }
+    }
+
+    fn failed_snapshot(error: &str) -> AudioProcessSnapshot {
+        // Parity with the Windows collector: a present-but-failing sensor is a
+        // transient runtime error, not an unsupported platform.
+        AudioProcessSnapshot {
+            supported: true,
+            processes: Vec::new(),
+            error: Some(error.to_string()),
+        }
+    }
+
+    /// `pw-dump` emits every PipeWire object; capture streams are Node objects
+    /// whose `media.class` is `Stream/Input/Audio`.
+    fn parse_pw_dump(json: &str, self_pid: i32) -> Result<Vec<AudioInputProcess>, String> {
+        let objects: serde_json::Value =
+            serde_json::from_str(json).map_err(|e| format!("pw-dump parse error: {e}"))?;
+        let objects = objects
+            .as_array()
+            .ok_or_else(|| "pw-dump output is not a JSON array".to_string())?;
+
+        let mut out = Vec::new();
+        let mut seen: HashSet<(i32, String)> = HashSet::new();
+        for obj in objects {
+            if obj["type"].as_str() != Some("PipeWire:Interface:Node") {
+                continue;
+            }
+            let props = &obj["info"]["props"];
+            if props["media.class"].as_str() != Some("Stream/Input/Audio") {
+                continue;
+            }
+            let Some(pid) = prop_i32(&props["application.process.id"]) else {
+                // Graph-internal node (filter chain, loopback): not a client.
+                debug!(
+                    "audio-process snapshot: skip pid-less capture node {:?}",
+                    props["node.name"].as_str().unwrap_or("?")
+                );
+                continue;
+            };
+            let process = AudioInputProcess {
+                // Deliberately no audio_session_id: PipeWire node names are
+                // stream labels, not stable process identity — they rotate on
+                // device switches and stream recreation, and ProcessKey would
+                // prefer them over the pid.
+                audio_session_id: None,
+                audio_object_id: obj["id"].as_u64().map(|id| id as u32),
+                pid: Some(pid),
+                bundle_id: None,
+                process_name: props["application.process.binary"].as_str().map(str::to_string),
+                owner_app_name: props["application.name"].as_str().map(str::to_string),
+                owner_bundle_id: None,
+                first_seen_at_ms: None,
+            };
+            push_deduped(&mut out, &mut seen, process, self_pid);
+        }
+        Ok(out)
+    }
+
+    /// `pactl --format=json list source-outputs`: one object per client
+    /// recording from a source, with the same PulseAudio-style property keys.
+    fn parse_pactl_source_outputs(
+        json: &str,
+        self_pid: i32,
+    ) -> Result<Vec<AudioInputProcess>, String> {
+        let objects: serde_json::Value =
+            serde_json::from_str(json).map_err(|e| format!("pactl parse error: {e}"))?;
+        let objects = objects
+            .as_array()
+            .ok_or_else(|| "pactl output is not a JSON array".to_string())?;
+
+        let mut out = Vec::new();
+        let mut seen: HashSet<(i32, String)> = HashSet::new();
+        for obj in objects {
+            let props = &obj["properties"];
+            let Some(pid) = prop_i32(&props["application.process.id"]) else {
+                continue;
+            };
+            let process = AudioInputProcess {
+                // No audio_session_id here either — pactl media.name is a
+                // stream label, same instability as PipeWire node names.
+                audio_session_id: None,
+                audio_object_id: obj["index"].as_u64().map(|id| id as u32),
+                pid: Some(pid),
+                bundle_id: None,
+                process_name: props["application.process.binary"].as_str().map(str::to_string),
+                owner_app_name: props["application.name"].as_str().map(str::to_string),
+                owner_bundle_id: None,
+                first_seen_at_ms: None,
+            };
+            push_deduped(&mut out, &mut seen, process, self_pid);
+        }
+        Ok(out)
+    }
+
+    /// Both PipeWire (number) and PulseAudio (string) spellings of a pid.
+    fn prop_i32(value: &serde_json::Value) -> Option<i32> {
+        value
+            .as_i64()
+            .map(|v| v as i32)
+            .or_else(|| value.as_str().and_then(|s| s.trim().parse().ok()))
+    }
+
+    fn push_deduped(
+        out: &mut Vec<AudioInputProcess>,
+        seen: &mut HashSet<(i32, String)>,
+        process: AudioInputProcess,
+        self_pid: i32,
+    ) {
+        if is_screenpipe_process(&process, self_pid) {
+            return;
+        }
+        let key = (
+            process.pid.unwrap_or(-1),
+            process.process_name.clone().unwrap_or_default(),
+        );
+        // The same app commonly holds several capture streams (one per device).
+        if seen.insert(key) {
+            out.push(process);
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        // Trimmed from a real `pw-dump` on PipeWire 1.4 (Arch): an rnnoise
+        // filter-chain capture node (no pid — must be dropped), screenpipe's
+        // own capture streams (must be dropped), and a teams-for-linux client.
+        const PW_DUMP_FIXTURE: &str = r#"[
+            {"id":35,"type":"PipeWire:Interface:Node","info":{"props":{
+                "media.class":"Stream/Input/Audio","node.name":"effect_input.rnnoise"}}},
+            {"id":87,"type":"PipeWire:Interface:Node","info":{"props":{
+                "media.class":"Stream/Input/Audio","node.name":"screenpipe",
+                "application.name":"screenpipe","application.process.binary":"screenpipe-app",
+                "application.process.id":1401111}}},
+            {"id":93,"type":"PipeWire:Interface:Node","info":{"props":{
+                "media.class":"Stream/Output/Audio","node.name":"spotify",
+                "application.name":"Spotify","application.process.binary":"spotify",
+                "application.process.id":4242}}},
+            {"id":210,"type":"PipeWire:Interface:Node","info":{"props":{
+                "media.class":"Stream/Input/Audio","node.name":"alsa_capture.teams-for-linux",
+                "application.name":"teams-for-linux","application.process.binary":"teams-for-linux",
+                "application.process.id":31337}}},
+            {"id":211,"type":"PipeWire:Interface:Node","info":{"props":{
+                "media.class":"Stream/Input/Audio","node.name":"alsa_capture.teams-for-linux.2",
+                "application.name":"teams-for-linux","application.process.binary":"teams-for-linux",
+                "application.process.id":31337}}}
+        ]"#;
+
+        const PACTL_FIXTURE: &str = r#"[
+            {"index":12,"properties":{
+                "media.name":"recStream","application.name":"Zoom",
+                "application.process.binary":"zoom","application.process.id":"555"}},
+            {"index":13,"properties":{
+                "media.name":"capture","application.name":"screenpipe",
+                "application.process.binary":"screenpipe-app","application.process.id":"999"}}
+        ]"#;
+
+        #[test]
+        fn pw_dump_keeps_only_client_capture_streams() {
+            let processes = parse_pw_dump(PW_DUMP_FIXTURE, 1).unwrap();
+            assert_eq!(processes.len(), 1, "{processes:?}");
+            let teams = &processes[0];
+            assert_eq!(teams.pid, Some(31337));
+            assert_eq!(teams.process_name.as_deref(), Some("teams-for-linux"));
+            assert_eq!(teams.owner_app_name.as_deref(), Some("teams-for-linux"));
+            assert_eq!(teams.audio_object_id, Some(210));
+        }
+
+        #[test]
+        fn pw_dump_drops_screenpipe_and_pidless_nodes() {
+            let processes = parse_pw_dump(PW_DUMP_FIXTURE, 1).unwrap();
+            assert!(processes
+                .iter()
+                .all(|p| p.process_name.as_deref() != Some("screenpipe-app")));
+            // The pid-less rnnoise filter-chain node must not survive, and no
+            // surviving process may carry a stream label as session identity.
+            assert!(processes.iter().all(|p| p.pid.is_some()));
+            assert!(processes.iter().all(|p| p.audio_session_id.is_none()));
+        }
+
+        #[test]
+        fn pactl_parses_string_pids_and_drops_screenpipe() {
+            let processes = parse_pactl_source_outputs(PACTL_FIXTURE, 1).unwrap();
+            assert_eq!(processes.len(), 1, "{processes:?}");
+            assert_eq!(processes[0].pid, Some(555));
+            assert_eq!(processes[0].owner_app_name.as_deref(), Some("Zoom"));
+        }
+
+        #[test]
+        fn malformed_json_is_an_error_not_a_panic() {
+            assert!(parse_pw_dump("not json", 1).is_err());
+            assert!(parse_pactl_source_outputs("{}", 1).is_err());
+        }
+
+        /// Live smoke test: the collector must return a coherent snapshot on
+        /// whatever this machine has (PipeWire, PulseAudio, or neither) and
+        /// never hang past the tool timeout.
+        #[test]
+        fn live_collector_returns_coherent_snapshot() {
+            let snapshot = super::current_input_processes();
+            if snapshot.supported {
+                // Errors and processes are exclusive: a parse/tool failure
+                // yields an error with no processes.
+                if snapshot.error.is_some() {
+                    assert!(snapshot.processes.is_empty());
+                }
+                assert!(snapshot.processes.iter().all(|p| p.pid.is_some()));
+            } else {
+                assert!(snapshot.processes.is_empty());
+                assert!(snapshot.error.is_some());
+            }
+        }
+    }
+}
+
+#[cfg(all(
+    not(target_os = "macos"),
+    not(target_os = "windows"),
+    not(target_os = "linux")
+))]
 mod platform {
     use super::AudioProcessSnapshot;
 
@@ -716,7 +1073,7 @@ mod tests {
         }
     }
 
-    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
     #[test]
     fn unsupported_platform_stub_reports_no_processes() {
         let snapshot = current_input_processes();

--- a/crates/screenpipe-engine/src/meeting_watcher/audio_process/resolve.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/audio_process/resolve.rs
@@ -536,7 +536,16 @@ pub(crate) fn known_native_bundle_platform(field_lower: &str) -> Option<&'static
     // Signal is kept here (not gated) because its Electron AX tree is opaque
     // — we can't distinguish calls from voice notes, so requires_call_signal
     // is false and it doesn't need a profile index for the gate (#4776).
-    if field_lower.contains("signal") {
+    // Matched by explicit bundle/app/exe forms rather than a bare `contains`:
+    // the Linux collector reports the process binary `signal-desktop` with no
+    // bundle ids, so a substring match would resolve it here and the
+    // voice-note bundle gate would fail open — every Linux voice note would
+    // start a phantom meeting. Until Linux has a discriminating signal, that
+    // binary must fall through unresolved (fail closed).
+    if field_lower.starts_with("org.whispersystems")
+        || field_lower == "signal"
+        || field_lower == "signal.exe"
+    {
         return Some("Signal");
     }
     // WhatsApp and Telegram are intentionally NOT matched here. They must

--- a/crates/screenpipe-engine/src/meeting_watcher/audio_process/resolve.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/audio_process/resolve.rs
@@ -578,8 +578,30 @@ pub(crate) fn browser_app_name(process: &AudioInputProcess) -> Option<String> {
         }
     }
 
+    // Electron apps on Linux surface PipeWire streams as
+    // `application.name = "Chromium"`/"Chromium input" while
+    // `application.process.binary` names the real app (e.g. teams-for-linux).
+    // The binary is ground truth there: when it exists and is not itself a
+    // browser, the generic Chromium owner name must not classify the stream
+    // as a browser — that would trap native Electron call apps in the
+    // unresolved-browser state forever.
+    // cfg-gated: the masquerade shape is a PipeWire artifact; macOS/Windows
+    // identity fields must keep their existing classification unchanged.
+    let owner_is_electron_masquerade = cfg!(target_os = "linux")
+        && process
+            .owner_app_name
+            .as_deref()
+            .map(is_electron_chromium_masquerade)
+            .unwrap_or(false)
+        && process
+            .process_name
+            .as_deref()
+            .is_some_and(|binary| !is_browser_app(binary));
+
     [
-        process.owner_app_name.as_deref(),
+        (!owner_is_electron_masquerade)
+            .then_some(process.owner_app_name.as_deref())
+            .flatten(),
         process.process_name.as_deref(),
         process.bundle_id.as_deref(),
     ]
@@ -587,6 +609,17 @@ pub(crate) fn browser_app_name(process: &AudioInputProcess) -> Option<String> {
     .flatten()
     .find(|name| is_browser_app(name))
     .map(normalize_browser_display_name)
+}
+
+/// PipeWire identity Electron's Chromium engine reports for ALL Electron
+/// apps: exactly "Chromium" or "Chromium input"/"Chromium output". A real
+/// Chromium browser still classifies as a browser through its process
+/// binary ("chromium"), which `browser_app_name` consults separately.
+pub(crate) fn is_electron_chromium_masquerade(owner_app_name: &str) -> bool {
+    let owner = owner_app_name.trim();
+    owner.eq_ignore_ascii_case("chromium")
+        || owner.eq_ignore_ascii_case("chromium input")
+        || owner.eq_ignore_ascii_case("chromium output")
 }
 
 pub(crate) fn browser_name_for_bundle(bundle: &str) -> Option<&'static str> {

--- a/crates/screenpipe-engine/src/meeting_watcher/audio_process/resolve.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/audio_process/resolve.rs
@@ -449,23 +449,31 @@ pub(crate) fn resolve_native_platform(
     }
 
     for (idx, profile) in profiles.iter().enumerate() {
-        // Match against every platform's name list: identity fields are macOS
-        // bundle ids/app names on macOS, Windows exe names (e.g.
-        // "whatsapp.exe") on Windows, and PipeWire process binaries (e.g.
-        // "teams-for-linux") on Linux, so a profile with only one platform's
-        // list populated would otherwise never resolve elsewhere once it's not
-        // also in `known_native_bundle_platform` (#4998 review).
-        let matches = profile
+        // macOS/Windows: match against both platforms' name lists — identity
+        // fields are macOS bundle ids/app names on macOS and Windows exe names
+        // (e.g. "whatsapp.exe") on Windows, so a profile with only
+        // `macos_app_names` populated (WhatsApp, Telegram, ...) would
+        // otherwise never resolve on Windows once it's not also in
+        // `known_native_bundle_platform` (#4998 review).
+        #[cfg(not(target_os = "linux"))]
+        let mut platform_names = profile
             .app_identifiers
             .macos_app_names
             .iter()
-            .chain(profile.app_identifiers.windows_process_names.iter())
-            .chain(profile.app_identifiers.linux_process_names.iter())
-            .any(|name| {
-                fields
-                    .iter()
-                    .any(|field| field.eq_ignore_ascii_case(name) || field == &name.to_lowercase())
-            });
+            .chain(profile.app_identifiers.windows_process_names.iter());
+        // Linux: match ONLY linux_process_names. The collector also reports a
+        // human-readable app name (PipeWire `application.name`) that often
+        // equals the macOS app name (e.g. "Signal", "Telegram"), so chaining
+        // the other platforms' lists here would defeat a deliberately empty
+        // Linux list — Signal and Telegram must fail closed on Linux because
+        // the call-signal scanner that gates their voice notes is a stub.
+        #[cfg(target_os = "linux")]
+        let mut platform_names = profile.app_identifiers.linux_process_names.iter();
+        let matches = platform_names.any(|name| {
+            fields
+                .iter()
+                .any(|field| field.eq_ignore_ascii_case(name) || field == &name.to_lowercase())
+        });
         if matches {
             return Some((platform_name_for_profile(profile, false), Some(idx)));
         }
@@ -536,16 +544,18 @@ pub(crate) fn known_native_bundle_platform(field_lower: &str) -> Option<&'static
     // Signal is kept here (not gated) because its Electron AX tree is opaque
     // — we can't distinguish calls from voice notes, so requires_call_signal
     // is false and it doesn't need a profile index for the gate (#4776).
-    // Matched by explicit bundle/app/exe forms rather than a bare `contains`:
-    // the Linux collector reports the process binary `signal-desktop` with no
-    // bundle ids, so a substring match would resolve it here and the
-    // voice-note bundle gate would fail open — every Linux voice note would
-    // start a phantom meeting. Until Linux has a discriminating signal, that
-    // binary must fall through unresolved (fail closed).
-    if field_lower.starts_with("org.whispersystems")
-        || field_lower == "signal"
-        || field_lower == "signal.exe"
-    {
+    // Matched by explicit bundle/app/exe forms rather than a bare `contains`,
+    // and the bare app-name form is compiled out on Linux: the Linux collector
+    // reports the binary `signal-desktop` and often the app name `Signal`,
+    // with no bundle ids, so either would resolve here and the voice-note
+    // bundle gate would fail open — every Linux voice note would start a
+    // phantom meeting. Until Linux has a discriminating signal, Signal must
+    // fall through unresolved there (fail closed).
+    if field_lower.starts_with("org.whispersystems") || field_lower == "signal.exe" {
+        return Some("Signal");
+    }
+    #[cfg(not(target_os = "linux"))]
+    if field_lower == "signal" {
         return Some("Signal");
     }
     // WhatsApp and Telegram are intentionally NOT matched here. They must

--- a/crates/screenpipe-engine/src/meeting_watcher/audio_process/resolve.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/audio_process/resolve.rs
@@ -449,17 +449,18 @@ pub(crate) fn resolve_native_platform(
     }
 
     for (idx, profile) in profiles.iter().enumerate() {
-        // Match against both macOS app names and Windows process names: identity
-        // fields are macOS bundle ids/app names on macOS and Windows exe names
-        // (e.g. "whatsapp.exe") on Windows, so a profile with only
-        // `macos_app_names` populated (WhatsApp, Telegram, ...) would otherwise
-        // never resolve on Windows once it's not also in
-        // `known_native_bundle_platform` (#4998 review).
+        // Match against every platform's name list: identity fields are macOS
+        // bundle ids/app names on macOS, Windows exe names (e.g.
+        // "whatsapp.exe") on Windows, and PipeWire process binaries (e.g.
+        // "teams-for-linux") on Linux, so a profile with only one platform's
+        // list populated would otherwise never resolve elsewhere once it's not
+        // also in `known_native_bundle_platform` (#4998 review).
         let matches = profile
             .app_identifiers
             .macos_app_names
             .iter()
             .chain(profile.app_identifiers.windows_process_names.iter())
+            .chain(profile.app_identifiers.linux_process_names.iter())
             .any(|name| {
                 fields
                     .iter()

--- a/crates/screenpipe-engine/src/meeting_watcher/audio_process/tests.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/audio_process/tests.rs
@@ -2186,3 +2186,54 @@ fn zoom_still_resolves_on_linux_via_known_native_arm() {
     assert!(result.is_some(), "zoom should resolve on Linux");
     assert_eq!(result.unwrap().0, "Zoom");
 }
+
+#[cfg(target_os = "linux")]
+#[test]
+fn electron_chromium_masquerade_resolves_native_not_browser() {
+    // Real-world PipeWire identity for teams-for-linux (observed live):
+    // application.name = "Chromium input", application.process.binary =
+    // "teams-for-linux". The generic Chromium owner name must not classify
+    // the stream as a browser — the binary is ground truth and must reach
+    // linux_process_names matching.
+    let profiles = load_detection_profiles();
+    let process = linux_process("teams-for-linux", "Chromium input");
+    assert_eq!(browser_app_name(&process), None);
+    let candidate = resolve_process_candidate(
+        ProcessKey::from_process(&process).unwrap(),
+        Instant::now(),
+        &process,
+        &profiles,
+        &[],
+        &[],
+        &[],
+    );
+    assert!(
+        matches!(
+            candidate,
+            ResolvedMeetingCandidate::Native { ref platform, .. } if platform == "Microsoft Teams"
+        ),
+        "expected Native Microsoft Teams, got {candidate:?}"
+    );
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn real_chromium_browser_still_classifies_as_browser_on_linux() {
+    // A genuine Chromium browser's binary is itself a browser name, so the
+    // masquerade gate must not fire and the stream stays on the browser
+    // (fail-closed, evidence-gated) path.
+    let process = linux_process("chromium", "Chromium");
+    assert!(browser_app_name(&process).is_some());
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn electron_masquerade_signal_still_fails_closed_on_linux() {
+    // Signal is also Electron and also masquerades as Chromium. Bypassing
+    // the browser gate must NOT open a resolution path for it: voice notes
+    // hold the mic exactly like a call and must stay fail-closed.
+    let profiles = load_detection_profiles();
+    let process = linux_process("signal-desktop", "Chromium input");
+    assert_eq!(browser_app_name(&process), None);
+    assert_eq!(resolve_native_platform(&process, &profiles), None);
+}

--- a/crates/screenpipe-engine/src/meeting_watcher/audio_process/tests.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/audio_process/tests.rs
@@ -1320,6 +1320,9 @@ fn unicode_ltr_mark_stripped_from_whatsapp_identity() {
     );
 }
 
+// Cross-platform name-list matching is macOS/Windows-only; on Linux the
+// profile loop consults linux_process_names alone (fail closed for gated apps).
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 #[test]
 fn whatsapp_resolves_to_native_with_profile_index() {
     // WhatsApp must fall through `known_native_bundle_platform` and match via
@@ -1405,6 +1408,9 @@ fn signal_call_passes_renderer_gate() {
     );
 }
 
+// Cross-platform name-list matching is macOS/Windows-only; on Linux the
+// profile loop consults linux_process_names alone (fail closed for gated apps).
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 #[test]
 fn telegram_resolves_to_native_with_profile_index() {
     let profiles = load_detection_profiles();
@@ -1458,6 +1464,9 @@ fn teams_unaffected_by_call_signal_gate() {
     assert_eq!(platform, "Microsoft Teams");
 }
 
+// Cross-platform name-list matching is macOS/Windows-only; on Linux the
+// profile loop consults linux_process_names alone (fail closed for gated apps).
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 #[test]
 fn whatsapp_without_call_signal_blocked_by_gate() {
     // Voice note scenario: WhatsApp holds the mic but no Calling_Window is
@@ -1505,6 +1514,9 @@ fn whatsapp_without_call_signal_blocked_by_gate() {
     );
 }
 
+// Cross-platform name-list matching is macOS/Windows-only; on Linux the
+// profile loop consults linux_process_names alone (fail closed for gated apps).
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 #[test]
 fn whatsapp_with_call_signal_passes_gate() {
     // Real call scenario: WhatsApp holds the mic AND Calling_Window is present.
@@ -1635,6 +1647,9 @@ fn signal_process_windows() -> AudioInputProcess {
     }
 }
 
+// Cross-platform name-list matching is macOS/Windows-only; on Linux the
+// profile loop consults linux_process_names alone (fail closed for gated apps).
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 #[test]
 fn whatsapp_resolves_to_native_on_windows_identity_shape() {
     // Windows never populates bundle_id/owner_bundle_id, so identity is
@@ -1658,6 +1673,9 @@ fn whatsapp_resolves_to_native_on_windows_identity_shape() {
     );
 }
 
+// Cross-platform name-list matching is macOS/Windows-only; on Linux the
+// profile loop consults linux_process_names alone (fail closed for gated apps).
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 #[test]
 fn telegram_resolves_to_native_on_windows_identity_shape() {
     let profiles = load_detection_profiles();
@@ -2083,4 +2101,88 @@ fn resolved_platform_identity_heals_pid_from_matching_candidate() {
         None,
         "an unresolved browser alone must not be adopted (could be any WebRTC page)"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Linux identity-shape tests: the PipeWire/PulseAudio collector reports a
+// process binary and a human-readable app name, never bundle ids. Call-first
+// apps must resolve from linux_process_names; messaging-first apps (Signal,
+// Telegram, WhatsApp) must fail CLOSED because the Linux call-signal scanner
+// is a stub and their voice notes hold the mic exactly like a call.
+// ---------------------------------------------------------------------------
+
+#[cfg(target_os = "linux")]
+fn linux_process(binary: &str, app_name: &str) -> AudioInputProcess {
+    AudioInputProcess {
+        audio_session_id: None,
+        audio_object_id: Some(210),
+        pid: Some(31337),
+        bundle_id: None,
+        process_name: Some(binary.to_string()),
+        owner_app_name: Some(app_name.to_string()),
+        owner_bundle_id: None,
+        first_seen_at_ms: None,
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn teams_for_linux_resolves_via_linux_process_names() {
+    let profiles = load_detection_profiles();
+    let process = linux_process("teams-for-linux", "teams-for-linux");
+    let result = resolve_native_platform(&process, &profiles);
+    assert!(result.is_some(), "teams-for-linux should resolve as native");
+    let (platform, _) = result.unwrap();
+    assert_eq!(platform, "Microsoft Teams");
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn signal_binary_fails_closed_on_linux() {
+    // Both the binary and the PipeWire application.name shape must fall
+    // through unresolved: with no bundle ids the .helper.Renderer voice-note
+    // gate cannot discriminate, so resolving here would start a phantom
+    // meeting for every voice note.
+    let profiles = load_detection_profiles();
+    for process in [
+        linux_process("signal-desktop", "Signal"),
+        linux_process("signal-desktop", "signal"),
+    ] {
+        assert_eq!(
+            resolve_native_platform(&process, &profiles),
+            None,
+            "Signal must fail closed on Linux: {process:?}"
+        );
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn messaging_first_app_names_fail_closed_on_linux() {
+    // The macOS app-name lists ("whatsapp", "telegram") must NOT be consulted
+    // for Linux identity fields — PipeWire's application.name often equals the
+    // macOS app name, which would defeat the empty linux_process_names.
+    let profiles = load_detection_profiles();
+    for process in [
+        linux_process("telegram-desktop", "Telegram"),
+        linux_process("whatsapp-for-linux", "WhatsApp"),
+    ] {
+        assert_eq!(
+            resolve_native_platform(&process, &profiles),
+            None,
+            "messaging-first app must fail closed on Linux: {process:?}"
+        );
+    }
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn zoom_still_resolves_on_linux_via_known_native_arm() {
+    // Call-first apps keep the fail-open path: bare "zoom" stays in
+    // known_native_bundle_platform on every platform.
+    let profiles = load_detection_profiles();
+    let process = linux_process("zoom", "Zoom");
+    let result = resolve_native_platform(&process, &profiles);
+    assert!(result.is_some(), "zoom should resolve on Linux");
+    assert_eq!(result.unwrap().0, "Zoom");
 }

--- a/crates/screenpipe-engine/src/meeting_watcher/mod.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/mod.rs
@@ -82,9 +82,14 @@ enum MeetingDetectorMode {
 fn selected_detector_mode() -> MeetingDetectorMode {
     // AudioProcess (mic-capture sensor) is the default on every platform where
     // `meeting_processes::current_input_processes()` is implemented: macOS
-    // (CoreAudio) and Windows (WASAPI). Linux has no sensor yet, so it falls
-    // back to UI scanning. Override on any platform with SCREENPIPE_MEETING_DETECTOR.
-    let audio_process_is_default = cfg!(target_os = "macos") || cfg!(target_os = "windows");
+    // (CoreAudio), Windows (WASAPI), and Linux (PipeWire/PulseAudio). On a
+    // Linux system without pw-dump or pactl the sensor reports unsupported and
+    // the detector idles; UI scanning is no loss there because its Linux
+    // backend is a stub anyway. Override on any platform with
+    // SCREENPIPE_MEETING_DETECTOR.
+    let audio_process_is_default = cfg!(target_os = "macos")
+        || cfg!(target_os = "windows")
+        || cfg!(target_os = "linux");
     selected_detector_mode_from(
         std::env::var("SCREENPIPE_MEETING_DETECTOR").ok().as_deref(),
         audio_process_is_default,
@@ -122,12 +127,13 @@ mod tests {
 
     #[test]
     fn default_detector_mode_follows_audio_process_default() {
-        // Platforms with a mic-capture sensor (macOS, Windows) default to AudioProcess.
+        // Platforms with a mic-capture sensor (macOS, Windows, Linux) default
+        // to AudioProcess.
         assert_eq!(
             selected_detector_mode_from(None, true),
             MeetingDetectorMode::AudioProcess
         );
-        // Platforms without one (e.g. Linux) default to UI scanning.
+        // Platforms without one default to UI scanning.
         assert_eq!(
             selected_detector_mode_from(None, false),
             MeetingDetectorMode::UiScan

--- a/crates/screenpipe-engine/src/meeting_watcher/shared/profiles.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/shared/profiles.rs
@@ -11,6 +11,9 @@ pub struct AppIdentifiers {
     pub macos_app_names: &'static [&'static str],
     /// Process names to match on Windows (with `.exe` suffix).
     pub windows_process_names: &'static [&'static str],
+    /// Process binary names to match on Linux (as reported by PipeWire's
+    /// `application.process.binary` / PulseAudio's equivalent property).
+    pub linux_process_names: &'static [&'static str],
     /// URL substrings to match in browser window titles/AXDocument.
     pub browser_url_patterns: &'static [&'static str],
     /// Page title patterns to match when the URL isn't in the window title.
@@ -117,6 +120,7 @@ pub fn load_detection_profiles() -> Vec<MeetingDetectionProfile> {
         MeetingDetectionProfile {
             app_identifiers: AppIdentifiers {
                 macos_app_names: &["microsoft teams", "teams", "msteams"],
+                linux_process_names: &["teams-for-linux", "teams"],
                 windows_process_names: &["ms-teams.exe", "teams.exe"],
                 browser_url_patterns: &["teams.microsoft.com", "teams.live.com", "Microsoft Teams"],
                 browser_title_patterns: &[],
@@ -164,6 +168,7 @@ pub fn load_detection_profiles() -> Vec<MeetingDetectionProfile> {
         MeetingDetectionProfile {
             app_identifiers: AppIdentifiers {
                 macos_app_names: &["zoom.us", "zoom"],
+                linux_process_names: &["zoom"],
                 windows_process_names: &["zoom.exe"],
                 browser_url_patterns: &[
                     "zoom.us/j",
@@ -231,6 +236,7 @@ pub fn load_detection_profiles() -> Vec<MeetingDetectionProfile> {
             app_identifiers: AppIdentifiers {
                 macos_app_names: &[],
                 windows_process_names: &[],
+                linux_process_names: &[],
                 browser_url_patterns: &["meet.google.com"],
                 // Arc and other browsers show just "Meet" as the page title
                 browser_title_patterns: &["Meet"],
@@ -255,6 +261,7 @@ pub fn load_detection_profiles() -> Vec<MeetingDetectionProfile> {
         MeetingDetectionProfile {
             app_identifiers: AppIdentifiers {
                 macos_app_names: &["slack"],
+                linux_process_names: &["slack"],
                 windows_process_names: &["slack.exe"],
                 browser_url_patterns: &["app.slack.com/huddle"],
                 browser_title_patterns: &[],
@@ -277,6 +284,7 @@ pub fn load_detection_profiles() -> Vec<MeetingDetectionProfile> {
         MeetingDetectionProfile {
             app_identifiers: AppIdentifiers {
                 macos_app_names: &["facetime"],
+                linux_process_names: &[],
                 windows_process_names: &[],
                 browser_url_patterns: &[],
                 browser_title_patterns: &[],
@@ -299,6 +307,7 @@ pub fn load_detection_profiles() -> Vec<MeetingDetectionProfile> {
         MeetingDetectionProfile {
             app_identifiers: AppIdentifiers {
                 macos_app_names: &["webex", "cisco webex meetings"],
+                linux_process_names: &[],
                 windows_process_names: &["webexmta.exe", "ciscowebex.exe"],
                 browser_url_patterns: &["webex.com"],
                 browser_title_patterns: &[],
@@ -343,6 +352,7 @@ pub fn load_detection_profiles() -> Vec<MeetingDetectionProfile> {
             app_identifiers: AppIdentifiers {
                 macos_app_names: &[],
                 windows_process_names: &[],
+                linux_process_names: &[],
                 browser_url_patterns: &["discord.com", "discordapp.com"],
                 browser_title_patterns: &[],
             },
@@ -365,6 +375,10 @@ pub fn load_detection_profiles() -> Vec<MeetingDetectionProfile> {
         MeetingDetectionProfile {
             app_identifiers: AppIdentifiers {
                 macos_app_names: &["signal"],
+                // No Linux names: Signal grabs the mic for voice notes and the
+                // Linux collector has no call-signal scanner to tell a call from
+                // a note, so listing signal-desktop would start phantom meetings.
+                linux_process_names: &[],
                 windows_process_names: &["signal.exe"],
                 browser_url_patterns: &[],
                 browser_title_patterns: &[],
@@ -414,6 +428,7 @@ pub fn load_detection_profiles() -> Vec<MeetingDetectionProfile> {
         MeetingDetectionProfile {
             app_identifiers: AppIdentifiers {
                 macos_app_names: &["whatsapp"],
+                linux_process_names: &[],
                 windows_process_names: &["whatsapp.exe"],
                 browser_url_patterns: &["web.whatsapp.com"],
                 browser_title_patterns: &[],
@@ -448,6 +463,10 @@ pub fn load_detection_profiles() -> Vec<MeetingDetectionProfile> {
         MeetingDetectionProfile {
             app_identifiers: AppIdentifiers {
                 macos_app_names: &["telegram"],
+                // No Linux names: this profile requires call-signal evidence and
+                // the Linux call-signal scanner is a stub, so telegram-desktop
+                // would resolve and then be dropped on every poll.
+                linux_process_names: &[],
                 windows_process_names: &["telegram.exe"],
                 browser_url_patterns: &["web.telegram.org"],
                 browser_title_patterns: &[],
@@ -510,6 +529,7 @@ pub fn load_detection_profiles() -> Vec<MeetingDetectionProfile> {
                     "bluejeans.exe",
                     "gotomeeting.exe",
                 ],
+                linux_process_names: &["skypeforlinux", "jitsi-meet"],
                 browser_url_patterns: &[
                     // Public Jitsi host. NOTE: a bare "jitsi" substring used to
                     // live here too, but it matched any URL containing the word

--- a/crates/screenpipe-engine/src/meeting_watcher/ui_scan/macos.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/ui_scan/macos.rs
@@ -539,6 +539,7 @@ pub(crate) fn discord_profile() -> Option<MeetingDetectionProfile> {
         app_identifiers: AppIdentifiers {
             macos_app_names: &["discord"],
             windows_process_names: &[],
+            linux_process_names: &[],
             browser_url_patterns: &[],
             browser_title_patterns: &[],
         },

--- a/crates/screenpipe-engine/src/meeting_watcher/ui_scan/tests.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/ui_scan/tests.rs
@@ -70,6 +70,7 @@ fn zoom_test_profile() -> MeetingDetectionProfile {
             // macos_app_names are stored lowercase by convention.
             macos_app_names: &["zoom.us", "zoom"],
             windows_process_names: &["Zoom.exe"],
+            linux_process_names: &["zoom"],
             browser_url_patterns: &["zoom.us/j", "zoom.us/wc"],
             browser_title_patterns: &[],
         },

--- a/crates/screenpipe-engine/src/meeting_watcher/ui_scan/windows.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/ui_scan/windows.rs
@@ -693,6 +693,7 @@ pub(crate) fn discord_profile() -> Option<MeetingDetectionProfile> {
         app_identifiers: AppIdentifiers {
             macos_app_names: &[],
             windows_process_names: &["discord.exe"],
+            linux_process_names: &[],
             browser_url_patterns: &[],
             browser_title_patterns: &[],
         },


### PR DESCRIPTION
## description

Linux has no working meeting detection: the `ui_scan` detector's platform hook is a stub (`find_running_meeting_apps not implemented for this platform`), and window titles carry no in-call cue for apps like teams-for-linux, so every meeting must be started manually. Meanwhile the audio-process detector — the default on macOS/Windows — only lacked a Linux sensor (`selected_detector_mode` comment: "Linux has no sensor yet").

This PR implements that sensor and flips the Linux default to the audio-process detector:

- **PipeWire snapshot** (`pw-dump` JSON): capture-stream Nodes (`media.class: Stream/Input/Audio`) with an `application.process.id` become `AudioInputProcess` entries; graph-internal nodes (filter chains, loopbacks) have no pid and are dropped; screenpipe's own streams are excluded via the shared helpers; deduped per (pid, binary).
- **`pactl --format=json list source-outputs` fallback** for every unusable pw-dump outcome — missing, failing (PipeWire not running), or parse-rejected output. Neither tool present → `unsupported` snapshot (existing contract); present-but-failing → `supported` with error, matching the Windows collector.
- **Bounded subprocesses**: each tool runs in its own process group with a 3s watchdog; both pipes are drained via `wait_with_output` on a collector thread; timeout SIGKILLs the whole group so a wedged audio service can't stall the detector poll loop or leak blocked threads.
- **`AppIdentifiers::linux_process_names`**, matched platform-scoped in `resolve_native_platform`: on Linux only the Linux list is consulted (PipeWire's `application.name` often equals the macOS app name, which would otherwise defeat an intentionally empty Linux list). macOS+Windows cross-matching (#4998) unchanged.
- **Messaging-first apps fail closed on Linux**: Signal/Telegram/WhatsApp ship no Linux names and the bare `"signal"` arm of `known_native_bundle_platform` is compiled out on Linux — their voice notes hold the mic exactly like a call and the Linux call-signal scanner is a stub, so resolving them would create phantom meetings. Call-first apps (Teams, Zoom, Slack, Skype, Jitsi) resolve normally.
- No `audio_session_id` from stream labels (PipeWire `node.name` rotates across device switches; `ProcessKey` must key on pid).
- **Electron Chromium masquerade gate** (found in live e2e): Electron apps surface PipeWire streams as `application.name: "Chromium input"` while `application.process.binary` names the real app (`teams-for-linux`). The browser classifier matched the owner name and trapped the candidate in the unresolved-browser state forever. On Linux (cfg-gated), when the owner name is exactly Chromium/"Chromium input"/"Chromium output" and the binary is not itself a browser, the binary wins and the stream reaches `linux_process_names` matching. A real Chromium browser still classifies via its binary; Electron Signal still fails closed.

Works on any PipeWire distro (Arch, Fedora, Ubuntu 22.10+, Debian 12) and PulseAudio-only systems via the pactl path; no compositor dependency (tested under Hyprland/Wayland).

related issue: #

## AI assistance and human ownership

- AI tool(s) used: Claude Code (Claude Fable 5), plus OpenAI Codex CLI for five adversarial review passes
- autonomy level: `agent`
- what I personally verified: the full live e2e on my Arch/PipeWire machine — I joined and left the teams-for-linux call that the detector auto-started and auto-ended (meeting id=1, detection_source=audio_process in the dev DB), and recorded the Signal voice note for the fail-closed negative check; reviewed the four commits and this PR body; test suite runs (engine meeting_watcher 202 passed, audio crate 363 passed) executed on my machine during the same session

- [x] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [x] The problem statement, rationale, and replies to maintainers are my own.

## evidence type

- [x] Backend change — regression tests and relevant logs/results

## before

not applicable — backend change. Behavior before: on Linux `meeting v2: detection loop started` runs but `find_running_meeting_apps` is the null stub, so no meeting is ever auto-detected (all meetings in my DB are `detection_source: manual`).

## after

not applicable (backend) — evidence below.

## how to test

1. `cargo test -p screenpipe-audio --lib meeting` → `test result: ok` (363 passed across the crate; includes fixture parsers for pw-dump/pactl and a live smoke test that runs the collector against the host's real audio stack)
2. `cargo test -p screenpipe-engine meeting_watcher` → `test result: ok. 202 passed; 0 failed` (includes Linux identity-shape tests: teams-for-linux resolves, Signal/Telegram/WhatsApp fail closed, Zoom keeps resolving, plus 3 Electron-masquerade regression tests)
3. **Full e2e, personally run on Arch/PipeWire 1.4 (Hyprland/Wayland):**
   ```
   CFLAGS="-D_GNU_SOURCE" cargo build --release --bin screenpipe
   ./target/release/screenpipe record --port 3035 --data-dir /tmp/sp
   ```
   - Startup log proves flipped Linux default (no env var set): `audio-process meeting detector: loop started (profiles=11, ignored_apps=0)`
   - Joined a Teams call in teams-for-linux → `audio-process meeting detector: meeting started (id=1, app=Microsoft Teams)`, `meeting_status_changed: active=true, manual=false, source=Some("audio_process")`
   - `sqlite3 /tmp/sp/db.sqlite "SELECT id, meeting_app, detection_source, meeting_start, meeting_end FROM meetings;"` → `1|Microsoft Teams|audio_process|2026-08-05T02:02:42.779Z|2026-08-05T02:03:41.759+00:00` (end stamped ~1min after leaving the call — auto-end works)
   - Negative check: recorded a Signal voice note → no candidate logged, meeting count stayed 1 (fail-closed holds live)
4. Env override still works both ways: `SCREENPIPE_MEETING_DETECTOR=ui-scan` restores the old default on Linux.

## desktop app checklist (if applicable)

not applicable — no `#[tauri::command]` or frontend-exported types changed.


