### PR TITLE
chore(deps): vendor build-critical crates into the screenpipe org

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3051,7 +3051,7 @@ dependencies = [
 [[package]]
 name = "eventkit-rs"
 version = "0.5.6"
-source = "git+https://github.com/divanshu-go/eventkit-rs?rev=9dd52787c8435d734ed443e2d5641f45b0177cae#9dd52787c8435d734ed443e2d5641f45b0177cae"
+source = "git+https://github.com/screenpipe/eventkit-rs?rev=9dd52787c8435d734ed443e2d5641f45b0177cae#9dd52787c8435d734ed443e2d5641f45b0177cae"
 dependencies = [
  "block2",
  "chrono",

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -4036,7 +4036,7 @@ dependencies = [
 [[package]]
 name = "eventkit-rs"
 version = "0.5.6"
-source = "git+https://github.com/divanshu-go/eventkit-rs?rev=9dd52787c8435d734ed443e2d5641f45b0177cae#9dd52787c8435d734ed443e2d5641f45b0177cae"
+source = "git+https://github.com/screenpipe/eventkit-rs?rev=9dd52787c8435d734ed443e2d5641f45b0177cae#9dd52787c8435d734ed443e2d5641f45b0177cae"
 dependencies = [
  "block2 0.6.2",
  "chrono",
@@ -7578,7 +7578,7 @@ dependencies = [
 [[package]]
 name = "muda"
 version = "0.19.3"
-source = "git+https://github.com/divanshu-go/muda?rev=327f3f8198b0ecdc3d58d7be85dfb83b2fa0d05d#327f3f8198b0ecdc3d58d7be85dfb83b2fa0d05d"
+source = "git+https://github.com/screenpipe/muda?rev=327f3f8198b0ecdc3d58d7be85dfb83b2fa0d05d#327f3f8198b0ecdc3d58d7be85dfb83b2fa0d05d"
 dependencies = [
  "crossbeam-channel",
  "dpi",
@@ -13873,7 +13873,7 @@ dependencies = [
 [[package]]
 name = "tauri-helper"
 version = "0.2.1"
-source = "git+https://github.com/divanshu-go/tauri-helper?rev=e25ff1d2c5026189305a0251a1e06788efe1d2b3#e25ff1d2c5026189305a0251a1e06788efe1d2b3"
+source = "git+https://github.com/screenpipe/tauri-helper?rev=e25ff1d2c5026189305a0251a1e06788efe1d2b3#e25ff1d2c5026189305a0251a1e06788efe1d2b3"
 dependencies = [
  "rayon",
  "serde",
@@ -14420,7 +14420,7 @@ dependencies = [
 [[package]]
 name = "tauri_helper_core"
 version = "0.2.1"
-source = "git+https://github.com/divanshu-go/tauri-helper?rev=e25ff1d2c5026189305a0251a1e06788efe1d2b3#e25ff1d2c5026189305a0251a1e06788efe1d2b3"
+source = "git+https://github.com/screenpipe/tauri-helper?rev=e25ff1d2c5026189305a0251a1e06788efe1d2b3#e25ff1d2c5026189305a0251a1e06788efe1d2b3"
 dependencies = [
  "serde",
  "toml 0.9.12+spec-1.1.0",
@@ -14429,7 +14429,7 @@ dependencies = [
 [[package]]
 name = "tauri_helper_macros"
 version = "0.1.4"
-source = "git+https://github.com/divanshu-go/tauri-helper?rev=e25ff1d2c5026189305a0251a1e06788efe1d2b3#e25ff1d2c5026189305a0251a1e06788efe1d2b3"
+source = "git+https://github.com/screenpipe/tauri-helper?rev=e25ff1d2c5026189305a0251a1e06788efe1d2b3#e25ff1d2c5026189305a0251a1e06788efe1d2b3"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.94"
 
 [build-dependencies]
 tauri-build = { version = "=2.6.2", features = [] }
-tauri-helper = { git = "https://github.com/divanshu-go/tauri-helper", rev = "e25ff1d2c5026189305a0251a1e06788efe1d2b3" }
+tauri-helper = { git = "https://github.com/screenpipe/tauri-helper", rev = "e25ff1d2c5026189305a0251a1e06788efe1d2b3" }
 # Used by build.rs on Windows MSVC targets (incl. cross-compiles from
 # Linux/macOS CI runners) to compile c/bswap_shim.c — provides
 # __builtin_bswap{16,32,64} as real functions to satisfy the aws-lc-sys
@@ -25,7 +25,7 @@ tauri-helper = { git = "https://github.com/divanshu-go/tauri-helper", rev = "e25
 cc = "1"
 
 [dependencies]
-tauri-helper = { git = "https://github.com/divanshu-go/tauri-helper", rev = "e25ff1d2c5026189305a0251a1e06788efe1d2b3" }
+tauri-helper = { git = "https://github.com/screenpipe/tauri-helper", rev = "e25ff1d2c5026189305a0251a1e06788efe1d2b3" }
 tauri = { version = "=2.11.2", features = [
   "protocol-asset",
   "macos-private-api",
@@ -145,7 +145,7 @@ screenpipe-connect = { path = "../../../crates/screenpipe-connect", features = [
 screenpipe-secrets = { path = "../../../crates/screenpipe-secrets" }
 screenpipe-events = { path = "../../../crates/screenpipe-events" }
 sqlx = { version = "=0.9.0", default-features = false, features = ["sqlite", "runtime-tokio"], optional = true }
-eventkit-rs = { git = "https://github.com/divanshu-go/eventkit-rs", rev = "9dd52787c8435d734ed443e2d5641f45b0177cae", default-features = false, features = ["events"] }
+eventkit-rs = { git = "https://github.com/screenpipe/eventkit-rs", rev = "9dd52787c8435d734ed443e2d5641f45b0177cae", default-features = false, features = ["events"] }
 # Async PII reconciliation (issue #3185 / PR #3188). `onnx-coreml` is
 # the right execution-provider for Apple Silicon (image PII via
 # rfdetr_v8); `opf-text` enables the local pure-Rust candle text
@@ -346,7 +346,7 @@ ignored = ["tauri-utils", "screenpipe-redact", "thiserror", "screenpipe-sync", "
 # of a raw pointer so stale AppKit items keep their Rust click data alive.
 # Pinned by commit (not branch) for reproducible builds; drop once
 # upstream tauri-apps/muda#361 merges and ships in a released muda.
-muda = { git = "https://github.com/divanshu-go/muda", rev = "327f3f8198b0ecdc3d58d7be85dfb83b2fa0d05d" }
+muda = { git = "https://github.com/screenpipe/muda", rev = "327f3f8198b0ecdc3d58d7be85dfb83b2fa0d05d" }
 
 [profile.release]
 codegen-units = 1

--- a/crates/screenpipe-connect/Cargo.toml
+++ b/crates/screenpipe-connect/Cargo.toml
@@ -72,7 +72,7 @@ default = []
 specta = ["dep:specta"]
 
 [target.'cfg(target_os = "macos")'.dependencies]
-eventkit-rs = { git = "https://github.com/divanshu-go/eventkit-rs", rev = "9dd52787c8435d734ed443e2d5641f45b0177cae", default-features = false, features = ["events"] }
+eventkit-rs = { git = "https://github.com/screenpipe/eventkit-rs", rev = "9dd52787c8435d734ed443e2d5641f45b0177cae", default-features = false, features = ["events"] }
 objc2 = "0.6"
 objc2-event-kit = "0.3"
 objc2-foundation = "0.3"

--- a/packages/sdk/Cargo.lock
+++ b/packages/sdk/Cargo.lock
@@ -2572,7 +2572,7 @@ dependencies = [
 [[package]]
 name = "eventkit-rs"
 version = "0.5.6"
-source = "git+https://github.com/divanshu-go/eventkit-rs?rev=9dd52787c8435d734ed443e2d5641f45b0177cae#9dd52787c8435d734ed443e2d5641f45b0177cae"
+source = "git+https://github.com/screenpipe/eventkit-rs?rev=9dd52787c8435d734ed443e2d5641f45b0177cae#9dd52787c8435d734ed443e2d5641f45b0177cae"
 dependencies = [
  "block2",
  "chrono",

--- a/packages/sdk/examples/tauri-app/src-tauri/Cargo.lock
+++ b/packages/sdk/examples/tauri-app/src-tauri/Cargo.lock
@@ -2625,7 +2625,7 @@ dependencies = [
 [[package]]
 name = "eventkit-rs"
 version = "0.5.6"
-source = "git+https://github.com/divanshu-go/eventkit-rs?rev=9dd52787c8435d734ed443e2d5641f45b0177cae#9dd52787c8435d734ed443e2d5641f45b0177cae"
+source = "git+https://github.com/screenpipe/eventkit-rs?rev=9dd52787c8435d734ed443e2d5641f45b0177cae#9dd52787c8435d734ed443e2d5641f45b0177cae"
 dependencies = [
  "block2",
  "chrono",


### PR DESCRIPTION
## Problem

Three crates the build depends on were pulled from a personal GitHub account rather than the org:

| crate | source | rev | used by |
|---|---|---|---|
| `eventkit-rs` | `divanshu-go/eventkit-rs` | `9dd5278` | `screenpipe-connect`, desktop app |
| `muda` | `divanshu-go/muda` | `327f3f8` | desktop app (`[patch]`) |
| `tauri-helper` | `divanshu-go/tauri-helper` | `e25ff1d` | desktop app (dep + build-dep) |

All three are rev-pinned, so **content** could not change silently. The exposure is **availability**: a repo going private, being renamed, or being deleted breaks the desktop build for everyone, including CI and release workflows, with no warning and no fix short of an emergency vendor.

## Where found

Auditing every git dependency across the workspace:

```
grep -rh 'source = "git+https://github.com/' --include="Cargo.lock" .
```

21 distinct git sources. 7 already in the org, 11 normal third-party upstreams, and 3 on a personal account. This PR moves those 3.

## Reproduction of the pre-fix risk

Make any one of the three repos private, then from a clean checkout:

```
cargo metadata --locked
# error: failed to load source for dependency `eventkit-rs`
# Caused by: failed to clone into: ~/.cargo/git/db/eventkit-rs-*
```

The build stops at dependency resolution, before compiling anything.

## Fix

```
BEFORE                                     AFTER

screenpipe-connect                         screenpipe-connect
  └── eventkit-rs ─────┐                     └── eventkit-rs ─────┐
                       │                                          │
screenpipe-app-tauri   │                   screenpipe-app-tauri   │
  ├── eventkit-rs ─────┤                     ├── eventkit-rs ─────┤
  ├── tauri-helper ────┤                     ├── tauri-helper ────┤
  └── muda ────────────┤                     └── muda ────────────┤
                       │                                          │
                       ▼                                          ▼
        ╔══════════════════════════╗            ╔══════════════════════════╗
        ║  github.com/divanshu-go  ║            ║  github.com/screenpipe   ║
        ║                          ║            ║                          ║
        ║  personal account        ║            ║  org owned               ║
        ║  availability outside    ║            ║  availability under      ║
        ║  org control             ║            ║  org control             ║
        ╚══════════════════════════╝            ╚══════════════════════════╝
```

Each crate is mirrored into the org. The mirrors were pushed with full history rather than forked, so **the pinned commits exist unchanged in the new repos**. Only the URLs change in this diff. Every `rev` is byte-identical, so this builds the exact same code.

All three upstreams are permissively licensed, and history plus `LICENSE` files are preserved intact for attribution:

| new repo | fork of | license |
|---|---|---|
| `screenpipe/eventkit-rs` | `Weekendsuperhero-io/eventkit-rs` | Apache-2.0 |
| `screenpipe/muda` | `tauri-apps/muda` | Apache-2.0 |
| `screenpipe/tauri-helper` | `RiadYan/tauri-helper` | MIT |

## Validation

**Content is provably identical.** Tree hash at each pinned commit, old vs new:

| crate | tree hash | match |
|---|---|---|
| `eventkit-rs` | `5901c949c2cf43c875a358f5adc3c79bca5e8531` | yes |
| `muda` | `d95704e15f43adad7123dd9405ea6a9527aceef2` | yes |
| `tauri-helper` | `0fb0971d2d13f4a66f7ca620461d95ea15c16557` | yes |

**Resolution and build:**

- `cargo metadata --locked` passes on the root workspace, which fetches from the org repos and proves the lockfile is consistent
- `cargo metadata --locked` passes on `apps/screenpipe-app-tauri/src-tauri`, covering all three crates including the `muda` patch entry
- `cargo check -p screenpipe-connect --locked` passes, exit 0. Only pre-existing `rand::Rng::gen` deprecation warnings in `screenpipe-core`, unrelated to this change
- `grep -rc divanshu-go --include=Cargo.toml --include=Cargo.lock` returns 0 matches

**Not run locally, deferred to CI:** full desktop release build, platform E2E, and the Windows and Linux build paths. This change touches only dependency URLs and no source, so the risk is resolution failure rather than behavior change, and resolution is verified above on both workspaces.

## Scope

6 files, URL substitutions only. No source changes, no rev changes, no feature flag changes, no new or removed dependencies.

## Known remaining item

`EzraEllette/permission-flow` is the one other build dependency still on a personal account. Same class of availability risk, left out of this PR to keep the diff to a single concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
