### PR TITLE
fix(macOS): prevent window focus and mic grant callbacks from re-enabling recording

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -818,6 +818,13 @@ async fn main() {
             tauri::WindowEvent::Focused(true) => {
                 let app = window.app_handle().clone();
                 tauri::async_runtime::spawn(async move {
+                    let capture_intended = app
+                        .try_state::<RecordingState>()
+                        .map(|s| s.capture_intended())
+                        .unwrap_or(false);
+                    if !capture_intended {
+                        return;
+                    }
                     let permission_granted =
                         permissions::check_microphone_permission().permitted();
                     let audio_devices_empty = health::get_audio_device_status().is_empty();

--- a/apps/screenpipe-app-tauri/src-tauri/src/permissions.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/permissions.rs
@@ -140,6 +140,14 @@ fn request_av_permission(app: tauri::AppHandle, media_type: nokhwa_bindings_maco
 
         let callback = move |granted: BOOL| {
             if is_audio && granted != NO {
+                let capture_intended = app_for_callback
+                    .try_state::<crate::recording::RecordingState>()
+                    .map(|s| s.capture_intended())
+                    .unwrap_or(false);
+                if !capture_intended {
+                    debug!("Microphone permission granted via AV callback — capture not intended, skipping restart");
+                    return;
+                }
                 info!(
                     "Microphone permission granted via AV callback — restarting capture for audio reinit"
                 );
@@ -201,6 +209,15 @@ const BOOT_WAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30
 #[cfg(target_os = "macos")]
 pub(crate) async fn restart_capture_on_mic_grant(app: tauri::AppHandle) {
     use tauri::Manager;
+
+    let capture_intended = app
+        .try_state::<crate::recording::RecordingState>()
+        .map(|s| s.capture_intended())
+        .unwrap_or(false);
+    if !capture_intended {
+        debug!("start_capture after mic grant: capture not intended (user disabled recording), skipping restart");
+        return;
+    }
 
     if MIC_GRANT_RESTART_IN_FLIGHT
         .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)

--- a/apps/screenpipe-app-tauri/src-tauri/src/permissions.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/permissions.rs
@@ -140,6 +140,7 @@ fn request_av_permission(app: tauri::AppHandle, media_type: nokhwa_bindings_maco
 
         let callback = move |granted: BOOL| {
             if is_audio && granted != NO {
+                use tauri::Manager;
                 let capture_intended = app_for_callback
                     .try_state::<crate::recording::RecordingState>()
                     .map(|s| s.capture_intended())


### PR DESCRIPTION
## description

Fixes an issue where unchecking "recording" in the Screenpipe menu bar temporarily stops recording, but screen capture automatically resumes seconds later (macOS screen-sharing indicator reappears).

### Root Cause
1. `WindowEvent::Focused(true)` in `main.rs` invoked `permissions::restart_capture_on_mic_grant(app)` whenever any window gained focus without checking whether recording was currently intended (`state.capture_intended()`).
2. `permissions::restart_capture_on_mic_grant` and `request_av_permission` callbacks restarted capture unconditionally, setting `capture_intended = true` and creating new ScreenCaptureKit streams.

related issue: #

## AI assistance and human ownership

- AI tool(s) used: Google Antigravity
- autonomy level: agent
- what I personally verified: Checked Rust code logic in `main.rs` and `permissions.rs`. Verified that `capture_intended()` is checked before any microphone focus recovery or AV callback triggers capture restarts.

- [x] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [x] The problem statement, rationale, and replies to maintainers are my own.

## evidence type

- [x] Backend change — regression tests and relevant logs/results

## before

Unchecking "recording" in menu bar stopped capture stream briefly, but focusing any window or receiving an AV callback re-triggered `start_capture()`.

## after

Unchecking "recording" persists `capture_intended = false`. Focus events and permission callbacks check `capture_intended()` and return early without restarting capture.

## how to test

1. Launch Screenpipe on macOS.
2. Uncheck "Recording" in the menu bar.
3. Focus and defocus windows; verify screen recording remains disabled and does not automatically re-enable.

## desktop app checklist (if applicable)

- [x] `bun run bindings:check`
- [x] `bun run typecheck`