### PR TITLE
fix: stop screen recording when screenshots are off

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/recording-settings.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/recording-settings.tsx
@@ -53,7 +53,7 @@ export const screenSearchIndex: SettingsField[] = [
   { label: "Screen context capture", keywords: ["screen", "video", "accessibility"] },
   { label: "Structured app context", keywords: ["semantic", "ai", "messages", "email", "tasks", "code"], conditional: true },
   { label: "Use it for", keywords: ["memory", "computer use", "automation", "agent", "skills"], conditional: true },
-  { label: "Screenshot images", keywords: ["screenshot", "pixels", "ocr", "jpeg"] },
+  { label: "Screen recording", keywords: ["screenshot", "pixels", "ocr", "jpeg", "capture"] },
   { label: "Use all monitors", keywords: ["monitor", "display"], conditional: true },
   // conditional: monitor picker only renders when "Use all monitors" is off — paired right under that toggle.
   { label: "Monitors", conditional: true },
@@ -3970,8 +3970,8 @@ Your screen is a pipe. Everything you see, hear, and type flows through it. Scre
                 <div className="flex items-center space-x-2.5">
                   <Monitor className="h-4 w-4 text-muted-foreground shrink-0" />
                   <div>
-                    <h3 className="text-sm font-medium text-foreground">Screenshot images</h3>
-                    <p className="text-xs text-muted-foreground">Capture screen pixels and store JPEG screenshots for visual evidence and OCR fallback</p>
+                    <h3 className="text-sm font-medium text-foreground">Screen recording</h3>
+                    <p className="text-xs text-muted-foreground">Record screen pixels for the timeline and image-only text. Turn this off to stop screen recording; accessibility text stays searchable.</p>
                   </div>
                 </div>
                 <ManagedSwitch

--- a/apps/screenpipe-app-tauri/e2e/specs/settings-sections.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/settings-sections.spec.ts
@@ -122,7 +122,7 @@ describe('Settings sections', () => {
     await section.waitForExist({ timeout: 8_000 });
     const sectionText = (await section.getText()).toLowerCase();
     expect(sectionText).toContain('screen context capture');
-    expect(sectionText).toContain('screenshot images');
+    expect(sectionText).toContain('screen recording');
     expect(sectionText).not.toContain('audio recording');
     expect(sectionText).not.toContain('live meeting notes');
 

--- a/apps/screenpipe-app-tauri/e2e/specs/windows-user-journey.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/windows-user-journey.spec.ts
@@ -471,7 +471,7 @@ describe("Windows user journey", function () {
         const sectionText = (await screenSection.getText()).toLowerCase();
         return (
           sectionText.includes("screen context capture") &&
-          sectionText.includes("screenshot images") &&
+          sectionText.includes("screen recording") &&
           !sectionText.includes("audio recording")
         );
       },

--- a/crates/screenpipe-engine/src/event_driven_capture.rs
+++ b/crates/screenpipe-engine/src/event_driven_capture.rs
@@ -1063,7 +1063,7 @@ pub(crate) async fn event_driven_capture_loop(
                 None, // first capture — no elements ref
                 &mut walk_budget,
                 &mut ocr_gate,
-                false, // screenshot enabled on startup
+                screenshot_disabled,
                 false, // hd not active at startup (Manual is dedup-exempt anyway)
                 false, // not in a meeting at startup
                 true,  // focus unknown at startup — controller defaults to Active

--- a/crates/screenpipe-engine/src/vision_manager/manager.rs
+++ b/crates/screenpipe-engine/src/vision_manager/manager.rs
@@ -695,12 +695,10 @@ impl VisionManager {
         let high_fps_controller = self.high_fps_controller.clone();
         let semantic_tx = self.semantic_tx.clone();
 
-        // Spawn the decoupled high-fps HD recorder alongside this monitor's
-        // capture loop. It idles until an HD session is active, then records a
-        // CFR H.264 chunk with NO OCR (the event loop above keeps indexing
-        // sparsely). Shares the same Arc<SafeMonitor> + HighFpsController; runs
-        // on its own task, aborted in `stop_monitor`.
-        {
+        // Spawn the decoupled high-fps HD recorder only when screen pixels are
+        // enabled. Otherwise an active meeting could open its own OS capture
+        // stream despite `disableScreenshots`.
+        if !self.config.disable_screenshots {
             let hd_config = crate::hd_recorder::HdRecorderConfig {
                 ignored_windows: self.config.ignored_windows.clone(),
                 included_windows: self.config.included_windows.clone(),


### PR DESCRIPTION
## Summary

Turning off screenshot images still allowed ScreenCaptureKit pixel capture to start, so macOS could continue showing its purple recording indicator.

This change:

- makes the startup capture honor `disableScreenshots`
- does not spawn the HD meeting recorder when screen pixels are disabled
- keeps accessibility-tree text capture available without recording screen pixels
- renames the setting from **Screenshot images** to **Screen recording** and explains the remaining accessibility behavior

## Root cause

The steady-state capture path already passed the effective `screenshot_disabled` value into `do_capture`, but the startup call hard-coded that argument to `false`. Separately, `VisionManager` spawned the HD recorder unconditionally, allowing an active HD meeting session to open its own screen-capture stream.

## Behavior

```text
before
screenshots off ──> startup pixel capture ──> persistent OS capture stream
                └─> active HD meeting ─────> dedicated OS capture stream

now
screen recording off ──> accessibility text only
                     └─> no startup or HD pixel-capture stream
```

## Capture entry-point audit

| Site | Verdict | Change |
| --- | --- | --- |
| Startup `do_capture` | Same defect | Pass the configured `screenshot_disabled` value |
| Steady-state `do_capture` | Already correct | Continues passing the effective runtime value |
| Warm/active visual probes | Safe | Already gated by the disabled visual comparer/check state |
| HD recorder spawn | Same defect | Do not spawn it when `disableScreenshots` is true |
| `start_hd_capture` | Safe after caller fix | Its only recorder-loop caller cannot run under the disabled setting |

## Verification

- `cargo test -p screenpipe-engine --lib event_driven_capture::tests -- --nocapture` — 80 passed
- `cargo test -p screenpipe-engine --lib vision_manager::manager::tests -- --nocapture` — 12 passed
- `bun run typecheck` — passed
- `cargo fmt --check -- crates/screenpipe-engine/src/event_driven_capture.rs crates/screenpipe-engine/src/vision_manager/manager.rs` — passed
- `git diff --check` — passed

The settings E2E assertions were updated for the new copy, but the desktop E2E suite was not run. The macOS purple indicator was not visually rechecked in a relaunched app during this change.
