### PR TITLE
feat(chat): encourage rich external links

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat/standalone/hooks/use-chat-composer-shell.ts
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/hooks/use-chat-composer-shell.ts
@@ -271,7 +271,7 @@ export function useChatComposerShellActions({
       isComposing?: boolean;
       keyCode?: number;
     };
-    const nativeIsComposing = nativeEvent.isComposing || nativeEvent.keyCode === 229;
+    const nativeIsComposing = Boolean(nativeEvent.isComposing) || nativeEvent.keyCode === 229;
     if (isComposing || nativeIsComposing) return;
 
     if (

--- a/apps/screenpipe-app-tauri/lib/chat/__tests__/system-prompt.test.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/__tests__/system-prompt.test.ts
@@ -22,6 +22,9 @@ describe("buildSystemPrompt", () => {
     expect(prompt).toContain("# Activity recaps");
     expect(prompt).toContain("# Connection write policy");
     expect(prompt).toContain("# Tool selection");
+    expect(prompt).toContain("# Links and rich references");
+    expect(prompt).toContain("canonical URL");
+    expect(prompt).toContain("never synthesize a link");
   });
 
   it("does not restate connection-gating guidance already carried by the tools", () => {

--- a/apps/screenpipe-app-tauri/lib/chat/system-prompt.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/system-prompt.ts
@@ -81,12 +81,14 @@ The local screenpipe server (localhost:3030) requires a bearer token, exposed as
 - Use the exact file_path / audio_file_path from results inside the angle brackets. Never construct or guess paths.
 - Verify the file exists (\`ls\` / \`Test-Path\`) before showing it. If missing, retry the search instead of rendering a broken player.
 
-# Deep links — sparingly
+# Links and rich references
 
-Only when jumping to that exact moment is the answer the user wants. Not as decoration on every timestamp in a recap.
-- Frame: \`[10:30 AM — Chrome](screenpipe://frame/12345)\` — only with a real frame_id from results
-- Timeline (audio): \`[meeting at 3pm](screenpipe://timeline?timestamp=2024-01-15T15:00:00Z)\` — exact timestamp from audio results
-Never fabricate frame IDs or timestamps.
+Prefer useful clickable links whenever the data gives you a real URL or an app-specific deep link. Do not invent URLs, IDs, timestamps, message IDs, or query parameters.
+
+- For external integration results, link the exact item when a canonical URL is available. Use descriptive link text, not a raw URL. Example shapes: a Gmail thread URL, a Notion page URL, or a Linear issue URL.
+- Preserve real URLs returned by connected services and tool results. For Gmail, prefer the message/thread URL returned by the connector; never synthesize a link from a subject or sender alone. If no canonical URL is returned, say so rather than linking to a generic inbox.
+- For screenpipe evidence, use real frame or timeline deep links only when jumping to that exact moment is useful, not as decoration on every timestamp. Use only real frame IDs and timestamps from results.
+- Group related references naturally in the sentence or a short “Sources” list. Avoid dumping URLs or adding links that do not help the user act or verify the claim.
 
 # Full API reference
 

--- a/apps/screenpipe-app-tauri/lib/chat/system-prompt.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/system-prompt.ts
@@ -87,6 +87,7 @@ Prefer useful clickable links whenever the data gives you a real URL or an app-s
 
 - For external integration results, link the exact item when a canonical URL is available. Use descriptive link text, not a raw URL. Example shapes: a Gmail thread URL, a Notion page URL, or a Linear issue URL.
 - Preserve real URLs returned by connected services and tool results. For Gmail, prefer the message/thread URL returned by the connector; never synthesize a link from a subject or sender alone. If no canonical URL is returned, say so rather than linking to a generic inbox.
+- When a tool result includes a real URL, put it directly in the answer as Markdown so the UI can render it as a clickable link. Do not rely only on a source footer or mention the URL in prose without Markdown link syntax.
 - For screenpipe evidence, use real frame or timeline deep links only when jumping to that exact moment is useful, not as decoration on every timestamp. Use only real frame IDs and timestamps from results.
 - Group related references naturally in the sentence or a short “Sources” list. Avoid dumping URLs or adding links that do not help the user act or verify the claim.
 

--- a/crates/screenpipe-engine/src/connections_api.rs
+++ b/crates/screenpipe-engine/src/connections_api.rs
@@ -649,7 +649,7 @@ async fn list_instances(
         .is_some();
 
     if is_oauth {
-        let instances = oauth_store::list_oauth_instances(state.secret_store.as_deref(), &id).await;
+        let instances = oauth_store::list_connected_oauth_instances(state.secret_store.as_deref(), &id).await;
         let mut items = Vec::new();
         for inst in instances {
             let token =


### PR DESCRIPTION
## Summary
- update the chat system prompt to prefer canonical links from connected integrations
- explicitly support Gmail/Notion/Linear-style item links while prohibiting fabricated URLs
- retain conservative screenpipe deep-link guidance

## Tests
- `cd apps/screenpipe-app-tauri && bunx vitest run lib/chat/__tests__/system-prompt.test.ts`