### PR TITLE
fix(privacy): stop calling account-linked analytics "anonymous"

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/privacy-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/privacy-section.tsx
@@ -1977,11 +1977,12 @@ export function PrivacySection() {
               <div className="flex items-center space-x-2.5">
                 <Monitor className="h-4 w-4 text-muted-foreground shrink-0" />
                 <div>
-                  <h3 className="text-sm font-medium text-foreground">
+                  <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
                     Analytics
+                    <HelpTooltip text="Product usage events only — features used, errors, performance. Never your screen recordings, audio, transcripts, or OCR text. Signed out, events carry only a random device ID. Signed in, they are linked to your account, including your email." />
                   </h3>
                   <p className="text-xs text-muted-foreground">
-                    Anonymous usage data
+                    Usage data, linked to your account when signed in
                   </p>
                 </div>
               </div>

--- a/apps/screenpipe-app-tauri/lib/utils/tauri.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/tauri.ts
@@ -3627,7 +3627,9 @@ keepComputerAwake?: boolean;
  */
 useChineseMirror: boolean;
 /**
- * Enable anonymous analytics (PostHog).
+ * Enable product analytics (PostHog). Events carry only a random device
+ * ID when signed out; when signed in they are linked to the account,
+ * including its email. Never includes recordings, audio, or OCR text.
  */
 analyticsEnabled: boolean;
 /**

--- a/crates/screenpipe-config/src/recording.rs
+++ b/crates/screenpipe-config/src/recording.rs
@@ -649,7 +649,9 @@ pub struct RecordingSettings {
     #[serde(rename = "useChineseMirror")]
     pub use_chinese_mirror: bool,
 
-    /// Enable anonymous analytics (PostHog).
+    /// Enable product analytics (PostHog). Events carry only a random device
+    /// ID when signed out; when signed in they are linked to the account,
+    /// including its email. Never includes recordings, audio, or OCR text.
     #[serde(rename = "analyticsEnabled")]
     pub analytics_enabled: bool,
 


### PR DESCRIPTION
## Problem

Settings → Privacy → Telemetry describes the Analytics toggle as **"Anonymous usage data"**.

It isn't. Once a user signs in, the desktop client sends `email`, `name`, `github_username`, `website` and `contact` to PostHog as person properties, and identifies by `clerk_id` (`apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx`, the identify effect around L1673-L1685).

The analytics themselves are fine. Product analytics keyed to an authenticated account is ordinary and defensible — legitimate interest under GDPR, a disclosed business purpose under CPRA, and PostHog is a contracted processor. **The disclosure is the defect.** Describing account-linked personal data as anonymous is a transparency problem under GDPR Art. 5(1)(a) and a misrepresentation risk under FTC Act §5. It is also the cheapest thing in this whole area to fix.

## Fix

Copy only. **Nothing about what is collected changes.**

![before and after](https://raw.githubusercontent.com/screenpipe/screenpipe/f5d8e611828282f78a0c22faa05be2ba4f22a77a/analytics-copy.png)

- Card description → `Usage data, linked to your account when signed in`
- Adds a `HelpTooltip` stating the boundary that actually matters: product usage events only, **never screen recordings, audio, transcripts, or OCR text**, and that signed-out events carry only a random device ID
- `analyticsEnabled` doc comment in `screenpipe-config` updated to match, plus the regenerated Tauri binding

Signed out the claim really is anonymous (machine `analyticsId` + app version, no user fields), so the new copy is conditional rather than a blanket retraction.

## Testing

- `bun run bindings:check` — pass (binding regenerated from the Rust doc comment, not hand-edited)
- `bun run typecheck` — pass
- `cargo fmt -p screenpipe-config --check` — pass
- `git diff --check` — pass
- Frontend Vitest: 2586 passed. 62 failures in 7 files are a local-sandbox `localStorage` jsdom quirk (`theme-provider`, `use-enterprise-policy`, `font-size`, `free-plan-wall`, `acp-session-config`, `browser-log`) — all pre-existing and unrelated to a copy change. CI runs these with the repo's configured environment.

No test asserted on the old string.

## Deliberately not in scope

Three adjacent items worth a decision, each its own change:

1. **Move `identify()` server-side.** Today the raw email sits in browser network requests and is visible to devtools and any browser extension. A stable pseudonymous ID with the email joined in Supabase/Clerk costs nothing analytically. Not done here because `email` in PostHog is load-bearing for existing workflows (the hot-leads work-domain matching, several usage analyses) and ripping it out unilaterally would break them.
2. **Drop `contact` / `website` / `github_username`.** Less obviously needed than email, but I don't know what dashboards depend on them.
3. **Enterprise flows.** If an Enterprise customer's *employees'* emails reach our PostHog, we're a processor for that customer and it belongs in their DPA, not the consumer privacy policy. Worth checking separately given the existing PHI boundary work.

Also worth confirming out-of-band that PostHog is named in the privacy policy's subprocessor list and that account deletion triggers PostHog person deletion.

> Not legal advice — I'm not a lawyer. This fixes an accuracy gap between the UI copy and the shipped payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)