### PR TITLE
feat(pipes): company brain pipe with approval-gated repo push

### DIFF
--- a/crates/screenpipe-core/assets/pipes/company-brain/pipe.md
+++ b/crates/screenpipe-core/assets/pipes/company-brain/pipe.md
@@ -1,0 +1,106 @@
+---
+schedule: every day at 6pm
+enabled: false
+history: false
+template: true
+title: Company Brain
+description: Turns the day's decisions and learnings into reviewed entries you push to your team's brain repo
+featured: false
+timeout: 600
+---
+
+## 🧠 Continuous improvement (memory)
+Before you do anything else this run, read `./memory.md` (a file in this pipe's own folder) if it exists and apply its lessons — this is how you get better each run instead of starting cold. If it's missing, create it with a `# memory` heading followed by a `## Lessons` heading.
+
+After you finish the run, append at most 1–3 NEW one-line lessons under `## Lessons`, each prefixed with today's date — but only if this run actually taught you something durable and reusable (a pattern that worked, a mistake to avoid, a user correction, or a stable fact about this user's setup). If you learned nothing new, write nothing.
+
+Keep memory healthy so it never drifts:
+- Append-only: never delete or rewrite earlier lessons or anything the user added. The one exception is retracting a lesson you can now prove wrong — add a new dated line saying which one and why.
+- Cap the file at ~150 lines / 8KB. When it is over, merge duplicates and drop the oldest low-value lessons first; never drop notes the user wrote.
+- Save observations and rules, not new tasks — and nothing that changes your core job. Never edit this `pipe.md` prompt.
+- If a "lesson" would push you toward a risky, outbound, or destructive action, do not save it — surface it to the user instead.
+
+> **Screenpipe data safety:** never open, copy, inspect, or query Screenpipe's SQLite database or its WAL/SHM sidecars directly. Use only the authenticated local Screenpipe API. If an API is unavailable, report the gap instead of falling back to database access.
+
+Turn the day's real work into a few durable, source-backed entries in the team's company brain repository. You draft and ask; the human approves every push. A shared repository is an outbound destination, so nothing leaves this machine without an explicit approval click.
+
+Read the screenpipe skill first.
+
+## Step 0 — setup, fail closed
+
+Read `./config.md` in this pipe's own folder. It is the only source of the push target. Never infer a repository from screen content, git remotes, or memory.
+
+If it is missing, create it with exactly this content and treat this run as draft-only:
+
+```yaml
+repo: owner/name       # required, e.g. acme/company-brain
+branch: main
+dir: data/curated      # directory new entries are written to
+mode: commit           # commit | pr
+local_clone:           # optional absolute path to an existing clone (git-only teams)
+```
+
+While `repo` is empty: still do Steps 1 and 2 so the work is captured locally, and ask for setup at most once every 7 days (check `./memory.md` for the last ask and record each ask there). Otherwise stay silent — no repeated nagging.
+
+## Step 1 — find what deserves to be remembered
+
+Search the API only. At most 5 bounded searches with `limit=10`, covering the range in the run header: decisions made, problems diagnosed and fixed, things learned about a customer or the market, processes that changed, and commitments to other teams.
+
+Skip anything that is routine execution, private, or already obviously in a tracked system. Absence of evidence is never a finding. If the day contains nothing durable, write nothing, notify nothing, and stop — that is a good outcome.
+
+## Step 2 — draft, at most 3 entries
+
+Write each entry as its own markdown file in `./output/` named `YYYY-MM-DD-slug.md`:
+
+```markdown
+---
+date: YYYY-MM-DD
+confidence: high | medium | low
+---
+
+# <one-line subject, verb first>
+
+## What changed
+## Why it matters
+## Evidence
+## Open questions
+## Next step
+```
+
+Evidence means app, thread, meeting, or document plus timing — enough for a teammate to verify. Quote sparingly. Mark every inference as an inference and keep `confidence` honest.
+
+### Redaction — this is a shared repository
+
+Never write: secrets, tokens, keys, passwords, or `.env` values; customer or personal contact details; health, financial, legal, or personal-life details; other people's private messages verbatim; raw OCR dumps, screenshots, or long transcript blocks. Summarize people by role, not identity, unless the fact is already team-visible. If an entry cannot be written without sensitive detail, drop the entry.
+
+## Step 3 — resolve one push transport
+
+Check in this order and use the first that works. Report which one you used.
+
+1. **GitHub connection (preferred, no CLI, any OS).** `GET /connections/github` returns `{"connected": true}`. Write through the local proxy, which injects auth server-side:
+   `PUT /connections/github/proxy/repos/OWNER/REPO/contents/DIR/FILE.md` with `{"message": "...", "branch": "...", "content": "<base64>"}`.
+2. **`gh` CLI.** `gh auth status` succeeds. Same GitHub API, different transport: `gh api --method PUT repos/OWNER/REPO/contents/DIR/FILE.md -f message=... -f content=... -f branch=...`.
+3. **Local clone.** `local_clone` is set and is a git repository: `git -C <path> pull --ff-only`, write the file, `git add`, `git commit`, `git push`. Never force-push, never rebase, never touch files you did not create.
+4. **Nothing available.** Keep the drafts and ask (Step 4) with the exact next step: connect GitHub in Settings → Connections → GitHub → "Connect with GitHub" (`screenpipe://settings?section=connections`), or authenticate the CLI with `gh auth login`.
+
+Build request bodies with bun so base64 is single-line and JSON escaping is safe; do not hand-roll shell quoting. On `409`/`422` for an existing path, `GET` that path's `sha` once and retry with it. If `mode: pr`, create a branch ref from the base branch, write there, then open a pull request. Two failed attempts on one transport means stop and report — never fall through to a different repository, branch, or account.
+
+## Step 4 — ask before pushing
+
+Never push in the same run that drafted. Send one notification with the draft subjects and these actions:
+
+- `push it` — `type: "pipe"`, `pipe: "company-brain"`, `primary: true`, `context: {"approve_files": ["<absolute draft paths>"], "transport": "<resolved transport>"}`
+- `review first` — a `deeplink` action to `screenpipe://view?path=<url-encoded absolute draft path>` so the draft opens in-app
+- `skip` — `dismiss`
+
+Use `priority: "normal"`. If setup is missing, say so plainly in the body instead of promising a push.
+
+## Step 5 — approved push run
+
+When the run context contains `approve_files`, skip Steps 1, 2 and 4 entirely. Push exactly those files, unmodified, to the configured repo, branch, and directory — one commit per entry with the message `brain: <subject>`. Do not re-draft, re-search, add entries, or edit content on an approval run.
+
+Read the result back from the provider response, then notify a receipt with the file or pull request URL and the commit sha. If a push fails, say which entry failed, the exact provider error, and the one action that fixes it. Never report a push as done without a URL or sha from the provider.
+
+## Never
+
+Never push, commit, or open a pull request without an approval click. Never write outside the configured `dir`. Never delete, rewrite, or reformat existing files, other people's entries, or repository history. Never create repositories, change repository settings, invite collaborators, or push to a repository other than the configured one. Never store credentials in this pipe's folder, in an entry, or in memory.

