### PR TITLE
fix(chat): stop telling a monthly usage cap to retry in a few seconds

### DIFF
--- a/apps/screenpipe-app-tauri/lib/chat/__tests__/quota-errors.test.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/__tests__/quota-errors.test.ts
@@ -391,4 +391,51 @@ describe("presentQuotaError", () => {
       upgrade: null,
     });
   });
+  it("does not tell a monthly cap to retry in a few seconds", () => {
+    // The bug: a monthly spend cap whose body also mentions a rate limit fell
+    // into the transient branch and told the user to wait seconds for a limit
+    // that does not move until next month.
+    const error = JSON.stringify({
+      error: "monthly_cost_limit_exceeded",
+      message: "Rate limited - try again in a moment or switch to a different model.",
+      resets_at: null,
+    });
+    const msg = buildDailyLimitMessage(error);
+    expect(msg).not.toContain("few seconds");
+    expect(msg).not.toContain("temporarily rate-limited");
+    expect(msg).toContain("this month");
+  });
+
+  it("never promises a reset for a trial allowance that does not refill", () => {
+    const error = JSON.stringify({
+      error: "trial_cost_limit_exceeded",
+      resets_at: null,
+    });
+    const msg = buildDailyLimitMessage(error);
+    expect(msg).toContain("doesn't refill");
+    expect(msg).not.toMatch(/resets (at|on|tomorrow)/);
+    expect(msg).not.toContain("few seconds");
+  });
+
+  it("uses the gateway reset timestamp instead of inventing one", () => {
+    const soon = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const msg = buildDailyLimitMessage(
+      JSON.stringify({ error: "daily_cost_limit_exceeded", resets_at: soon }),
+    );
+    expect(msg).toMatch(/It resets at /);
+  });
+
+  it("falls back to a vague window when resets_at is unparseable", () => {
+    const msg = buildDailyLimitMessage(
+      JSON.stringify({ error: "daily_cost_limit_exceeded", resets_at: "not-a-date" }),
+    );
+    expect(msg).toContain("It resets tomorrow");
+    expect(msg).not.toContain("Invalid Date");
+  });
+
+  it("still treats a genuine provider rate limit as transient", () => {
+    const msg = buildDailyLimitMessage("429 rate_limit from upstream provider");
+    expect(msg).toContain("temporarily rate-limited");
+  });
+
 });

--- a/apps/screenpipe-app-tauri/lib/chat/quota-errors.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/quota-errors.ts
@@ -73,6 +73,57 @@ function isCostLimitError(errorStr: string): boolean {
   return COST_LIMIT_CODES.some((code) => normalized.includes(code));
 }
 
