### PR TITLE
fix(ci): stop the Debian AppImage smoke masking a missing OpenBLAS bundle

### DIFF
--- a/.github/workflows/linux-appimage-smoke.yml
+++ b/.github/workflows/linux-appimage-smoke.yml
@@ -269,7 +269,6 @@ jobs:
                 libasound2t64 \
                 libayatana-appindicator3-1 \
                 libgtk-3-0 \
-                libopenblas0 \
                 libpulse0 \
                 librsvg2-2 \
                 libsecret-1-0 \
@@ -352,9 +351,15 @@ jobs:
               check_ldd squashfs-root/usr/bin/ffmpeg /tmp/ffmpeg.ldd
               check_ldd squashfs-root/usr/bin/ffprobe /tmp/ffprobe.ldd
               check_ldd squashfs-root/usr/bin/tesseract /tmp/tesseract.ldd
-              if [ -e squashfs-root/usr/lib/libopenblas.so.0 ]; then
-                check_ldd squashfs-root/usr/lib/libopenblas.so.0 /tmp/openblas.ldd
+              # OpenBLAS is bundled by bundle-appimage-runtime-deps.sh because OCR
+              # needs it and Debian does not install it by default. This container
+              # deliberately does not install libopenblas0, so a missing bundle is a
+              # hard failure here rather than something the host quietly satisfies.
+              if [ ! -e squashfs-root/usr/lib/libopenblas.so.0 ]; then
+                echo "::error::libopenblas.so.0 is not bundled in the AppImage; OCR breaks on hosts without the system package"
+                exit 1
               fi
+              check_ldd squashfs-root/usr/lib/libopenblas.so.0 /tmp/openblas.ldd
               if grep -R "not found" /tmp/ffmpeg.ldd /tmp/ffprobe.ldd /tmp/tesseract.ldd /tmp/openblas.ldd 2>/dev/null; then
                 exit 1
               fi


### PR DESCRIPTION
## Problem

The Debian 13 AppImage smoke could pass while the AppImage was broken for real users.

It installed `libopenblas0` into the test container, then only checked the *bundled* library if it happened to exist:

```bash
apt-get install -y --no-install-recommends \
  ...
  libopenblas0 \        # <-- host package satisfies everything
  ...

if [ -e squashfs-root/usr/lib/libopenblas.so.0 ]; then   # <-- skipped if bundling failed
  check_ldd squashfs-root/usr/lib/libopenblas.so.0 /tmp/openblas.ldd
fi
```

If `bundle_named_lib "libopenblas.so.0"` ever silently failed, the check was skipped entirely and `tesseract`'s `ldd` resolved OpenBLAS from the package the test had just installed. Green CI, broken AppImage on any host without `libopenblas0`.

```
BEFORE                                   AFTER
------                                   -----
container installs libopenblas0          container does NOT install it
        |                                        |
bundling silently fails                  bundling silently fails
        |                                        |
[ -e bundled ] -> false -> SKIP          [ ! -e bundled ] -> ::error:: exit 1
        |                                        |
tesseract ldd resolves from host         nothing to fall back to
        |                                        |
   CI GREEN, user broken                    CI RED, caught
```

## Where found

Debugging a Debian 13 user report: OCR required manually installing `libopenblas0`, alongside an FFmpeg `libavdevice.so.60` vs `.61` mismatch. The bundling fix landed in 557392369 (v2.5.79), but the smoke that should guard it could not actually catch a regression in the OpenBLAS half.

## Reproduction

On current `main` the masking is structural:

- `.github/workflows/linux-appimage-smoke.yml:272` installs `libopenblas0`
- `.github/workflows/linux-appimage-smoke.yml:355` guards the assertion behind `[ -e ... ]`

Delete `bundle_named_lib "libopenblas.so.0"` from `bundle-appimage-runtime-deps.sh` and the Debian job still passes today. With this change it fails.

## Root cause

The test provided the dependency it was supposed to be verifying was bundled, and made its only assertion conditional on the thing it was asserting.

## Fix

- Drop `libopenblas0` from the Debian container. `tesseract-ocr` is already correctly absent for the same reason.
- Make the bundled library a hard requirement with an explicit `::error::`, then `check_ldd` it unconditionally.

Scoped to the Debian job deliberately: its `not found` assertions cover `ffmpeg`, `ffprobe`, `tesseract` and `openblas`. The Arch job installs `openblas` too, but its `not found` check only covers PipeWire modules and SPA plugins, so removing it there would add risk without adding coverage.

No change to the bundler, the AppImage contents, or any shipped artifact. Test-only.

## Validation

- YAML parses, single `appimage-smoke` job intact
- All embedded `run:` blocks pass `bash -n` (0 syntax errors)
- Confirmed `bundle_named_lib "libopenblas.so.0"` still stages the library, so the new assertion is satisfiable on a healthy build
- Diff is 8 insertions, 3 deletions, one file

**Not yet validated:** this needs a real run of the Debian job to confirm OpenBLAS genuinely bundles today. If it does not, this PR correctly turns the job red and the bundler needs fixing first. Please do not merge on a green-by-default assumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
