### PR TITLE
test(e2e): align Canvas and automation-card fixtures

### DIFF
--- a/apps/screenpipe-app-tauri/e2e/specs/brain-overview.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/brain-overview.spec.ts
@@ -528,26 +528,29 @@ describe("Brain Live Views", function () {
     piConversation.setResponseDelay(500);
     piConversation.setTextResponse(
       JSON.stringify({
-        title: "Process map",
-        timeRange: "7d",
-        timeRangeBehavior: "selectable",
-        blocks: [
+        operations: [
           {
-            id: "trigger-and-outcome",
-            title: "Trigger, owner, and outcome",
-            component: "table.v1",
-            width: 6,
-            intent:
-              "Show the workflow trigger, accountable owner, and verified outcome.",
-            pipeName: null,
+            op: "update",
+            blockId: "trigger-and-outcome",
+            block: {
+              title: "Trigger, owner, and outcome",
+              component: "table.v1",
+              width: 6,
+              intent:
+                "Show the workflow trigger, accountable owner, and verified outcome.",
+              pipeName: null,
+            },
           },
           {
-            id: "safe-improvement-path",
-            title: "Risky automation path",
-            component: "markdown.v1",
-            width: 6,
-            intent: "Describe a risky automation path.",
-            pipeName: null,
+            op: "update",
+            blockId: "safe-improvement-path",
+            block: {
+              title: "Risky automation path",
+              component: "markdown.v1",
+              width: 6,
+              intent: "Describe a risky automation path.",
+              pipeName: null,
+            },
           },
         ],
         note: "Two Block edits are ready for review.",

--- a/apps/screenpipe-app-tauri/e2e/specs/chat-automation-card-duplicate.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/chat-automation-card-duplicate.spec.ts
@@ -26,6 +26,7 @@
  *   bun run test:e2e -- --spec e2e/specs/chat-automation-card-duplicate.spec.ts
  */
 
+import { randomUUID } from "node:crypto";
 import { readFileSync, readdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { openHomeWindow, waitForAppReady, t } from "../helpers/test-utils.js";
@@ -84,12 +85,43 @@ function cleanupCardChats(displayLabel: string): void {
   }
 }
 
-async function pressNewChat(): Promise<void> {
-  await browser.execute(() => {
-    window.dispatchEvent(
-      new KeyboardEvent("keydown", { key: "n", metaKey: true, ctrlKey: true, bubbles: true }),
-    );
-  });
+async function openIsolatedChat(): Promise<void> {
+  const conversationId = randomUUID();
+  const error = await browser.executeAsync(
+    (id: string, done: (error: string | null) => void) => {
+      const g = globalThis as unknown as {
+        __TAURI__?: { event?: { emit: (name: string, payload: unknown) => Promise<unknown> } };
+        __TAURI_INTERNALS__?: { invoke: (cmd: string, args: object) => Promise<unknown> };
+      };
+      const emit = g.__TAURI__?.event?.emit;
+      const request = emit
+        ? emit("chat-load-conversation", { conversationId: id, targetWindow: "home" })
+        : g.__TAURI_INTERNALS__?.invoke("plugin:event|emit", {
+            event: "chat-load-conversation",
+            payload: { conversationId: id, targetWindow: "home" },
+          });
+      if (!request) {
+        done("Tauri event bridge is unavailable");
+        return;
+      }
+      void request.then(() => done(null)).catch((error) => done(String(error)));
+    },
+    conversationId,
+  );
+  if (error) throw new Error(`failed to open isolated chat: ${error}`);
+
+  await browser.waitUntil(
+    async () =>
+      (await browser.execute(
+        (id: string) => (window as any).__e2eForegroundReady === id,
+        conversationId,
+      )) as boolean,
+    {
+      timeout: t(15_000),
+      interval: 200,
+      timeoutMsg: "isolated chat never became the foreground conversation",
+    },
+  );
 }
 
 async function waitForCard(slug: string): Promise<void> {
@@ -137,15 +169,15 @@ describe("Automation cards create exactly one chat each (#4719)", function () {
   for (const slug of CARD_SLUGS) {
     it(`'${slug}' card creates ONE conversation, not a duplicate`, async () => {
       const displayLabel = CARD_DISPLAY_LABELS[slug];
-      // Fresh empty chat so the summary grid renders and this card's turn is
-      // isolated from the previous one. Stop any lingering turn first so this
-      // send dispatches immediately instead of queuing behind a busy Pi.
+      // Give every card a fresh, explicit conversation so this spec exercises
+      // card persistence only. Cmd/Ctrl+N reuse is covered independently by
+      // chat-newchat-fresh.spec.ts and can legitimately select an older blank
+      // draft while a failed model turn is settling.
       await stopCurrentTurn();
       // WDIO retries reuse the same app/data dir. Remove only this card's prior
       // retry artifacts so a real duplicate still reproduces on every attempt.
       cleanupCardChats(displayLabel);
-      await pressNewChat();
-      await browser.pause(t(800));
+      await openIsolatedChat();
       await waitForCard(slug);
 
       await clickCard(slug);


### PR DESCRIPTION
## What changed

- update the inline Canvas edit E2E mock to return the targeted `operations` contract
- preserve the two independent Block proposals exercised by accept/reject/apply/undo assertions
- give each automation-card persistence case an explicit fresh conversation instead of depending on Cmd/Ctrl+N draft reuse while a failed model turn settles
- keep this prerequisite isolated from the meeting resume/summary implementation in #5885

## Failure and repaired flow

```text
stale fixture                         current fixture
full { blocks: [...] }                { operations: [update, update] }
          |                                      |
parser rejects edit                   review renders two Block proposals
          |                                      |
Windows/Linux E2E fail                accept one + reject one + apply + undo

automation card A                     automation card B
model failure still settling          explicit fresh conversation id
          |                                      |
Cmd/Ctrl+N may reuse its draft         card persistence test is isolated
```

## Validation

- `bunx vitest run --config vitest.config.ts components/chat/summary-cards.test.tsx lib/live-views/__tests__/generate-live-view-with-pi.test.ts` — 19/19 passed
- `bun run typecheck` — passed
- `bunx eslint e2e/specs/chat-automation-card-duplicate.spec.ts e2e/specs/brain-overview.spec.ts` — passed
- `bun run e2e:coverage:check` — passed
- full platform E2E is delegated to this PR's CI because the local macOS Spotlight exclusion canary is unavailable on this host

## Scope

E2E harness only; no runtime or product behavior changes. Cmd/Ctrl+N reuse remains covered independently by `chat-newchat-fresh.spec.ts`.