+type CostLimitWindow = "day" | "month" | "trial" | "unknown";
+
+function costLimitWindow(errorStr: string): CostLimitWindow {
+  const normalized = errorStr.toLowerCase();
+  if (normalized.includes("trial_cost_limit_exceeded")) return "trial";
+  if (normalized.includes("monthly_cost_limit_exceeded")) return "month";
+  if (normalized.includes("daily_cost_limit_exceeded")) return "day";
+  return "unknown";
+}
+
+/**
+ * Say when the allowance actually comes back.
+ *
+ * The gateway sends `resets_at: null` for a trial cap because a trial budget is
+ * cumulative and never resets. Rendering that as "try again shortly" sends the
+ * user to wait for something that cannot happen, so each window states its own
+ * truth and only a real timestamp is ever turned into a time.
+ */
+function costLimitReason(window: CostLimitWindow, errorStr: string): string {
+  const resetsAt = structuredString(errorStr, "resets_at");
+  const resetTime = formatResetMoment(resetsAt);
+  // Background pipes draw on the same budget, which is why this fires for
+  // people who feel they barely used chat. Keep saying so.
+  const shared = "Background scheduled tasks share this budget.";
+  switch (window) {
+    case "trial":
+      return `you've used the hosted AI allowance included with your trial. It doesn't refill during the trial. ${shared}`;
+    case "month":
+      return resetTime
+        ? `you've used this month's hosted AI usage limit. It resets ${resetTime}. ${shared}`
+        : `you've used this month's hosted AI usage limit. It resets at the start of next month. ${shared}`;
+    case "day":
+      return resetTime
+        ? `you've used today's hosted AI usage limit. It resets ${resetTime}. ${shared}`
+        : `you've used today's hosted AI usage limit. It resets tomorrow. ${shared}`;
+    default:
+      return `your plan's hosted AI usage limit is reached. ${shared}`;
+  }
+}
+
+/** Only a parseable timestamp becomes a time. Never invent one. */
+function formatResetMoment(resetsAt: string | null): string | null {
+  if (!resetsAt) return null;
+  const at = new Date(resetsAt);
+  if (Number.isNaN(at.getTime())) return null;
+  const withinADay = at.getTime() - Date.now() < 24 * 60 * 60 * 1000;
+  return withinADay
+    ? `at ${at.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" })}`
+    : `on ${at.toLocaleDateString(undefined, { month: "short", day: "numeric" })}`;
+}
+
 function isUpgradeLimitError(errorStr: string): boolean {
   const normalized = errorStr.toLowerCase();
   return UPGRADE_LIMIT_CODES.some((code) => normalized.includes(code));
@@ -129,22 +180,25 @@ export function buildDailyLimitMessage(errorStr: string): string {
     const isRateLimit =
       normalized.includes("rate limit") || normalized.includes("rate_limit");
 
-    if (isRateLimit) {
-      return "This model is temporarily rate-limited. Try again in a few seconds, or switch to a different model.";
-    }
-
+    // A spend cap is terminal for its whole window; a provider rate limit
+    // clears in seconds. These must never be confused, so the cap is matched
+    // FIRST. A monthly cap body that merely mentions "rate limit" used to fall
+    // into the transient branch and tell the user to retry in a few seconds —
+    // for a limit that does not move until the 1st of the month.
     if (isCostLimit) {
       // Don't leak the raw dollar cap — that's our internal margin. Frame it
       // as an account-wide budget so the user understands why it fired even
       // when they "didn't use much" (background pipes consume it too).
-      const upgrade = parseQuotaUpgradeAction(errorStr);
-      if (upgrade) {
-        // The persistent recovery panel owns the explanation and actions. Keep
-        // the transcript entry short so the same technical paragraph is not
-        // repeated immediately above it.
-        return "Hosted AI didn't run this request because your plan's usage limit is reached. Choose a recovery option below.";
-      }
-      return "Hosted AI didn't run this request because your plan's usage limit is reached. Background scheduled tasks share this budget. Switch to a local model or your own provider key to keep working.";
+      const window = costLimitWindow(errorStr);
+      const recovery = parseQuotaUpgradeAction(errorStr)
+        ? // The persistent recovery panel owns the explanation and actions.
+          "Choose a recovery option below."
+        : "Switch to a local model or your own provider key to keep working.";
+      return `Hosted AI didn't run this request because ${costLimitReason(window, errorStr)} ${recovery}`;
+    }
+
+    if (isRateLimit) {
+      return "This model is temporarily rate-limited. Try again in a few seconds, or switch to a different model.";
     }
 
     if (parseQuotaUpgradeAction(errorStr)) {


### PR DESCRIPTION
## Problem

`buildDailyLimitMessage` checked `isRateLimit` **before** `isCostLimit`:

```ts
if (isRateLimit) return "This model is temporarily rate-limited. Try again in a few seconds…"
if (isCostLimit) return "…your plan's usage limit is reached…"
```

`isRateLimit` is a substring match on `"rate limit"` / `"rate_limit"`. So a **monthly** spend cap whose body happens to mention a rate limit fell into the transient branch and told the user to wait a few seconds — for a limit that does not move until the 1st of the month.

The gateway was reporting this correctly the whole time. It sends `monthly_cost_limit_exceeded` / `trial_cost_limit_exceeded` with an explicit `resets_at`, and `resets_at: null` for trial allowances because they are cumulative and never refill. The desktop discarded all of it.

## Where found

Support triage. A customer hit his monthly cap, was shown "Rate limited — try again in a moment", and waited. He came back four days running. Three separate replies told him it was fixed, because each of us read the same misleading message. Two other customers hit the identical wall the same week.

## Reproduction

Before this change:

```ts
buildDailyLimitMessage(JSON.stringify({
  error: "monthly_cost_limit_exceeded",
  message: "Rate limited - try again in a moment or switch to a different model.",
  resets_at: null,
}))
// → "This model is temporarily rate-limited. Try again in a few seconds…"
```

## Root cause

Branch ordering, plus discarding the window and `resets_at` the gateway already provides.

## Fix

- **Match the spend cap first.** A cap is terminal for its window; a provider rate limit clears in seconds. They must never be confused.
- **Say which window was hit and when it actually returns**, derived from `resets_at`.
- **A trial allowance says it does not refill**, rather than implying a wait that can never end.
- **Only a parseable timestamp becomes a time.** Never invent one.
- Genuine provider rate limits still read as transient.
- Still says background scheduled tasks share the budget — that's why this fires for people who feel they barely used chat.

| case | before | after |
| --- | --- | --- |
| monthly cap | "try again in a few seconds" | "you've used this month's hosted AI usage limit. It resets on Sep 1." |
| trial cap | "try again in a few seconds" | "the allowance included with your trial… doesn't refill during the trial." |
| daily cap | "try again in a few seconds" | "you've used today's hosted AI usage limit. It resets at 12:00 AM." |
| provider 429 | transient | unchanged, still transient |

## Validation

- 42 tests pass in `quota-errors.test.ts` — 37 existing, 5 new regressions covering each case above
- `bun run typecheck` clean
- `lib/chat` + `lib/events`: 308 passing. Two pre-existing `free-wall.test.ts` failures reproduce on clean `origin/main`, so they are not from this PR.

No dollar figures or plan ceilings are added to any message — internal margin stays internal.
