### PR TITLE
fix(ci): classify new contributors from live PR data

### DIFF
--- a/.github/workflows/close-new-contributor-prs.yml
+++ b/.github/workflows/close-new-contributor-prs.yml
@@ -10,9 +10,6 @@ permissions:
 
 jobs:
   close:
-    if: >-
-      github.event.pull_request.author_association == 'FIRST_TIMER' ||
-      github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
     runs-on: ubuntu-latest
 
     steps:
@@ -20,7 +17,10 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const pullRequest = context.payload.pull_request;
+            const { data: pullRequest } = await github.rest.pulls.get({
+              ...context.repo,
+              pull_number: context.payload.pull_request.number,
+            });
             const newContributorAssociations = new Set([
               "FIRST_TIMER",
               "FIRST_TIME_CONTRIBUTOR",


### PR DESCRIPTION
## Summary

- remove the job-level association condition that skipped the entire runner
- fetch the current pull request through GitHub’s API inside the trusted job
- classify `FIRST_TIMER` and `FIRST_TIME_CONTRIBUTOR` from that live record before commenting or closing

## Evidence

PRs #6001 and #6002 were both open and reported `FIRST_TIME_CONTRIBUTOR` by the Pull Requests API, while runs `31211991062` and `31212165527` skipped the `close` job with zero steps. This proves the pre-run condition evaluated false for those events. GitHub does not expose the condition’s original payload value in the skipped-job logs, so the underlying payload discrepancy is not asserted as fact.

## Before / after

```text
before: event payload condition -> skipped job -> no observable classification
after:  trusted job -> GET current PR -> classify -> comment + close or log + leave open
```

## Mechanism audit

Repository search found one new-contributor association mechanism:

- `.github/workflows/close-new-contributor-prs.yml` job condition: affected; removed
- same workflow script classification: correct after switching its input to the live Pull Requests API record
- no other workflow or action uses `FIRST_TIMER`, `FIRST_TIME_CONTRIBUTOR`, or `author_association`

## Verification

- `actionlint .github/workflows/close-new-contributor-prs.yml`
- extracted-script harness: `FIRST_TIMER` comments and closes
- extracted-script harness: `FIRST_TIME_CONTRIBUTOR` comments and closes
- extracted-script harness: `CONTRIBUTOR` logs and remains open
- `git diff --check`

## Remaining scope

This fixes future opened or reopened events. Existing PRs #6001 and #6002 require a separate explicit backfill action.