### PR TITLE
feat(chat): / command palette, and a Claude-style composer hint

### DIFF
--- a/apps/screenpipe-app-tauri/components/__tests__/global-chat-mentions.test.ts
+++ b/apps/screenpipe-app-tauri/components/__tests__/global-chat-mentions.test.ts
@@ -9,6 +9,7 @@ import {
   buildChatMentionSuggestions,
   buildSkillMentionSuggestions,
   buildTagMentionSuggestions,
+  COMPOSER_COMMAND_SUGGESTIONS,
   findComposerMention,
   filterMentionSuggestions,
   mentionSuggestionIdentity,
@@ -383,6 +384,65 @@ describe("global chat mentions", () => {
     ["search #project:atlas", "#", "project:atlas"],
   ])("detects the %s composer command", (input, trigger, filter) => {
     expect(findComposerMention(input)).toEqual({ trigger, filter });
+  });
+
+  it.each([
+    ["/", ""],
+    ["/n", "n"],
+    ["/new", "new"],
+    ["/clear-filters", "clear-filters"],
+  ])("opens the command palette for %s", (input, filter) => {
+    expect(findComposerMention(input)).toEqual({ trigger: "/", filter });
+  });
+
+  // A slash is only a command at position 0. Dates and paths keep typing.
+  it.each([
+    ["03/04/2025"],
+    ["look at src/lib/chat-utils.ts"],
+    ["tell me /new"],
+    ["/new and then"],
+  ])("does not open the command palette for %s", (input) => {
+    const match = findComposerMention(input);
+    expect(match?.trigger).not.toBe("/");
+  });
+
+  it("filters commands by tag and description", () => {
+    const base = {
+      atMentionSuggestions: [],
+      tagMentionSuggestions: [],
+      allTagMentionSuggestions: [],
+      tagSearchSuggestions: [],
+      speakerSuggestions: [],
+    };
+
+    expect(
+      filterMentionSuggestions({ ...base, mentionTrigger: "/", mentionFilter: "" }),
+    ).toEqual(COMPOSER_COMMAND_SUGGESTIONS);
+
+    expect(
+      filterMentionSuggestions({
+        ...base,
+        mentionTrigger: "/",
+        mentionFilter: "new",
+      }).map((suggestion) => suggestion.tag),
+    ).toEqual(["/new"]);
+
+    // matches the description, not just the tag
+    expect(
+      filterMentionSuggestions({
+        ...base,
+        mentionTrigger: "/",
+        mentionFilter: "inspector",
+      }).map((suggestion) => suggestion.tag),
+    ).toEqual(["/inspector"]);
+  });
+
+  it("gives every command an action id so picking one never inserts text", () => {
+    for (const suggestion of COMPOSER_COMMAND_SUGGESTIONS) {
+      expect(suggestion.category).toBe("command");
+      expect(suggestion.commandId).toBeTruthy();
+      expect(suggestion.tag.startsWith("/")).toBe(true);
+    }
   });
 
   it("shows speaker suggestions from the @ composer trigger", () => {

--- a/apps/screenpipe-app-tauri/components/chat/standalone/composer-input-box.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/composer-input-box.tsx
@@ -69,7 +69,10 @@ export function ComposerInputBox({
               ? input.disabledReason
               : input.isLoading || input.isStreaming
                 ? "Message will be queued..."
-                : "Ask about your screen... (@ chats, $ skills, ~ time, # tags)"
+                : // Kept to the same rendered width as the previous legend so it
+                  // still fits the 600px minimum chat window on one line. `~`
+                  // and `#` stay live and are taught by the palette itself.
+                  "Ask about your screen... (/ for commands, @ chats, $ skills)"
           }
           disabled={!input.canChat}
           spellCheck={false}

--- a/apps/screenpipe-app-tauri/components/chat/standalone/hooks/use-chat-mentions.ts
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/hooks/use-chat-mentions.ts
@@ -13,7 +13,9 @@ import {
   mentionSuggestionIdentity,
   parseMentions,
   resolvePinnedMentionIndex,
+  COMPOSER_COMMAND_SUGGESTIONS,
   TIME_RANGE_MENTION_SUGGESTIONS,
+  type ComposerCommandId,
   type MentionSuggestion as ChatMentionSuggestion,
   type MentionTrigger,
 } from "@/lib/chat-utils";
@@ -53,6 +55,7 @@ interface UseChatMentionsOptions {
   tagMentionSuggestions: MentionSuggestion[];
   allTagMentionSuggestions: MentionSuggestion[];
   onOpenConversation: (conversationId: string) => void | Promise<void>;
+  onRunCommand: (commandId: ComposerCommandId) => void | Promise<void>;
 }
 
 export function useChatMentions({
@@ -66,6 +69,7 @@ export function useChatMentions({
   tagMentionSuggestions,
   allTagMentionSuggestions,
   onOpenConversation,
+  onRunCommand,
 }: UseChatMentionsOptions) {
   const [showMentionDropdown, setShowMentionDropdown] = useState(false);
   const [isComposing, setIsComposing] = useState(false);
@@ -631,6 +635,22 @@ export function useChatMentions({
   }, [hasConnectionChip, setChipScrollTop, setInput]);
 
   const insertMention = useCallback((tag: string) => {
+    // A `/` entry is an action, not a token. Consume the typed command and run
+    // it, keeping anything the cursor was sitting in front of.
+    const command = COMPOSER_COMMAND_SUGGESTIONS.find(
+      (suggestion) => suggestion.tag === tag,
+    );
+    if (command?.commandId) {
+      const cursorPos = inputRef.current?.selectionStart ?? input.length;
+      setInput(input.slice(cursorPos));
+      setShowMentionDropdown(false);
+      setMentionFilter("");
+      setMentionTrigger("@");
+      inputRef.current?.focus();
+      void onRunCommand(command.commandId);
+      return;
+    }
+
     const chatSuggestion = recentChatSuggestions.find(
       (suggestion) => suggestion.tag === tag && suggestion.conversationId,
     );
@@ -661,7 +681,7 @@ export function useChatMentions({
     setMentionFilter("");
     setMentionTrigger("@");
     inputRef.current?.focus();
-  }, [input, inputRef, onOpenConversation, recentChatSuggestions, setInput]);
+  }, [input, inputRef, onOpenConversation, onRunCommand, recentChatSuggestions, setInput]);
 
   return {
     showMentionDropdown,

--- a/apps/screenpipe-app-tauri/components/chat/standalone/mention-dropdown.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/mention-dropdown.tsx
@@ -23,9 +23,10 @@ export function MentionDropdown({
         animate={{ opacity: 1, y: 0 }}
         exit={{ opacity: 0, y: 4 }}
         transition={{ duration: 0.1 }}
-        className="absolute bottom-full left-0 right-0 mb-1 bg-background border border-border shadow-lg overflow-hidden z-50 max-h-[240px] overflow-y-auto"
+        className="absolute bottom-full left-0 right-0 mb-1 bg-background border border-border shadow-lg overflow-hidden z-50 flex flex-col"
       >
-        {["chat", "skill", "range", "time", "content", "app", "tag", "speaker"].map((category) => {
+        <div className="max-h-[240px] overflow-y-auto">
+        {["command", "chat", "skill", "range", "time", "content", "app", "tag", "speaker"].map((category) => {
           const items = mentions.suggestions.filter(
             (suggestion) => suggestion.category === category,
           );
@@ -33,7 +34,9 @@ export function MentionDropdown({
           return (
             <div key={category}>
               <div className="px-2 py-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground bg-muted/30 border-b border-border/50">
-                {category === "chat"
+                {category === "command"
+                  ? "commands"
+                  : category === "chat"
                   ? "recent chats"
                   : category === "skill"
                     ? "installed skills"
@@ -87,6 +90,10 @@ export function MentionDropdown({
             <span>Searching tags...</span>
           </div>
         )}
+        </div>
+        <div className="px-3 py-1.5 text-[10px] text-muted-foreground border-t border-border/50 bg-muted/20">
+          type to filter · ↓/enter to select · esc to clear
+        </div>
       </motion.div>
     </AnimatePresence>
   );

--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -43,6 +43,7 @@ import {
   isConversationHistorySyncPrompt,
   isInjectedTitleSourcePrompt,
   normalizeComposerMentionsForModel,
+  type ComposerCommandId,
   type ComposerSkillReference,
 } from "@/lib/chat-utils";
 import { useAutoSuggestions } from "@/lib/hooks/use-auto-suggestions";
@@ -418,6 +419,11 @@ export function StandaloneChat({
   const openMentionConversationRef = useRef<
     ((conversationId: string) => void | Promise<void>) | null
   >(null);
+  // `/` commands run handlers that are declared further down this component, so
+  // they are reached through a ref rather than reordering the whole file.
+  const runComposerCommandRef = useRef<
+    ((commandId: ComposerCommandId) => void | Promise<void>) | null
+  >(null);
 
   const atMentionSuggestions = React.useMemo(
     () => [...STATIC_MENTION_SUGGESTIONS, ...appMentionSuggestions],
@@ -475,6 +481,7 @@ export function StandaloneChat({
     allTagMentionSuggestions,
     onOpenConversation: (targetConversationId) =>
       openMentionConversationRef.current?.(targetConversationId),
+    onRunCommand: (commandId) => runComposerCommandRef.current?.(commandId),
   });
   const dropdownRef = useRef<HTMLDivElement>(null);
   // Root of the chat surface. The webview drag-drop event is window-global and
@@ -1200,6 +1207,25 @@ export function StandaloneChat({
   if (typeof window !== "undefined") {
     (window as any).__e2eStopChat = handleStop;
   }
+
+  // Render assignment, matching openMentionConversationRef above: every handler
+  // a `/` command needs is defined by this point.
+  runComposerCommandRef.current = async (commandId: ComposerCommandId) => {
+    switch (commandId) {
+      case "new-chat":
+        await startNewConversationRef.current?.();
+        return;
+      case "stop":
+        await handleStop();
+        return;
+      case "inspector":
+        toggleInspector();
+        return;
+      case "pipes":
+        await commands.showWindow({ Home: { page: "pipes" } });
+        return;
+    }
+  };
 
 
   const answerPiExtensionUiRequest = useCallback(async (

--- a/apps/screenpipe-app-tauri/lib/chat-utils.ts
+++ b/apps/screenpipe-app-tauri/lib/chat-utils.ts
@@ -933,10 +933,21 @@ export function parseMentions(input: string, options?: ParseMentionsOptions): Pa
 export interface MentionSuggestion {
   tag: string;
   description: string;
-  category: "chat" | "skill" | "range" | "time" | "content" | "app" | "speaker" | "tag";
+  category:
+    | "command"
+    | "chat"
+    | "skill"
+    | "range"
+    | "time"
+    | "content"
+    | "app"
+    | "speaker"
+    | "tag";
   label?: string;
   appName?: string;
   conversationId?: string;
+  /** Present only on `/` entries. Picking one runs an action instead of inserting text. */
+  commandId?: ComposerCommandId;
 }
 
 export function mentionSuggestionIdentity(suggestion: MentionSuggestion): string {
@@ -1093,11 +1104,56 @@ function formatTagAutocompleteDescription(item: AppAutocompleteItem) {
   return pluralize(item.count, "use");
 }
 
-export type MentionTrigger = "@" | "#" | "$" | "~";
+export type ComposerCommandId = "new-chat" | "stop" | "inspector" | "pipes";
+
+/**
+ * `/` entries run an action rather than inserting a token. Ordered the way they
+ * are offered, so the first row is the one a bare `/` most likely wants.
+ */
+export const COMPOSER_COMMAND_SUGGESTIONS: MentionSuggestion[] = [
+  {
+    tag: "/new",
+    label: "/new",
+    description: "start a new chat",
+    category: "command",
+    commandId: "new-chat",
+  },
+  {
+    tag: "/stop",
+    label: "/stop",
+    description: "stop the current response",
+    category: "command",
+    commandId: "stop",
+  },
+  {
+    tag: "/inspector",
+    label: "/inspector",
+    description: "toggle the inspector panel",
+    category: "command",
+    commandId: "inspector",
+  },
+  {
+    tag: "/pipes",
+    label: "/pipes",
+    description: "open pipes",
+    category: "command",
+    commandId: "pipes",
+  },
+];
+
+export type MentionTrigger = "@" | "#" | "$" | "~" | "/";
 
 export function findComposerMention(
   textBeforeCursor: string,
 ): { trigger: MentionTrigger; filter: string } | null {
+  // Anchored to position 0 on purpose: a slash only opens the palette when the
+  // message starts with it. Otherwise `03/04` and `src/lib` would open a menu
+  // mid-sentence.
+  const commandMatch = textBeforeCursor.match(/^\/([\w-]*)$/);
+  if (commandMatch) {
+    return { trigger: "/", filter: commandMatch[1] };
+  }
+
   const match =
     textBeforeCursor.match(/([@#$])([\w:.-]*)$/) ??
     textBeforeCursor.match(/(~)([^~@#$]*)$/);
@@ -1140,6 +1196,10 @@ export function filterMentionSuggestions({
     suggestion.tag.toLowerCase().includes(filter) ||
     suggestion.label?.toLowerCase().includes(filter) ||
     suggestion.description.toLowerCase().includes(filter);
+
+  if (mentionTrigger === "/") {
+    return COMPOSER_COMMAND_SUGGESTIONS.filter(matchesFilter);
+  }
 
   if (mentionTrigger === "#") {
     if (!filter) return tagMentionSuggestions;


### PR DESCRIPTION
## Problem

The composer advertised `@ chats, $ skills, ~ time, # tags` in its placeholder, but every one of those triggers **inserts a token**. There was no way to *do* anything from the composer: no `/`, and no hint that the open dropdown could be filtered.

## Where found and evidence

Asked to make our placeholder behave like Claude's, I pulled the strings out of the shipped Claude products rather than guessing.

`Claude.app` turned out to be a dead end for this, because its main chat is remote web content, so the composer isn't in the bundle (`en-US.json` is 482 Electron shell strings; `.vite/renderer` has no matching placeholder). The strings **are** in the Claude Code binary:

```
$ rg -a -o '.{60}for commands.{60}' ~/.local/share/claude/versions/2.1.143
… createElement(V,{dimColor:q},"/ for commands") …
```

The full hint block and the palette footer:

```
! for shell mode        type to filter · ↓/enter to select · esc to clear
/ for commands
@ for file paths
& for background
/btw for side question
```

So the two things being copied here are `/ for commands` and `type to filter · ↓/enter to select · esc to clear`, verbatim.

## Root cause

`findComposerMention` (`lib/chat-utils.ts`) only matched `[@#$]` and `~`, and `MentionSuggestion` had no notion of an entry that runs rather than inserts. The dropdown had no footer at all.

## Fix

`/` opens a command palette **reusing the existing mention machinery**, so arrow keys, Enter/Tab, Escape, and the identity-pinned selection all behave exactly as they do for the other four triggers. Picking an entry runs an action instead of inserting text:

| command | action |
|---|---|
| `/new` | start a new chat |
| `/stop` | stop the current response |
| `/inspector` | toggle the inspector panel |
| `/pipes` | open pipes |

Each maps to a handler `standalone-chat.tsx` already owned, reached through a ref like the existing `openMentionConversationRef`.

**The trigger is anchored to position 0 on purpose.** A bare `\/` regex would open the palette inside `03/04/2025` and `src/lib/chat-utils.ts`, so a slash is only a command when the message *starts* with it, and it closes again once you type a space. Selecting a command consumes only the typed token and keeps whatever the cursor was sitting in front of.

![slash command palette](https://raw.githubusercontent.com/screenpipe/screenpipe/assets-slash-commands-eb243b/slash-commands.png)

## One judgement call worth your review

`~ time` and `# tags` left the placeholder string. That is a width constraint, not a preference. The `Chat` window minimum is `600x750` (`src-tauri/src/window/show.rs:135`), and the textarea is `min-h-[44px]` with `rows={1}`, so a placeholder that wraps gets its second line **clipped**, not revealed.

Measured in the real component at the real font:

| placeholder | width |
|---|---|
| today's, shipped | **506px** |
| `+ / for commands`, all five kept | 641px, clips |
| `/ commands`, all five kept | 607px, clips |
| **shipped here** | **506px**, same as today |

No variant keeps all five triggers under the ~530px that fits at minimum width. Both dropped triggers stay fully live and are still taught by their own dropdowns. If you'd rather keep all five and accept wrapping on narrow windows, that's a one-line change, say the word.

## Relationship to #5956

#5956 also implements `/` commands, but it is a **draft, `CONFLICTING`/`DIRTY`, 47 commits behind main**, and bundles a second concern (changing `@` to reference a chat instead of switching to it). This PR is the slash half only, on current main. Happy to close either one; flagging rather than deciding.

## Validation

- `bun run typecheck` clean
- `bun test components/__tests__/global-chat-mentions.test.ts`: **37 pass**, 10 new, covering `/` detection, the `03/04/2025` and `src/lib/…` negative cases, filtering by tag and description, and that every command carries an action id so it can never insert text
- `bun run build` exit 0
- Screenshot above is a **real React render** of `ComposerInputBox` + `MentionDropdown` via a throwaway preview route (deleted before commit), verified non-wrapping (`scrollHeight 44 === clientHeight 44`)
- Existing E2E selector `placeholder*="Ask about your screen"` still matches, so `chat-composer-isolation.spec.ts` is unaffected

Full-suite note: 14 files fail locally with `localStorage.clear()` of undefined. I confirmed these are **pre-existing** by running them at base `main` (`5967184bb`) in a scratch worktree: identical failures, and none import anything this PR touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
