### PR TITLE
fix(linux): clipboard copy actions silently write nothing

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -519,6 +519,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "windows-sys 0.60.2",
+ "wl-clipboard-rs",
  "x11rb",
 ]
 
@@ -9059,6 +9060,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.13.0",
+]
+
+[[package]]
 name = "phf"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15233,6 +15245,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom 8.0.0",
+ "petgraph",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17135,6 +17158,24 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix 1.1.4",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
 ]
 
 [[package]]

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
@@ -93,7 +93,9 @@ tracing-appender = "0.2.3"
 sha2 = "0.10"
 libc = "0.2"
 anyhow = "1.0.71"
-arboard = "3.4"
+# wayland-data-control: without it, Wayland sessions get the clipboard only via
+# the XWayland bridge, which depends on X11 window focus and silently drops copies.
+arboard = { version = "3.4", features = ["wayland-data-control"] }
 
 # System information
 sysinfo = "=0.29.0"

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -4309,6 +4309,71 @@ pub async fn perform_ocr_on_image(
     Ok(text)
 }
 
+/// Put text on the system clipboard.
+///
+/// On Linux there is no OS-side clipboard buffer: content is served by the
+/// process owning the selection, and arboard releases ownership as soon as the
+/// `Clipboard` instance is dropped (a 100ms clipboard-manager handover is
+/// attempted, which fails on typical Wayland setups). Creating a clipboard,
+/// setting text, and returning therefore looks successful but leaves the
+/// clipboard empty. Serve the selection from a detached thread until another
+/// application replaces it; the thread exits on the next clipboard write.
+pub(crate) fn set_clipboard_text(text: String) -> Result<(), String> {
+    #[cfg(target_os = "linux")]
+    {
+        std::thread::Builder::new()
+            .name("clipboard-owner".to_string())
+            .spawn(move || {
+                use arboard::SetExtLinux;
+                let result = arboard::Clipboard::new()
+                    .and_then(|mut clipboard| clipboard.set().wait().text(text));
+                if let Err(e) = result {
+                    error!("failed to set clipboard: {}", e);
+                }
+            })
+            .map_err(|e| format!("failed to spawn clipboard thread: {}", e))?;
+        Ok(())
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let mut clipboard =
+            arboard::Clipboard::new().map_err(|e| format!("clipboard error: {}", e))?;
+        clipboard
+            .set_text(text)
+            .map_err(|e| format!("failed to set clipboard: {}", e))?;
+        Ok(())
+    }
+}
+
+/// Put an image on the system clipboard. Same Linux ownership rules as
+/// [`set_clipboard_text`].
+pub(crate) fn set_clipboard_image(image: arboard::ImageData<'static>) -> Result<(), String> {
+    #[cfg(target_os = "linux")]
+    {
+        std::thread::Builder::new()
+            .name("clipboard-owner".to_string())
+            .spawn(move || {
+                use arboard::SetExtLinux;
+                let result = arboard::Clipboard::new()
+                    .and_then(|mut clipboard| clipboard.set().wait().image(image));
+                if let Err(e) = result {
+                    error!("failed to set clipboard image: {}", e);
+                }
+            })
+            .map_err(|e| format!("failed to spawn clipboard thread: {}", e))?;
+        Ok(())
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let mut clipboard =
+            arboard::Clipboard::new().map_err(|e| format!("clipboard error: {}", e))?;
+        clipboard
+            .set_image(image)
+            .map_err(|e| format!("failed to set clipboard: {}", e))?;
+        Ok(())
+    }
+}
+
 /// Copy a frame image to the system clipboard (native API, works in Tauri webview).
 /// Fetches the frame from the local server and uses arboard for clipboard access.
 #[tauri::command]
@@ -4331,16 +4396,11 @@ pub async fn copy_frame_to_clipboard(app: tauri::AppHandle, frame_id: i64) -> Re
         image::load_from_memory(&bytes).map_err(|e| format!("failed to decode image: {}", e))?;
     let rgba = img.to_rgba8();
 
