### PR TITLE
fix(engine): remove unused direct hyper dependency

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -32,15 +32,15 @@ results and `cargo llvm-cov` data on top when judging release confidence.
 
 - Mapped suites: 32
 - Mapped Rust files: 310
-- Active test blocks: 2915
+- Active test blocks: 2916
 - Ignored/manual test blocks: 134
-- Weighted coverage points: 2396.1
+- Weighted coverage points: 2396.8
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 2787 | 129 | 2337.3 | 21 | 11 | 100% |
-| macos | 29 | 2838 | 109 | 2347.2 | 22 | 11 | 100% |
-| linux | 25 | 2476 | 102 | 2056.2 | 20 | 11 | 100% |
+| windows | 29 | 2788 | 129 | 2338.0 | 21 | 11 | 100% |
+| macos | 29 | 2839 | 109 | 2347.9 | 22 | 11 | 100% |
+| linux | 25 | 2477 | 102 | 2056.9 | 20 | 11 | 100% |
 
 ## Refresh
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8619,7 +8619,6 @@ dependencies = [
  "futures",
  "hostname",
  "http-body-util",
- "hyper",
  "hyper-util",
  "image",
  "libc",

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -11517,7 +11517,6 @@ dependencies = [
  "futures",
  "hostname",
  "http-body-util",
- "hyper 1.8.1",
  "hyper-util",
  "image 0.25.10",
  "libc",

--- a/crates/screenpipe-engine/Cargo.toml
+++ b/crates/screenpipe-engine/Cargo.toml
@@ -55,7 +55,6 @@ sentry = { workspace = true }
 # Server
 axum = { workspace = true }
 http-body-util = "0.1"
-hyper = "1"
 hyper-util = { version = "0.1", features = ["server-auto", "tokio", "service"] }
 tower = { version = "0.4", default-features = false }
 tokio = { workspace = true }

--- a/docs/coverage/CORE.md
+++ b/docs/coverage/CORE.md
@@ -9,10 +9,10 @@ confidence, and criticality.
 - Tracked crates: screenpipe-engine, screenpipe-db, screenpipe-sqlite-coordinator, screenpipe-audio, screenpipe-screen, screenpipe-a11y
 - Mapped suites: 32
 - Mapped Rust files: 310
-- Active test blocks: 2915
+- Active test blocks: 2916
 - Ignored/manual test blocks: 134
-- Declared test blocks: 3049
-- Weighted coverage points: 2396.1
+- Declared test blocks: 3050
+- Weighted coverage points: 2396.8
 
 Confidence weights: strong=1.0, partial=0.7, conditional=0.4, smoke=0.3.
 Criticality weights: high=1.0, medium=0.7, low=0.4.
@@ -23,15 +23,15 @@ are explicitly enabled in a runtime lane.
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 2787 | 129 | 2337.3 | 21 | 11 | 100% |
-| macos | 29 | 2838 | 109 | 2347.2 | 22 | 11 | 100% |
-| linux | 25 | 2476 | 102 | 2056.2 | 20 | 11 | 100% |
+| windows | 29 | 2788 | 129 | 2338.0 | 21 | 11 | 100% |
+| macos | 29 | 2839 | 109 | 2347.9 | 22 | 11 | 100% |
+| linux | 25 | 2477 | 102 | 2056.9 | 20 | 11 | 100% |
 
 ## Crate Summary
 
 | Crate | Suites | Integration files | Source unit files | Active tests | Ignored tests | Weighted points | Flows |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| screenpipe-engine | 10 | 18 | 100 | 1396 | 42 | 1072.5 | 10 |
+| screenpipe-engine | 10 | 18 | 100 | 1397 | 42 | 1073.2 | 10 |
 | screenpipe-db | 5 | 49 | 14 | 415 | 16 | 394.7 | 9 |
 | screenpipe-sqlite-coordinator | 1 | 0 | 2 | 11 | 0 | 11.0 | 2 |
 | screenpipe-audio | 6 | 23 | 47 | 529 | 40 | 458.1 | 5 |
@@ -68,8 +68,8 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | database | 6 suites / 333 active / 12 ignored / 312.7 pts | 6 suites / 333 active / 12 ignored / 312.7 pts | 6 suites / 333 active / 12 ignored / 312.7 pts |
 | db-search | 2 suites / 105 active / 9 ignored / 105.0 pts | 2 suites / 105 active / 9 ignored / 105.0 pts | 2 suites / 105 active / 9 ignored / 105.0 pts |
 | engine-lifecycle | 6 suites / 204 active / 1 ignored / 179.3 pts | 6 suites / 204 active / 1 ignored / 179.3 pts | 5 suites / 198 active / 1 ignored / 177.6 pts |
-| local-api | 2 suites / 297 active / 9 ignored / 209.1 pts | 2 suites / 297 active / 9 ignored / 209.1 pts | 2 suites / 297 active / 9 ignored / 209.1 pts |
-| meeting | 6 suites / 1317 active / 16 ignored / 1070.4 pts | 6 suites / 1317 active / 16 ignored / 1070.4 pts | 4 suites / 1041 active / 12 ignored / 816.3 pts |
+| local-api | 2 suites / 298 active / 9 ignored / 209.8 pts | 2 suites / 298 active / 9 ignored / 209.8 pts | 2 suites / 298 active / 9 ignored / 209.8 pts |
+| meeting | 6 suites / 1318 active / 16 ignored / 1071.1 pts | 6 suites / 1318 active / 16 ignored / 1071.1 pts | 4 suites / 1042 active / 12 ignored / 817.0 pts |
 | ocr | 4 suites / 120 active / 7 ignored / 114.3 pts | 4 suites / 124 active / 7 ignored / 119.8 pts | 3 suites / 115 active / 6 ignored / 110.8 pts |
 | os-integration | 1 suites / 6 active / 0 ignored / 1.7 pts | 1 suites / 6 active / 0 ignored / 1.7 pts | - |
 | performance | 13 suites / 1325 active / 67 ignored / 1171.3 pts | 14 suites / 1420 active / 70 ignored / 1209.3 pts | 13 suites / 1325 active / 67 ignored / 1171.3 pts |
@@ -79,8 +79,8 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | speaker | 2 suites / 292 active / 5 ignored / 292.0 pts | 2 suites / 292 active / 5 ignored / 292.0 pts | 2 suites / 292 active / 5 ignored / 292.0 pts |
 | storage | 3 suites / 454 active / 29 ignored / 368.2 pts | 3 suites / 454 active / 29 ignored / 368.2 pts | 3 suites / 454 active / 29 ignored / 368.2 pts |
 | sync | 1 suites / 456 active / 3 ignored / 319.2 pts | 1 suites / 456 active / 3 ignored / 319.2 pts | 1 suites / 456 active / 3 ignored / 319.2 pts |
-| timeline | 4 suites / 885 active / 33 ignored / 723.0 pts | 4 suites / 885 active / 33 ignored / 723.0 pts | 4 suites / 885 active / 33 ignored / 723.0 pts |
-| transcription | 5 suites / 624 active / 37 ignored / 487.1 pts | 5 suites / 624 active / 37 ignored / 487.1 pts | 5 suites / 624 active / 37 ignored / 487.1 pts |
+| timeline | 4 suites / 886 active / 33 ignored / 723.7 pts | 4 suites / 886 active / 33 ignored / 723.7 pts | 4 suites / 886 active / 33 ignored / 723.7 pts |
+| transcription | 5 suites / 625 active / 37 ignored / 487.8 pts | 5 suites / 625 active / 37 ignored / 487.8 pts | 5 suites / 625 active / 37 ignored / 487.8 pts |
 | ui-events | 4 suites / 691 active / 28 ignored / 527.6 pts | 3 suites / 643 active / 5 ignored / 494.0 pts | 3 suites / 643 active / 5 ignored / 494.0 pts |
 | vision-capture | 5 suites / 472 active / 32 ignored / 377.4 pts | 5 suites / 476 active / 32 ignored / 382.9 pts | 4 suites / 467 active / 31 ignored / 373.9 pts |
 
@@ -133,7 +133,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | db-runtime-reliability | screenpipe-db | windows, macos, linux | database, performance | performance-liveness | high | partial | mixed | 12 | 27 | 6 | SQLite hard-fault classification, failpoint VFS injection, fresh-identity recovery verification with integrity/FK/write canaries, query cancellation, close-severs-connections regressions, multi-pool WAL parity, runtime version pinning, and WAL chaos plus memory-pressure probes. |
 | db-search-indexing | screenpipe-db | windows, macos, linux | db-search, ocr, accessibility, performance | local-api-search, capture-ocr-pipeline, accessibility-ui-events, performance-liveness | high | strong | mixed | 13 | 101 | 4 | FTS, tokenizer, OCR snapshot search, query planning, ordering, accessibility search, and contention coverage. |
 | db-timeline-frames | screenpipe-db | windows, macos, linux | database, timeline, storage, performance | timeline-streaming, performance-liveness | high | strong | mixed | 17 | 168 | 3 | Frame/audio joins, timeline query shape, suggestions frames, write queue, DB primitives (src/db.rs split into src/db/ modules), feedback record upserts, media eviction anti-join regressions, SAF output registry, semantic storage, and timeline performance. |
-| engine-api-routes | screenpipe-engine | windows, macos, linux | local-api, timeline, meeting, transcription | local-api-search, timeline-streaming, meeting-live-notes, audio-record-transcribe | high | partial | mixed | 29 | 293 | 4 | Route/unit coverage for search, health, streaming, meetings, time/timezone, and transcription. Legacy endpoint/websocket tests require local data and remain ignored. |
+| engine-api-routes | screenpipe-engine | windows, macos, linux | local-api, timeline, meeting, transcription | local-api-search, timeline-streaming, meeting-live-notes, audio-record-transcribe | high | partial | mixed | 29 | 294 | 4 | Route/unit coverage for search, health, streaming, meetings, time/timezone, and transcription. Legacy endpoint/websocket tests require local data and remain ignored. |
 | engine-capture-timeline | screenpipe-engine | windows, macos, linux | vision-capture, timeline, storage, performance | capture-ocr-pipeline, timeline-streaming, performance-liveness | high | partial | mixed | 23 | 247 | 26 | Covers capture trigger logic, frame/audio linking, hot cache, timeline refresh regressions, fragmented MP4 extraction, and HD-mode control. Several real-data tests are intentionally ignored by default. |
 | engine-config-lifecycle | screenpipe-engine | windows, macos, linux | configuration, engine-lifecycle, performance | settings-to-engine-config, engine-health-lifecycle, performance-liveness | high | strong | mixed | 11 | 111 | 1 | Fast logic coverage for the config bridge, tray health debounce, sleep/power policies, and queue backpressure. |
 | engine-db-recovery-cli | screenpipe-engine | windows, macos, linux | database, engine-lifecycle | engine-health-lifecycle, performance-liveness | high | strong | unit | 1 | 8 | 0 | Exact DB/WAL/SHM working-copy preservation, rollback on archive failure, and restart repair for crashes during the multi-file generation swap. |
@@ -405,7 +405,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | engine-api-routes | screenpipe-engine | src/routes/websocket.rs | source | 1 | 0 | 1 |
 | engine-config-lifecycle | screenpipe-engine | src/schedule_monitor.rs | source | 8 | 0 | 8 |
 | engine-capture-timeline | screenpipe-engine | src/semantic_worker.rs | source | 6 | 0 | 6 |
-| engine-api-routes | screenpipe-engine | src/server.rs | source | 11 | 0 | 11 |
+| engine-api-routes | screenpipe-engine | src/server.rs | source | 12 | 0 | 12 |
 | engine-config-lifecycle | screenpipe-engine | src/sleep_monitor.rs | source | 11 | 1 | 12 |
 | engine-capture-timeline | screenpipe-engine | src/snapshot_compaction.rs | source | 18 | 0 | 18 |
 | engine-meeting-privacy-sync | screenpipe-engine | src/structured_outputs.rs | source | 8 | 0 | 8 |


### PR DESCRIPTION
## Summary

- remove the unused direct `hyper` dependency introduced by #5822
- retain `hyper-util`, which owns the server connection API used by `screenpipe-engine`
- refresh both root and desktop lockfile dependency lists
- refresh generated core/unified coverage counts for the test already merged by #5892

## Why

Cargo Machete reports `screenpipe-engine -> hyper` as unused on current `main`, which makes the required Dependency & Performance Checks fail for every new PR. The server code references `hyper_util` only; `hyper` remains available transitively where `hyper-util` needs it.

The required coverage freshness check was also failing on current `main`: #5892 added one `screenpipe-engine/src/server.rs` test without regenerating the core and unified dashboards. The second commit contains that generated-only refresh, separate from the dependency repair.

## Validation

- `cargo machete`: passed, no unused dependencies
- root `cargo metadata --locked --format-version 1`: passed
- desktop `cargo metadata --locked --format-version 1`: passed
- `cargo check -p screenpipe-engine --lib`: passed
- `bun run coverage:all:check`: passed
- `git diff --check`: passed

This PR changes dependency declarations and generated coverage counts only; it does not change runtime server behavior.
