### PR TITLE
fix(ui): polish scheduled tasks navigation and detail layout

### DIFF
--- a/apps/screenpipe-app-tauri/app/(main)/home/page.tsx
+++ b/apps/screenpipe-app-tauri/app/(main)/home/page.tsx
@@ -6,10 +6,10 @@
 import React, { useEffect, useState, useRef, Suspense, useCallback } from "react";
 import {
   Settings as SettingsIcon,
-  Workflow,
+  TimerReset,
   Plus,
   Brain,
-  Clock,
+  MonitorPlay,
   HelpCircle,
   PanelLeftClose,
   PanelLeftOpen,
@@ -965,8 +965,8 @@ function HomeContent() {
     // rows are not reused — that felt like opening an old recent).
     { id: "home", label: "Chat", icon: <Plus className="h-3.5 w-3.5" /> },
     { id: "brain", label: "Brain", icon: <Brain className="h-3.5 w-3.5" /> },
-    { id: "pipes", label: "Scheduled", icon: <Workflow className="h-3.5 w-3.5" /> },
-    { id: "timeline", label: "Timeline", icon: <Clock className="h-3.5 w-3.5" /> },
+    { id: "pipes", label: "Scheduled", icon: <TimerReset className="h-3.5 w-3.5" /> },
+    { id: "timeline", label: "Timeline", icon: <MonitorPlay className="h-3.5 w-3.5" /> },
     { id: "connections", label: "Connections", icon: <Plug className="h-3.5 w-3.5" /> },
   ]
     .filter((s) => !isSectionHidden(s.id) && !(s.id === "brain" && isSectionHidden("memories")))

--- a/apps/screenpipe-app-tauri/app/(main)/home/page.tsx
+++ b/apps/screenpipe-app-tauri/app/(main)/home/page.tsx
@@ -1329,7 +1329,12 @@ function HomeContent() {
                 </div>
               ) : (
                 <div className="flex-1 overflow-y-auto overflow-x-hidden min-h-0">
-                  <div className="p-6 pb-12 max-w-4xl mx-auto">
+                  <div
+                    className={cn(
+                      "mx-auto max-w-4xl px-6",
+                      activeSection === "pipes" ? "pb-6 pt-10" : "pb-12 pt-6",
+                    )}
+                  >
                     {renderMainSection()}
                   </div>
                 </div>

--- a/apps/screenpipe-app-tauri/components/pipe-store.tsx
+++ b/apps/screenpipe-app-tauri/components/pipe-store.tsx
@@ -359,22 +359,19 @@ export function PipeStoreView() {
 
   return (
     <div className="space-y-4">
-      <div className="space-y-1">
-        <h1 className="text-2xl font-semibold tracking-tight">Scheduled tasks</h1>
-        <p className="text-sm text-muted-foreground">
-          Run tasks on a schedule, after meetings, or when events happen.
-        </p>
-      </div>
+      <p className="text-sm text-muted-foreground">
+        Run tasks on a schedule, after meetings, or when events happen.
+      </p>
 
       {/* Tab bar */}
-      <div className="flex items-center gap-6 border-b border-border pb-0 mb-6">
+      <div className="mb-6 flex h-10 items-stretch gap-6 border-b border-border">
         {tabs.map(({ key, label }) => (
           <button
             key={key}
             data-testid={`tab-${key}`}
             onClick={() => setActiveTab(key)}
             className={cn(
-              "pb-3 text-sm font-medium transition-colors duration-150 border-b-2 -mb-px",
+              "-mb-px flex items-center border-b-2 text-sm font-medium transition-colors duration-150",
               activeTab === key
                 ? "border-foreground text-foreground"
                 : "border-transparent text-muted-foreground hover:text-foreground"
@@ -384,9 +381,8 @@ export function PipeStoreView() {
           </button>
         ))}
         {/* Notifications are pipe output, so the bell lives here rather
-            than in the global window chrome. mb-3 cancels the tabs'
-            pb-3 so the bell centers on the tab labels, not the row. */}
-        <div className="ml-auto mb-3">
+            than in the global window chrome. */}
+        <div className="ml-auto flex items-center">
           <NotificationBell />
         </div>
       </div>

--- a/apps/screenpipe-app-tauri/components/pipe-store.tsx
+++ b/apps/screenpipe-app-tauri/components/pipe-store.tsx
@@ -360,7 +360,9 @@ export function PipeStoreView() {
   return (
     <div className="space-y-4">
       <p className="text-sm text-muted-foreground">
-        Run tasks on a schedule, after meetings, or when events happen.
+        {activeTab === "discover"
+          ? "browse, install, and review community scheduled tasks"
+          : "Run tasks on a schedule, after meetings, or when events happen."}
       </p>
 
       {/* Tab bar */}
@@ -937,26 +939,13 @@ function DiscoverView({ onInstalled }: { onInstalled?: () => void }) {
         </div>
       )}
 
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <p className="text-sm text-muted-foreground">
-            browse, install, and review community scheduled tasks
-          </p>
-        </div>
-        <Button variant="outline" size="sm" onClick={() => setPublishOpen(true)}>
-          <Upload className="h-4 w-4 mr-1.5" />
-          PUBLISH
-        </Button>
-      </div>
-
       {/* Search & Filters */}
       <div className="space-y-3">
         <div className="flex items-center gap-2">
           <div className="relative flex-1">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
             <Input
-              placeholder="search scheduled tasks..."
+              placeholder="search community tasks..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               className="pl-9 h-9"
@@ -974,6 +963,15 @@ function DiscoverView({ onInstalled }: { onInstalled?: () => void }) {
               ))}
             </SelectContent>
           </Select>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-9 shrink-0"
+            onClick={() => setPublishOpen(true)}
+          >
+            <Upload className="mr-1.5 h-4 w-4" />
+            PUBLISH
+          </Button>
         </div>
 
         {/* Category pills */}

--- a/apps/screenpipe-app-tauri/components/settings/pipes-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/pipes-section.tsx
@@ -2736,7 +2736,7 @@ export function PipesSection() {
               if (!isSelected) continue;
 
               detail = (
-                <div key={pipe.config.name} data-testid="pipe-detail" className="flex flex-col">
+                <div key={pipe.config.name} data-testid="pipe-detail" className="relative flex flex-col">
                   <div className="border-b border-border px-5 pb-3 pt-4">
                     <h3 className="truncate text-base font-medium" title={pipe.config.name}>
                       {pipe.config.name}
@@ -2883,12 +2883,12 @@ export function PipesSection() {
                     <div className="flex items-center gap-1 px-5 py-2.5">
                       {/* Run is the primary action: keep it first and visually larger
                           than the AI editing actions that follow. */}
-                      <div className="flex items-center shrink-0">
+                      <div className="flex shrink-0 items-center gap-2">
                         {isRunning ? (
                           <Button
                             variant="outline"
-                            size="icon"
-                            className="h-9 w-9"
+                            size="sm"
+                            className="h-9 gap-2 rounded-none px-3 font-mono text-xs uppercase"
                             onClick={() => stopPipe(pipe.config.name)}
                             disabled={stoppingPipe === pipe.config.name}
                             title="stop scheduled task"
@@ -2897,14 +2897,18 @@ export function PipesSection() {
                             {stoppingPipe === pipe.config.name ? (
                               <Loader2 className="h-5 w-5 animate-spin" />
                             ) : (
-                              <Square className="h-5 w-5" />
+                              <Square className="h-4 w-4" />
                             )}
+                            stop
                           </Button>
                         ) : (
                           <Button
                             variant={hasMissingConnections ? "outline" : "default"}
-                            size="icon"
-                            className={cn("h-9 w-9", hasMissingConnections && "text-destructive")}
+                            size="sm"
+                            className={cn(
+                              "h-9 gap-2 rounded-none px-3 font-mono text-xs uppercase",
+                              hasMissingConnections && "text-destructive",
+                            )}
                             onClick={() => {
                               if (hasMissingConnections) {
                                 setConnectionModal({ pipeName: pipe.config.name, connections: pipe.config.connections ?? [] });
@@ -2917,8 +2921,9 @@ export function PipesSection() {
                             aria-label={hasMissingConnections ? "configure required connections first" : "run scheduled task"}
                           >
                             {hasMissingConnections
-                              ? <AlertCircle className="h-5 w-5" />
-                              : <Play className="h-5 w-5 fill-current" />}
+                              ? <AlertCircle className="h-4 w-4" />
+                              : <Play className="h-4 w-4 fill-current" />}
+                            run now
                           </Button>
                         )}
                       </div>
@@ -2926,31 +2931,34 @@ export function PipesSection() {
                     {/* optimize with ai — opens a chat that reads the pipe's prompt
                         + recent run logs and suggests improvements in plain english */}
                     {!isReadOnlyPipe(pipe) && (
-                      <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-7 gap-1.5 px-2 shrink-0 text-muted-foreground hover:text-foreground"
-                        onClick={() => {
-                          posthog.capture("pipe_optimize_started", { source: "row_button" });
-                          navigateHomeAndPrefill({
-                            context: "the user wants to optimize their pipe",
-                            prompt: buildOptimizePrompt(pipe.config.name),
-                            displayLabel: buildOptimizeDisplayLabel(pipe.config.name),
-                            autoSend: true,
-                          });
-                        }}
-                        title="optimize this scheduled task with ai — reads recent runs and improves the prompt"
-                      >
-                        <Sparkles className="h-3.5 w-3.5" />
-                        optimize with ai
-                      </Button>
+                      <>
+                        <span aria-hidden className="mx-1 h-5 w-px shrink-0 bg-border" />
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-7 gap-1.5 px-2 shrink-0 text-muted-foreground hover:text-foreground"
+                          onClick={() => {
+                            posthog.capture("pipe_optimize_started", { source: "row_button" });
+                            navigateHomeAndPrefill({
+                              context: "the user wants to optimize their pipe",
+                              prompt: buildOptimizePrompt(pipe.config.name),
+                              displayLabel: buildOptimizeDisplayLabel(pipe.config.name),
+                              autoSend: true,
+                            });
+                          }}
+                          title="optimize this scheduled task with ai — reads recent runs and improves the prompt"
+                        >
+                          <Sparkles className="h-3.5 w-3.5" />
+                          optimize
+                        </Button>
+                      </>
                     )}
 
                     {/* fork lives in the overflow menu: it creates a *different*
                         task, so it isn't part of operating this one. */}
 
                     {/* Overflow menu */}
-                    <div className="flex items-center shrink-0">
+                    <div className="absolute right-4 top-3 z-10 flex items-center">
                       <DropdownMenu>
                         <DropdownMenuTrigger asChild>
                           <Button variant="ghost" size="icon" className="h-7 w-7 shrink-0">
@@ -3096,7 +3104,6 @@ export function PipesSection() {
                         </DropdownMenuContent>
                       </DropdownMenu>
                     </div>
-
                     {/* Enable toggle — always visible, pushed to the far right.
                         Missing connections block ENABLING (can't run), but never
                         block DISABLING — a stuck-on pipe with broken deps must
@@ -3126,7 +3133,7 @@ export function PipesSection() {
                         }
                       />
                     </div>
-                    </div>
+                  </div>
                   </div>
                   {/* Last failure, surfaced above the tabs so you see why a run
                       broke before digging into runs or logs. */}
@@ -3143,11 +3150,11 @@ export function PipesSection() {
                   })()}
                   <div className="px-5 pt-4 pb-6">
                     <Tabs defaultValue="config" className="w-full">
-                      <TabsList className="w-full justify-start h-9 bg-transparent border-b rounded-none p-0 gap-4 mb-2">
-                        <TabsTrigger value="config" className="rounded-none border-b-2 border-transparent data-[state=active]:border-foreground data-[state=active]:bg-transparent data-[state=active]:shadow-none text-xs uppercase tracking-wider px-3 h-8">
+                      <TabsList className="mb-2 h-9 w-full items-stretch justify-start gap-4 rounded-none border-b bg-transparent p-0">
+                        <TabsTrigger value="config" className="-mb-px rounded-none border-b-2 border-transparent px-3 text-xs uppercase tracking-wider data-[state=active]:border-foreground data-[state=active]:bg-transparent data-[state=active]:shadow-none">
                           config
                         </TabsTrigger>
-                        <TabsTrigger value="runs" className="rounded-none border-b-2 border-transparent data-[state=active]:border-foreground data-[state=active]:bg-transparent data-[state=active]:shadow-none text-xs uppercase tracking-wider px-3 h-8">
+                        <TabsTrigger value="runs" className="-mb-px rounded-none border-b-2 border-transparent px-3 text-xs uppercase tracking-wider data-[state=active]:border-foreground data-[state=active]:bg-transparent data-[state=active]:shadow-none">
                           runs{(pipe.execution_count ?? executions.length) > 0
                             ? ` (${pipe.execution_count ?? executions.length})`
                             : ""}
@@ -3155,14 +3162,14 @@ export function PipesSection() {
                         <TabsTrigger
                           value="advanced"
                           data-testid={`pipe-advanced-tab-${pipe.config.name}`}
-                          className="rounded-none border-b-2 border-transparent data-[state=active]:border-foreground data-[state=active]:bg-transparent data-[state=active]:shadow-none text-xs uppercase tracking-wider px-3 h-8"
+                          className="-mb-px rounded-none border-b-2 border-transparent px-3 text-xs uppercase tracking-wider data-[state=active]:border-foreground data-[state=active]:bg-transparent data-[state=active]:shadow-none"
                         >
                           advanced
                         </TabsTrigger>
                       </TabsList>
 
                       {/* ═══ CONFIG TAB ═══ */}
-                      <TabsContent value="config" className="mt-4 space-y-6">
+                      <TabsContent value="config" className="mt-4">
 
                         {enterpriseManaged ? (
                           <div className="border border-border p-4">
@@ -3185,9 +3192,10 @@ export function PipesSection() {
                             </dl>
                           </div>
                         ) : (
-                          <>
+                          <div className="divide-y divide-border border border-border">
 
                         {/* Triggers — Notion-style picker (schedule, events + per-app connection sources) */}
+                        <div className="p-4">
                         <PipeTriggerPicker
                           pipeName={pipe.config.name}
                           trigger={pipe.config.trigger}
@@ -3240,9 +3248,10 @@ export function PipesSection() {
                             }).then(() => fetchPipes());
                           }}
                         />
+                        </div>
 
                         {/* Connections */}
-                        <div>
+                        <div className="p-4">
                           <Label className="text-xs mb-2 block cursor-help" title="give the agent access to your apps (Slack, Obsidian, CRM, etc.) — credentials are fetched at runtime">connections</Label>
                           <div className="flex flex-wrap items-center gap-2">
                             {(pipe.config.connections || []).map((connId) => {
@@ -3311,6 +3320,7 @@ export function PipesSection() {
 
 
                         {/* Model — secondary; most pipes run fine on the default */}
+                        <div className="p-4">
                         <PipePresetSelector
                           pipe={pipe}
                           setPipes={setPipes}
@@ -3318,15 +3328,16 @@ export function PipesSection() {
                           pendingConfigSaves={pendingConfigSaves}
                           apiBase={apiBase}
                         />
+                        </div>
 
-                          </>
+                          </div>
                         )}
 
                       </TabsContent>
 
                       {/* ═══ RUNS TAB ═══ */}
                       <TabsContent value="runs" className="mt-3">
-                        <div className="space-y-2 max-h-80 overflow-y-auto">
+                        <div className="scrollbar-minimal max-h-[calc(70vh-14rem)] space-y-2 overflow-y-auto">
                           {executionsLoading && executions.length === 0 ? (
                             <div className="space-y-2 py-2">
                               {[...Array(3)].map((_, i) => (
@@ -3464,11 +3475,18 @@ export function PipesSection() {
                       </TabsContent>
 
                       {/* ═══ ADVANCED TAB ═══ */}
-                      <TabsContent value="advanced" className="mt-3 space-y-3">
+                      <TabsContent value="advanced" className="mt-4 space-y-4">
                       {!enterpriseManaged && (
                         <>
+                      <section className="divide-y divide-border border border-border">
+                      <div className="px-4 py-3">
+                        <p className="text-sm font-medium">runtime</p>
+                        <p className="mt-0.5 text-[11px] text-muted-foreground">
+                          control external notifications and execution limits.
+                        </p>
+                      </div>
                       {/* Notification API permission */}
-                      <div className="flex items-center justify-between gap-3 border px-3 py-2.5">
+                      <div className="flex items-center justify-between gap-3 px-4 py-3">
                         <div className="min-w-0">
                           <span className="text-xs font-medium cursor-help" title="allows this scheduled task to call POST /notify">Allow notification API</span>
                           <p className="mt-0.5 text-[11px] text-muted-foreground">
@@ -3482,8 +3500,13 @@ export function PipesSection() {
                       </div>
 
                       {/* Timeout */}
-                      <div>
-                        <Label className="text-xs mb-2 block cursor-help" title="max execution time before the scheduled task is stopped — increase for slow LLMs or complex tasks">timeout</Label>
+                      <div className="grid gap-3 p-4 sm:grid-cols-[minmax(0,1fr)_11rem] sm:items-center">
+                        <div>
+                          <Label className="cursor-help text-xs font-medium" title="max execution time before the scheduled task is stopped — increase for slow LLMs or complex tasks">timeout</Label>
+                          <p className="mt-0.5 text-[11px] text-muted-foreground">
+                            stop a run if it exceeds this limit.
+                          </p>
+                        </div>
                         <Select
                           value={String(pipe.config.timeout || 600)}
                           onValueChange={(value) => {
@@ -3509,7 +3532,7 @@ export function PipesSection() {
                             pendingConfigSaves.current[pipeName] = savePromise;
                           }}
                         >
-                          <SelectTrigger className="mt-1 h-8 text-xs">
+                          <SelectTrigger className="h-8 w-full text-xs">
                             <SelectValue />
                           </SelectTrigger>
                           <SelectContent>
@@ -3528,8 +3551,9 @@ export function PipesSection() {
                           </SelectContent>
                         </Select>
                       </div>
+                      </section>
 
-                      <div className="flex items-start justify-between gap-4 border px-3 py-2.5">
+                      <section className="flex items-start justify-between gap-4 border border-border p-4">
                         <div className="min-w-0">
                           <Label
                             htmlFor={`pipe-history-switch-${pipe.config.name}`}
@@ -3626,12 +3650,15 @@ export function PipesSection() {
                             void savePipeHistoryMode(pipe, checked).catch(() => undefined);
                           }}
                         />
-                      </div>
+                      </section>
                         </>
                       )}
 
-                      <div className="flex items-center gap-2">
-                        <Label className="text-xs">pipe.md</Label>
+                      <section className="border border-border">
+                      <div className="flex items-center gap-2 border-b border-border px-4 py-3">
+                        <Label className="text-sm font-medium">task definition</Label>
+                        <span className="font-mono text-[11px] text-muted-foreground">pipe.md</span>
+                        <div className="ml-auto flex items-center gap-2">
                         {saveStatus[pipe.config.name] === "saving" && (
                           <span className="text-[11px] text-muted-foreground flex items-center gap-1">
                             <Loader2 className="h-3 w-3 animate-spin" /> saving...
@@ -3650,9 +3677,10 @@ export function PipesSection() {
                         {promptDrafts[pipe.config.name] !== undefined && !saveStatus[pipe.config.name] && (
                           <span className="text-[11px] text-muted-foreground">unsaved</span>
                         )}
+                        </div>
                       </div>
                       {isReadOnlyPipe(pipe) && (
-                        <p className="text-[11px] text-muted-foreground mt-1">
+                        <p className="px-4 pt-3 text-[11px] text-muted-foreground">
                           {isEnterpriseManagedPipe(pipe)
                             ? "managed by your organization (read-only, restored automatically)"
                             : "shared by your team (read-only, updates automatically) — fork it to make an editable copy"}
@@ -3663,13 +3691,14 @@ export function PipesSection() {
                         onChange={(e) => handlePipeEdit(pipe.config.name, e.target.value)}
                         readOnly={isReadOnlyPipe(pipe)}
                         className={cn(
-                          "text-xs font-mono h-64 mt-1",
+                          "h-72 rounded-none border-0 font-mono text-xs focus-visible:ring-0",
                           isReadOnlyPipe(pipe) && "opacity-70 cursor-not-allowed"
                         )}
                         autoCorrect="off"
                         autoCapitalize="off"
                         spellCheck={false}
                       />
+                      </section>
                       </TabsContent>
 
                     </Tabs>
@@ -3824,7 +3853,7 @@ export function PipesSection() {
                 <div className="scrollbar-minimal max-h-[70vh] w-[19rem] shrink-0 divide-y divide-border overflow-y-auto overscroll-contain border-r border-border [scrollbar-gutter:stable]">
                   {rows}
                 </div>
-                <div className="scrollbar-minimal max-h-[70vh] min-w-0 flex-1 overflow-y-auto overscroll-contain [scrollbar-gutter:stable]">
+                <div className="scrollbar-minimal max-h-[70vh] min-w-0 flex-1 overflow-y-auto overscroll-contain">
                   {creating ? (
                     <div className="px-5 pb-6 pt-4" data-testid="pipe-create-pane">
                       <div className="flex items-start gap-2">

--- a/apps/screenpipe-app-tauri/components/settings/pipes-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/pipes-section.tsx
@@ -2647,13 +2647,19 @@ export function PipesSection() {
                       ?.focus();
                   }}
                   className={cn(
-                    "group flex cursor-pointer select-none items-center gap-2.5 border-l-2 px-3 py-2.5 transition-colors duration-150 focus:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                    "group relative flex cursor-pointer select-none items-center gap-2.5 px-3 py-2.5 transition-colors duration-150 focus:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring",
                     isSelected
-                      ? "border-l-foreground bg-accent/60"
-                      : "border-l-transparent hover:bg-accent/30",
+                      ? "bg-accent/60"
+                      : "hover:bg-accent/30",
                     !pipe.config.enabled && !isSelected && "opacity-60",
                   )}
                 >
+                  {isSelected && (
+                    <span
+                      aria-hidden
+                      className="absolute inset-y-0 left-0 w-0.5 bg-foreground"
+                    />
+                  )}
                   {/* In select mode the status dot gives way to a checkbox. */}
                   {selectMode && !enterpriseManaged ? (
                     <Checkbox
@@ -3815,10 +3821,10 @@ export function PipesSection() {
 
             return (
               <>
-                <div className="max-h-[70vh] w-[19rem] shrink-0 divide-y divide-border overflow-y-auto border-r border-border">
+                <div className="scrollbar-minimal max-h-[70vh] w-[19rem] shrink-0 divide-y divide-border overflow-y-auto overscroll-contain border-r border-border [scrollbar-gutter:stable]">
                   {rows}
                 </div>
-                <div className="max-h-[70vh] min-w-0 flex-1 overflow-y-auto">
+                <div className="scrollbar-minimal max-h-[70vh] min-w-0 flex-1 overflow-y-auto overscroll-contain [scrollbar-gutter:stable]">
                   {creating ? (
                     <div className="px-5 pb-6 pt-4" data-testid="pipe-create-pane">
                       <div className="flex items-start gap-2">


### PR DESCRIPTION
This PR improves the Scheduled tasks experience and makes the page clearer and more consistent with the rest of the app.

1. Updates the Scheduled and Timeline sidebar icons so their purposes are easier to distinguish.
2. Improves page spacing, selection borders, and scrolling.
3. Adds clearer Discover copy and a more relevant search placeholder.
4. Refines the task detail header with a labeled Run now button, simplified Optimize action, and top-right overflow menu.
5. Aligns the Config, Runs, and Advanced tab styling.
6. Organizes Config and Advanced settings into clearer sections.

Before -
<img width="744" height="267" alt="image" src="https://github.com/user-attachments/assets/07fbf98a-ecde-4057-a22f-c72bd8424a4f" />
<img width="744" height="267" alt="image" src="https://github.com/user-attachments/assets/ea06ed81-c5cc-469a-b25b-9ed82101b31a" />
<img width="424" height="631" alt="image" src="https://github.com/user-attachments/assets/a9b0170f-843d-41ec-875f-86f6ce30fbd2" />
<img width="778" height="727" alt="image" src="https://github.com/user-attachments/assets/fc9fc68e-9240-4085-a59b-7f6dcba2fe4e" />
<img width="262" height="298" alt="image" src="https://github.com/user-attachments/assets/41a87ede-086b-49a0-99aa-0e48741102b7" />




After -

https://github.com/user-attachments/assets/3827fe18-adac-46e9-881c-87ea2a94dfdd


