### PR TITLE
[codex] normalize settings casing

### DIFF
--- a/apps/screenpipe-app-tauri/app/(main)/settings/page.tsx
+++ b/apps/screenpipe-app-tauri/app/(main)/settings/page.tsx
@@ -333,6 +333,12 @@ function SettingsContent() {
   // (main)/layout.tsx so the sidebar width survives navigation to /home.
   return (
     <>
+      <style>{`
+        body * {
+          text-transform: none !important;
+        }
+      `}</style>
+
       {/* Drag region */}
       <div className="absolute top-0 left-0 right-0 h-8 z-10" data-tauri-drag-region />
 


### PR DESCRIPTION
## What changed

- Add one route-mounted UI style to the Settings page.
- Preserve authored casing across settings content and portaled dialogs/popovers.
- Leave the rest of the app unchanged when the Settings page unmounts.

## Why

The shared UI primitives force uppercase buttons and lowercase card/dialog titles. Settings also had local uppercase transforms, producing inconsistent casing across sections and overlays.

## User impact

Settings now preserves the casing authored in each label instead of forcing upper- or lowercase. Behavior and saved settings are unchanged.

## Visual

```text
BEFORE                              AFTER
CAPTURE & AI                        Capture & AI
CREATE PRESET                       Create Preset
background transcription backlog   Background transcription backlog
```

## Checks

- `bun run typecheck`
- `git diff --check`

## Current-main CI boundary

After rebasing onto `cf2686d16`, the full frontend/typecheck gate passes. Current `main` and this branch both fail the same unrelated Rust-maintenance gates: stale core coverage, stale Tauri `Cargo.lock`, and cargo-machete reporting `screenpipe-engine`'s `hyper` dependency. The settings diff changes one TSX file, so this PR does not bundle those base repairs.
