### PR TITLE
fix(ai): describe weekly hosted usage limits

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -32,15 +32,15 @@ results and `cargo llvm-cov` data on top when judging release confidence.
 
 - Mapped suites: 32
 - Mapped Rust files: 317
-- Active test blocks: 2988
+- Active test blocks: 2989
 - Ignored/manual test blocks: 137
-- Weighted coverage points: 2456.8
+- Weighted coverage points: 2457.5
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 2857 | 132 | 2396.8 | 21 | 11 | 100% |
-| macos | 29 | 2911 | 112 | 2407.9 | 22 | 11 | 100% |
-| linux | 25 | 2544 | 105 | 2114.3 | 20 | 11 | 100% |
+| windows | 29 | 2858 | 132 | 2397.5 | 21 | 11 | 100% |
+| macos | 29 | 2912 | 112 | 2408.6 | 22 | 11 | 100% |
+| linux | 25 | 2545 | 105 | 2115.0 | 20 | 11 | 100% |
 
 ## Refresh
 

--- a/apps/screenpipe-app-tauri/components/chat/standalone/composer-controls-row.test.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/composer-controls-row.test.tsx
@@ -38,6 +38,9 @@ vi.mock("@/components/chat/standalone/acp-config-selector", () => ({
 vi.mock("@/components/thinking-level-selector", () => ({
   ThinkingLevelSelector: () => null,
 }));
+vi.mock("@/components/usage/usage-popover", () => ({
+  UsagePopover: () => null,
+}));
 
 import { ComposerControlsRow } from "./composer-controls-row";
 

--- a/apps/screenpipe-app-tauri/components/chat/standalone/upgrade-quota-banner.test.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/upgrade-quota-banner.test.tsx
@@ -32,7 +32,6 @@ vi.mock("@/lib/hooks/use-usage-status", () => ({
   useUsageStatus: () => mocks.usageState,
   formatResetTime: () => "5:00 PM",
   formatAllowanceReset: () => "Aug 17, 5:00 PM",
-  formatAllowanceWindow: () => "30-day",
   formatUsagePercent: (percent: number) => `${percent}%`,
 }));
 
@@ -115,20 +114,28 @@ describe("UpgradeQuotaBanner", () => {
     );
   });
 
-  it("reports Cloudflare allowance utilization without sensitive amounts when upsell UI is off", () => {
+  it("presents a combined seven-day allowance as a weekly limit", () => {
     mocks.usageState = {
       ...mocks.usageState,
+      tier: "business_max",
       remaining: 999_999,
       upsell_banner: false,
       hosted_ai: {
+        plan: "business_max",
         allowance_managed_by: "cloudflare",
         usage_as_of: "2026-08-04T16:30:00.000Z",
+        upgrade: {
+          requiredPlan: "business_ultra",
+          upgradeUrl:
+            "https://screenpipe.com/account/billing?target_plan=pro_ultra&interval=month",
+          resetsAt: null,
+        },
         allowances: [
           {
-            lane: "auto",
+            lane: "combined",
             used_percent: 100,
             remaining_percent: 0,
-            window_seconds: 2_592_000,
+            window_seconds: 604_800,
             technique: "fixed",
             resets_at: "2026-08-17T00:00:00.000Z",
           },
@@ -140,10 +147,46 @@ describe("UpgradeQuotaBanner", () => {
     render(<UpgradeQuotaBanner />);
 
     expect(screen.getByTestId("hosted-ai-allowance-banner")).toBeTruthy();
-    expect(screen.getByText(/100% used/i)).toBeTruthy();
-    expect(screen.getByText(/30-day fixed period/i)).toBeTruthy();
+    expect(screen.getByText("Weekly hosted AI limit reached")).toBeTruthy();
+    expect(screen.getByText(/100% used this week/i)).toBeTruthy();
     expect(screen.getByText(/resets Aug 17, 5:00 PM/i)).toBeTruthy();
-    expect(screen.queryByRole("button", { name: "View Business" })).toBeNull();
+    expect(screen.getByText(/Switch to Auto or upgrade/i)).toBeTruthy();
+    expect(screen.queryByText(/explicit model/i)).toBeNull();
+    expect(screen.queryByText(/fixed period/i)).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Upgrade to Business Ultra" }),
+    ).toBeTruthy();
+  });
+
+  it("does not promise an upgrade when the server offers no next plan", () => {
+    mocks.usageState = {
+      ...mocks.usageState,
+      tier: "business_ultra",
+      remaining: 999_999,
+      upsell_banner: false,
+      hosted_ai: {
+        plan: "business_ultra",
+        allowance_managed_by: "cloudflare",
+        usage_as_of: "2026-08-04T16:30:00.000Z",
+        upgrade: null,
+        allowances: [
+          {
+            lane: "combined",
+            used_percent: 100,
+            remaining_percent: 0,
+            window_seconds: 604_800,
+            technique: "fixed",
+            resets_at: "2026-08-17T00:00:00.000Z",
+          },
+        ],
+      },
+    };
+
+    render(<UpgradeQuotaBanner />);
+
+    expect(screen.getByText(/Switch to Auto\./i)).toBeTruthy();
+    expect(screen.queryByText(/Switch to Auto or upgrade/i)).toBeNull();
+    expect(screen.queryByRole("button", { name: /upgrade/i })).toBeNull();
   });
 
   it.each([

--- a/apps/screenpipe-app-tauri/components/chat/standalone/upgrade-quota-banner.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/upgrade-quota-banner.tsx
@@ -9,7 +9,6 @@ import posthog from "posthog-js";
 import { Button } from "@/components/ui/button";
 import {
   formatAllowanceReset,
-  formatAllowanceWindow,
   formatResetTime,
   formatUsagePercent,
   useUsageStatus,
@@ -123,8 +122,10 @@ export function UpgradeQuotaBanner() {
     ? quotaPlanLabel(activeUpgrade.requiredPlan)
     : null;
   const requiredPlanProse = requiredPlanLabel ?? "a higher plan";
-  const blockedTitle = cloudflareBlocked
-    ? `${cloudflareAllowance.lane === "auto" ? "Auto" : "Explicit model"} hosted AI limit reached`
+  const weeklyAllowance =
+    cloudflareBlocked && cloudflareAllowance.window_seconds === 7 * 86_400;
+  const blockedTitle = weeklyAllowance
+    ? "Weekly hosted AI limit reached"
     : "Hosted AI usage limit reached";
 
   return (
@@ -153,13 +154,10 @@ export function UpgradeQuotaBanner() {
             <div className="mt-0.5 text-muted-foreground">
               {cloudflareBlocked ? (
                 <>
-                  {formatUsagePercent(cloudflareAllowance.used_percent)} used for this{" "}
-                  {formatAllowanceWindow(cloudflareAllowance.window_seconds)}{" "}
-                  {cloudflareAllowance.technique} period.
+                  {formatUsagePercent(cloudflareAllowance.used_percent)} used
+                  {weeklyAllowance ? " this week." : "."}
                   {resets ? ` Resets ${resets}.` : " Usage falls as the window moves."}{" "}
-                  {cloudflareAllowance.lane === "auto"
-                    ? "Choose an explicit hosted model, or use a local or own-key preset."
-                    : "Switch to Auto, or use a local or own-key preset."}
+                  {activeUpgrade ? "Switch to Auto or upgrade." : "Switch to Auto."}
                 </>
               ) : legacyCostBlocked ? (
                 activeUpgrade ? (

--- a/apps/screenpipe-app-tauri/lib/chat/__tests__/quota-errors.test.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/__tests__/quota-errors.test.ts
@@ -90,29 +90,32 @@ describe("hosted busy messages", () => {
 });
 
 describe("buildDailyLimitMessage", () => {
-  it("suggests the independent explicit lane when Auto is exhausted", () => {
+  it("keeps hosted allowance recovery independent of internal lane metadata", () => {
     const message = buildDailyLimitMessage(
       '{"error":{"code":"hosted_ai_allowance_exceeded"},"allowance":{"lane":"auto","plan":"basic","managed_by":"cloudflare"}}',
     );
-    expect(message).toContain("current hosted AI allowance for Auto");
-    expect(message).toContain("explicit hosted model");
+    expect(message).toBe(
+      "Your hosted AI usage limit is reached. Switch to Auto.",
+    );
+    expect(message).not.toContain("explicit");
     expect(message).not.toMatch(/\$\d/);
   });
 
-  it("suggests Auto when the explicit lane is exhausted", () => {
+  it("offers the validated upgrade without exposing the exhausted lane", () => {
     const message = buildDailyLimitMessage(
-      '{"error":{"code":"hosted_ai_allowance_exceeded"},"allowance":{"lane":"explicit","plan":"business","managed_by":"cloudflare"}}',
+      '{"error":{"code":"hosted_ai_allowance_exceeded"},"allowance":{"lane":"explicit","plan":"business","managed_by":"cloudflare"},"required_plan":"business_max","upgrade_url":"https://screenpipe.com/account/billing?target_plan=pro_max&interval=month"}',
     );
-    expect(message).toContain("explicit models");
-    expect(message).toContain("Switch to Auto");
+    expect(message).toBe(
+      "Your hosted AI usage limit is reached. Switch to Auto or upgrade.",
+    );
+    expect(message).not.toContain("explicit");
   });
 
-  it("does not suggest an unavailable explicit hosted lane to Free users", () => {
+  it("does not promise an upgrade when the gateway did not provide one", () => {
     const message = buildDailyLimitMessage(
       '{"error":{"code":"hosted_ai_allowance_exceeded"},"allowance":{"lane":"auto","plan":"free","managed_by":"cloudflare"}}',
     );
-    expect(message).toContain("Upgrade");
-    expect(message).not.toContain("explicit hosted model");
+    expect(message).not.toMatch(/upgrade/i);
   });
 
   it("shows the daily free message wall without immediate retry copy", () => {
@@ -241,7 +244,9 @@ describe("buildDailyLimitMessage", () => {
         "https://screenpipe.com/account/billing?target_plan=pro_max&interval=month",
     });
     expect(parseQuotaUpgradeAction(error)?.requiredPlan).toBe("business_max");
-    expect(buildDailyLimitMessage(error)).toContain("explicit hosted model");
+    expect(buildDailyLimitMessage(error)).toBe(
+      "Your hosted AI usage limit is reached. Switch to Auto or upgrade.",
+    );
   });
 
   it("recognizes monthly and trial cost limits through the same upgrade contract", () => {
@@ -367,12 +372,15 @@ describe("presentQuotaError", () => {
     });
   });
 
-  it("keeps the allowance-specific copy for hosted allowance exhaustion", () => {
+  it("keeps hosted allowance exhaustion generic across internal lanes", () => {
     const presented = presentQuotaError(
       'HTTP 429 {"error":"hosted_ai_allowance_exceeded","lane":"auto","plan":"free"}',
     );
     expect(presented.kind).toBe("daily");
-    expect(presented.message.toLowerCase()).toContain("allowance");
+    expect(presented.message).toBe(
+      "Your hosted AI usage limit is reached. Switch to Auto.",
+    );
+    expect(presented.message).not.toContain("explicit");
   });
 
   it("classifies rate limits with retry copy and no upgrade", () => {

--- a/apps/screenpipe-app-tauri/lib/chat/quota-errors.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/quota-errors.ts
@@ -160,15 +160,9 @@ export function buildDailyLimitMessage(errorStr: string): string {
   try {
     const normalized = errorStr.toLowerCase();
     if (normalized.includes("hosted_ai_allowance_exceeded")) {
-      const lane = structuredString(errorStr, "lane")?.toLowerCase();
-      const plan = structuredString(errorStr, "plan")?.toLowerCase();
-      if (lane === "explicit") {
-        return "Your current hosted AI allowance for explicit models is used up. Switch to Auto, or use Ollama, Claude, Codex, or your own provider key.";
-      }
-      if (plan === "free") {
-        return "Your current hosted AI allowance for Auto is used up. Upgrade, or switch your AI preset to Ollama, Claude, Codex, or your own provider key.";
-      }
-      return "Your current hosted AI allowance for Auto is used up. Choose an explicit hosted model, or use Ollama, Claude, Codex, or your own provider key.";
+      return parseQuotaUpgradeAction(errorStr)
+        ? "Your hosted AI usage limit is reached. Switch to Auto or upgrade."
+        : "Your hosted AI usage limit is reached. Switch to Auto.";
     }
     if (normalized.includes("free_chat_limit_exceeded")) {
       return "You've used today's 2 free hosted AI messages. Try again tomorrow, upgrade, or switch your AI preset to Ollama, Claude, Codex, or your own provider key.";

--- a/docs/coverage/CORE.md
+++ b/docs/coverage/CORE.md
@@ -9,10 +9,10 @@ confidence, and criticality.
 - Tracked crates: screenpipe-engine, screenpipe-db, screenpipe-sqlite-coordinator, screenpipe-audio, screenpipe-screen, screenpipe-a11y
 - Mapped suites: 32
 - Mapped Rust files: 317
-- Active test blocks: 2988
+- Active test blocks: 2989
 - Ignored/manual test blocks: 137
-- Declared test blocks: 3125
-- Weighted coverage points: 2456.8
+- Declared test blocks: 3126
+- Weighted coverage points: 2457.5
 
 Confidence weights: strong=1.0, partial=0.7, conditional=0.4, smoke=0.3.
 Criticality weights: high=1.0, medium=0.7, low=0.4.
@@ -23,15 +23,15 @@ are explicitly enabled in a runtime lane.
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 2857 | 132 | 2396.8 | 21 | 11 | 100% |
-| macos | 29 | 2911 | 112 | 2407.9 | 22 | 11 | 100% |
-| linux | 25 | 2544 | 105 | 2114.3 | 20 | 11 | 100% |
+| windows | 29 | 2858 | 132 | 2397.5 | 21 | 11 | 100% |
+| macos | 29 | 2912 | 112 | 2408.6 | 22 | 11 | 100% |
+| linux | 25 | 2545 | 105 | 2115.0 | 20 | 11 | 100% |
 
 ## Crate Summary
 
 | Crate | Suites | Integration files | Source unit files | Active tests | Ignored tests | Weighted points | Flows |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| screenpipe-engine | 10 | 18 | 102 | 1430 | 42 | 1096.9 | 10 |
+| screenpipe-engine | 10 | 18 | 102 | 1431 | 42 | 1097.6 | 10 |
 | screenpipe-db | 5 | 50 | 14 | 417 | 16 | 396.7 | 9 |
 | screenpipe-sqlite-coordinator | 1 | 0 | 2 | 11 | 0 | 11.0 | 2 |
 | screenpipe-audio | 6 | 25 | 49 | 563 | 43 | 491.2 | 5 |
@@ -68,8 +68,8 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | database | 6 suites / 335 active / 12 ignored / 314.7 pts | 6 suites / 335 active / 12 ignored / 314.7 pts | 6 suites / 335 active / 12 ignored / 314.7 pts |
 | db-search | 2 suites / 107 active / 9 ignored / 107.0 pts | 2 suites / 107 active / 9 ignored / 107.0 pts | 2 suites / 107 active / 9 ignored / 107.0 pts |
 | engine-lifecycle | 6 suites / 205 active / 1 ignored / 180.0 pts | 6 suites / 205 active / 1 ignored / 180.0 pts | 5 suites / 199 active / 1 ignored / 178.3 pts |
-| local-api | 2 suites / 320 active / 9 ignored / 225.8 pts | 2 suites / 320 active / 9 ignored / 225.8 pts | 2 suites / 320 active / 9 ignored / 225.8 pts |
-| meeting | 6 suites / 1371 active / 19 ignored / 1116.0 pts | 6 suites / 1371 active / 19 ignored / 1116.0 pts | 4 suites / 1093 active / 15 ignored / 860.5 pts |
+| local-api | 2 suites / 321 active / 9 ignored / 226.5 pts | 2 suites / 321 active / 9 ignored / 226.5 pts | 2 suites / 321 active / 9 ignored / 226.5 pts |
+| meeting | 6 suites / 1372 active / 19 ignored / 1116.7 pts | 6 suites / 1372 active / 19 ignored / 1116.7 pts | 4 suites / 1094 active / 15 ignored / 861.2 pts |
 | ocr | 4 suites / 120 active / 7 ignored / 114.3 pts | 4 suites / 124 active / 7 ignored / 119.8 pts | 3 suites / 115 active / 6 ignored / 110.8 pts |
 | os-integration | 1 suites / 6 active / 0 ignored / 1.7 pts | 1 suites / 6 active / 0 ignored / 1.7 pts | - |
 | performance | 13 suites / 1339 active / 67 ignored / 1183.2 pts | 14 suites / 1437 active / 70 ignored / 1222.4 pts | 13 suites / 1339 active / 67 ignored / 1183.2 pts |
@@ -79,8 +79,8 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | speaker | 2 suites / 318 active / 8 ignored / 318.0 pts | 2 suites / 318 active / 8 ignored / 318.0 pts | 2 suites / 318 active / 8 ignored / 318.0 pts |
 | storage | 3 suites / 461 active / 29 ignored / 373.4 pts | 3 suites / 461 active / 29 ignored / 373.4 pts | 3 suites / 461 active / 29 ignored / 373.4 pts |
 | sync | 1 suites / 461 active / 3 ignored / 322.7 pts | 1 suites / 461 active / 3 ignored / 322.7 pts | 1 suites / 461 active / 3 ignored / 322.7 pts |
-| timeline | 4 suites / 912 active / 33 ignored / 742.2 pts | 4 suites / 912 active / 33 ignored / 742.2 pts | 4 suites / 912 active / 33 ignored / 742.2 pts |
-| transcription | 5 suites / 671 active / 40 ignored / 527.5 pts | 5 suites / 671 active / 40 ignored / 527.5 pts | 5 suites / 671 active / 40 ignored / 527.5 pts |
+| timeline | 4 suites / 913 active / 33 ignored / 742.9 pts | 4 suites / 913 active / 33 ignored / 742.9 pts | 4 suites / 913 active / 33 ignored / 742.9 pts |
+| transcription | 5 suites / 672 active / 40 ignored / 528.2 pts | 5 suites / 672 active / 40 ignored / 528.2 pts | 5 suites / 672 active / 40 ignored / 528.2 pts |
 | ui-events | 4 suites / 696 active / 28 ignored / 531.1 pts | 3 suites / 648 active / 5 ignored / 497.5 pts | 3 suites / 648 active / 5 ignored / 497.5 pts |
 | vision-capture | 5 suites / 477 active / 32 ignored / 380.9 pts | 5 suites / 481 active / 32 ignored / 386.4 pts | 4 suites / 472 active / 31 ignored / 377.4 pts |
 
@@ -133,7 +133,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | db-runtime-reliability | screenpipe-db | windows, macos, linux | database, performance | performance-liveness | high | partial | mixed | 12 | 27 | 6 | SQLite hard-fault classification, failpoint VFS injection, fresh-identity recovery verification with integrity/FK/write canaries, query cancellation, close-severs-connections regressions, multi-pool WAL parity, runtime version pinning, and WAL chaos plus memory-pressure probes. |
 | db-search-indexing | screenpipe-db | windows, macos, linux | db-search, ocr, accessibility, performance | local-api-search, capture-ocr-pipeline, accessibility-ui-events, performance-liveness | high | strong | mixed | 13 | 101 | 4 | FTS, tokenizer, OCR snapshot search, query planning, ordering, accessibility search, and contention coverage. |
 | db-timeline-frames | screenpipe-db | windows, macos, linux | database, timeline, storage, performance | timeline-streaming, performance-liveness | high | strong | mixed | 17 | 169 | 3 | Frame/audio joins, timeline query shape, suggestions frames, write queue, DB primitives (src/db.rs split into src/db/ modules), feedback record upserts, media eviction anti-join regressions, SAF output registry, semantic storage, and timeline performance. |
-| engine-api-routes | screenpipe-engine | windows, macos, linux | local-api, timeline, meeting, transcription | local-api-search, timeline-streaming, meeting-live-notes, audio-record-transcribe | high | partial | mixed | 31 | 314 | 4 | Route/unit coverage for search, health, streaming, meetings, time/timezone, and transcription. Legacy endpoint/websocket tests require local data and remain ignored. |
+| engine-api-routes | screenpipe-engine | windows, macos, linux | local-api, timeline, meeting, transcription | local-api-search, timeline-streaming, meeting-live-notes, audio-record-transcribe | high | partial | mixed | 31 | 315 | 4 | Route/unit coverage for search, health, streaming, meetings, time/timezone, and transcription. Legacy endpoint/websocket tests require local data and remain ignored. |
 | engine-capture-timeline | screenpipe-engine | windows, macos, linux | vision-capture, timeline, storage, performance | capture-ocr-pipeline, timeline-streaming, performance-liveness | high | partial | mixed | 23 | 252 | 26 | Covers capture trigger logic, frame/audio linking, hot cache, timeline refresh regressions, fragmented MP4 extraction, and HD-mode control. Several real-data tests are intentionally ignored by default. |
 | engine-config-lifecycle | screenpipe-engine | windows, macos, linux | configuration, engine-lifecycle, performance | settings-to-engine-config, engine-health-lifecycle, performance-liveness | high | strong | mixed | 11 | 111 | 1 | Fast logic coverage for the config bridge, tray health debounce, sleep/power policies, and queue backpressure. |
 | engine-db-recovery-cli | screenpipe-engine | windows, macos, linux | database, engine-lifecycle | engine-health-lifecycle, performance-liveness | high | strong | unit | 1 | 8 | 0 | Exact DB/WAL/SHM working-copy preservation, rollback on archive failure, and restart repair for crashes during the multi-file generation swap. |
@@ -409,7 +409,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | engine-api-routes | screenpipe-engine | src/routes/structured_outputs.rs | source | 1 | 0 | 1 |
 | engine-api-routes | screenpipe-engine | src/routes/time.rs | source | 9 | 0 | 9 |
 | engine-api-routes | screenpipe-engine | src/routes/timezone.rs | source | 8 | 0 | 8 |
-| engine-api-routes | screenpipe-engine | src/routes/websocket.rs | source | 3 | 0 | 3 |
+| engine-api-routes | screenpipe-engine | src/routes/websocket.rs | source | 4 | 0 | 4 |
 | engine-config-lifecycle | screenpipe-engine | src/schedule_monitor.rs | source | 8 | 0 | 8 |
 | engine-capture-timeline | screenpipe-engine | src/semantic_worker.rs | source | 6 | 0 | 6 |
 | engine-api-routes | screenpipe-engine | src/server.rs | source | 13 | 0 | 13 |

--- a/packages/ai-gateway/src/handlers/chat.ts
+++ b/packages/ai-gateway/src/handlers/chat.ts
@@ -749,14 +749,10 @@ function errorResponse(body: RequestBody, status: number, message: string): Resp
   }));
 }
 
-function allowanceMessage(allowance: HostedChatAllowanceExceededError['allowance']): string {
-  if (allowance.lane === 'explicit') {
-    return 'Your current hosted AI allowance for explicit models is used up. Switch to Auto, or use a local model or your own provider key.';
-  }
-  if (allowance.plan === 'free') {
-    return 'Your current hosted AI allowance for Auto is used up. Upgrade, or use a local model or your own provider key.';
-  }
-  return 'Your current hosted AI allowance for Auto is used up. Choose an explicit hosted model, or use a local model or your own provider key.';
+function allowanceMessage(canUpgrade: boolean): string {
+  return canUpgrade
+    ? 'Your hosted AI usage limit is reached. Switch to Auto or upgrade.'
+    : 'Your hosted AI usage limit is reached. Switch to Auto.';
 }
 
 /** Render the stable terminal contract Pi uses to avoid generic 429 retries. */
@@ -766,7 +762,7 @@ export function allowanceErrorResponse(body: RequestBody, error: HostedChatAllow
     : getHostedAiCapacityUpgrade(error.allowance.plan);
   const payload = {
     error: {
-      message: allowanceMessage(error.allowance),
+      message: allowanceMessage(upgrade !== null),
       type: 'insufficient_quota',
       code: 'hosted_ai_allowance_exceeded',
     },

--- a/packages/ai-gateway/src/test/cloudflare-chat-routing.unit.test.ts
+++ b/packages/ai-gateway/src/test/cloudflare-chat-routing.unit.test.ts
@@ -139,6 +139,10 @@ describe('Cloudflare hosted-chat routing', () => {
 			expect(json.allowance).toEqual({ lane: 'auto', plan: accountPlan, managed_by: 'cloudflare' });
 			expect(json.required_plan).toBe(requiredPlan);
 			expect(json.upgrade_url).toBe(upgradeUrl);
+			expect(json.error.message).toBe(requiredPlan
+				? 'Your hosted AI usage limit is reached. Switch to Auto or upgrade.'
+				: 'Your hosted AI usage limit is reached. Switch to Auto.');
+			expect(json.error.message).not.toMatch(/explicit|allowance for Auto/i);
 			expect(JSON.stringify(json)).not.toMatch(/usd|dollar|amount/i);
 
 			const streamResponse = allowanceErrorResponse({ ...body, model: 'auto', stream: true }, error);


### PR DESCRIPTION
## Summary

- present seven-day hosted AI exhaustion as a weekly limit
- remove internal Auto/explicit lane explanations from customer-facing errors
- say “Switch to Auto or upgrade” only when the gateway provides a valid next-plan action
- keep the preset-selection unit test isolated from the usage popover added on upstream main
- refresh the generated coverage dashboards required by the latest main commit’s new websocket test

## Usage-copy audit

| Site | Verdict |
| --- | --- |
| UpgradeQuotaBanner | affected; now shows weekly usage and generic recovery copy |
| buildDailyLimitMessage | affected; now ignores internal lane metadata |
| gateway allowanceErrorResponse | affected; now returns the same generic recovery copy |
| Settings usage meter | safe; combined production allowances already render as “all models” |
| Gateway lane metadata/routing | safe; retained as an internal enforcement detail |

## Visual

Before:

    Explicit model hosted AI limit reached
    100% used for this 7-day fixed period. Switch to Auto, or use a local or own-key preset.

After:

    Weekly hosted AI limit reached
    100% used this week. Switch to Auto or upgrade.

Top-tier accounts without another upgrade are offered only “Switch to Auto.”

## Testing

- `bun x vitest run components/chat/standalone/composer-controls-row.test.tsx components/chat/standalone/upgrade-quota-banner.test.tsx lib/chat/__tests__/quota-errors.test.ts` (60 passed)
- `bun test ./src/test/cloudflare-chat-routing.unit.test.ts` (8 passed)
- `bun run typecheck` (desktop)
- `bun x tsc --noEmit` (AI gateway)
- `bun run coverage:all:check`
- `git diff --check`