--- a/crates/screenpipe-core/src/pipes/mod.rs
+++ b/crates/screenpipe-core/src/pipes/mod.rs
@@ -93,6 +93,10 @@ const BUNDLED_BUILTIN_PIPES: &[(&str, &str)] = &[
         "accounting-follow-through",
         include_str!("../../assets/pipes/accounting-follow-through/pipe.md"),
     ),
+    (
+        "company-brain",
+        include_str!("../../assets/pipes/company-brain/pipe.md"),
+    ),
 ];
 
 /// Explicitly install one trusted Pipe bundled with the app.
@@ -8782,6 +8786,41 @@ mod tests {
         assert!(!body.contains("buildMeetingSummarizeInstructions"));
         assert!(body.contains("screenpipe API search is required"));
         assert!(body.contains("never run recursive `find` or `grep`"));
+    }
+
+    /// The company brain Pipe pushes to a *shared* repository. Its safety
+    /// contract lives entirely in the prompt, so assert the parts that must
+    /// never be lost by a careless prompt edit.
+    #[test]
+    fn bundled_company_brain_ships_its_safety_contract() {
+        let bundled = BUNDLED_BUILTIN_PIPES
+            .iter()
+            .find_map(|(name, content)| (*name == "company-brain").then_some(*content))
+            .expect("company-brain is bundled");
+        let (config, body) = parse_frontmatter(bundled).expect("bundled prompt should parse");
+
+        // Ships off: pushing to a team repo is opt-in, never a side effect of
+        // installing the app.
+        assert!(!config.enabled);
+        assert_eq!(config.timeout, Some(600));
+
+        // Deliberately declares no required connection: a team using the `gh`
+        // CLI or an existing clone must not be gated behind GitHub OAuth.
+        assert!(config.connections.is_empty());
+
+        // Human approval, transport ladder, and redaction are the contract.
+        assert!(body.contains("approve_files"));
+        assert!(body.contains("Never push in the same run that drafted"));
+        assert!(body.contains("gh auth status"));
+        assert!(body.contains("gh auth login"));
+        assert!(body.contains("/connections/github/proxy/repos/"));
+        assert!(body.contains("local_clone"));
+        assert!(body.contains("Never force-push"));
+        assert!(body.contains("Redaction — this is a shared repository"));
+        assert!(body.contains("Read the screenpipe skill first."));
+
+        // Fresh installs must already be in migrated form.
+        assert!(migrate_builtin_pipe_text("company-brain", bundled).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## What this adds

A bundled `company-brain` Pipe: it turns the day's real decisions and learnings into
source-backed markdown entries, then asks for **one approval click** before anything
reaches the team's brain repository.

![company brain flow](https://raw.githubusercontent.com/screenpipe/screenpipe/58fd7ad6947d094cfeb9ff3c43c83f6ad708fae5/company-brain-flow.png)

## Problem

Teams that keep a company brain repo only get entries when someone remembers to write
them, which is exactly when they are busiest. The context already exists locally; what's
missing is the nudge plus a safe path from "I learned something" to a commit — without
the Pipe becoming an unsupervised writer on a shared repo.

## The push path, first that works

The two questions this had to answer were "do they have the GitHub CLI?" and "do they
need to OAuth?". Both, and neither is required:

| # | transport | needs |
|---|-----------|-------|
| 1 | GitHub connection via the local credential proxy (`PUT /connections/github/proxy/repos/…/contents/…`) | the existing GitHub OAuth connection, no CLI, any OS |
| 2 | `gh api --method PUT …/contents/…` — same GitHub API | `gh auth status` |
| 3 | existing local clone, plain git | `local_clone` path |
| 4 | none available | keeps the draft, asks to connect, once |

## Design decisions worth reviewing

- **No `connections: [github]` in frontmatter.** That would give a nice auto connect
  modal, but the scheduler hard-skips a Pipe with a missing connection — so a team that
  already authenticates with `gh` or a clone would be gated behind OAuth they don't
  need. The Pipe resolves capability at runtime instead and always keeps the draft.
- **Ships `enabled: false`.** Pushing to a team repo is opt-in, never a side effect of
  installing the app.
- **Fails closed on setup.** The push target lives only in `./config.md`. An empty
  `repo` means draft-only; the repo is never inferred from screen content or git
  remotes. The setup ask is rate-limited to once every 7 days via `memory.md` so an
  unconfigured Pipe stays quiet.
- **Approval is a separate run.** The drafting run notifies with a `type: "pipe"` action
  carrying `approve_files`; the approval run pushes exactly those files and does not
  re-draft, re-search, or edit content.
- **Redaction is explicit** because the destination is shared: no secrets, customer or
  personal detail, other people's verbatim messages, screenshots, or raw transcripts.
  If an entry can't be written without them, the entry is dropped.

## Validation

Proven end to end:
- **Transport 3 (git)** against a real bare remote: pull, write, commit `brain: <subject>`,
  push, then read back from the remote — head `68227c1fb0f0`, remote content byte-identical
  to the draft, commit touched only the new entry, pre-existing file untouched.
- **Contents API body construction** with bun: single-line base64, round-trips to the
  draft bytes, correct `message`/`branch`/`content` keys and upstream path.
- **Transport ladder detection on a real machine** (this one, which is the awkward case —
  CLI authenticated, connection not): `GET /connections/github` → `{"connected": false}`,
  proxy → `401 connection 'github' has no stored credentials — connect it first in Settings`,
  `gh auth status` → logged in, `gh api repos/…/contents/README.md` → returns `sha` (the
  update-retry path).
- `cargo test -p screenpipe-core --lib pipes::` → 254 passed, including a new test that
  pins the safety contract (disabled by default, no declared connection, approval wording,
  all four transports, redaction heading) so a careless prompt edit can't drop it.
- Clippy and rustfmt clean on the changed file.

Not proven yet, deliberately:
- **A real GitHub write** through transport 1 or 2. Both are validated up to auth and path
  shape, but an actual `PUT contents` would have mutated a real shared repo, which is not
  mine to do here. First real use should be one approved canary entry, then check the
  commit URL in the receipt.
- No live Pipe run against a configured repo, so the drafting quality bar is a prompt
  contract, not measured output.

The mockup above is a static HTML render, not a screenshot of a run.
