### PR TITLE
fix(ai-presets): strip Gemini models/ prefix from fetched model ids

### DIFF
--- a/apps/screenpipe-app-tauri/components/rewind/ai-presets-selector.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/ai-presets-selector.tsx
@@ -8,6 +8,7 @@ import { testAiPresetConnection } from "@/lib/utils/ai-preset-connection";
 import {
   aiPresetConnectionFingerprint,
   isAiApiKeyRequired,
+  normalizeGeminiModelId,
   requiresAiPresetConnectionTest,
   shouldRequireAiPresetConnectionTest,
   validateAiPresetConnectionFields,
@@ -412,7 +413,14 @@ export function AIProviderConfig({
       }
 
       const data = await response.json();
-      setOpenAIModels(data.data || []);
+      // Gemini's /models returns "models/gemini-…" resource names; suggest the
+      // bare ids that chat/completions (and our validation) expect.
+      setOpenAIModels(
+        (data.data || []).map((m: { id: string }) => ({
+          ...m,
+          id: normalizeGeminiModelId(m.id, baseUrl),
+        }))
+      );
     } catch (error) {
       console.error("error fetching models:", error);
       setOpenAIModels([]);

--- a/apps/screenpipe-app-tauri/components/settings/ai-presets.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/ai-presets.tsx
@@ -126,6 +126,7 @@ import {
   aiPresetConnectionFingerprint,
   extractAiProviderErrorMessage,
   isAiApiKeyRequired,
+  normalizeGeminiModelId,
   shouldRequireAiPresetConnectionTest,
   validateAiPresetConnectionFields,
   validateAiProviderUrl,
@@ -294,9 +295,15 @@ const AISection = ({
   // flag, hydrated local entitlement, and gateway eligibility all agree. The
   // gateway's `locked` flag only takes visual effect when this is true.
   const showUpsell = useModelUpsellGating(usage?.upgrade_eligible);
+  // Self-heal presets saved with a Gemini "models/" resource name before we
+  // normalized fetched ids — they fail validation and deadlock the editor.
   const [settingsPreset, setSettingsPreset] = useState<
     Partial<AIPreset> | undefined
-  >(preset);
+  >(() =>
+    preset?.model
+      ? { ...preset, model: normalizeGeminiModelId(preset.model, preset.url) }
+      : preset
+  );
   const [isLoading, setIsLoading] = useState(false);
   const [showApiKey, setShowApiKey] = useState(false);
   const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
@@ -733,6 +740,9 @@ const AISection = ({
   const [isLoadingModels, setIsLoadingModels] = useState(false);
   const [isModelPickerOpen, setIsModelPickerOpen] = useState(false);
   const [modelSearch, setModelSearch] = useState("");
+  // True once the user arrow-navigates the model list; Enter then selects the
+  // highlighted item instead of committing the typed text.
+  const hasNavigatedModelList = useRef(false);
 
   const runDiagnostics = useCallback(async () => {
     if (settingsPreset?.provider === "screenpipe-cloud" || settingsPreset?.provider === "acp") return;
@@ -1091,12 +1101,21 @@ const AISection = ({
               return;
             }
             const customData = await customResponse.json();
+            // Gemini's /models returns "models/gemini-…" resource names that
+            // our own validation rejects — normalize (and dedupe) so every
+            // option in the dropdown is directly selectable.
+            const seenIds = new Set<string>();
             setModels(
-              (customData.data || []).map((model: { id: string }) => ({
-                id: model.id,
-                name: model.id,
-                provider: "custom",
-              }))
+              (customData.data || [])
+                .map((model: { id: string }) =>
+                  normalizeGeminiModelId(model.id, settingsPreset?.url)
+                )
+                .filter((id: string) => !seenIds.has(id) && (seenIds.add(id), true))
+                .map((id: string) => ({
+                  id,
+                  name: id,
+                  provider: "custom",
+                }))
             );
           } catch (error) {
             console.error(
@@ -1588,7 +1607,8 @@ const AISection = ({
             open={isModelPickerOpen}
             onOpenChange={(open) => {
               setIsModelPickerOpen(open);
-                setModelSearch("");
+              setModelSearch("");
+              hasNavigatedModelList.current = false;
             }}
           >
             <PopoverTrigger asChild>
@@ -1618,22 +1638,29 @@ const AISection = ({
                   value={modelSearch}
                   placeholder="Select or type model name" 
                   onKeyDown={(e) => {
+                    if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+                      // Explicit list navigation: hand Enter back to cmdk so
+                      // it selects the highlighted item.
+                      hasNavigatedModelList.current = true;
+                      return;
+                    }
                     if (e.key === "Enter") {
+                      if (hasNavigatedModelList.current) return;
                       const input = modelSearch.trim();
                       if (!input) return;
-                      const exactModel = models.find((m) => m.id === input);
-                      if (exactModel) {
-                        updateSettingsPreset({ model: exactModel.id });
-                        setIsModelPickerOpen(false);
-                        return;
-                      }
-                      if (models.every(m => m.id !== input)) {
-                        updateSettingsPreset({ model: input });
-                        setIsModelPickerOpen(false);
-                      }
+                      // Otherwise the typed text wins: stop cmdk's own Enter
+                      // handler from replacing it with the highlighted fuzzy
+                      // match (e.g. "gemini-2.5-flash" vs "models/gemini-2.5-flash").
+                      e.preventDefault();
+                      e.stopPropagation();
+                      updateSettingsPreset({
+                        model: models.find((m) => m.id === input)?.id ?? input,
+                      });
+                      setIsModelPickerOpen(false);
                     }
                   }}
                   onValueChange={(value) => {
+                    hasNavigatedModelList.current = false;
                     setModelSearch(value);
                   }}
                 />

--- a/apps/screenpipe-app-tauri/lib/utils/validation.test.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/validation.test.ts
@@ -8,6 +8,7 @@ import {
   aiProviderTypeSchema,
   extractAiProviderErrorMessage,
   GEMINI_OPENAI_BASE_URL,
+  normalizeGeminiModelId,
   shouldRequireAiPresetConnectionTest,
   validateAiModel,
   validateAiPresetConnectionFields,
@@ -83,6 +84,23 @@ describe("BYOK connection validation", () => {
     expect(
       validateAiModel("gemini-3.6-flash", "custom", GEMINI_OPENAI_BASE_URL),
     ).toEqual({ isValid: true });
+  });
+
+  it("strips the models/ prefix from Gemini-fetched ids only", () => {
+    expect(
+      normalizeGeminiModelId("models/gemini-3.6-flash", GEMINI_OPENAI_BASE_URL),
+    ).toBe("gemini-3.6-flash");
+    expect(
+      normalizeGeminiModelId("gemini-3.6-flash", GEMINI_OPENAI_BASE_URL),
+    ).toBe("gemini-3.6-flash");
+    // Non-Gemini endpoints may legitimately serve models/-prefixed ids.
+    expect(
+      normalizeGeminiModelId("models/custom-1", "https://provider.example.com/v1"),
+    ).toBe("models/custom-1");
+    expect(normalizeGeminiModelId("models/custom-1", undefined)).toBe(
+      "models/custom-1",
+    );
+    expect(normalizeGeminiModelId("models/custom-1", "")).toBe("models/custom-1");
   });
 
   it("requires credentials for known BYOK providers but leaves generic custom auth optional", () => {

--- a/apps/screenpipe-app-tauri/lib/utils/validation.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/validation.ts
@@ -178,6 +178,17 @@ const parseUrl = (url?: string | null): URL | null => {
 export const isGeminiApiUrl = (url?: string | null): boolean =>
   parseUrl(url)?.hostname.toLowerCase() === GEMINI_API_HOST;
 
+// Gemini's OpenAI-compat /models endpoint returns resource names
+// ("models/gemini-2.5-flash") while chat/completions is documented with bare
+// ids — strip the prefix so fetched options are directly usable.
+export const normalizeGeminiModelId = (
+  model: string,
+  url?: string | null,
+): string =>
+  isGeminiApiUrl(url) && model.startsWith("models/")
+    ? model.slice("models/".length)
+    : model;
+
 export const validateAiProviderUrl = (
   url: string,
   provider?: AIProviderType,


### PR DESCRIPTION
### Description:

Fixes #5963

after:


https://github.com/user-attachments/assets/53f5cbcc-8729-46b8-a554-45049fbb47ef

- Gemini's OpenAI-compatible `/models` endpoint returns resource names like `models/gemini-2.5-flash`; the Custom provider dropdown listed them verbatim while our own validation rejects the `models/` prefix, so every option was unselectable and the preset could never be saved.
- New `normalizeGeminiModelId` helper strips the prefix only for `generativelanguage.googleapis.com` URLs — other custom endpoints with legitimately prefixed ids are untouched. Applied at both fetch sites (settings model picker and the rewind preset dialog) with dedupe.
- Presets already saved with a stuck `models/…` model are auto-normalized when the editor opens, and the changed model correctly re-triggers the connection-test requirement.
- Fixed the model combobox so typed text actually wins on Enter: cmdk's fuzzy match was silently overwriting the typed value with the highlighted `models/…` item. Arrow-key navigation still selects the highlighted item as expected. This unblocks manual model entry for all custom providers, not just Gemini.
- Validation stays unchanged as a backstop for hand-typed prefixes; existing Gemini rejection test still passes, new unit tests cover the normalization edge cases.