### PR TITLE
fix(e2e): stop the onboarding poll from racing its own success condition

### DIFF
--- a/apps/screenpipe-app-tauri/e2e/specs/onboarding-background-ai-tools.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/onboarding-background-ai-tools.spec.ts
@@ -268,26 +268,48 @@ async function callActivitySummaryThroughMcp(
       // removed slide — it resumes at the engine and finishes. Sample the body
       // while the window is alive so we can prove the removed slides never
       // rendered, and stop as soon as the store says setup completed.
+      //
+      // Which window each half runs in is load-bearing. `invoke` executes in
+      // whichever window is currently switched to, and the engine slide closes
+      // Onboarding the moment it finishes setup. Polling the store from the
+      // onboarding handle therefore races its own success condition: completion
+      // destroys the context the completion check runs in, and the driver fails
+      // the whole `waitUntil` with "No window could be found" instead of
+      // reporting `isCompleted: true`. So the store is read from Home, which is
+      // opened above and outlives Onboarding, and only the body sample runs
+      // against Onboarding while that handle still exists.
       const seen: string[] = [];
       await browser.waitUntil(
         async () => {
+          // Driver-level, so it stays valid even with no live current window.
+          const handles = await browser.getWindowHandles();
+          if (!handles.includes("home")) {
+            throw new Error(
+              "home window disappeared; it is the surviving context this poll reads the onboarding store from",
+            );
+          }
+
+          if (handles.includes("onboarding")) {
+            try {
+              await browser.switchToWindow("onboarding");
+              seen.push(
+                (
+                  (await browser.execute(
+                    () => document.body?.innerText || "",
+                  )) as string
+                ).toLowerCase(),
+              );
+            } catch {
+              // Window closed underneath the sample. Expected once setup
+              // completes; the status check below settles it.
+            }
+          }
+
+          await browser.switchToWindow("home");
           const status = await invokeOrThrow<{ isCompleted: boolean }>(
             "get_onboarding_status",
           );
-          if (status.isCompleted) return true;
-          try {
-            seen.push(
-              (
-                (await browser.execute(
-                  () => document.body?.innerText || "",
-                )) as string
-              ).toLowerCase(),
-            );
-          } catch {
-            // window closed underneath the sample; the status check above is
-            // authoritative and will settle this on the next pass
-          }
-          return false;
+          return status.isCompleted;
         },
         {
           timeout: t(30_000),


### PR DESCRIPTION
## Why

`Linux E2E Tests` and `Windows E2E Tests` have been red on `main` since ~2026-08-08T01:48Z — five consecutive runs. Every open PR inherits the red check, so nothing on the board can show a clean board.

Both lanes fail on the same spec, at the same line, with the same error:

```
1) Native onboarding AI-tool setup resumes a saved connection slide at the engine step and finishes setup
   waitUntil condition failed with the following reason:
   WebDriverError: No window could be found when running "execute/async" with method "POST"
     at async invoke (e2e/helpers/tauri.ts:32:11)
     at async invokeOrThrow (e2e/helpers/tauri.ts:69:15)
     at async Browser.<anonymous> (e2e/specs/onboarding-background-ai-tools.spec.ts:274:26)
```

Deterministic, not flaky: it failed the initial attempt and all 3 retries, on both platforms.

## Root cause

`invoke()` runs through `browser.executeAsync`, which executes **in whatever window is currently switched to**.

The test switches to `onboarding`, then polls `get_onboarding_status` waiting for the engine slide to finish setup. But finishing setup is precisely what **closes the onboarding window**. So the poll races its own success condition: the instant the awaited thing happens, the context the check runs in is destroyed, and the driver fails the entire `waitUntil` instead of reporting `isCompleted: true`.

Half of this was already known. There is a try/catch around the body sample and a comment stating:

> window closed underneath the sample; the status check above is authoritative and will settle this on the next pass

It cannot settle it, because the status check is the thing that throws. `invokeOrThrow` only handles a returned `{ ok: false }` — a WebDriverError thrown by a dead context propagates straight through it.

macOS passes only because its timing differs. This is one race, not a platform quirk.

## The fix

Split the poll by window, since which window each half runs in is load-bearing:

- **Read the store from `home`**, which the test already opens two lines earlier and never closes, so it outlives Onboarding.
- **Sample the onboarding body only while that handle exists**, decided via `getWindowHandles()` — a driver-level call that stays valid with no live current window.

The contract the test asserts is unchanged: a saved `connect-apps` install must resume at the engine slide and finish, and the removed slides must never render.

## Validation

- Typecheck: no errors in the edited spec; the project's pre-existing error count is identical before and after (12 → 12, all in unrelated files).
- macOS lane run locally against a debug build with `--features e2e`, which is the platform that was already green — so this proves **no regression**, and exercises the new window-switching path against a real app.
- The platforms that actually reproduce the bug are Linux and Windows, and those lanes only run in CI. **This PR exists so those two lanes run against the fix** — they are the real proof, and this should merge only once both are green.

## Scope

One file, test-only. No product code, no helper shared by other specs.

I deliberately did not harden `invoke()` itself. Translating the driver's "No window could be found" into a clearer error would have saved this debugging session, but that helper backs ~100 specs and I cannot verify that blast radius locally. Worth doing separately.

Same latent pattern exists in `screen-recording-restart.spec.ts` (polls `invokeOrThrow` after a click that could close the window). It is currently green on every platform, so I left it alone rather than speculatively rewriting a passing spec — that is how real regressions get papered over. Noting it so it is on the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
