### PR TITLE
fix(ui): polish sidebar, home chat header and brain tabs

### DIFF
--- a/apps/screenpipe-app-tauri/app/(main)/home/page.tsx
+++ b/apps/screenpipe-app-tauri/app/(main)/home/page.tsx
@@ -1166,11 +1166,11 @@ function HomeContent() {
                         }
                       }}
                       className={cn(
-                        "relative w-full flex items-center gap-2.5 px-2.5 py-1.5 rounded-lg transition-all duration-150 text-left group",
+                        "relative w-full flex items-center gap-2.5 px-2.5 py-1.5 rounded-lg border border-transparent transition-all duration-150 text-left group",
                         isActive
                           ? isTranslucent
                             ? "vibrant-nav-active"
-                            : "bg-card shadow-sm border border-border text-foreground"
+                            : "bg-card shadow-sm border-border text-foreground"
                           : isTranslucent
                             ? "vibrant-nav-item vibrant-nav-hover"
                             : "hover:bg-card/50 text-muted-foreground hover:text-foreground",

--- a/apps/screenpipe-app-tauri/components/chat/standalone/standalone-chat-header.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/standalone-chat-header.tsx
@@ -24,6 +24,7 @@ interface StandaloneChatHeaderProps {
   isMac: boolean;
   isFullscreen: boolean;
   hideInlineHistory?: boolean;
+  hasRightActions?: boolean;
   showHistory: boolean;
   settings: {
     disabledShortcuts: string[];
@@ -46,6 +47,7 @@ export function StandaloneChatHeader({
   isMac,
   isFullscreen,
   hideInlineHistory,
+  hasRightActions,
   showHistory,
   settings,
   reloadStore,
@@ -76,6 +78,16 @@ export function StandaloneChatHeader({
         ? storeTitle
         : derivedTitle || (hasMessages ? "untitled" : ""));
   const useCompactHeaderPadding = !className || Boolean(conversationId && visibleTitle);
+  // With inline history hidden (main window) the row can end up with the title
+  // menu suppressed and no right actions — an empty strip. Nothing to show and
+  // nothing to drag (dragging is disabled whenever className is set), so drop
+  // the row entirely instead of leaving a bordered band of dead space.
+  const isEmpty =
+    Boolean(hideInlineHistory) &&
+    !(conversationId && visibleTitle) &&
+    !hasRightActions;
+
+  if (isEmpty) return null;
 
   return (
     <div

--- a/apps/screenpipe-app-tauri/components/settings/brain-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/brain-section.tsx
@@ -179,6 +179,12 @@ type UnifiedItem =
   | { kind: "artifact"; data: UnifiedArtifact; sortDate: number };
 
 type TypeFilter = "overview" | "memories" | "artifacts";
+
+const BRAIN_TAB_DESCRIPTIONS: Record<TypeFilter, string> = {
+  overview: "live dashboards the AI builds from your activity, updated as you work",
+  memories: "what the AI has learned about you from your activity",
+  artifacts: "documents, pages and files the AI has generated for you",
+};
 type SelectedBrainItem =
   | { kind: "memory"; key: string }
   | { kind: "artifact"; key: string };
@@ -1471,18 +1477,15 @@ export function BrainSection() {
     <div data-testid="section-brain" className="h-full overflow-hidden">
     <div
       data-testid="brain-content"
-      className={`mx-auto flex h-full flex-col px-3 pb-6 sm:px-6 ${
+      className={`mx-auto flex h-full flex-col px-3 pb-6 pt-10 sm:px-6 ${
         typeFilter === "overview"
-          ? "max-w-none space-y-2 pt-8"
-          : "max-w-6xl space-y-4 pt-10"
+          ? "max-w-none space-y-2"
+          : "max-w-6xl space-y-4"
       }`}
     >
-      {typeFilter !== "overview" && (
-        <p className="mb-4 text-sm text-muted-foreground">
-          what the AI has learned from your activity and what it has generated
-          for you
-        </p>
-      )}
+      <p className="mb-4 text-sm text-muted-foreground">
+        {BRAIN_TAB_DESCRIPTIONS[typeFilter]}
+      </p>
 
       {/* stale memories warning */}
       {typeFilter === "memories" && isStale && (

--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -1342,6 +1342,7 @@ export function StandaloneChat({
         isMac={isMac}
         isFullscreen={isFullscreen}
         hideInlineHistory={hideInlineHistory}
+        hasRightActions={inspectorHasContent || sidePanelHasContent}
         showHistory={showHistory}
         settings={settings}
         reloadStore={reloadStore}


### PR DESCRIPTION
This pr fixes three small ui rough edges in the main window: 

1. sidebar nav items shifted a bit when they became active, it's now always reserved as transparent.

Before -

https://github.com/user-attachments/assets/e07f8ae7-eac7-486d-8c9f-4039b4265dcd


After -

https://github.com/user-attachments/assets/2d4bfa54-696a-4180-853d-5d7d00edd5da


2. it also drops the home chat's header row entirely when there's nothing in it, instead of leaving a bordered band of dead space above an empty conversation.

Before -
<img width="935" height="460" alt="image" src="https://github.com/user-attachments/assets/433c052a-8cea-452c-86fa-32d150e8b822" />

After -

<img width="614" height="449" alt="image" src="https://github.com/user-attachments/assets/627069e7-e2cf-4a97-bded-36f5323d3c71" />

3.each brain settings tab now gets its own description line rather than sharing one generic sentence

Before -
<img width="487" height="365" alt="image" src="https://github.com/user-attachments/assets/5578ccac-f0c6-43d4-a222-b477b04ae246" />

After -

<img width="877" height="608" alt="image" src="https://github.com/user-attachments/assets/35d6e9aa-26d7-4d95-93fa-da131f641bcc" />
