### PR TITLE
fix(onboarding): stop asking new users to sign in to an account they do not have

### DIFF
--- a/apps/screenpipe-app-tauri/components/onboarding/login-gate.test.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/login-gate.test.tsx
@@ -186,11 +186,42 @@ describe("onboarding login gate", () => {
     vi.useRealTimers();
   });
 
-  it("shows the sign-in button when not signed in", () => {
+  it("shows the sign-in action when not signed in", () => {
     mocks.settings = { user: null };
     mocks.hasAppEntitlement.mockReturnValue(false);
     render(<OnboardingLogin handleNextSlide={vi.fn()} />);
+    expect(screen.getByText(/^get started$/i)).toBeInTheDocument();
+  });
+
+  // Everyone reaching this slide on a consumer build is a fresh install with
+  // no account. Labelling the only affordance "sign in" tells them the app is
+  // for people who already have one, and nothing on the slide offered to
+  // create an account: "sign up" appeared exactly once in the whole app UI,
+  // inside unrelated referral copy.
+  it("does not ask a brand-new user to sign in to an account they do not have", () => {
+    mocks.settings = { user: null };
+    mocks.hasAppEntitlement.mockReturnValue(false);
+
+    render(<OnboardingLogin handleNextSlide={vi.fn()} />);
+
+    expect(screen.getByText(/^get started$/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^sign in$/i)).toBeNull();
+    // Creating an account must be named, and it must stay free.
+    expect(
+      screen.getByText(/sign in or create a free account/i),
+    ).toBeInTheDocument();
+  });
+
+  it("still sends enterprise users to sign in, because their account already exists", () => {
+    mocks.settings = { user: null };
+    mocks.hasAppEntitlement.mockReturnValue(false);
+
+    render(<OnboardingLogin handleNextSlide={vi.fn()} suppressAutoAdvance />);
+
+    // An admin provisioned this account, so "create one" would be wrong.
     expect(screen.getByText(/^sign in$/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^get started$/i)).toBeNull();
+    expect(screen.queryByText(/create a free account/i)).toBeNull();
   });
 
   it("labels sign-in as the enterprise-account option during enterprise onboarding", () => {

--- a/apps/screenpipe-app-tauri/components/onboarding/login-gate.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/login-gate.tsx
@@ -354,7 +354,12 @@ const OnboardingLogin: React.FC<OnboardingLoginProps> = ({
 
               {/* Text */}
               <span className="relative z-10 font-mono text-sm tracking-[0.25em] uppercase font-medium text-foreground group-hover:text-background transition-colors duration-150">
-                sign in
+                {/* Enterprise users are handed an existing account by their
+                    admin, so "sign in" is literally correct there. Everyone
+                    else on this slide is a fresh install with no account yet,
+                    and "sign in" reads as an instruction for people who
+                    already have one. */}
+                {suppressAutoAdvance ? "sign in" : "get started"}
               </span>
 
               {/* Corner marks */}
@@ -373,7 +378,7 @@ const OnboardingLogin: React.FC<OnboardingLoginProps> = ({
             >
               {suppressAutoAdvance
                 ? "sign in with your enterprise account"
-                : "sign in to start free"}
+                : "sign in or create a free account"}
             </motion.p>
           </>
         )}


### PR DESCRIPTION
## Problem

Every consumer user who reaches the onboarding login slide is a **fresh install with no account**. The slide gave them exactly one affordance:

> **`sign in`**
> <sub>sign in to start free</sub>

"Sign in" is an instruction for people who already have an account. And nothing on the slide offered to make one. Grepping the entire app UI:

```
rg -i "sign ?up|create (an )?account" components app --glob '*.tsx' --glob '*.ts'
→ 1 hit: components/settings/referral-card.tsx  ("they sign up and get 10% off")
```

One occurrence, in referral copy about somebody else. So a first-time user is being asked to sign in to something they have never signed up for.

## Why it might matter

Last complete 7 days, macOS + Windows new installs, internal excluded (PostHog 330448):

| | users |
|---|---:|
| first open | 1,531 |
| clicked sign in | 1,229 |
| **never clicked at all** | **302 (19.7%)** |

A fifth of everyone who opens the app leaves before a single permission is requested. This is not proof the label caused it, and I want to be clear about that. But it is the cheapest hypothesis on the list, and it was raised independently by @EzraEllette on #5936, who said he has trouble finding the sign up button himself. He is right that it is hard to find. It is not there.

## Change

| | before | after |
|---|---|---|
| button | `sign in` | `get started` |
| sub-line | `sign in to start free` | `sign in or create a free account` |

Both populations now see themselves, and "free" stays on the slide.

**Enterprise is deliberately untouched.** Those accounts are provisioned by an admin, so `sign in` is literally correct there and "create one" would be actively wrong. The branch is on `suppressAutoAdvance`, the existing enterprise signal.

Two files, copy plus tests. No behaviour, no new events, no backend.

## Validation

`vitest components/onboarding/login-gate.test.tsx` — **11 passed**, 2 new:

- a brand-new user is never asked to "sign in", sees `get started`, and is told an account can be created for free
- enterprise still gets `sign in` and never sees the create-account copy

Also checked what else asserts on this string: `zz-app-entitlement-gate.spec.ts` matches `button*=sign in`, but that is the **entitlement gate** (`app-entitlement-gate.tsx`), a different component this PR does not touch. No other reference to the old copy exists anywhere in the repo.

## How to read the result

This is a copy change with no flag, so it can only be measured before/after on `onboarding_login_clicked` as a share of first-time `app_started`. That window is confounded by anything else shipping in the same release.

If you want a clean read, say so and I will put it behind a PostHog experiment instead, the same way `desktop-home-contextual-suggestions` is set up. I did not do that here to keep the change to two files, but the measurement caveat is real and I would rather flag it than quietly claim a lift later.

Deliberately separate from #5936. That one fixes the **254 who click and never come back** (cold WebView on Windows/Linux). This one is aimed at the **302 who never click**. Different populations, different mechanisms, worth keeping apart so the funnel can tell them apart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
