### PR TITLE
fix(e2e): raise the WebDriver script timeout past a cold Windows Pi install

### DIFF
--- a/apps/screenpipe-app-tauri/e2e/wdio.conf.ts
+++ b/apps/screenpipe-app-tauri/e2e/wdio.conf.ts
@@ -111,7 +111,21 @@ export const config: TestrunnerConfig = {
   // layout, journey/system specs, plus the workflow's separate core-recording spec.
   specs: isWindowsCi ? windowsCiSpecs : allSpecs,
   maxInstances: 1,
-  capabilities: [{ browserName: 'chrome' }],
+  // The W3C default script timeout is 30s, and every `invoke` helper goes
+  // through Execute Async Script, which that timeout governs. On a cold Windows
+  // runner the app installs Pi on first launch — measured at 119.5s, with the
+  // shared bun cache throwing `EBUSY: failed copying files from cache to
+  // destination` throughout — and an invoke issued while that runs is blocked
+  // behind it. The script timeout fired one second before an install completed,
+  // taking the webview's window with it, which is why `Verify background
+  // AI-tool connection` failed deterministically on Windows while macOS passed.
+  // Raise the ceiling past a cold install rather than leaving it under one.
+  capabilities: [
+    {
+      browserName: 'chrome',
+      timeouts: { script: isWindowsCi ? 180000 : 60000 },
+    },
+  ],
   hostname: '127.0.0.1',
   port: WEBDRIVER_PORT,
   path: '/',


### PR DESCRIPTION
## Problem

`Windows E2E Tests` fails deterministically on `Verify background AI-tool connection`, blocking a required context. It is red on four consecutive main commits, **including `078d77928`**, which already carries the onboarding fix that turned macOS green — so it is a different cause wearing the same job name.

```
WebDriverError: Script execution timed out when running "execute/async"
WebDriverError: No window could be found when running "execute/async"   (x many)
```

## Root cause

No `timeouts` capability was ever set, so the script timeout sat at the **W3C default of 30s**. Every `invoke` helper goes through Execute Async Script, which that timeout governs.

On a cold Windows runner the app installs Pi on first launch:

```
EBUSY: failed copying files from cache to destination for package @earendil-works/pi-tui
EBUSY: failed copying files from cache to destination for package @aws-sdk/core
...
130 packages installed [119.53s]
```

An `invoke` issued while that runs is blocked behind it. The log puts the timeout at `15:42:14` and the install completing at `15:42:15` — **one second apart**. The session then loses its window, and every later call reports `No window could be found`, which is what made this look like a window bug rather than a timeout.

macOS never hit it because its install is far faster and stays under 30s.

## Fix

Set an explicit script timeout: **180s on Windows CI, 60s elsewhere.**

This is a one-line capability plus comment — no product code, no test-logic changes.

## Note

The slow, `EBUSY`-ridden Windows bun install is worth fixing on its own (same partial-install family as the `screenpipe-mcp` `Cannot find package 'chalk'` errors seen in other runs). But a 30s ceiling sitting under a 120s first-run install is wrong regardless of how fast that install gets, and fixing the ceiling is the change that unblocks the required context now.

## Validation

- `bun run typecheck` clean
- Cause established from step-level CI history across 4 commits and the timestamp adjacency above
- Windows E2E on this PR is the verification