### PR TITLE
fix(pipes): give meeting summary 600s so long meetings still get summarized

### DIFF
--- a/crates/screenpipe-core/assets/pipes/meeting-summary/pipe.md
+++ b/crates/screenpipe-core/assets/pipes/meeting-summary/pipe.md
@@ -3,7 +3,7 @@ schedule: manual
 enabled: true
 preset:
   - screenpipe-cloud
-timeout: 300
+timeout: 600
 trigger:
   events:
     - meeting_ended

--- a/crates/screenpipe-core/src/pipes/mod.rs
+++ b/crates/screenpipe-core/src/pipes/mod.rs
@@ -8778,7 +8778,7 @@ mod tests {
             .expect("meeting-summary is bundled");
         assert!(migrate_builtin_pipe_text("meeting-summary", bundled).is_none());
         let (config, body) = parse_frontmatter(bundled).expect("bundled prompt should parse");
-        assert_eq!(config.timeout, Some(300));
+        assert_eq!(config.timeout, Some(600));
         assert!(!body.contains("buildMeetingSummarizeInstructions"));
         assert!(body.contains("screenpipe API search is required"));
         assert!(body.contains("never run recursive `find` or `grep`"));


### PR DESCRIPTION
## Problem

A `meeting_ended` run timed out at 300s today and produced no summary. This pipe is
event-triggered, so a timeout is a silently lost summary: the meeting note just stays
empty, with no failure surfaced where the user is looking.

```
2026-08-07T12:30:11  timed_out  300s  trigger=event
```

## Sizing

Duration distribution over the last 100 runs of this pipe on one machine:

| metric | value |
|---|---|
| median | 16s |
| p75 | 31s |
| p90 | 64s |
| p95 | 97s |
| runs over 240s | 4 / 100 |

300s covers the normal case with no margin for the tail, which is long meetings with
large transcripts. 600s restores the ceiling this pipe had before #5574 added the
explicit `timeout: 300`, and matches `company-brain`, the other long-running bundled
pipe.

## What reviewers should push back on

Raising the ceiling is not obviously the full fix, and I want that on the record rather
than buried:

- The same pipe **already timed out twice at 600s** (2026-07-28 11:08, 2026-07-29 05:26,
  both `trigger=event`), and one `rate_limited` run burned 599s before failing. With
  p95 at 97s, the tail does not look like legitimately long work, it looks like runs
  that do not converge.
- So for those runs this change converts a 300s failure into a 600s failure and doubles
  the token burn on the way. The durable fix is bounding the run (search/evidence caps,
  or failing fast when the transcript fetch is the thing hanging), which is out of scope
  here.

I still think 600 is the right immediate value, because the legitimate tail is currently
being cut off and a lost summary is worse than a slow one. But if you would rather bound
the run first and leave the ceiling alone, that is a reasonable call and this PR should
wait.

## Scope caveat

`install_builtin_pipes` never overwrites an existing local `pipe.md`, so this only
affects **fresh installs**. Existing users, including anyone hitting the timeout today,
keep `timeout: 300` until they delete and reinstall the pipe or edit it locally. If we
want this to reach current installs it needs a frontmatter migration, which I did not
add.

## Validation

- `cargo test -p screenpipe-core --lib pipes::` — 253 passed, 0 failed
- `bundled_meeting_summary_needs_no_migration` updated, since it pins the shipped value
  and would otherwise fail
- `rustfmt --check` clean on the changed file
- Diff is two lines: the frontmatter value and that assertion

No mockup: this is a timing constant with no UI surface, so the duration table above is
the evidence that matters.
