### PR TITLE
fix(windows): prevent terminal after app updates

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
@@ -55,6 +55,8 @@ const TITLE_SESSION_PREFIX: &str = "__title:";
 const REQUIRED_PI_EXTENSION_PACKAGE: &str = "npm:pi-subagents";
 const CONVERSATION_HISTORY_OPEN: &str = "<conversation_history>";
 const CONVERSATION_HISTORY_CLOSE: &str = "</conversation_history>";
+const PI_INSTALL_ARGS: [&str; 2] = ["install", "--ignore-scripts"];
+const NPM_INSTALL_ARGS: [&str; 4] = ["install", "--ignore-scripts", "--no-audit", "--no-fund"];
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum PiConversationSyncState {
@@ -1278,7 +1280,8 @@ fn npm_install_command(install_dir: &Path) -> Command {
     #[cfg(windows)]
     {
         let mut cmd = Command::new("cmd.exe");
-        cmd.args(["/C", "npm", "install", "--no-audit", "--no-fund"])
+        cmd.args(["/C", "npm"])
+            .args(NPM_INSTALL_ARGS)
             .current_dir(install_dir);
         cmd
     }
@@ -1286,8 +1289,7 @@ fn npm_install_command(install_dir: &Path) -> Command {
     #[cfg(not(windows))]
     {
         let mut cmd = Command::new("npm");
-        cmd.args(["install", "--no-audit", "--no-fund"])
-            .current_dir(install_dir);
+        cmd.args(NPM_INSTALL_ARGS).current_dir(install_dir);
         cmd
     }
 }
@@ -1356,8 +1358,9 @@ fn run_pi_package_install_once(install_dir: &Path, bun: &str) -> Result<(), Stri
     // from the log alone; a bun that can't even execute (e.g. SIGILL on an
     // unsupported CPU) shows up right here as the version probe failing.
     info!(
-        "Running Pi dependency install: {} install (cwd: {}, bun version: {})",
+        "Running Pi dependency install: {} {} (cwd: {}, bun version: {})",
         bun,
+        PI_INSTALL_ARGS.join(" "),
         install_dir.display(),
         screenpipe_core::agents::pi::bun_version_string(bun),
     );
@@ -1366,7 +1369,10 @@ fn run_pi_package_install_once(install_dir: &Path, bun: &str) -> Result<(), Stri
     bun_cmd
         .current_dir(install_dir)
         .env("BUN_INSTALL_CACHE_DIR", &cache_dir)
-        .args(["install"]);
+        // CREATE_NO_WINDOW only applies to this Bun process. Lifecycle scripts
+        // can launch fresh console processes, so disable them for ScreenPipe's
+        // app-managed dependency set as well.
+        .args(PI_INSTALL_ARGS);
 
     match run_command_output(bun_cmd) {
         Ok(output) if output.status.success() => verify_pi_package_install(install_dir),
@@ -5398,6 +5404,12 @@ mod tests {
 
     const REPLAYED_HISTORY: &str =
         "<conversation_history>\nuser: hello\nassistant: hi\n</conversation_history>\n\nwhat next?";
+
+    #[test]
+    fn managed_pi_installs_disable_dependency_lifecycle_scripts() {
+        assert!(super::PI_INSTALL_ARGS.contains(&"--ignore-scripts"));
+        assert!(super::NPM_INSTALL_ARGS.contains(&"--ignore-scripts"));
+    }
 
     #[test]
     fn prepares_prompt_for_pi_conversation_state() {

--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -20,6 +20,13 @@ pub const PI_PACKAGE: &str = "@earendil-works/pi-coding-agent@0.83.0";
 pub const PI_AI_PACKAGE: &str = "@earendil-works/pi-ai@0.83.0";
 pub const PI_NAMESPACE_DIR: &str = "@earendil-works";
 pub const SCREENPIPE_API_URL: &str = "https://api.screenpipe.com/v1";
+const PI_INSTALL_ARGS: [&str; 5] = [
+    "add",
+    "--ignore-scripts",
+    PI_PACKAGE,
+    PI_AI_PACKAGE,
+    "@anthropic-ai/sdk",
+];
 const CUSTOM_PROVIDER_USER_AGENT: &str = "screenpipe";
 const DEFAULT_CLOUD_MAX_OUTPUT_TOKENS: u64 = 32_000;
 
@@ -2246,20 +2253,21 @@ impl AgentExecutor for PiExecutor {
         // Log the exact command + bun version up front so a failed install is
         // reproducible from the log alone (and a bun that can't even run —
         // e.g. SIGILL on an unsupported CPU — is exposed before the install).
-        let args = ["add", PI_PACKAGE, PI_AI_PACKAGE, "@anthropic-ai/sdk"];
         info!(
             "installing pi into {} via bun at {} (version: {}); command: bun {}",
             install_dir.display(),
             bun,
             bun_version_string(&bun),
-            args.join(" "),
+            PI_INSTALL_ARGS.join(" "),
         );
 
         // Seed package.json with overrides to fix lru-cache resolution on Windows
         seed_pi_package_json(&install_dir);
 
         let mut cmd = tokio_bun_command(&bun);
-        cmd.current_dir(&install_dir).args(args);
+        // CREATE_NO_WINDOW only covers this Bun process. Lifecycle scripts can
+        // launch new consoles, so disable them for this pinned managed install.
+        cmd.current_dir(&install_dir).args(PI_INSTALL_ARGS);
 
         #[cfg(windows)]
         {
@@ -3853,6 +3861,11 @@ pub fn ensure_bash_available() -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn managed_pi_install_disables_dependency_lifecycle_scripts() {
+        assert!(PI_INSTALL_ARGS.contains(&"--ignore-scripts"));
+    }
 
     #[test]
     fn tool_use_without_an_executable_call_is_a_protocol_error() {


### PR DESCRIPTION
## description

Prevent a visible Windows Terminal window from appearing when ScreenPipe restarts after an update and repairs its managed Pi dependencies.

ScreenPipe's own capture and logs identified the foreground process as `WindowsTerminal.exe`, titled with the bundled `...\AppData\Local\screenpipe\bun.exe`. This occurred immediately after restart while the Pi version migration launched background dependency installs. The Bun parent already used `CREATE_NO_WINDOW`, but dependency lifecycle scripts can spawn fresh console processes outside that protection.

This PR:

- disables lifecycle scripts for the desktop Bun install and npm fallback
- applies the same protection to the core-managed Bun install
- keeps the existing hidden-process flags and install verification/self-healing
- adds regression tests for every managed install path

The managed package set installs and verifies successfully without lifecycle scripts. Bun documents this behavior under [`--ignore-scripts`](https://bun.sh/docs/pm/lifecycle).

related issue: none — reported from a Windows update/restart

## AI assistance and human ownership

read the [AI-assisted contribution policy](https://github.com/screenpipe/screenpipe/blob/main/CONTRIBUTING.md#ai-assisted-contributions).

- AI tool(s) used (`none` if not used): OpenAI Codex
- autonomy level (`none`, `autocomplete`, `chat`, or `agent`): agent
- what I personally verified: Agent-run verification is documented below; human ownership attestation remains intentionally unchecked for the submitter to confirm.

- [ ] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [ ] The problem statement, rationale, and replies to maintainers are my own.

## evidence type

- [x] UI or behavior change — before/after evidence below
- [x] Backend change — regression tests and relevant results below
- [ ] Performance change — reproducible before/after benchmarks
- [ ] Docs, CI, or pure refactor — relevant checks and an explanation; no video required

## before

Captured during the reported update from ScreenPipe 2.5.158 to 2.5.188:

```text
ScreenPipe update -> restart -> Pi dependency repair
                                  |
                                  v
+----------------------------------------------------+
| Windows Terminal                                   |
| ...\AppData\Local\screenpipe\bun.exe               |
+----------------------------------------------------+
                    visible and focused
```

The app log recorded `bun install`/`bun add` repair work at the same time the accessibility capture recorded the terminal becoming the foreground app.

## after

```text
ScreenPipe update -> restart -> managed Pi repair
                                  |
                                  v
               bun install --ignore-scripts
                                  |
                                  v
                       no terminal window
```

A fresh Windows install smoke test launched the bundled Bun with `CreateNoWindow=true`, installed the same managed package manifest, and polled visible `WindowsTerminal` windows every 100 ms for the complete run:

```text
bun_exit=0
visible_terminal_windows=0
```

## how to test

1. `cargo fmt --all -- --check` — passed.
2. From the repository root, `cargo test -p screenpipe-core agents::pi::tests` — 50 passed, 1 intentionally ignored.
3. From `apps/screenpipe-app-tauri/src-tauri`, in an MSVC x64 developer environment, `cargo test -p screenpipe-app pi::tests` — 71 passed, 1 intentionally ignored.
4. On Windows, launch a fresh `bun install --ignore-scripts` with `UseShellExecute=false` and `CreateNoWindow=true` while polling visible `WindowsTerminal` windows — install exited 0; zero terminal windows observed.

## desktop app checklist (if applicable)

No Tauri commands or frontend-exported Rust types changed, so bindings generation/check and frontend typecheck are not applicable.

- [ ] `bun run bindings:generate` (if bindings changed)
- [ ] `bun run bindings:check`
- [ ] `bun run typecheck`
