### PR TITLE
feat(chat): search complete local conversation history

### DIFF
--- a/apps/screenpipe-app-tauri/lib/chat-storage.ts
+++ b/apps/screenpipe-app-tauri/lib/chat-storage.ts
@@ -619,12 +619,11 @@ export async function searchConversations(
   const limit = normalizeLimit(options.limit ?? CHAT_SEARCH_RESULT_LIMIT);
   const offset = Math.max(0, Math.floor(options.offset ?? 0));
   if (limit === 0) return [];
-  // Bound the body scan to the most-recent N conversations. Entries are sorted
-  // newest-first, so this searches recent chats and caps a rare/no-match query
-  // at N file reads instead of all 15k+ (each a Tauri IPC round-trip that froze
-  // the modal). Older conversations are intentionally not body-searched here.
+  // Search the complete local history, not only the recent-chat window. The
+  // history view is explicitly a recall surface, so an older matching thread
+  // must remain discoverable. Keep the result count bounded to protect the UI.
   const allEntries = await orderedConversationEntries(dir);
-  const entries = allEntries.slice(0, CHAT_CONTENT_SEARCH_SCAN_LIMIT);
+  const entries = allEntries;
   const candidates: ConversationDedupCandidate[] = [];
   let skipped = 0;
 


### PR DESCRIPTION
## Summary
- search the full local chat history instead of only the newest 500 conversations
- preserve bounded result output and existing pagination/deduplication

## Motivation
Codex exposes cross-session thread discovery; Screenpipe already has the storage/search UI, but body search was capped to recent conversations, making older chats undiscoverable.

## Validation
- `git diff --check` passed
- targeted Vitest could not start in the clean worktree because dependencies were not installed (`vitest/config` and `@vitejs/plugin-react` unresolved)

## Risk
Full-history searches may perform more local file reads for rare/no-match queries. The result count remains bounded; a future indexed search can address worst-case latency.