### PR TITLE
[codex] show AI proposals on an empty Canvas

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/__tests__/brain-overview.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/brain-overview.test.tsx
@@ -1900,6 +1900,53 @@ describe("BrainOverview", () => {
     );
   });
 
+  it("shows proposed Blocks on an empty Canvas before acceptance", async () => {
+    const emptyView: ViewDefinition = {
+      ...populatedView,
+      id: "empty-canvas",
+      title: "Empty Canvas",
+      slots: [],
+    };
+    const proposedBlocks = [
+      ["current-priorities", "Current priorities", "list.v1"],
+      ["focus-time", "Focus time", "metric.v1"],
+      ["open-follow-ups", "Open follow-ups", "table.v1"],
+      ["activity-summary", "Activity summary", "markdown.v1"],
+    ] as const;
+    mocks.listBrainViews.mockResolvedValue({ status: "ok", data: [emptyView] });
+    mocks.generateLiveViewWithPi.mockResolvedValue({
+      title: emptyView.title,
+      timeRange: emptyView.timeRange,
+      periodPolicy: emptyView.periodPolicy,
+      note: "Four Blocks are ready for review.",
+      blocks: proposedBlocks.map(([id, title, component]) => ({
+        id,
+        title,
+        component,
+        width: 6,
+        intent: `Show source-backed ${title.toLowerCase()}.`,
+        pipeName: null,
+      })),
+    });
+    render(<BrainOverview />);
+
+    expect(await screen.findByText("add your first Block")).toBeTruthy();
+    fireEvent.change(screen.getByTestId("live-view-ai-prompt"), {
+      target: { value: "add four useful Blocks" },
+    });
+    fireEvent.click(screen.getByTestId("live-view-ai-generate"));
+
+    expect(await screen.findByTestId("live-view-ai-review")).toHaveTextContent(
+      "Review 4 proposed Blocks",
+    );
+    expect(screen.queryByText("add your first Block")).toBeNull();
+    expect(screen.getByTestId("live-view-canvas")).toBeTruthy();
+    for (const [id] of proposedBlocks) {
+      expect(screen.getByTestId(`canvas-block-${id}`)).toBeTruthy();
+    }
+    expect(mocks.saveBrainView).not.toHaveBeenCalled();
+  });
+
   it("accept all applies every proposal in one action", async () => {
     mocks.listBrainViews.mockResolvedValue({
       status: "ok",

--- a/apps/screenpipe-app-tauri/components/settings/brain-overview.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/brain-overview.tsx
@@ -3101,7 +3101,7 @@ export function BrainOverview({
           />
         )}
         {showOnboardingActivation &&
-        !onboardingHasResult ? null : slots.length === 0 ? (
+        !onboardingHasResult ? null : proposalSlots.length === 0 ? (
           <button
             type="button"
             className="flex min-h-0 w-full flex-1 items-center justify-center border border-dashed border-border text-xs text-muted-foreground hover:text-foreground"

--- a/apps/screenpipe-app-tauri/e2e/COVERAGE.md
+++ b/apps/screenpipe-app-tauri/e2e/COVERAGE.md
@@ -7,8 +7,8 @@ and layer declared in the manifest, weighted by confidence and criticality.
 - Manifest: `e2e/coverage-map.json`
 - Specs directory: `e2e/specs`
 - Mapped specs: 98
-- Declared test blocks: 268
-- Weighted coverage points: 207.7
+- Declared test blocks: 269
+- Weighted coverage points: 208.7
 
 Confidence weights: strong=1.0, partial=0.7, conditional=0.4, smoke=0.3.
 Criticality weights: high=1.0, medium=0.7, low=0.4.
@@ -19,9 +19,9 @@ can execute more runtime cases than this number shows.
 
 | Platform | Specs | Declared tests | Weighted points | Layers | Features | Critical score |
 | --- | --- | --- | --- | --- | --- | --- |
-| windows | 76 | 230 | 187.2 | 15 | 78 | 91% |
-| macos | 94 | 231 | 178.5 | 17 | 80 | 89% |
-| linux | 66 | 190 | 157.0 | 14 | 73 | 88% |
+| windows | 76 | 231 | 188.2 | 15 | 78 | 91% |
+| macos | 94 | 232 | 179.5 | 17 | 80 | 89% |
+| linux | 66 | 191 | 158.0 | 14 | 73 | 88% |
 
 ## Runtime Results
 
@@ -39,13 +39,13 @@ pass/fail/skip counts.
 | capture-ocr | 2 specs / 16 tests / 6.4 pts | 7 specs / 11 tests / 4.4 pts | 1 specs / 3 tests / 1.2 pts |
 | chat-ai | 23 specs / 37 tests / 28.1 pts | 32 specs / 56 tests / 39.7 pts | 22 specs / 36 tests / 27.6 pts |
 | entitlement | - | 1 specs / 1 tests / 1.0 pts | - |
-| local-api | 20 specs / 104 tests / 86.8 pts | 24 specs / 88 tests / 74.4 pts | 16 specs / 75 tests / 66.2 pts |
+| local-api | 20 specs / 105 tests / 87.8 pts | 24 specs / 89 tests / 75.4 pts | 16 specs / 76 tests / 67.2 pts |
 | notifications | 4 specs / 25 tests / 16.3 pts | 3 specs / 5 tests / 3.4 pts | 2 specs / 4 tests / 3.1 pts |
 | onboarding | 4 specs / 10 tests / 7.6 pts | 5 specs / 11 tests / 8.0 pts | 4 specs / 10 tests / 7.6 pts |
 | os-integration | 6 specs / 18 tests / 17.1 pts | 11 specs / 13 tests / 6.7 pts | 1 specs / 1 tests / 1.0 pts |
 | performance | 2 specs / 44 tests / 44.0 pts | 4 specs / 34 tests / 30.5 pts | 1 specs / 29 tests / 29.0 pts |
-| pipes | 6 specs / 18 tests / 18.0 pts | 7 specs / 23 tests / 23.0 pts | 6 specs / 18 tests / 18.0 pts |
-| real-ui-e2e | 53 specs / 147 tests / 120.0 pts | 62 specs / 146 tests / 119.1 pts | 49 specs / 125 tests / 106.4 pts |
+| pipes | 6 specs / 19 tests / 19.0 pts | 7 specs / 24 tests / 24.0 pts | 6 specs / 19 tests / 19.0 pts |
+| real-ui-e2e | 53 specs / 148 tests / 121.0 pts | 62 specs / 147 tests / 120.1 pts | 49 specs / 126 tests / 107.4 pts |
 | settings | 14 specs / 37 tests / 34.0 pts | 16 specs / 32 tests / 27.7 pts | 13 specs / 29 tests / 26.0 pts |
 | storage-privacy | 9 specs / 39 tests / 30.3 pts | 9 specs / 25 tests / 24.1 pts | 6 specs / 18 tests / 17.1 pts |
 | tauri-command | 13 specs / 22 tests / 15.3 pts | 17 specs / 27 tests / 18.2 pts | 12 specs / 21 tests / 14.3 pts |
@@ -105,7 +105,7 @@ pass/fail/skip counts.
 | app-lifecycle.spec.ts | windows, macos, linux | real-ui-e2e, window-lifecycle | app-launch, home-navigation, webview-stability, route-churn, browser-storage | high | strong | mixed | 14 | Home webview, routing, reload, focus, resize, and storage stability. |
 | artifacts-api.spec.ts | windows, macos, linux | local-api | local-api-auth, artifacts | medium | strong | api | 7 | CRUD coverage for artifact registration, validation, unified listing, upsert, and delete. |
 | audio-fallback.spec.ts | macos | audio-device, settings, notifications | audio-device-health, settings-recording, notifications | medium | conditional | real-user-flow | 1 | Opt-in macOS cloud audio fallback seed. |
-| brain-overview.spec.ts | windows, macos, linux | real-ui-e2e, local-api, pipes | brain, brain-overview, brain-canvas, artifacts, pipes | high | strong | real-user-flow | 4 | Deletes the last dashboard at 800x600, scrolls to the final starter template, verifies the real local builder keeps its generated dashboard on review through save, and samples the native Canvas viewport across an AI-added Block focus to prove eased intermediate movement instead of a teleport. Also renders source-backed selectable and fixed-period Live Views, verifies dashboard switching stays available during refresh, omits fixed-period controls from view and Customize, exercises durable Canvas notes, connections, keyboard movement, navigation restore, deletion cleanup, and checks layout bounds from 800x600 through 1920x1080. |
+| brain-overview.spec.ts | windows, macos, linux | real-ui-e2e, local-api, pipes | brain, brain-overview, brain-canvas, artifacts, pipes | high | strong | real-user-flow | 5 | Deletes the last dashboard at 800x600, scrolls to the final starter template, verifies the real local builder keeps its generated dashboard on review through save, requires four AI-proposed Blocks to be visible on an empty Canvas before acceptance, and samples the native Canvas viewport across an AI-added Block focus to prove eased intermediate movement instead of a teleport. Also renders source-backed selectable and fixed-period Live Views, verifies dashboard switching stays available during refresh, omits fixed-period controls from view and Customize, exercises durable Canvas notes, connections, keyboard movement, navigation restore, deletion cleanup, and checks layout bounds from 800x600 through 1920x1080. |
 | brain-section.spec.ts | windows, macos, linux | real-ui-e2e | brain, artifacts, memories, viewer-deeplink | medium | strong | real-user-flow | 10 | Brain coverage for filters, search, delete flows, selection pruning, add memory, and inline artifact markdown preview. |
 | capture-frequency-floor.spec.ts | macos | capture-ocr, settings, real-ui-e2e | capture-ocr, settings-recording, restart-flow | high | conditional | real-user-flow | 1 | macOS fixed screenshot cadence regression: persists the 1s setting before immediate Apply & Restart, then verifies real capture attempts and frame writes. |
 | capture-loop-liveness.spec.ts | macos | capture-ocr, local-api, os-integration | app-launch, capture-ocr | high | conditional | api | 1 | Opt-in macOS fault injection wedges a visual-change probe; asserts the bounded probe keeps the capture loop and its /health heartbeat live (no false stale/incident). |

--- a/apps/screenpipe-app-tauri/e2e/coverage-map.json
+++ b/apps/screenpipe-app-tauri/e2e/coverage-map.json
@@ -1142,7 +1142,7 @@
       "criticality": "high",
       "confidence": "strong",
       "ux": "real-user-flow",
-      "notes": "Deletes the last dashboard at 800x600, scrolls to the final starter template, verifies the real local builder keeps its generated dashboard on review through save, and samples the native Canvas viewport across an AI-added Block focus to prove eased intermediate movement instead of a teleport. Also renders source-backed selectable and fixed-period Live Views, verifies dashboard switching stays available during refresh, omits fixed-period controls from view and Customize, exercises durable Canvas notes, connections, keyboard movement, navigation restore, deletion cleanup, and checks layout bounds from 800x600 through 1920x1080."
+      "notes": "Deletes the last dashboard at 800x600, scrolls to the final starter template, verifies the real local builder keeps its generated dashboard on review through save, requires four AI-proposed Blocks to be visible on an empty Canvas before acceptance, and samples the native Canvas viewport across an AI-added Block focus to prove eased intermediate movement instead of a teleport. Also renders source-backed selectable and fixed-period Live Views, verifies dashboard switching stays available during refresh, omits fixed-period controls from view and Customize, exercises durable Canvas notes, connections, keyboard movement, navigation restore, deletion cleanup, and checks layout bounds from 800x600 through 1920x1080."
     },
     {
       "spec": "live-view-item-actions.spec.ts",

--- a/apps/screenpipe-app-tauri/e2e/specs/brain-overview.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/brain-overview.spec.ts
@@ -894,6 +894,198 @@ describe("Brain Live Views", function () {
     }
   });
 
+  it("shows AI-proposed Blocks on an empty Canvas before acceptance", async () => {
+    await waitForAppReady();
+    await seedEntitledAccount();
+    await openHomeWithDiagnostics();
+    const emptyViewId = "empty-canvas-ai-review";
+    const proposedBlocks = [
+      {
+        id: "current-priorities",
+        title: "Current priorities",
+        component: "list.v1",
+        width: 6,
+        intent: "Show the current source-backed priorities.",
+        pipeName: null,
+      },
+      {
+        id: "focus-time",
+        title: "Focus time",
+        component: "metric.v1",
+        width: 6,
+        intent: "Calculate source-backed focus time for the selected period.",
+        pipeName: null,
+      },
+      {
+        id: "open-follow-ups",
+        title: "Open follow-ups",
+        component: "table.v1",
+        width: 6,
+        intent: "List source-backed follow-ups that still appear open.",
+        pipeName: null,
+      },
+      {
+        id: "activity-summary",
+        title: "Activity summary",
+        component: "markdown.v1",
+        width: 6,
+        intent: "Summarize source-backed activity for the selected period.",
+        pipeName: null,
+      },
+    ];
+    const piConversation = new PiConversationHarness(
+      "e2e-live-view-empty-canvas-builder",
+    );
+    await piConversation.initialize();
+    await piConversation.configureAppPreset();
+    await restartPiAfterInstallSettles(piConversation, "Empty Canvas model");
+    await piConversation.prompt(
+      "reply with ready",
+      "Empty Canvas model preflight",
+    );
+    await piConversation.waitForRequestCount(1, "Empty Canvas model preflight");
+    await piConversation.clearCaptures();
+    piConversation.setResponseDelay(350);
+    piConversation.setTextResponse(
+      JSON.stringify({
+        operations: proposedBlocks.map((block) => ({ op: "add", block })),
+        note: "Four Blocks are ready for review.",
+      }),
+    );
+
+    try {
+      const existingViews =
+        await invokeOrThrow<BrainView[]>("list_brain_views");
+      if (existingViews.some((candidate) => candidate.id === emptyViewId)) {
+        await invokeOrThrow("delete_brain_view", { id: emptyViewId });
+      }
+      await invokeOrThrow("save_brain_view", {
+        request: {
+          id: emptyViewId,
+          title: "Empty Canvas",
+          expectedRevision: null,
+          timeRange: "7d",
+          periodPolicy: {
+            type: "selectable.v1",
+            values: ["7d", "30d"],
+          },
+          slots: [],
+        },
+      });
+
+      const pipesNav = await waitForTestId("nav-pipes", 10_000);
+      await pipesNav.click();
+      await waitForTestId("section-pipes", 15_000);
+      const brainNav = await waitForTestId("nav-brain", 10_000);
+      await brainNav.click();
+      await waitForTestId("section-brain", 15_000);
+      await selectDashboard(emptyViewId);
+      await $("button=add your first Block").waitForDisplayed({
+        timeout: t(10_000),
+      });
+
+      const prompt = await waitForTestId("live-view-ai-prompt", 10_000);
+      await prompt.setValue("add four useful Blocks to this Canvas");
+      await waitForTestId("live-view-ai-generate", 10_000).then((element) =>
+        element.click(),
+      );
+      await piConversation.waitForRequestCount(
+        1,
+        "Empty Canvas builder request",
+      );
+      const review = await waitForTestId("live-view-ai-review", 45_000);
+      expect(await review.getText()).toContain("Review 4 proposed Blocks");
+
+      const persistedBeforeAcceptance = (
+        await invokeOrThrow<BrainView[]>("list_brain_views")
+      ).find((candidate) => candidate.id === emptyViewId);
+      expect(persistedBeforeAcceptance?.slots).toHaveLength(0);
+
+      const readPreviewAudit = async () =>
+        (await browser.execute(() => {
+          const isVisible = (element: Element | null) => {
+            if (!(element instanceof HTMLElement)) return false;
+            const rect = element.getBoundingClientRect();
+            const style = getComputedStyle(element);
+            return (
+              rect.width > 0 &&
+              rect.height > 0 &&
+              style.display !== "none" &&
+              style.visibility !== "hidden"
+            );
+          };
+          return {
+            canvasVisible: isVisible(
+              document.querySelector("[data-testid='live-view-canvas']"),
+            ),
+            emptyStateVisible: Array.from(
+              document.querySelectorAll("button"),
+            ).some(
+              (button) =>
+                button.textContent?.trim() === "add your first Block" &&
+                isVisible(button),
+            ),
+            visibleBlockIds: Array.from(
+              document.querySelectorAll<HTMLElement>(
+                "[data-testid^='canvas-block-']",
+              ),
+            )
+              .filter(isVisible)
+              .map((element) =>
+                (element.dataset.testid ?? "").replace("canvas-block-", ""),
+              )
+              .sort(),
+          };
+        })) as {
+          canvasVisible: boolean;
+          emptyStateVisible: boolean;
+          visibleBlockIds: string[];
+        };
+      const expectedBlockIds = proposedBlocks.map((block) => block.id).sort();
+      await browser.waitUntil(
+        async () => {
+          const audit = await readPreviewAudit();
+          return (
+            audit.canvasVisible &&
+            !audit.emptyStateVisible &&
+            JSON.stringify(audit.visibleBlockIds) ===
+              JSON.stringify(expectedBlockIds)
+          );
+        },
+        {
+          timeout: t(10_000),
+          interval: 100,
+          timeoutMsg: "proposed Blocks did not render on the empty Canvas",
+        },
+      );
+      const previewAudit = await readPreviewAudit();
+      expect(previewAudit).toEqual({
+        canvasVisible: true,
+        emptyStateVisible: false,
+        visibleBlockIds: expectedBlockIds,
+      });
+      await browser.pause(100);
+      const reviewScreenshot = await saveScreenshot(
+        "brain-empty-canvas-ai-block-review",
+      );
+      expect(existsSync(reviewScreenshot)).toBe(true);
+    } finally {
+      await browser
+        .execute(() => {
+          document
+            .querySelector<HTMLButtonElement>(
+              "[data-testid='live-view-ai-reject-all']",
+            )
+            ?.click();
+        })
+        .catch(() => undefined);
+      await piConversation.dispose();
+      await invokeOrThrow("delete_brain_view", { id: emptyViewId }).catch(
+        () => undefined,
+      );
+    }
+  });
+
   it("reviews Canvas edits per Block without opening Chat", async () => {
     await waitForAppReady();
     // Seed the isolated account before Home navigation so the current


### PR DESCRIPTION
## What

- Render the Canvas from `proposalSlots` while AI changes are awaiting review, even when the persisted Canvas is empty.
- Add a component regression test and a native E2E reproducer using the local Pi harness.
- Keep the persisted dashboard unchanged until the user accepts a proposal.

## Why

The empty-state branch checked persisted `slots`. On a new Canvas those stay empty during review, so the UI showed “Review 4 proposed Blocks” while still rendering “add your first Block”. The proposed Blocks only became visible after acceptance persisted them.

## Impact

AI-proposed Blocks are now visible and individually reviewable before acceptance. Existing non-empty Canvas behavior and the acceptance boundary are unchanged.

## Visual

```text
Before                              After
┌ Review 4 proposed Blocks ┐        ┌ Review 4 proposed Blocks ┐
│                          │        │ Current priorities       │ │ Focus time       │
│  + add your first Block  │        │ Open follow-ups          │ │ Activity summary │
└──────────────────────────┘        └──────────────────────────┘
```

## Checks

- `bun x vitest run --config vitest.config.ts components/settings/__tests__/brain-overview.test.tsx` — 53 passed
- `bun run e2e:coverage:check` — passed
- `NEXT_PUBLIC_SCREENPIPE_E2E=true bun tauri build --no-sign --debug --verbose --no-bundle -- --features e2e` — passed
- focused native E2E `shows AI-proposed Blocks on an empty Canvas before acceptance` — 1 passed
- `git diff --check origin/main...HEAD` — passed
