### PR TITLE
fix(overlay): stack the live-meeting dot under the bell's unread dot

### DIFF
--- a/apps/screenpipe-app-tauri/app/shortcut-reminder/page.test.tsx
+++ b/apps/screenpipe-app-tauri/app/shortcut-reminder/page.test.tsx
@@ -156,6 +156,36 @@ describe("recording health hover detail", () => {
     expect(mocks.stopMeeting).toHaveBeenCalledTimes(1);
   });
 
+  it("stacks the meeting dot under the unread dot on the notifications bell", async () => {
+    mocks.getRecordingHealthState.mockResolvedValue("normal");
+    mocks.meetingOverlayState.active = true;
+    mocks.meetingOverlayState.activeMeetingId = 42;
+    mocks.meetingOverlayState.stoppableMeetingId = 42;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => [{ read: false, priority: "high" }],
+      }),
+    );
+
+    render(<ShortcutReminderPage />);
+
+    const meetingDot = await screen.findByRole("status", { name: "Meeting live" });
+    const bell = screen.getByTitle("notifications");
+    // Both live signals hang off the same bell, so a running meeting never
+    // moves the "we are live" marker somewhere else in the pill.
+    expect(bell).toContainElement(meetingDot);
+    const unreadDot = bell.querySelector("span.bg-white");
+    expect(unreadDot).not.toBeNull();
+
+    // Mirrored: unread sits top right, meeting sits bottom right, same column.
+    expect(meetingDot).toHaveStyle({ bottom: "-1px", right: "-1px" });
+    expect(unreadDot).toHaveStyle({ top: "-1px", right: "-1px" });
+    // The dot must never eat the click that opens the inbox.
+    expect(meetingDot.className).toContain("pointer-events-none");
+  });
+
   it("keeps recording health ahead of the meeting preview", async () => {
     mocks.meetingOverlayState.active = true;
     mocks.meetingOverlayState.activeMeetingId = 42;

--- a/apps/screenpipe-app-tauri/app/shortcut-reminder/page.tsx
+++ b/apps/screenpipe-app-tauri/app/shortcut-reminder/page.tsx
@@ -558,15 +558,6 @@ export default function ShortcutReminderPage() {
               active={overlayData.audioActive}
               speechRatio={overlayData.speechRatio}
             />
-            {meetingOverlay.active && (
-              <span
-                role="status"
-                aria-label="Meeting live"
-                title="Meeting live — hover for transcript"
-                className="ml-auto rounded-full bg-red-500 shrink-0"
-                style={{ width: `${dotPx}px`, height: `${dotPx}px` }}
-              />
-            )}
           </div>
           <div className="bg-white/15" />
           <div className="min-w-0 overflow-hidden flex items-center" style={{ padding: `${padY}px ${padX}px` }}>
@@ -593,6 +584,18 @@ export default function ShortcutReminderPage() {
                 <span
                   className="absolute rounded-full bg-white"
                   style={{ top: -1, right: -1, width: `${dotPx}px`, height: `${dotPx}px` }}
+                />
+              )}
+              {/* Live meeting mirrors the unread dot on the same bell, so both
+                  "we are live" signals share one column instead of the meeting
+                  dot floating in the audio cell. */}
+              {meetingOverlay.active && (
+                <span
+                  role="status"
+                  aria-label="Meeting live"
+                  title="Meeting live — hover for transcript"
+                  className="absolute rounded-full bg-red-500 pointer-events-none"
+                  style={{ bottom: -1, right: -1, width: `${dotPx}px`, height: `${dotPx}px` }}
                 />
               )}
               <Bell

--- a/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder.swift
+++ b/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder.swift
@@ -490,19 +490,9 @@ struct ShortcutReminderView: View {
             HStack(spacing: s(3)) {
                 AudioEqualizerView(active: metrics.audioActive, speechRatio: metrics.speechRatio)
                     .frame(width: s(18), height: s(12))
-                ZStack(alignment: .topTrailing) {
-                    ScreenMatrixView(active: metrics.screenActive, captureFps: metrics.captureFps)
-                        .frame(width: s(18), height: s(12))
-                        .clipShape(RoundedRectangle(cornerRadius: 1))
-                    if metrics.meetingActive {
-                        Circle()
-                            .fill(Color.red)
-                            .frame(width: s(5), height: s(5))
-                            .overlay(Circle().stroke(Color.black.opacity(0.75), lineWidth: s(1)))
-                            .offset(x: s(2), y: -s(2))
-                            .help("meeting live — hover for transcript")
-                    }
-                }
+                ScreenMatrixView(active: metrics.screenActive, captureFps: metrics.captureFps)
+                    .frame(width: s(18), height: s(12))
+                    .clipShape(RoundedRectangle(cornerRadius: 1))
             }
             .padding(.horizontal, s(3))
             .frame(maxHeight: .infinity)
@@ -510,6 +500,7 @@ struct ShortcutReminderView: View {
 
             CollapsedBellButton(
                 unread: metrics.inboxUnread,
+                meetingActive: metrics.meetingActive,
                 scale: scale,
                 action: { onAction("open_inbox") }
             )
@@ -541,6 +532,9 @@ struct ShortcutReminderView: View {
                 .frame(width: s(24), height: s(12))
                 .padding(.horizontal, s(3))
 
+            // The expanded bar keeps the meeting dot on the screen matrix: its
+            // bell already carries an unread dot at an unscaled 1pt offset, so
+            // a second dot there collides with the glyph at larger sizes.
             ZStack(alignment: .topTrailing) {
                 ScreenMatrixView(active: metrics.screenActive, captureFps: metrics.captureFps)
                     .frame(width: s(24), height: s(12))
@@ -741,9 +735,15 @@ struct CollapsedAppIconButton: View {
 // inbox; the dot mirrors the pipes-store bell's unread marker. Crucially:
 // no .onHover wired to isExpanded — clicking it opens the inbox without
 // forcing the user through the expanded layout.
+//
+// Both live signals sit in one column on the bell: unread notifications is
+// the white dot above it, a live meeting is the red dot mirrored below it.
+// Before, the meeting dot floated over the screen matrix mid-pill, so "we
+// are live" moved around depending on which signal fired.
 @available(macOS 13.0, *)
 struct CollapsedBellButton: View {
     let unread: Bool
+    let meetingActive: Bool
     let scale: CGFloat
     let action: () -> Void
     @State private var hovered = false
@@ -761,6 +761,12 @@ struct CollapsedBellButton: View {
                     Circle().fill(.white)
                         .frame(width: 4 * scale, height: 4 * scale)
                         .offset(x: 5 * scale, y: -5 * scale)
+                }
+                if meetingActive {
+                    Circle().fill(Color.red)
+                        .frame(width: 4 * scale, height: 4 * scale)
+                        .offset(x: 5 * scale, y: 5 * scale)
+                        .help("meeting live — hover for transcript")
                 }
             }
             .frame(width: 14 * scale)


### PR DESCRIPTION
## problem

On the collapsed shortcut-reminder pill, the two \"something is live right now\" signals sit in different places:

- unread notifications → white dot on the bell, at the right edge
- live meeting → red dot pinned to the top-right of the screen matrix, mid-pill

So the marker that means \"live\" moves depending on which signal fires, and the meeting dot overlaps the capture visualisation it is drawn on top of.

## where found

Reported directly while a meeting was running: the red dot should sit bottom right of the pill, lined up with the bell's white dot.

## reproduction

Start a meeting with the overlay visible. The red dot appears over the screen matrix, roughly two thirds across the pill, not near the bell.

Rendered from the shipped SwiftUI (see validation for how):

![before and after](https://raw.githubusercontent.com/screenpipe/screenpipe/claude/assets-meeting-dot-77aa9e/pr-before-after.png)

## root cause

[`shortcut_reminder.swift`](https://github.com/screenpipe/screenpipe/blob/main/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder.swift) wrapped `ScreenMatrixView` in a `ZStack(alignment: .topTrailing)` and hung the meeting dot off that, while the unread dot lives inside `CollapsedBellButton` at `offset(x: 5, y: -5)`. Two owners, two anchors. The webview overlay had the same split: the meeting dot was `ml-auto` in the audio-equalizer cell, the unread dot absolutely positioned on the bell button.

## fix

Both dots now hang off the bell in one column, same size, mirrored offsets:

- collapsed pill: red dot moves into `CollapsedBellButton` at `offset(x: 5, y: 5)`, matching the white dot's `4 * scale` size and `-5` mirror
- webview overlay: red dot moves into the bell button at `bottom: -1, right: -1`, mirroring the white `top: -1, right: -1`, with `pointer-events-none` so it cannot eat the click that opens the inbox

The screen matrix goes back to being just the screen matrix.

![states](https://raw.githubusercontent.com/screenpipe/screenpipe/claude/assets-meeting-dot-77aa9e/pr-states.png)

**The expanded bar is deliberately untouched.** Its bell already draws the unread dot at an unscaled `offset(x: 1, y: -1)`, so at `large` overlay scale a second dot buries the glyph. I tried it, rendered it, and backed it out — that offset needs scaling first, which is a separate change. Verified by rendering the expanded bar before and after: byte-identical to `main`.

Transcript-on-hover is unaffected — that is driven by the panel-wide `NSTrackingArea`, not the dot. The `.help()` tooltip moved with the dot.

## validation

- `swiftc -typecheck -target arm64-apple-macos13.0 shortcut_reminder.swift` — clean
- `bun run typecheck` — clean
- `bun x eslint` on both changed frontend files — clean
- `vitest run app/shortcut-reminder/page.test.tsx` — 4 passed
- new test `stacks the meeting dot under the unread dot on the notifications bell` asserts containment in the bell, the mirrored offsets, and `pointer-events-none`. Confirmed it is a real guard: it **fails** against the old markup (`expect(element).toContainElement(element)`) and passes after.

The images above are not redrawn mockups. They are screenshots of the real `ShortcutReminderView`, rendered offscreen by compiling the shipped `shortcut_reminder.swift` against a small `NSHostingView` harness and running the same before/after code paths. Two known harness artifacts: the app icon falls back to the generic folder icon because `NSApp.applicationIconImage` is unset in a CLI process, and the equalizer/matrix look sparse because the shared animation tick has not run. Neither is touched by this PR.

Not yet validated: no packaged-app run, no signed build, no installed canary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)