### PR TITLE
ci: close first-time contributor pull requests

### DIFF
--- a/.github/workflows/close-new-contributor-prs.yml
+++ b/.github/workflows/close-new-contributor-prs.yml
@@ -1,0 +1,54 @@
+name: Close new contributor PRs
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  close:
+    if: >-
+      github.event.pull_request.author_association == 'FIRST_TIMER' ||
+      github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Close pull request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pullRequest = context.payload.pull_request;
+            const newContributorAssociations = new Set([
+              "FIRST_TIMER",
+              "FIRST_TIME_CONTRIBUTOR",
+            ]);
+
+            if (!newContributorAssociations.has(pullRequest.author_association)) {
+              core.info(
+                `Leaving PR #${pullRequest.number} open: author association is ${pullRequest.author_association}.`,
+              );
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: pullRequest.number,
+              body: [
+                "Thanks for your interest in contributing to screenpipe.",
+                "",
+                "This repository currently does not accept pull requests from first-time contributors, so this pull request has been closed automatically.",
+              ].join("\n"),
+            });
+
+            await github.rest.pulls.update({
+              ...context.repo,
+              pull_number: pullRequest.number,
+              state: "closed",
+            });
+
+            core.info(
+              `Closed PR #${pullRequest.number}: author association is ${pullRequest.author_association}.`,
+            );


### PR DESCRIPTION
## Summary

- add a `pull_request_target` workflow for opened and reopened pull requests
- close authors classified by GitHub as `FIRST_TIMER` or `FIRST_TIME_CONTRIBUTOR`
- post a clear explanation before closing
- leave every other author association unchanged

## Flow

```text
Contributor fork
      |
      | opens or reopens PR
      v
Screenpipe default-branch workflow
      |
      +-- FIRST_TIMER ----------------> comment + close
      +-- FIRST_TIME_CONTRIBUTOR -----> comment + close
      +-- any other association ------> no job
```

## Security

The workflow uses `pull_request_target` so GitHub loads the trusted workflow from the base repository default branch. It does not check out, download, or execute contributor-controlled code. The job receives only `contents: read` and `pull-requests: write`. The association is checked both in the job condition and again inside the script before mutation.

## Behavior audit

| GitHub author association | Result |
| --- | --- |
| `FIRST_TIMER` | close |
| `FIRST_TIME_CONTRIBUTOR` | close |
| `CONTRIBUTOR` | leave open |
| `COLLABORATOR` | leave open |
| `MEMBER` | leave open |
| `OWNER` | leave open |
| `NONE` | leave open |

## Verification

- `actionlint .github/workflows/close-new-contributor-prs.yml`
- predicate matrix covering all author associations
- `git diff --check`

## Remaining risk

GitHub Actions availability and repository or organization policies can prevent execution. GitHub also documents that some SHA-like head branch names may not trigger `pull_request_target`; a scheduled reconciliation sweep is intentionally outside this focused change.