### PR TITLE
[codex] enable Pipes used by Live View

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/__tests__/brain-overview.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/brain-overview.test.tsx
@@ -849,7 +849,7 @@ describe("BrainOverview", () => {
     expect(JSON.stringify(properties)).not.toContain("private failure detail");
   });
 
-  it("does not run a disabled Pipe when refreshing a Live View", async () => {
+  it("enables a disabled Pipe before refreshing a Live View", async () => {
     mocks.pipes[0].config.enabled = false;
     mocks.listBrainViews.mockResolvedValue({
       status: "ok",
@@ -859,8 +859,44 @@ describe("BrainOverview", () => {
 
     fireEvent.click(await screen.findByTestId("overview-refresh-data"));
 
+    await waitFor(() =>
+      expect(
+        mocks.localFetch.mock.calls.some(
+          ([path]) => path === "/pipes/daily-summary/run",
+        ),
+      ).toBe(true),
+    );
+    const pipeRequests = mocks.localFetch.mock.calls.filter(([path]) =>
+      String(path).startsWith("/pipes/daily-summary/"),
+    );
+    expect(pipeRequests.map(([path]) => path)).toEqual([
+      "/pipes/daily-summary/enable",
+      "/pipes/daily-summary/run",
+    ]);
+    expect(JSON.parse(pipeRequests[0][1].body)).toEqual({ enabled: true });
+    expect(mocks.refetchPipes).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not run a disabled Pipe when enabling it fails", async () => {
+    mocks.pipes[0].config.enabled = false;
+    mocks.listBrainViews.mockResolvedValue({
+      status: "ok",
+      data: [populatedView],
+    });
+    mocks.localFetch.mockImplementation(async (path: string) => ({
+      ok: !path.endsWith("/enable"),
+      status: path.endsWith("/enable") ? 500 : 200,
+      json: async () =>
+        path.endsWith("/enable")
+          ? { error: "permission denied" }
+          : { success: true },
+    }));
+    render(<BrainOverview />);
+
+    fireEvent.click(await screen.findByTestId("overview-refresh-data"));
+
     expect(await screen.findByTestId("live-view-data-status")).toHaveTextContent(
-      "daily-summary is disabled. Enable it in Pipes to refresh this Live View.",
+      "Could not start daily-summary: failed to enable (permission denied)",
     );
     expect(
       mocks.localFetch.mock.calls.some(
@@ -1939,7 +1975,7 @@ describe("BrainOverview", () => {
     );
   });
 
-  it("offers only enabled Pipes to Live View generation", async () => {
+  it("offers disabled installed Pipes to Live View generation", async () => {
     mocks.pipes.push({
       config: {
         name: "disabled-summary",
@@ -1980,12 +2016,13 @@ describe("BrainOverview", () => {
     await waitFor(() => expect(mocks.generateLiveViewWithPi).toHaveBeenCalled());
     expect(mocks.generateLiveViewWithPi).toHaveBeenCalledWith(
       expect.objectContaining({
-        pipes: [expect.objectContaining({ name: "daily-summary" })],
+        pipes: expect.arrayContaining([
+          expect.objectContaining({ name: "daily-summary" }),
+          expect.objectContaining({ name: "disabled-summary" }),
+        ]),
       }),
     );
-    expect(
-      JSON.stringify(mocks.generateLiveViewWithPi.mock.calls[0][0].pipes),
-    ).not.toContain("disabled-summary");
+    expect(mocks.generateLiveViewWithPi.mock.calls[0][0].pipes).toHaveLength(2);
   });
 
   it("shows proposed Blocks on an empty Canvas before acceptance", async () => {

--- a/apps/screenpipe-app-tauri/components/settings/__tests__/brain-overview.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/brain-overview.test.tsx
@@ -30,6 +30,16 @@ const mocks = vi.hoisted(() => ({
   toast: vi.fn(),
   refetchPipes: vi.fn(),
   capture: vi.fn(),
+  pipes: [] as Array<{
+    config: {
+      name: string;
+      schedule: string;
+      enabled: boolean;
+      config: Record<string, unknown>;
+    };
+    prompt_body: string;
+    is_running: boolean;
+  }>,
   usageState: null as any,
   openBusinessUpgradeSurface: vi.fn(),
 }));
@@ -75,18 +85,7 @@ vi.mock("@/lib/api", () => ({
 }));
 vi.mock("@/lib/hooks/use-pipes", () => ({
   usePipes: () => ({
-    pipes: [
-      {
-        config: {
-          name: "daily-summary",
-          schedule: "daily",
-          enabled: true,
-          config: {},
-        },
-        prompt_body: "summarize",
-        is_running: false,
-      },
-    ],
+    pipes: mocks.pipes,
     refetch: mocks.refetchPipes,
   }),
 }));
@@ -348,6 +347,18 @@ const processMapTemplate = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.pipes = [
+    {
+      config: {
+        name: "daily-summary",
+        schedule: "daily",
+        enabled: true,
+        config: {},
+      },
+      prompt_body: "summarize",
+      is_running: false,
+    },
+  ];
   mocks.usageState = null;
   mocks.openBusinessUpgradeSurface.mockResolvedValue(undefined);
   Object.defineProperty(window, "localStorage", {
@@ -836,6 +847,34 @@ describe("BrainOverview", () => {
     )?.[1];
     expect(JSON.stringify(properties)).not.toContain("daily-summary");
     expect(JSON.stringify(properties)).not.toContain("private failure detail");
+  });
+
+  it("does not run a disabled Pipe when refreshing a Live View", async () => {
+    mocks.pipes[0].config.enabled = false;
+    mocks.listBrainViews.mockResolvedValue({
+      status: "ok",
+      data: [populatedView],
+    });
+    render(<BrainOverview />);
+
+    fireEvent.click(await screen.findByTestId("overview-refresh-data"));
+
+    expect(await screen.findByTestId("live-view-data-status")).toHaveTextContent(
+      "daily-summary is disabled. Enable it in Pipes to refresh this Live View.",
+    );
+    expect(
+      mocks.localFetch.mock.calls.some(
+        ([path]) => path === "/pipes/daily-summary/run",
+      ),
+    ).toBe(false);
+    expect(mocks.capture).toHaveBeenCalledWith(
+      "live_view_refresh_completed",
+      expect.objectContaining({
+        status: "error",
+        requested_pipe_count: 1,
+        pipe_start_failure_count: 1,
+      }),
+    );
   });
 
   it("keeps primary controls visible and moves setup actions into More", async () => {
@@ -1898,6 +1937,55 @@ describe("BrainOverview", () => {
         slots: [expect.objectContaining({ title: "Focus time" })],
       }),
     );
+  });
+
+  it("offers only enabled Pipes to Live View generation", async () => {
+    mocks.pipes.push({
+      config: {
+        name: "disabled-summary",
+        schedule: "daily",
+        enabled: false,
+        config: {},
+      },
+      prompt_body: "summarize archived work",
+      is_running: false,
+    });
+    mocks.listBrainViews.mockResolvedValue({
+      status: "ok",
+      data: [populatedView],
+    });
+    mocks.generateLiveViewWithPi.mockResolvedValue({
+      title: populatedView.title,
+      timeRange: populatedView.timeRange,
+      periodPolicy: populatedView.periodPolicy,
+      note: "Kept the current Block.",
+      blocks: [
+        {
+          id: "focus-time",
+          title: "Focus time",
+          intent: "Calculate focused work time",
+          component: "metric.v1",
+          width: 6,
+          pipeName: "daily-summary",
+        },
+      ],
+    });
+    render(<BrainOverview />);
+
+    fireEvent.change(await screen.findByTestId("live-view-ai-prompt"), {
+      target: { value: "keep this focused on active work" },
+    });
+    fireEvent.click(screen.getByTestId("live-view-ai-generate"));
+
+    await waitFor(() => expect(mocks.generateLiveViewWithPi).toHaveBeenCalled());
+    expect(mocks.generateLiveViewWithPi).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pipes: [expect.objectContaining({ name: "daily-summary" })],
+      }),
+    );
+    expect(
+      JSON.stringify(mocks.generateLiveViewWithPi.mock.calls[0][0].pipes),
+    ).not.toContain("disabled-summary");
   });
 
   it("shows proposed Blocks on an empty Canvas before acceptance", async () => {

--- a/apps/screenpipe-app-tauri/components/settings/brain-overview.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/brain-overview.tsx
@@ -600,17 +600,19 @@ export function BrainOverview({
     () => [...pipes].sort((a, b) => a.config.name.localeCompare(b.config.name)),
     [pipes],
   );
-  const enabledPipes = useMemo(
-    () => installedPipes.filter((pipe) => pipe.config.enabled),
-    [installedPipes],
-  );
   const installedPipeNames = useMemo(
     () => new Set(installedPipes.map((pipe) => pipe.config.name)),
     [installedPipes],
   );
-  const enabledPipeNames = useMemo(
-    () => new Set(enabledPipes.map((pipe) => pipe.config.name)),
-    [enabledPipes],
+  const pipeEnabledByName = useMemo(
+    () =>
+      new Map(
+        installedPipes.map((pipe) => [
+          pipe.config.name,
+          pipe.config.enabled,
+        ]),
+      ),
+    [installedPipes],
   );
   const aiPresets = useMemo(
     () => (settings.aiPresets ?? []) as AIPreset[],
@@ -1042,11 +1044,7 @@ export function BrainOverview({
         ),
       );
       const disabledPipeNames = pipeNames.filter(
-        (pipeName) =>
-          installedPipeNames.has(pipeName) && !enabledPipeNames.has(pipeName),
-      );
-      const runnablePipeNames = pipeNames.filter(
-        (pipeName) => !disabledPipeNames.includes(pipeName),
+        (pipeName) => pipeEnabledByName.get(pipeName) === false,
       );
       const analyticsProperties = {
         ...liveViewAnalyticsProperties(targetView, views.length),
@@ -1081,7 +1079,45 @@ export function BrainOverview({
         total: boundSlots.length,
       });
 
-      const runFailures: string[] = [];
+      const failures: string[] = [];
+      const enableFailures = new Set<string>();
+      await Promise.all(
+        disabledPipeNames.map(async (pipeName) => {
+          try {
+            const response = await localFetch(
+              `/pipes/${encodeURIComponent(pipeName)}/enable`,
+              {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ enabled: true }),
+              },
+            );
+            const body = (await response.json().catch(() => ({}))) as {
+              error?: string;
+              success?: boolean;
+            };
+            if (!response.ok || body.error || body.success === false) {
+              throw new Error(body.error || `HTTP ${response.status}`);
+            }
+          } catch (enableError) {
+            enableFailures.add(pipeName);
+            failures.push(
+              `${pipeName}: failed to enable${
+                enableError instanceof Error && enableError.message
+                  ? ` (${enableError.message})`
+                  : ""
+              }`,
+            );
+          }
+        }),
+      );
+      if (disabledPipeNames.length > 0) {
+        await refetchPipes();
+      }
+
+      const runnablePipeNames = pipeNames.filter(
+        (pipeName) => !enableFailures.has(pipeName),
+      );
       await Promise.all(
         runnablePipeNames.map(async (pipeName) => {
           try {
@@ -1115,7 +1151,7 @@ export function BrainOverview({
               throw new Error(body.error || `HTTP ${response.status}`);
             }
           } catch (runError) {
-            runFailures.push(
+            failures.push(
               `${pipeName}: ${
                 runError instanceof Error ? runError.message : String(runError)
               }`,
@@ -1124,36 +1160,22 @@ export function BrainOverview({
         }),
       );
 
-      const startFailureCount = disabledPipeNames.length + runFailures.length;
-      const disabledPipeMessage =
-        disabledPipeNames.length > 0
-          ? `${disabledPipeNames.join(", ")} ${
-              disabledPipeNames.length === 1 ? "is" : "are"
-            } disabled. Enable ${
-              disabledPipeNames.length === 1 ? "it" : "them"
-            } in Pipes to refresh this Live View.`
-          : null;
-      const failureMessage = [
-        disabledPipeMessage,
-        runFailures.length > 0
-          ? `Could not start ${runFailures.join(", ")}`
-          : null,
-      ]
-        .filter((message): message is string => Boolean(message))
-        .join(" ");
       setDataRefresh((current) =>
         current && current.startedAt === startedAt
           ? {
               ...current,
               status:
-                startFailureCount === pipeNames.length ? "error" : "running",
-              startFailureCount,
-              message: failureMessage || undefined,
+                failures.length === pipeNames.length ? "error" : "running",
+              startFailureCount: failures.length,
+              message:
+                failures.length > 0
+                  ? `Could not start ${failures.join(", ")}`
+                  : undefined,
             }
           : current,
       );
     },
-    [enabledPipeNames, installedPipeNames, views.length],
+    [pipeEnabledByName, refetchPipes, views.length],
   );
 
   useEffect(() => {
@@ -1544,7 +1566,7 @@ export function BrainOverview({
           selectedAiPreset.provider === "screenpipe-cloud"
             ? (settings.user?.token ?? null)
             : null,
-        pipes: enabledPipes.map((pipe) => ({
+        pipes: installedPipes.map((pipe) => ({
           name: pipe.config.name,
           description:
             typeof pipe.config.config?.description === "string"
@@ -2838,7 +2860,7 @@ export function BrainOverview({
         draft={draft}
         saving={saving}
         componentOptions={COMPONENTS}
-        pipeNames={enabledPipes.map((pipe) => pipe.config.name)}
+        pipeNames={installedPipes.map((pipe) => pipe.config.name)}
         onChange={setDraft}
         onCancel={() => {
           setDraft(null);

--- a/apps/screenpipe-app-tauri/components/settings/brain-overview.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/brain-overview.tsx
@@ -600,9 +600,17 @@ export function BrainOverview({
     () => [...pipes].sort((a, b) => a.config.name.localeCompare(b.config.name)),
     [pipes],
   );
+  const enabledPipes = useMemo(
+    () => installedPipes.filter((pipe) => pipe.config.enabled),
+    [installedPipes],
+  );
   const installedPipeNames = useMemo(
     () => new Set(installedPipes.map((pipe) => pipe.config.name)),
     [installedPipes],
+  );
+  const enabledPipeNames = useMemo(
+    () => new Set(enabledPipes.map((pipe) => pipe.config.name)),
+    [enabledPipes],
   );
   const aiPresets = useMemo(
     () => (settings.aiPresets ?? []) as AIPreset[],
@@ -1033,6 +1041,13 @@ export function BrainOverview({
             .filter((name): name is string => Boolean(name)),
         ),
       );
+      const disabledPipeNames = pipeNames.filter(
+        (pipeName) =>
+          installedPipeNames.has(pipeName) && !enabledPipeNames.has(pipeName),
+      );
+      const runnablePipeNames = pipeNames.filter(
+        (pipeName) => !disabledPipeNames.includes(pipeName),
+      );
       const analyticsProperties = {
         ...liveViewAnalyticsProperties(targetView, views.length),
         trigger,
@@ -1066,9 +1081,9 @@ export function BrainOverview({
         total: boundSlots.length,
       });
 
-      const failures: string[] = [];
+      const runFailures: string[] = [];
       await Promise.all(
-        pipeNames.map(async (pipeName) => {
+        runnablePipeNames.map(async (pipeName) => {
           try {
             const response = await localFetch(
               `/pipes/${encodeURIComponent(pipeName)}/run`,
@@ -1100,7 +1115,7 @@ export function BrainOverview({
               throw new Error(body.error || `HTTP ${response.status}`);
             }
           } catch (runError) {
-            failures.push(
+            runFailures.push(
               `${pipeName}: ${
                 runError instanceof Error ? runError.message : String(runError)
               }`,
@@ -1109,22 +1124,36 @@ export function BrainOverview({
         }),
       );
 
+      const startFailureCount = disabledPipeNames.length + runFailures.length;
+      const disabledPipeMessage =
+        disabledPipeNames.length > 0
+          ? `${disabledPipeNames.join(", ")} ${
+              disabledPipeNames.length === 1 ? "is" : "are"
+            } disabled. Enable ${
+              disabledPipeNames.length === 1 ? "it" : "them"
+            } in Pipes to refresh this Live View.`
+          : null;
+      const failureMessage = [
+        disabledPipeMessage,
+        runFailures.length > 0
+          ? `Could not start ${runFailures.join(", ")}`
+          : null,
+      ]
+        .filter((message): message is string => Boolean(message))
+        .join(" ");
       setDataRefresh((current) =>
         current && current.startedAt === startedAt
           ? {
               ...current,
               status:
-                failures.length === pipeNames.length ? "error" : "running",
-              startFailureCount: failures.length,
-              message:
-                failures.length > 0
-                  ? `Could not start ${failures.join(", ")}`
-                  : undefined,
+                startFailureCount === pipeNames.length ? "error" : "running",
+              startFailureCount,
+              message: failureMessage || undefined,
             }
           : current,
       );
     },
-    [views.length],
+    [enabledPipeNames, installedPipeNames, views.length],
   );
 
   useEffect(() => {
@@ -1515,7 +1544,7 @@ export function BrainOverview({
           selectedAiPreset.provider === "screenpipe-cloud"
             ? (settings.user?.token ?? null)
             : null,
-        pipes: installedPipes.map((pipe) => ({
+        pipes: enabledPipes.map((pipe) => ({
           name: pipe.config.name,
           description:
             typeof pipe.config.config?.description === "string"
@@ -2809,7 +2838,7 @@ export function BrainOverview({
         draft={draft}
         saving={saving}
         componentOptions={COMPONENTS}
-        pipeNames={installedPipes.map((pipe) => pipe.config.name)}
+        pipeNames={enabledPipes.map((pipe) => pipe.config.name)}
         onChange={setDraft}
         onCancel={() => {
           setDraft(null);


### PR DESCRIPTION
## What changed

- keep all installed Pipes available to Live View generation and manual layout editing
- when a bound Pipe is disabled, call its enable endpoint before starting the refresh run
- refetch Pipe state after enabling so the schedule toggle reflects the change
- skip the run and show an error if enabling fails
- add regressions for generation, enable-then-run ordering, and enable failure

## Root cause

Live View could manually run a disabled Pipe, but the manual run endpoint intentionally does not change recurring schedule state. The Pipe produced fresh data while still looking disabled in the Pipe list.

Live View is meant to keep its bound data fresh, so accepting or refreshing a Live View now enables any disabled installed Pipe it uses before running it.

## User impact

```text
before
disabled Pipe -> Live View /run -> schedule still disabled

after
disabled Pipe -> /enable -> refetch state -> /run -> schedule enabled
                               |
                               +-> enable failure: no run, visible error
```

## Validation

- focused Brain Overview suite — 56 passed
- related Live View suite — 70 passed
- `bun run typecheck` — passed
- focused ESLint — 0 errors; two pre-existing hook dependency warnings in `brain-overview.tsx`
- `git diff --check` — passed

The earlier GitHub frontend failure was infrastructure-only: GitHub returned `Service Unavailable` while resolving action downloads before the job ran source or tests.

This is source and local-test proof only; it is not merged, released, or installed-app recovery proof.