-    let mut clipboard = arboard::Clipboard::new().map_err(|e| format!("clipboard error: {}", e))?;
-    clipboard
-        .set_image(arboard::ImageData {
-            width: rgba.width() as usize,
-            height: rgba.height() as usize,
-            bytes: std::borrow::Cow::from(rgba.into_raw()),
-        })
-        .map_err(|e| format!("failed to set clipboard: {}", e))?;
-
-    Ok(())
+    set_clipboard_image(arboard::ImageData {
+        width: rgba.width() as usize,
+        height: rgba.height() as usize,
+        bytes: std::borrow::Cow::from(rgba.into_raw()),
+    })
 }
 
 /// Copy a frame deeplink (screenpipe://frame/N) to clipboard. Native API only.
@@ -4348,11 +4408,7 @@ pub async fn copy_frame_to_clipboard(app: tauri::AppHandle, frame_id: i64) -> Re
 #[specta::specta]
 pub async fn copy_deeplink_to_clipboard(frame_id: i64) -> Result<(), String> {
     let link = format!("screenpipe://frame/{}", frame_id);
-    let mut clipboard = arboard::Clipboard::new().map_err(|e| format!("clipboard error: {}", e))?;
-    clipboard
-        .set_text(link)
-        .map_err(|e| format!("failed to set clipboard: {}", e))?;
-    Ok(())
+    set_clipboard_text(link)
 }
 
 /// Read text from the system clipboard (native API — navigator.clipboard.readText()
