### PR TITLE
fix(pi): repair installs missing runtime artifact

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
@@ -1190,6 +1190,16 @@ fn local_pi_install_integrity_error(install_dir: &Path) -> Option<String> {
     if !cli_js.exists() {
         return Some(format!("missing Pi entrypoint at {}", cli_js.display()));
     }
+    let agent_session_runtime = pi_dir
+        .join("dist")
+        .join("core")
+        .join("agent-session-runtime.js");
+    if !agent_session_runtime.is_file() {
+        return Some(format!(
+            "missing Pi runtime artifact at {}",
+            agent_session_runtime.display()
+        ));
+    }
 
     if !is_local_pi_version_current(install_dir) {
         return Some(format!("Pi package version is not {}", PI_PACKAGE));
@@ -6023,8 +6033,13 @@ printf '%s\n' '{"type":"agent_end"}'
             super::PI_PACKAGE.rsplit('@').next().unwrap_or(""),
         );
         let dist = pi_dir.join("dist");
-        std::fs::create_dir_all(&dist).expect("create dist");
+        std::fs::create_dir_all(dist.join("core")).expect("create dist");
         std::fs::write(dist.join("cli.js"), "console.log('pi')").expect("write cli");
+        std::fs::write(
+            dist.join("core").join("agent-session-runtime.js"),
+            "export class AgentSessionRuntime {}",
+        )
+        .expect("write agent session runtime");
     }
 
     /// Regression guard for the empty "Pi background install failed: " log
@@ -6142,6 +6157,44 @@ printf '%s\n' '{"type":"agent_end"}'
             .expect("missing pi-ai should make install unhealthy");
         assert!(
             error.contains("@earendil-works/pi-ai"),
+            "unexpected integrity error: {}",
+            error
+        );
+    }
+
+    #[test]
+    fn local_pi_integrity_detects_missing_agent_session_runtime() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let install_dir = dir.path();
+        let pi_dir = super::pi_package_dir(install_dir);
+        write_pi_package(install_dir);
+        write_package_json(
+            &super::node_module_package_dir(install_dir, "@earendil-works/pi-ai"),
+            "@earendil-works/pi-ai",
+            super::PI_AI_PACKAGE.rsplit('@').next().unwrap_or(""),
+        );
+        write_package_json(
+            &super::node_module_package_dir(install_dir, "@anthropic-ai/sdk"),
+            "@anthropic-ai/sdk",
+            "0.91.1",
+        );
+        write_package_json(
+            &super::node_module_package_dir(install_dir, "cross-spawn"),
+            "cross-spawn",
+            "7.0.6",
+        );
+        std::fs::remove_file(
+            pi_dir
+                .join("dist")
+                .join("core")
+                .join("agent-session-runtime.js"),
+        )
+        .expect("remove agent session runtime");
+
+        let error = super::local_pi_install_integrity_error(install_dir)
+            .expect("missing agent session runtime should make install unhealthy");
+        assert!(
+            error.contains("agent-session-runtime.js"),
             "unexpected integrity error: {}",
             error
         );


### PR DESCRIPTION
## Source

- Feedback task: `t_6c1a658a`
- Discord feedback identity: channel `1339037549926289500`, message `1535976048833990738`
- Reported environment: Windows 10.0.26200, screenpipe 2.6.0
- Symptom: the AI agent crash-looped and restarted automatically.

## Root cause

The managed `@earendil-works/pi-coding-agent` install could retain `dist/cli.js` while missing `dist/core/agent-session-runtime.js`. The existing integrity check accepted that partial package, so startup skipped the established repair path and Pi crashed when its main module imported the absent runtime artifact.

## Fix

- Require `dist/core/agent-session-runtime.js` to be a regular file in `local_pi_install_integrity_error`.
- Let the existing managed-package recovery flow clear and reinstall any package missing that required artifact.
- Update the healthy fixture and add a regression test for the partial-install shape.

This covers the full managed desktop surface because Windows, macOS, and Linux use the same path-based integrity check and repair flow; no platform-specific branch is involved. Public package versions 0.80.6 (reported) and 0.83.0 (currently pinned) both contain this artifact and import it from `dist/main.js`, so the check is valid for both known package surfaces.

## Verification

- **RED:** the exact pre-fix production function accepted an install with `dist/cli.js` but no runtime artifact.
- **GREEN:** the exact reviewed function rejects the missing artifact and accepts the same fixture after the file is restored.
- Independent reviewer reproduced both behaviors: 2/2 exact-source harness runs passed.
- `git diff --check origin/main...HEAD` passed.
- Security and one-file scope inspection passed.
- Canonical focused command attempted: `cargo test --manifest-path apps/screenpipe-app-tauri/src-tauri/Cargo.toml local_pi_integrity_detects_missing_agent_session_runtime -- --nocapture`. The host stopped before app compilation because GLib/GObject/GIO pkg-config metadata is unavailable.

## Platform scope

Windows, macOS, and Linux managed Pi installations. The original report was Windows.

## Visual evidence

Not applicable: this is a non-UI integrity/repair-path change. Deterministic RED/GREEN runtime-artifact evidence is provided above.