### PR TITLE
fix(chat): repair stale Anthropic preset URL

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
@@ -7,8 +7,8 @@
 //! Manages the pi coding agent via RPC mode (stdin/stdout JSON protocol).
 
 use screenpipe_core::agents::pi::{
-    apply_custom_provider_compat, screenpipe_cloud_models, PI_AI_PACKAGE, PI_NAMESPACE_DIR,
-    PI_PACKAGE, SCREENPIPE_API_URL,
+    anthropic_preset_base_url, apply_custom_provider_compat, screenpipe_cloud_models,
+    PI_AI_PACKAGE, PI_NAMESPACE_DIR, PI_PACKAGE, SCREENPIPE_API_URL,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -1928,8 +1928,8 @@ async fn build_models_json_with_api_url(
                 "http://localhost:11434/v1".to_string()
             } else if config.provider == "openai-chatgpt" {
                 "https://chatgpt.com/backend-api".to_string()
-            } else if config.provider == "anthropic" && config.url.is_empty() {
-                "https://api.anthropic.com".to_string()
+            } else if config.provider == "anthropic" {
+                anthropic_preset_base_url(&config.url)
             } else if config.provider == "openai" && config.url.is_empty() {
                 "https://api.openai.com/v1".to_string()
             } else {
@@ -6872,6 +6872,19 @@ error: InstallFailed extracting tarball"#;
             "https://api.anthropic.com"
         );
         assert_eq!(providers["anthropic-byok"]["api"], "anthropic-messages");
+    }
+
+    #[tokio::test]
+    async fn test_build_models_json_anthropic_normalizes_stale_openai_url() {
+        let mut pc = make_provider_config("anthropic", "claude-sonnet-5");
+        pc.url = "https://api.openai.com/v1".to_string();
+
+        let config = build_models_json(None, Some(&pc)).await;
+
+        assert_eq!(
+            config["providers"]["anthropic-byok"]["baseUrl"],
+            "https://api.anthropic.com"
+        );
     }
 
     #[tokio::test]

--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -65,6 +65,18 @@ pub fn apply_custom_provider_compat(provider: &mut serde_json::Value) {
     }
 }
 
+/// Repair the stale OpenAI default that older desktop presets could retain
+/// after switching to Anthropic, while preserving intentional compatible
+/// proxy URLs.
+pub fn anthropic_preset_base_url(saved_url: &str) -> String {
+    let normalized = saved_url.trim().trim_end_matches('/');
+    if normalized.is_empty() || normalized.eq_ignore_ascii_case("https://api.openai.com/v1") {
+        "https://api.anthropic.com".to_string()
+    } else {
+        saved_url.to_string()
+    }
+}
+
 /// Windows creation flags for background agent spawns: CREATE_NO_WINDOW
 /// (0x08000000) so no console flashes, plus BELOW_NORMAL_PRIORITY_CLASS
 /// (0x00004000) so the bun→pi→tool-call subtree yields CPU to whatever the
@@ -5085,6 +5097,23 @@ mod tests {
         assert_eq!(provider["headers"]["user-agent"], "my-client");
         assert_eq!(provider["headers"]["x-tenant"], "tenant-1");
         assert_eq!(provider["headers"].as_object().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn anthropic_preset_url_repairs_stale_openai_default() {
+        assert_eq!(anthropic_preset_base_url(""), "https://api.anthropic.com");
+        assert_eq!(
+            anthropic_preset_base_url("https://api.openai.com/v1"),
+            "https://api.anthropic.com"
+        );
+        assert_eq!(
+            anthropic_preset_base_url("https://api.openai.com/v1/"),
+            "https://api.anthropic.com"
+        );
+        assert_eq!(
+            anthropic_preset_base_url("https://anthropic-proxy.example.com"),
+            "https://anthropic-proxy.example.com"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- repair saved Anthropic presets that still carry Screenpipe's historical OpenAI default base URL
- normalize only an empty URL or the exact OpenAI default (`https://api.openai.com/v1`) to Anthropic's API
- preserve intentional Anthropic-compatible proxy and gateway URLs

## Source feedback

Discord feedback message `1535102660191977503` (tracked internally as task `t_1b8963bf`) reported an empty-body 404 in chat after configuring Anthropic on Screenpipe 2.5.175 / macOS 26.4.

## Root cause

The Anthropic connection probe targets Anthropic directly, but the chat runtime previously honored any non-empty saved preset URL. Older presets could therefore retain the OpenAI default, pass setup, and later send `anthropic-messages` traffic to the wrong API, which returned 404.

## Why this covers the surface

The shared core helper defines the normalization rule, and the Tauri preset-to-runtime model path applies it when building the models JSON consumed by chat. The match is case/whitespace/trailing-slash tolerant but intentionally exact to the stale OpenAI default; every other non-empty URL remains unchanged, including custom Anthropic-compatible proxies.

## Behavior diagram

```text
Before: saved Anthropic preset -> stale api.openai.com/v1 -> Anthropic request shape -> 404
After:  saved Anthropic preset -> api.anthropic.com       -> Anthropic request shape -> OK
Proxy:  saved Anthropic preset -> custom proxy URL        -> unchanged
```

## Verification

RED:
- regression referenced the URL-repair helper before implementation and failed to compile with `E0425`

GREEN / broad checks on exact commit `72aa43aeed71d580805edd62532442a624b92494`:
- `cargo test -p screenpipe-core anthropic_preset_url_repairs_stale_openai_default -- --nocapture` — 1 passed
- `cargo test -p screenpipe-core --lib` — 449 passed, 1 ignored
- `cargo check -p screenpipe-core` — passed
- `cargo fmt --all -- --check` — passed
- commit whitespace/diff check — passed

Independent review unconditionally approved this exact commit with no engineering corrections.

## Platform scope and limitations

The report was observed on macOS, while the preset normalization path itself is platform-independent. A Tauri compile attempt on the Linux review host was blocked before app code compilation because native pkg-config dependencies were unavailable (`openssl.pc`; a separate attempt also lacked `glib-2.0.pc`). The changed shared core code and its regression suite compiled and passed as listed above.

## Visual evidence

This is a non-visual routing/configuration repair, so there is no changed UI to screenshot. The behavior diagram above documents the before/after request routing and proxy-preservation case.