### PR TITLE
fix(onboarding): accept complete legacy free entitlement evidence

### DIFF
--- a/apps/screenpipe-app-tauri/lib/app-entitlement.test.ts
+++ b/apps/screenpipe-app-tauri/lib/app-entitlement.test.ts
@@ -396,7 +396,7 @@ describe("app entitlement", () => {
     expect(getLocalPlanPolicy(normalized)).toBe("unknown");
   });
 
-  it("requires explicit feature denials before accepting newer free evidence", () => {
+  it("requires explicit feature evidence before accepting newer free evidence", () => {
     const normalized = normalizeAppUser(
       {
         id: "user_incomplete_free",

--- a/apps/screenpipe-app-tauri/lib/app-entitlement.test.ts
+++ b/apps/screenpipe-app-tauri/lib/app-entitlement.test.ts
@@ -587,13 +587,13 @@ describe("isAuthenticatedFreeUser", () => {
     return user({
       id: "user_free",
       subscription_plan: "none",
-      app_entitled: false,
+      app_entitled: true,
       entitlement: {
-        active: false,
+        active: true,
         plan: "none",
         source: "none",
         checked_at: "2026-06-05T11:00:00.000Z",
-        features: { app: false, cloud: false },
+        features: { app: true },
       },
       ...overrides,
     });
@@ -617,11 +617,11 @@ describe("isAuthenticatedFreeUser", () => {
       isAuthenticatedFreeUser(
         explicitFree({
           entitlement: {
-            active: false,
+            active: true,
             plan: "none",
             source: "none",
             checked_at: "2026-06-01T11:59:59.000Z",
-            features: { app: false, cloud: false },
+            features: { app: true },
           },
         }),
       ),

--- a/apps/screenpipe-app-tauri/lib/app-entitlement.test.ts
+++ b/apps/screenpipe-app-tauri/lib/app-entitlement.test.ts
@@ -368,6 +368,21 @@ describe("app entitlement", () => {
     expect(hasCloudEntitlement(normalized)).toBe(true);
   });
 
+  it("normalizes an authenticated legacy cloud denial as verified free", () => {
+    const normalized = normalizeAppUser(
+      {
+        id: "user_legacy_free",
+        cloud_subscribed: false,
+      },
+      "token",
+    );
+
+    expect(getLocalPlanPolicy(normalized)).toBe("verified-free");
+    expect(isAuthenticatedFreeUser(normalized)).toBe(true);
+    expect(hasVerifiedPaidPlan(normalized)).toBe(false);
+    expect(hasAppEntitlement(normalized)).toBe(false);
+  });
+
   // The server computes `subscription_plan` per request and may omit it while
   // still returning a complete entitlement. Falling back to an invented label
   // ("pro"/"standard") then contradicted the entitlement's own plan, and

--- a/apps/screenpipe-app-tauri/lib/app-entitlement.test.ts
+++ b/apps/screenpipe-app-tauri/lib/app-entitlement.test.ts
@@ -383,6 +383,36 @@ describe("app entitlement", () => {
     expect(hasAppEntitlement(normalized)).toBe(false);
   });
 
+  it("keeps a partial newer entitlement unknown instead of synthesizing verified free", () => {
+    const normalized = normalizeAppUser(
+      {
+        id: "user_partial_entitlement",
+        cloud_subscribed: false,
+        entitlement: { plan: "none" },
+      },
+      "token",
+    );
+
+    expect(getLocalPlanPolicy(normalized)).toBe("unknown");
+  });
+
+  it("requires explicit feature denials before accepting newer free evidence", () => {
+    const normalized = normalizeAppUser(
+      {
+        id: "user_incomplete_free",
+        cloud_subscribed: false,
+        entitlement: {
+          active: false,
+          plan: "none",
+          source: "none",
+        },
+      },
+      "token",
+    );
+
+    expect(getLocalPlanPolicy(normalized)).toBe("unknown");
+  });
+
   // The server computes `subscription_plan` per request and may omit it while
   // still returning a complete entitlement. Falling back to an invented label
   // ("pro"/"standard") then contradicted the entitlement's own plan, and
@@ -557,13 +587,13 @@ describe("isAuthenticatedFreeUser", () => {
     return user({
       id: "user_free",
       subscription_plan: "none",
-      app_entitled: true,
+      app_entitled: false,
       entitlement: {
-        active: true,
+        active: false,
         plan: "none",
         source: "none",
         checked_at: "2026-06-05T11:00:00.000Z",
-        features: { app: true },
+        features: { app: false, cloud: false },
       },
       ...overrides,
     });
@@ -587,14 +617,21 @@ describe("isAuthenticatedFreeUser", () => {
       isAuthenticatedFreeUser(
         explicitFree({
           entitlement: {
-            active: true,
+            active: false,
             plan: "none",
             source: "none",
             checked_at: "2026-06-01T11:59:59.000Z",
+            features: { app: false, cloud: false },
           },
         }),
       ),
     ).toBe(true);
+  });
+
+  it("rejects a whitespace-only authentication token", () => {
+    expect(isAuthenticatedFreeUser(explicitFree({ token: "   " }))).toBe(
+      false,
+    );
   });
 
   it("fails safe on missing or conflicting plan fields", () => {

--- a/apps/screenpipe-app-tauri/lib/app-entitlement.ts
+++ b/apps/screenpipe-app-tauri/lib/app-entitlement.ts
@@ -558,9 +558,16 @@ export function normalizeAppUser(rawUser: any, token: string): AppUser {
       : rawEntitlement
         ? rawEntitlement.features?.app === true
         : cloudSubscribed;
+  const legacyVerifiedFree =
+    rawUser?.cloud_subscribed === false &&
+    rawUser?.app_entitled === undefined &&
+    rawUser?.subscription_plan === undefined &&
+    rawUser?.entitlement === undefined;
   // Explicit server denial is stronger than a stale users.plan label left by a
   // canceled or refunded account.
-  const explicitlyFree = rawUser?.app_entitled === false && !cloudSubscribed;
+  const explicitlyFree =
+    legacyVerifiedFree ||
+    (rawUser?.app_entitled === false && !cloudSubscribed);
   // The server computes `subscription_plan` per request and can omit it while
   // still returning a full entitlement. The cloud_subscribed/app_entitled
   // fallbacks below invent a *label* ("pro"/"standard"), and the entitlement is

--- a/apps/screenpipe-app-tauri/lib/app-entitlement.ts
+++ b/apps/screenpipe-app-tauri/lib/app-entitlement.ts
@@ -222,9 +222,9 @@ function hasVerifiedFreePlan(user: AppUser | null | undefined): boolean {
       : null;
   if (
     source !== "none" ||
-    entitlement?.active !== false ||
-    entitlement.features?.app !== false ||
-    entitlement.features?.cloud !== false ||
+    typeof entitlement?.active !== "boolean" ||
+    typeof entitlement.features?.app !== "boolean" ||
+    entitlement.features.cloud === true ||
     hasFutureGrace(entitlement)
   ) {
     return false;

--- a/apps/screenpipe-app-tauri/lib/app-entitlement.ts
+++ b/apps/screenpipe-app-tauri/lib/app-entitlement.ts
@@ -196,7 +196,7 @@ function isEntitlementFresh(entitlement: AppEntitlement | null) {
  */
 function hasVerifiedFreePlan(user: AppUser | null | undefined): boolean {
   const stableAccountId = getStableAccountId(user);
-  if (!user || !stableAccountId || user.cloud_subscribed === true) return false;
+  if (!user || !stableAccountId || user.cloud_subscribed !== false) return false;
 
   const entitlement = asEntitlement(user.entitlement);
   // Once verified, free limits persist offline; merely waiting 72 hours must
@@ -221,10 +221,10 @@ function hasVerifiedFreePlan(user: AppUser | null | undefined): boolean {
       ? entitlement.source.trim().toLowerCase()
       : null;
   if (
-    source === "manual" ||
-    source === "enterprise" ||
-    source === "lifetime" ||
-    source === "dev" ||
+    source !== "none" ||
+    entitlement?.active !== false ||
+    entitlement.features?.app !== false ||
+    entitlement.features?.cloud !== false ||
     hasFutureGrace(entitlement)
   ) {
     return false;
@@ -253,7 +253,11 @@ export function hasFreePlanPolicy(user: AppUser | null | undefined): boolean {
 export function isAuthenticatedFreeUser(
   user: AppUser | null | undefined,
 ): boolean {
-  return Boolean(user?.token) && hasFreePlanPolicy(user);
+  return (
+    typeof user?.token === "string" &&
+    user.token.trim().length > 0 &&
+    hasFreePlanPolicy(user)
+  );
 }
 
 function hasVerifiedPaidPlanAt(


### PR DESCRIPTION
## Summary

- recognize the exact authenticated legacy free-account response (`cloud_subscribed: false` with all newer entitlement fields absent) as verified free
- preserve fail-closed behavior for partial, malformed, conflicting, or incomplete entitlement evidence
- require stable identity and a nonblank trimmed token before treating a free user as authenticated
- keep paid, cloud, consumer-subscription, and enterprise access behind explicit complete evidence

## Source and review provenance

- original read-only Discord intake task: `t_fec66cd8` (message identity `1532690461884551264`)
- refreshed implementation task: `t_a4060968`
- independent reviewer task: `t_a75c1427`
- unconditional approval applies to exact head `1d713573bd178d7fd451838cf2ee28fc31decd67`
- reviewed base: `1f38a057c48625a6c951e7a40c99daa23ee83793`
- superseded rejected review `t_a4382cc8` covered stale head `4976d9cd` and is not publication authority

## Root cause

Older authenticated account responses can explicitly deny cloud subscription while omitting the newer app-entitlement, subscription-plan, and entitlement object fields. The shared normalizer treated that complete legacy free shape as unknown, so onboarding rejected a legitimate free user.

The initial narrow compatibility path exposed a broader fail-closed issue: partial free-looking evidence (for example, plan-only `none`) and whitespace-only tokens could be accepted. This correction validates complete free evidence and trims authentication tokens while retaining a strict exception only for the exact all-undefined legacy shape.

## Why this covers the surface

Both production changes are in the shared entitlement boundary:

- normalization/classification validates legacy and current evidence before policy is derived
- authenticated-free detection validates the token at the access decision

Tests cover the legacy shape plus sibling malformed, partial, conflicting, paid, cloud, and enterprise paths. Negative cases verify that no app, cloud, or consumer-subscription access is granted.

## Behavior evidence

```text
Account evidence                                      Result
----------------------------------------------------  ------------------------------
stable id + token + cloud=false + newer fields absent verified-free; no paid/cloud
plan-only none                                        unknown; fail closed
missing source / active / feature evidence            unknown; fail closed
blank identity or empty/whitespace token              not authenticated free
cloud grant or conflicting/malformed evidence         no implicit free/paid access
complete explicit paid/cloud evidence                 existing explicit paths retained
```

This is logic-only evidence; there is no new or changed UI to screenshot.

## RED / GREEN evidence

- RED: reviewer regressions failed 2/48 for plan-only free evidence and whitespace-token authentication
- GREEN: corrected focused entitlement suite passed 48/48
- RED: missing-feature-evidence regression failed 1/49
- GREEN: final focused entitlement suite passed 49/49

## Broad verification

- focused entitlement tests: 49/49 passed
- retention integration: 9/9 passed
- full app package-script suite: passed (all 285 Vitest files plus Bun-native 233/233)
- typecheck: passed
- independent adversarial matrix: 23/23 passed
- exact two-file scope, required headers, `git diff --check`, targeted security scan, and clean worktree: passed

## Platform scope

The source report was from Windows 10 / app 2.5.149. The fix changes shared TypeScript entitlement normalization and authentication policy, with no OS-specific APIs or UI changes; behavior applies wherever the Screenpipe app consumes these account responses.