@@ -4371,11 +4427,7 @@ pub async fn read_clipboard_text() -> Result<String, String> {
 #[tauri::command]
 #[specta::specta]
 pub async fn copy_text_to_clipboard(text: String) -> Result<(), String> {
-    let mut clipboard = arboard::Clipboard::new().map_err(|e| format!("clipboard error: {}", e))?;
-    clipboard
-        .set_text(text)
-        .map_err(|e| format!("failed to set clipboard: {}", e))?;
-    Ok(())
+    set_clipboard_text(text)
 }
 
 /// Open a local markdown note in Obsidian (if available), then fallback to OS default app.
@@ -4664,4 +4716,38 @@ pub fn set_autostart(app_handle: tauri::AppHandle, enabled: bool) -> Result<(), 
         manager.is_enabled().unwrap_or(false)
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod clipboard_tests {
+    /// Regression test for the Linux copy-button bug: clipboard content used to
+    /// vanish as soon as the per-call `arboard::Clipboard` instance was dropped,
+    /// because on Linux the selection is hosted by the owning instance. The
+    /// helper must keep serving the selection after `set_clipboard_text` returns.
+    ///
+    /// Needs a live display server, so it cannot run in headless CI. Run locally:
+    /// `cargo test -p screenpipe-app clipboard -- --ignored`
+    #[test]
+    #[ignore = "requires a display server (X11/Wayland); run with -- --ignored"]
+    fn set_clipboard_text_persists_after_call_returns() {
+        let marker = format!("screenpipe-clipboard-test-{}", std::process::id());
+        super::set_clipboard_text(marker.clone()).expect("set clipboard");
+        // The Linux path serves the selection from a detached thread; poll until
+        // it has taken ownership rather than trusting a fixed sleep.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            let read = arboard::Clipboard::new()
+                .expect("open clipboard")
+                .get_text()
+                .unwrap_or_default();
+            if read == marker {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "clipboard still reads {read:?} after 5s, expected {marker:?}"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+    }
 }

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -4318,21 +4318,68 @@ pub async fn perform_ocr_on_image(
 /// setting text, and returning therefore looks successful but leaves the
 /// clipboard empty. Serve the selection from a detached thread until another
 /// application replaces it; the thread exits on the next clipboard write.
+/// Serializes Linux clipboard ownership handoff: rapid successive copies must
+/// acquire the selection in call order so the last command deterministically
+/// wins, and each command must not return before its worker owns the selection.
+#[cfg(target_os = "linux")]
+static CLIPBOARD_HANDOFF: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Linux ownership handoff: spawn a single owner thread that sets the
+/// selection once via `set().wait()` (serving it until another clipboard write
+/// replaces it), then block until a fresh read observes the new content — so
+/// the command never returns before an immediate paste would succeed. The set
+/// happens exactly once per command; a superseded waiter simply unblocks and
+/// exits, it can never re-acquire and resurrect a stale value.
+#[cfg(target_os = "linux")]
+fn set_clipboard_linux(
+    serve: impl FnOnce(&mut arboard::Clipboard) -> Result<(), arboard::Error> + Send + 'static,
+    confirmed: impl Fn(&mut arboard::Clipboard) -> bool,
+) -> Result<(), String> {
+    use std::sync::mpsc;
+    use std::time::{Duration, Instant};
+
+    let _guard = CLIPBOARD_HANDOFF
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    let (err_tx, err_rx) = mpsc::channel::<String>();
+    std::thread::Builder::new()
+        .name("clipboard-owner".to_string())
+        .spawn(move || {
+            let result = arboard::Clipboard::new()
+                .and_then(|mut clipboard| serve(&mut clipboard));
+            if let Err(e) = result {
+                let _ = err_tx.send(format!("failed to set clipboard: {}", e));
+            }
+        })
+        .map_err(|e| format!("failed to spawn clipboard thread: {}", e))?;
+
+    let mut reader =
+        arboard::Clipboard::new().map_err(|e| format!("clipboard error: {}", e))?;
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Ok(e) = err_rx.try_recv() {
+            return Err(e);
+        }
+        if confirmed(&mut reader) {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err("clipboard ownership handoff timed out".to_string());
+        }
+        std::thread::sleep(Duration::from_millis(5));
+    }
+}
+
 pub(crate) fn set_clipboard_text(text: String) -> Result<(), String> {
     #[cfg(target_os = "linux")]
     {
-        std::thread::Builder::new()
-            .name("clipboard-owner".to_string())
-            .spawn(move || {
-                use arboard::SetExtLinux;
-                let result = arboard::Clipboard::new()
-                    .and_then(|mut clipboard| clipboard.set().wait().text(text));
-                if let Err(e) = result {
-                    error!("failed to set clipboard: {}", e);
-                }
-            })
-            .map_err(|e| format!("failed to spawn clipboard thread: {}", e))?;
-        Ok(())
+        use arboard::SetExtLinux;
+        let expected = text.clone();
+        set_clipboard_linux(
+            move |clipboard| clipboard.set().wait().text(text),
+            move |clipboard| clipboard.get_text().is_ok_and(|read| read == expected),
+        )
     }
     #[cfg(not(target_os = "linux"))]
     {
@@ -4350,18 +4397,16 @@ pub(crate) fn set_clipboard_text(text: String) -> Result<(), String> {
 pub(crate) fn set_clipboard_image(image: arboard::ImageData<'static>) -> Result<(), String> {
     #[cfg(target_os = "linux")]
     {
-        std::thread::Builder::new()
-            .name("clipboard-owner".to_string())
-            .spawn(move || {
-                use arboard::SetExtLinux;
-                let result = arboard::Clipboard::new()
-                    .and_then(|mut clipboard| clipboard.set().wait().image(image));
-                if let Err(e) = result {
-                    error!("failed to set clipboard image: {}", e);
-                }
-            })
-            .map_err(|e| format!("failed to spawn clipboard thread: {}", e))?;
-        Ok(())
+        use arboard::SetExtLinux;
+        let expected = image.clone();
+        set_clipboard_linux(
+            move |clipboard| clipboard.set().wait().image(image),
+            move |clipboard| clipboard.get_image().is_ok_and(|read| {
+                read.width == expected.width
+                    && read.height == expected.height
+                    && read.bytes == expected.bytes
+            }),
+        )
     }
     #[cfg(not(target_os = "linux"))]
     {
@@ -4720,34 +4765,48 @@ pub fn set_autostart(app_handle: tauri::AppHandle, enabled: bool) -> Result<(), 
 
 #[cfg(test)]
 mod clipboard_tests {
-    /// Regression test for the Linux copy-button bug: clipboard content used to
-    /// vanish as soon as the per-call `arboard::Clipboard` instance was dropped,
-    /// because on Linux the selection is hosted by the owning instance. The
-    /// helper must keep serving the selection after `set_clipboard_text` returns.
-    ///
-    /// Needs a live display server, so it cannot run in headless CI. Run locally:
-    /// `cargo test -p screenpipe-app clipboard -- --ignored`
+    //! Regression tests for the Linux copy bug: clipboard content used to
+    //! vanish as soon as the per-call `arboard::Clipboard` instance was
+    //! dropped, because on Linux the selection is hosted by the owning
+    //! instance. These need a live display server, so they cannot run in
+    //! headless CI. Run locally:
+    //! `cargo test -p screenpipe-app clipboard -- --ignored`
+
+    fn read_clipboard() -> String {
+        arboard::Clipboard::new()
+            .expect("open clipboard")
+            .get_text()
+            .unwrap_or_default()
+    }
+
+    /// The command must not return before its worker owns the selection: a
+    /// paste immediately after the call returns has to see the new value.
+    /// No polling or sleeps — an ownership race fails this deterministically.
     #[test]
+    #[serial_test::serial]
     #[ignore = "requires a display server (X11/Wayland); run with -- --ignored"]
-    fn set_clipboard_text_persists_after_call_returns() {
-        let marker = format!("screenpipe-clipboard-test-{}", std::process::id());
+    fn set_clipboard_text_is_immediately_pastable() {
+        let marker = format!("screenpipe-clipboard-immediate-{}", std::process::id());
         super::set_clipboard_text(marker.clone()).expect("set clipboard");
-        // The Linux path serves the selection from a detached thread; poll until
-        // it has taken ownership rather than trusting a fixed sleep.
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
-        loop {
-            let read = arboard::Clipboard::new()
-                .expect("open clipboard")
-                .get_text()
-                .unwrap_or_default();
-            if read == marker {
-                break;
-            }
-            assert!(
-                std::time::Instant::now() < deadline,
-                "clipboard still reads {read:?} after 5s, expected {marker:?}"
-            );
-            std::thread::sleep(std::time::Duration::from_millis(100));
+        assert_eq!(read_clipboard(), marker);
+    }
+
+    /// Rapid successive copies must acquire ownership in call order: after N
+    /// back-to-back writes the clipboard holds the last one, and it survives
+    /// the earlier waiter threads exiting.
+    #[test]
+    #[serial_test::serial]
+    #[ignore = "requires a display server (X11/Wayland); run with -- --ignored"]
+    fn rapid_copies_last_write_wins() {
+        let base = format!("screenpipe-clipboard-rapid-{}", std::process::id());
+        let mut last = String::new();
+        for i in 0..5 {
+            last = format!("{base}-{i}");
+            super::set_clipboard_text(last.clone()).expect("set clipboard");
         }
+        assert_eq!(read_clipboard(), last);
+        // The final owner keeps serving after the superseded waiters exited.
+        std::thread::sleep(std::time::Duration::from_millis(250));
+        assert_eq!(read_clipboard(), last);
     }
 }

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands/native_actions.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands/native_actions.rs
@@ -207,12 +207,9 @@ fn native_notif_action_callback_inner(json_ptr: *const std::os::raw::c_char) {
             warn!("copy notification action has no value: {}", json);
             return;
         };
-        std::thread::spawn(move || {
-            match arboard::Clipboard::new().and_then(|mut clipboard| clipboard.set_text(text)) {
-                Ok(()) => {}
-                Err(e) => error!("failed to copy notification action value: {}", e),
-            }
-        });
+        if let Err(e) = crate::commands::set_clipboard_text(text) {
+            error!("failed to copy notification action value: {}", e);
+        }
         return;
     }
 


### PR DESCRIPTION
## description

On Linux, every clipboard action in the app — the chat "Copy message" button, copy deeplink, copy frame image, and the notification copy action — silently writes nothing. The button shows its success check, but pasting yields the previous clipboard content. Select-all + Ctrl+C inside the webview works, which makes the button look "randomly broken."

Root cause, two stacked Linux-only issues:

1. **Clipboard ownership dies immediately.** Linux has no OS-side clipboard buffer — content is served by the process owning the selection. Every command did `Clipboard::new()` → `set_text(...)` → return, dropping the arboard instance and with it the selection (arboard's 100 ms clipboard-manager handover on drop fails on typical setups, always on Wayland). The selection lived for microseconds. macOS/Windows are unaffected because the OS stores clipboard content.
2. **No Wayland backend.** arboard was built without `wayland-data-control`, so Wayland sessions only ever got the clipboard via the focus-dependent XWayland bridge.

The fix:

- New `set_clipboard_text` / `set_clipboard_image` helpers: on Linux the selection is served from a detached thread via arboard's `set().wait()` until another application takes ownership. At most one waiter thread lingers; it exits on the next clipboard write. macOS/Windows paths are byte-for-byte the previous behavior.
- Enable arboard's `wayland-data-control` feature so Wayland sessions get a native clipboard (falls back to X11 on compositors without the protocol, e.g. older Mutter).
- All four call sites rewired: `copy_text_to_clipboard`, `copy_deeplink_to_clipboard`, `copy_frame_to_clipboard`, and the notification copy action.

One deliberate trade-off: on Linux, errors inside the serving thread are logged rather than returned (the command has already returned by then). Previously the command returned `Ok` while the clipboard ended up empty, so error reporting is strictly no worse.

related issue: #

![clipboard evidence matrix](https://github.com/machug/screenpipe/releases/download/media/clipboard-evidence.png)

## AI assistance and human ownership

read the [AI-assisted contribution policy](https://github.com/screenpipe/screenpipe/blob/main/CONTRIBUTING.md#ai-assisted-contributions).

- AI tool(s) used: Claude Code (Claude Fable 5), including an adversarial review pass over the diff
- autonomy level: `agent`
- what I personally verified: I hit this bug in daily use on my own machine (Arch/Hyprland) and reported it; the repro matrix, regression test, bindings check, and typecheck below were all executed on my machine in the same session; I reviewed the diff and this PR body and submitted the PR myself

- [x] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [x] The problem statement, rationale, and replies to maintainers are my own.

## evidence type

- [x] Backend change — regression tests and relevant logs/results

## before

not applicable (Rust command layer only — no UI code changed). Behavior before, shown by a repro harness that runs the exact code path of `copy_text_to_clipboard` on Arch/Hyprland with the process kept alive after the call:

```
$ cliprepro bug            # Clipboard::new() → set_text → drop, process stays alive
wl-paste: Nothing is copied
xclip:    Error: target STRING not available
```

## after

not applicable (backend) — same harness with the patched code path:

```
$ cliprepro fix            # set().wait() served from a detached thread
wl-paste: cliprepro-fix-2490676     (wayland-data-control build)
xclip:    cliprepro-fix-2488739     (x11-only build)
```

Full 2×2 matrix (upstream vs patched build × old vs new code path) in the image above: the upstream build loses the selection on both wl-paste and xclip while the process is still alive; each half of the patch independently fixes its protocol.

## how to test

1. `cargo test -p screenpipe-app clipboard -- --ignored` (needs a display server, hence `#[ignore]`d for headless CI; both fail against the previous implementation) → `set_clipboard_text_is_immediately_pastable ... ok` (single read immediately after the command returns, no retries) and `rapid_copies_last_write_wins ... ok` (5 back-to-back copies, final value persists after superseded waiters exit) — 30/30 stress runs green on an idle desktop
2. `cargo test -p screenpipe-app` → 612 passed, 1 failed: `skills::tests::validate_repo_rejects_junk`, which fails identically on unmodified `main` in this environment and is untouched by this change
3. Manual: build the app on any Linux machine, open a chat, click "Copy message", then `wl-paste` (Wayland) or `xclip -o -selection clipboard` (X11) → message text
4. `bun run bindings:check` → `test specta_bindings::tests::tauri_bindings_are_current ... ok`

## desktop app checklist (if applicable)

- [ ] `bun run bindings:generate` — not applicable, no command signatures changed
- [x] `bun run bindings:check`
- [x] `bun run typecheck`
