### PR TITLE
fix(acp): never offer Claude subscription sign-in, API key only

### DIFF
--- a/apps/screenpipe-app-tauri/lib/acp/agents.json
+++ b/apps/screenpipe-app-tauri/lib/acp/agents.json
@@ -21,7 +21,11 @@
     "imageSrc": "/images/claude-ai.svg",
     "presetName": "claude code",
     "description": "Use your existing Claude Code account and configuration.",
-    "launch": { "kind": "npx", "package": "@agentclientprotocol/claude-agent-acp@0.61.0", "args": [] }
+    "launch": {
+      "kind": "npx",
+      "package": "@agentclientprotocol/claude-agent-acp@0.61.0",
+      "args": ["--hide-claude-auth"]
+    }
   },
   {
     "id": "opencode",

--- a/apps/screenpipe-app-tauri/src-tauri/src/acp_runtime.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/acp_runtime.rs
@@ -2233,10 +2233,31 @@ fn terminal_auth_args(method: &Value) -> Option<Vec<String>> {
     Some(args.iter().filter_map(Value::as_str).map(str::to_owned).collect())
 }
 
+/// Consumer Claude subscription sign-in, which Screenpipe must never offer.
+///
+/// Anthropic's guidance to third-party developers is that a product embedding
+/// Claude Code uses an API key (Anthropic Console) or a supported cloud, and
+/// does not put users through Claude.ai login or route Free/Pro/Max credentials
+/// on their behalf. The adapter is launched with `--hide-claude-auth`
+/// (agents.json), which drops exactly these methods and keeps the Console
+/// method. This is the second layer: an adapter upgrade that renames the flag,
+/// ignores it, or advertises the method anyway must not silently put the
+/// subscription option back in front of a user.
+fn is_claude_subscription_auth(id: &str, name: &str) -> bool {
+    let id = id.to_ascii_lowercase();
+    let name = name.to_ascii_lowercase();
+    // Codex's ChatGPT method is deliberately not matched: OpenAI supports
+    // signing into Codex with a ChatGPT plan, so it is not the same boundary.
+    id == "claude-ai-login" || id == "claude-login" || name.contains("claude subscription")
+}
+
 fn available_auth_methods(
     init: &InitializeResponse,
 ) -> Vec<&agent_client_protocol::schema::v1::AuthMethod> {
-    init.auth_methods.iter().collect()
+    init.auth_methods
+        .iter()
+        .filter(|method| !is_claude_subscription_auth(&method.id().to_string(), method.name()))
+        .collect()
 }
 
 async fn authenticate(
@@ -3658,6 +3679,57 @@ mod tests {
         // Invalid boolean strings and unknown options are skipped, never sent.
         assert_eq!(default_option_value(&session, "fast", "yes"), None);
         assert_eq!(default_option_value(&session, "gone", "a"), None);
+    }
+
+    /// Anthropic's guidance is that an embedding product uses an API key or a
+    /// supported cloud, not Claude.ai login on the user's behalf. Both layers
+    /// are pinned: the launch flag that makes the adapter withhold the method,
+    /// and the filter that drops it if an adapter advertises it anyway.
+    #[test]
+    fn claude_adapter_launches_with_subscription_auth_hidden() {
+        let claude = agent_catalog()
+            .into_iter()
+            .find(|agent| agent.id == "claude-acp")
+            .expect("claude-acp in catalog");
+
+        match claude.launch {
+            AgentLaunch::Npx { ref args, .. } => {
+                assert!(
+                    args.iter().any(|arg| arg == "--hide-claude-auth"),
+                    "claude-acp must launch with --hide-claude-auth, got {args:?}"
+                );
+            }
+            AgentLaunch::Binary { .. } => panic!("claude-acp should launch via npx"),
+        }
+    }
+
+    #[test]
+    fn claude_subscription_auth_methods_are_never_offered() {
+        // The adapter's own ids/labels for consumer sign-in.
+        assert!(is_claude_subscription_auth(
+            "claude-ai-login",
+            "Claude Subscription"
+        ));
+        assert!(is_claude_subscription_auth(
+            "claude-login",
+            "Log in with Claude"
+        ));
+        // Matched by label too, so a renamed id still cannot slip through.
+        assert!(is_claude_subscription_auth(
+            "something-new",
+            "Claude subscription "
+        ));
+
+        // The API-key path must survive: hiding every method would leave the
+        // agent unusable rather than compliant.
+        assert!(!is_claude_subscription_auth(
+            "console-login",
+            "Anthropic Console"
+        ));
+        // Codex signs in with a ChatGPT plan, which OpenAI supports. Not the
+        // same boundary, and filtering it would break Codex sign-in.
+        assert!(!is_claude_subscription_auth("chatgpt", "ChatGPT"));
+        assert!(!is_claude_subscription_auth("cursor-login", "Cursor Login"));
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Screenpipe was offering **Claude Subscription** as a sign-in method for the Claude Code agent.

Anthropic's guidance to third-party developers is that a product embedding Claude Code authenticates with an API key (Anthropic Console) or a supported cloud, and does not put users through Claude.ai login or route Free/Pro/Max credentials on their behalf. Offering it is a licensing boundary we should not be on the wrong side of.

## Where found

`available_auth_methods` returned every method the adapter advertised, and the comment above it said so out loud:

> because we declare the terminal-auth capability — Claude Subscription / Anthropic Console for Claude

Confirmed against the shipped adapter (`@agentclientprotocol/claude-agent-acp@0.61.0`, `dist/acp-agent.js`). It builds two terminal methods and gates them differently:

```js
if (!shouldHideClaudeAuth() && (supportsTerminalAuth || supportsMetaTerminalAuth)) {
  terminalAuthMethods.push(claudeLoginMethod);   // "Claude Subscription", --claudeai
}
if (supportsTerminalAuth || supportsMetaTerminalAuth) {
  terminalAuthMethods.push(consoleLoginMethod);  // "Anthropic Console", --console
}
```

`shouldHideClaudeAuth()` is `process.argv.includes("--hide-claude-auth")`. We launch with `"args": []`, so the subscription method was always advertised, and we always showed it.

Critically, the Console (API key) method is pushed **unconditionally**, so hiding the subscription method does not leave the agent unusable.

## Fix

Two layers, because this is a licensing boundary rather than a UX preference.

1. **Launch flag.** `claude-acp` now launches with `--hide-claude-auth`, so the adapter never advertises the subscription method in the first place.
2. **Runtime filter.** `available_auth_methods` drops subscription methods by id (`claude-ai-login`, `claude-login`) and by label. An adapter upgrade that renames the flag, ignores it, or advertises the method anyway cannot silently put the option back in front of a user.

Codex's ChatGPT method is deliberately **not** filtered: OpenAI supports signing into Codex with a ChatGPT plan, so it is not the same boundary, and filtering it would break Codex sign-in. The filter is scoped to Claude only, with a test pinning that.

## Validation

- `cargo test --bin screenpipe-app acp_runtime`: 24 passed, 0 failed. Two new tests:
  - `claude_adapter_launches_with_subscription_auth_hidden` reads the real catalog and asserts the flag is in the launch args. It would have failed before this change, where args were `[]`.
  - `claude_subscription_auth_methods_are_never_offered` pins that both subscription ids and the label match, that Anthropic Console survives, and that Codex ChatGPT and Cursor Login are untouched.
- `cargo fmt --check`: no diff in any line this PR adds. The file has 126 pre-existing diff hunks on `main` under a standalone rustfmt invocation; that count is unchanged by this PR and none of them are in changed code.

Stated gaps:

- Not exercised against a live Claude Code sign-in. The adapter behaviour is read from the shipped `dist/acp-agent.js` of the exact pinned version, not observed in a packaged run. Worth one manual check that the sign-in card now shows only **Anthropic Console** before this reaches users.
- Anyone who already signed in with a Claude subscription keeps that credential in the agent's own local store; this stops us offering the method, it does not revoke an existing login. If that matters, it needs a separate migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
