### PR TITLE
feat(brain): lead the Live View empty state with templates

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/__tests__/brain-overview.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/brain-overview.test.tsx
@@ -1263,6 +1263,42 @@ describe("BrainOverview", () => {
     expect(screen.getByTestId("live-view-template-process-map")).toBeTruthy();
   });
 
+  // Setup no longer builds a dashboard, so this empty state is the first
+  // dashboard surface a new user sees. On a cold install, facing an empty
+  // prompt is the worst starting point; a known-good kit is far likelier to
+  // produce something real. Pinned because a reorder here is invisible in
+  // review and silently undoes that.
+  it("offers templates before the prompt, without hiding the prompt", async () => {
+    mocks.listBrainViewTemplateKits.mockResolvedValue({
+      status: "ok",
+      data: [dailyMemoryTemplate, processMapTemplate],
+    });
+    mocks.listBrainViews.mockResolvedValue({
+      status: "ok",
+      data: [populatedView],
+    });
+    render(<BrainOverview />);
+
+    await openDashboardMenu();
+    fireEvent.click(await screen.findByText("delete"));
+    fireEvent.click(await screen.findByTestId("overview-confirm-delete"));
+
+    const content = await screen.findByTestId("brain-overview-empty-content");
+    const firstTemplate = await screen.findByTestId(
+      "live-view-template-daily-memory",
+    );
+    const composer = content.querySelector("textarea, input");
+    expect(composer).toBeTruthy();
+
+    // Both present, template first in document order.
+    expect(
+      firstTemplate.compareDocumentPosition(composer as Node) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    // The manual escape hatch survives the reorder.
+    expect(screen.getByTestId("overview-create")).toBeTruthy();
+  });
+
   it("keeps a template-generated new dashboard in review until it is saved", async () => {
     const generatedView = {
       title: "Daily memory, personalized",

--- a/apps/screenpipe-app-tauri/components/settings/brain-overview.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/brain-overview.tsx
@@ -2508,16 +2508,18 @@ export function BrainOverview({
           data-testid="brain-overview-empty-content"
           className="mx-auto flex min-h-full w-full max-w-5xl flex-col items-center justify-center px-6 py-8 text-center"
         >
-          <LiveViewAiComposer
-            busy={builderFeedback?.tone === "working"}
-            feedback={builderFeedback}
-            onCancel={() => builderAbortRef.current?.abort()}
-            selectedPresetId={selectedAiPreset?.id ?? null}
-            onSelectedPresetIdChange={selectAiPreset}
-            onGenerate={generateFromComposer}
-          />
+          {/* Templates lead, the composer follows.
+           *
+           * Setup no longer builds a dashboard, so this is now the first
+           * dashboard surface every new user sees rather than a rare state
+           * reached by deleting the last one. On a cold install there are only
+           * minutes of capture and no sense yet of what a Live View can even
+           * be, which is the worst possible moment to face an empty prompt —
+           * a known-good kit is far likelier to produce something real. The
+           * composer stays fully present for anyone who knows what they want,
+           * and neither is visually subordinate to the other. */}
           {templateKits.length > 0 && (
-            <div className="mt-8 w-full border-t border-border pt-6 text-left">
+            <div className="w-full text-left">
               <LiveViewTemplateGallery
                 kits={templateKits}
                 installedPipeNames={installedPipeNames}
@@ -2525,6 +2527,27 @@ export function BrainOverview({
               />
             </div>
           )}
+          <div
+            className={
+              templateKits.length > 0
+                ? "mt-8 w-full border-t border-border pt-6"
+                : "w-full"
+            }
+          >
+            {templateKits.length > 0 && (
+              <p className="mb-3 text-xs text-muted-foreground">
+                Or describe the dashboard you want
+              </p>
+            )}
+            <LiveViewAiComposer
+              busy={builderFeedback?.tone === "working"}
+              feedback={builderFeedback}
+              onCancel={() => builderAbortRef.current?.abort()}
+              selectedPresetId={selectedAiPreset?.id ?? null}
+              onSelectedPresetIdChange={selectAiPreset}
+              onGenerate={generateFromComposer}
+            />
+          </div>
           <button
             data-testid="overview-create"
             type="button"


### PR DESCRIPTION
## Problem

Setup no longer builds a dashboard (#6013), so the Live View empty state stopped being a rare place you reach by deleting your last dashboard and became **the first dashboard surface every new user sees**.

It is still laid out for the old meaning: the AI composer centered as the main path, templates below a divider as an afterthought, manual creation as a text link.

## Why that is backwards for a cold install

A user two minutes past setup has almost no captured data and no sense yet of what a Live View even is. That is the worst possible moment to face an empty prompt. A known-good kit is far likelier to produce something real, and it doubles as an explanation of what these things are.

## Before / after

![Live View empty state, before and after](https://raw.githubusercontent.com/screenpipe/screenpipe/visuals-live-view-empty-state/.github/pr-assets/live-view-empty-state.png)

Left: the composer takes the centre and the templates sit greyed out below a divider — the option most likely to work for a cold user is the one de-emphasised. Right: kits lead, the composer keeps its full size and function directly under "Or describe the dashboard you want", and the manual link survives underneath.

Layout mockup rendered at 2x from the real copy and structure, not a production capture — the change is ordering and weight, which is exactly what it shows.

## Fix

Templates lead. The composer follows under "Or describe the dashboard you want". Neither is visually subordinate to the other.

- Composer is **unchanged and fully present** — anyone who knows what they want loses nothing.
- "or build it manually" still sits underneath.
- Same kits, same per-Pipe install readiness, same preview and apply flow, same scrolling behaviour.

This is a layout and hierarchy change only. No new data, no new calls, no behaviour change.

## Validation

- 54 tests pass in `brain-overview.test.tsx`, including a new one asserting templates precede the composer in document order while both remain present, plus the manual escape hatch.
- The order test is pinned deliberately: a reorder here is invisible in review and would silently undo this.
- TypeScript, ESLint on the changed file, and the coverage gate are clean.

## Note on the base

Stacked on `claude/onboarding-first-run-learning-window` (#6013) because the rationale depends on setup no longer building a dashboard. Retarget to `main` if #6013 lands first.

## Not in this PR

- The **non-empty** state still keeps templates behind the "More" menu. That is right for a user with real dashboards, arguably wrong for a user whose only dashboard is a throwaway — worth a separate look.
