### PR TITLE
fix(copy): repair phrasing broken by the pipes to scheduled tasks rename

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat/pipe-context-banner.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/pipe-context-banner.tsx
@@ -48,7 +48,7 @@ export function PipeContextBanner({
         className,
       )}
       role="status"
-      aria-label={done ? `scheduled run: ${pipeName}` : `watching scheduled task: ${pipeName}`}
+      aria-label={done ? `task run: ${pipeName}` : `watching scheduled task: ${pipeName}`}
     >
       <span
         className={cn(

--- a/apps/screenpipe-app-tauri/components/pipe-install-dialog.tsx
+++ b/apps/screenpipe-app-tauri/components/pipe-install-dialog.tsx
@@ -201,7 +201,7 @@ export function PipeInstallDialog() {
                 ? registryRisk === "high"
                   ? "Unverified publisher. Can access all your screen data."
                   : "Review the requested access before installing."
-                : "a scheduled task from an external link wants to install. scheduled tasks are AI agents that run on your screen data — review the prompt below before installing."}
+                : "an external link wants to install a scheduled task. these are AI agents that run on your screen data — review the prompt below before installing."}
             </AlertDialogDescription>
           </AlertDialogHeader>
 

--- a/apps/screenpipe-app-tauri/components/rewind/ai-presets-selector.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/ai-presets-selector.tsx
@@ -1069,7 +1069,7 @@ export function AIProviderConfig({
                       {m.name}{m.free ? " (free)" : ""}
                       {locked && <span className="text-[9px] font-medium text-muted-foreground border rounded px-1">business</span>}
                       {!locked && costLabel && <span className="text-[9px] font-medium text-muted-foreground">{costLabel}</span>}
-                      {m.recommended_for?.includes('pipes') && <span className="text-[9px] text-muted-foreground bg-muted rounded px-1">pipes</span>}
+                      {m.recommended_for?.includes('pipes') && <span className="text-[9px] text-muted-foreground bg-muted rounded px-1">tasks</span>}
                       {m.health?.status === 'down' && <span className="text-[9px] text-red-400 ml-1">overloaded</span>}
                     </span>
                   </SelectItem>

--- a/apps/screenpipe-app-tauri/components/settings/account-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/account-section.tsx
@@ -13,7 +13,7 @@ export const searchIndex: SettingsField[] = [
   { label: "Sign in to Screenpipe", keywords: ["login", "log in", "sign in"] },
   { label: "Logout", keywords: ["signout", "sign out", "log out"] },
   { label: "Screenpipe Business", keywords: ["subscription", "billing", "plan", "pro", "business", "max", "ultra", "upgrade", "manage"] },
-  { label: "scheduled sync across devices", keywords: ["scheduled sync", "pipe sync", "sync"] },
+  { label: "sync scheduled tasks across devices", keywords: ["scheduled sync", "pipe sync", "sync"] },
   { label: "memories sync across devices", keywords: ["memories sync", "sync", "facts"] },
   { label: "connection sync across devices", keywords: ["connection sync", "sync", "slack", "notion"] },
 ];
@@ -590,7 +590,7 @@ export function AccountSection() {
           <div className="mt-4 pt-4 border-t border-border/50">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium">scheduled sync across devices</p>
+                <p className="text-sm font-medium">sync scheduled tasks across devices</p>
                 <p className="text-xs text-muted-foreground">
                   sync your scheduled tasks & configs to all devices linked to your account
                 </p>
@@ -603,7 +603,7 @@ export function AccountSection() {
                     onCheckedChange={async (checked) => {
                       await updateSettings({ pipeSyncEnabled: checked });
                       toast({
-                        title: checked ? "scheduled sync enabled" : "scheduled sync disabled",
+                        title: checked ? "scheduled task sync enabled" : "scheduled task sync disabled",
                         description: checked
                           ? "scheduled tasks will sync across your devices"
                           : "scheduled tasks will no longer sync",
@@ -830,7 +830,7 @@ export function AccountSection() {
           <Card className="p-4 opacity-75">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium">scheduled sync across devices</p>
+                <p className="text-sm font-medium">sync scheduled tasks across devices</p>
                 <p className="text-xs text-muted-foreground">
                   sync your scheduled tasks & configs to all devices linked to your account
                 </p>
@@ -927,7 +927,7 @@ export function AccountSection() {
           <Card className="p-4 opacity-75">
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium">scheduled sync across devices</p>
+                <p className="text-sm font-medium">sync scheduled tasks across devices</p>
                 <p className="text-xs text-muted-foreground">
                   sync your scheduled tasks & configs to all devices linked to your account
                 </p>

--- a/apps/screenpipe-app-tauri/components/settings/brain-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/brain-section.tsx
@@ -2068,7 +2068,7 @@ export function BrainSection() {
                         }
                       >
                         <MessageSquare className="mr-2 h-3.5 w-3.5" />
-                        {target.mode === "pipe-run" ? "go to scheduled run" : "go to chat"}
+                        {target.mode === "pipe-run" ? "go to task run" : "go to chat"}
                       </DropdownMenuItem>
                     )}
                     <DropdownMenuItem
@@ -2633,7 +2633,7 @@ export function BrainSection() {
                               >
                                 <MessageSquare className="mr-2 h-3.5 w-3.5" />
                                 {target.mode === "pipe-run"
-                                  ? "go to scheduled run"
+                                  ? "go to task run"
                                   : "go to chat"}
                               </DropdownMenuItem>
                             )}

--- a/apps/screenpipe-app-tauri/components/settings/disk-usage-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/disk-usage-section.tsx
@@ -312,7 +312,7 @@ export function DiskUsageSection() {
                 </p>
               )}
               <div className="flex items-center justify-between text-xs">
-                <span className="text-muted-foreground">Scheduled</span>
+                <span className="text-muted-foreground">Scheduled tasks</span>
                 <span className="font-medium">
                   {diskUsage?.other?.pipes_size || "0 KB"}
                 </span>

--- a/apps/screenpipe-app-tauri/components/settings/general-settings.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/general-settings.tsx
@@ -39,7 +39,7 @@ export const searchIndex: SettingsField[] = [
   { label: "Auto-start", keywords: ["autostart", "launch", "startup"] },
   { label: "Auto-update", keywords: ["updates"] },
   { label: "Check for updates", keywords: ["version"] },
-  { label: "Auto-Update Scheduled" },
+  { label: "Auto-update scheduled tasks", keywords: ["pipes", "store", "tasks"] },
   { label: "Reset Onboarding", keywords: ["setup"] },
   { label: "Your goal", keywords: ["onboarding", "purpose", "personalization"] },
 ];
@@ -349,8 +349,8 @@ export default function GeneralSettings() {
               <div className="flex items-center space-x-2.5">
                 <RefreshCw className="h-4 w-4 text-muted-foreground shrink-0" />
                 <div>
-                  <h3 className="text-sm font-medium text-foreground">Auto-Update Scheduled</h3>
-                  <p className="text-xs text-muted-foreground">Update Store tasks you haven&apos;t modified</p>
+                  <h3 className="text-sm font-medium text-foreground">Auto-update scheduled tasks</h3>
+                  <p className="text-xs text-muted-foreground">Keep tasks you installed from the Store up to date, unless you&apos;ve edited them</p>
                 </div>
               </div>
               <Switch

--- a/apps/screenpipe-app-tauri/components/settings/live-view-card.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/live-view-card.tsx
@@ -55,9 +55,9 @@ const SOURCE_STATUS_LABELS: Record<LiveViewSourceStatus, string | null> = {
 const SOURCE_STATUS_TITLES: Record<LiveViewSourceStatus, string | null> = {
   auto: null,
   manual:
-    "This scheduled task has no schedule, so this block only changes when you press refresh.",
+    "This task has no schedule, so this block only changes when you press refresh.",
   paused:
-    "This scheduled task is turned off, so this block only changes when you press refresh.",
+    "This task is turned off, so this block only changes when you press refresh.",
   unknown: null,
 };
 

--- a/apps/screenpipe-app-tauri/components/settings/notification-registry.ts
+++ b/apps/screenpipe-app-tauri/components/settings/notification-registry.ts
@@ -70,7 +70,7 @@ export const NOTIFICATION_GROUPS: NotificationGroup[] = [
   },
   {
     id: "automation",
-    label: "scheduled & automation",
+    label: "scheduled tasks & automation",
     description: "ideas and alerts from your automations",
   },
   {
@@ -138,7 +138,7 @@ export const NOTIFICATION_CATEGORIES: NotificationCategory[] = [
   },
   {
     id: "pipeNotifications",
-    label: "Scheduled notifications",
+    label: "Scheduled task alerts",
     description: "Alerts from installed scheduled tasks",
     group: "automation",
     default: true,

--- a/apps/screenpipe-app-tauri/components/settings/pipes-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/pipes-section.tsx
@@ -1938,7 +1938,7 @@ export function PipesSection() {
     if (isEnterpriseManagedName(name)) {
       toast({
         title: "managed by your organization",
-        description: "an organization admin controls this scheduled task's schedule and enabled state",
+        description: "an organization admin controls when this task runs and whether it is enabled",
       });
       return;
     }
@@ -3117,7 +3117,7 @@ export function PipesSection() {
                           ? "configure required connections before enabling auto-run"
                           : pipe.config.enabled
                             ? "auto-running on schedule — click to disable"
-                            : "auto-run disabled — scheduled task can still be run manually"
+                            : "auto-run disabled — you can still run this task manually"
                       }
                     >
                       {/* A naked switch doesn't say what it controls. Name the

--- a/apps/screenpipe-app-tauri/components/settings/usage-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/usage-section.tsx
@@ -551,7 +551,7 @@ export function UsageSection() {
         <Card>
           <CardContent className="pt-6">
             <div className="text-2xl font-bold">{filteredPipeExecs}</div>
-            <p className="text-xs text-muted-foreground">Scheduled runs</p>
+            <p className="text-xs text-muted-foreground">Task runs</p>
           </CardContent>
         </Card>
       </div>

--- a/apps/screenpipe-app-tauri/lib/__tests__/pipe-errors.test.ts
+++ b/apps/screenpipe-app-tauri/lib/__tests__/pipe-errors.test.ts
@@ -71,7 +71,7 @@ describe("parsePipeError", () => {
   it("classifies Pi's content-filter finish reason as a safety refusal", () => {
     const r = parsePipeError("Error: Provider finish_reason: content_filter");
     expect(r.type).toBe("safety_refusal");
-    expect(r.message).toBe("AI provider declined this Pipe under its safety policy");
+    expect(r.message).toBe("AI provider declined this scheduled task under its safety policy");
   });
 
   it("classifies a structured provider safety refusal", () => {

--- a/apps/screenpipe-app-tauri/lib/chat-utils.ts
+++ b/apps/screenpipe-app-tauri/lib/chat-utils.ts
@@ -1135,7 +1135,7 @@ export const COMPOSER_COMMAND_SUGGESTIONS: MentionSuggestion[] = [
   {
     tag: "/pipes",
     label: "/pipes",
-    description: "open pipes",
+    description: "open scheduled tasks",
     category: "command",
     commandId: "pipes",
   },

--- a/apps/screenpipe-app-tauri/lib/pipe-errors.ts
+++ b/apps/screenpipe-app-tauri/lib/pipe-errors.ts
@@ -59,7 +59,7 @@ export function parsePipeError(stderr: string): ParsedPipeError {
   if (hasSafetyRefusalToken(normalized)) {
     return {
       type: "safety_refusal",
-      message: "AI provider declined this Pipe under its safety policy",
+      message: "AI provider declined this scheduled task under its safety policy",
     };
   }
   if (
@@ -140,7 +140,7 @@ function classifyStructuredPipeError(value: unknown): ParsedPipeError | null {
   if (hasSafetyRefusalToken(combined)) {
     return {
       type: "safety_refusal",
-      message: message || "AI provider declined this Pipe under its safety policy",
+      message: message || "AI provider declined this scheduled task under its safety policy",
     };
   }
   if (combined.includes("daily_limit_exceeded")) {


### PR DESCRIPTION
## Problem

The `pipes` → `scheduled tasks` rename was applied mechanically, and it left user-facing English that reads wrong. Reported directly:

> "auto update scheduled its so weird englihs bro"

**Where found:** Settings → General. `Auto-Update Pipes` had `Pipes` swapped for `Scheduled` and the noun dropped, so the toggle reads as *"auto-update **was** scheduled"* instead of *"auto-update **the** scheduled tasks"*. It was also the only Title Case heading among its siblings (`Auto-start`, `Auto-update`, `Check for updates`, `App updates`, `Your goal`).

A sweep for the same class of damage found 12 more strings.

## Reproduction

Open Settings → General. The third card reads `Auto-Update Scheduled` / `Update Store tasks you haven't modified`. Searching settings for "pipes" returns nothing.

## Root cause

Find-and-replace substituted the token without re-reading the sentence. Three failure shapes:

1. **Truncated substitution** — `pipes` → `Scheduled`, leaving a bare adjective where a noun belonged.
2. **Doubled / self-contradicting** — `scheduled task's schedule`, and `This scheduled task has no schedule`.
3. **Missed renames** — user-facing `Pipe`/`pipes` the pass never reached.

## Fix

**Broken grammar**

| file | before | after |
|---|---|---|
| `general-settings.tsx` | `Auto-Update Scheduled` | `Auto-update scheduled tasks` |
| `general-settings.tsx` | `Update Store tasks you haven't modified` | `Keep tasks you installed from the Store up to date, unless you've edited them` |
| `pipes-section.tsx` | `controls this scheduled task's schedule and enabled state` | `controls when this task runs and whether it is enabled` |
| `live-view-card.tsx` | `This scheduled task has no schedule` | `This task has no schedule` |
| `live-view-card.tsx` | `This scheduled task is turned off` | `This task is turned off` |
| `pipes-section.tsx` | `auto-run disabled — scheduled task can still be run manually` | `auto-run disabled — you can still run this task manually` |
| `pipe-install-dialog.tsx` | `a scheduled task from an external link wants to install.` (no object) | `an external link wants to install a scheduled task.` |

**Bare "Scheduled" as a noun**

| file | before | after |
|---|---|---|
| `account-section.tsx` ×4 | `scheduled sync across devices` | `sync scheduled tasks across devices` |
| `account-section.tsx` | `scheduled sync enabled/disabled` | `scheduled task sync enabled/disabled` |
| `disk-usage-section.tsx` | `Scheduled` (disk category) | `Scheduled tasks` |
| `usage-section.tsx` | `Scheduled runs` | `Task runs` |
| `notification-registry.ts` | `scheduled & automation` | `scheduled tasks & automation` |
| `notification-registry.ts` | `Scheduled notifications` | `Scheduled task alerts` |
| `brain-section.tsx` ×2 | `go to scheduled run` | `go to task run` |
| `pipe-context-banner.tsx` | `scheduled run: {name}` | `task run: {name}` |

**Missed renames**

| file | before | after |
|---|---|---|
| `pipe-errors.ts` ×2 | `AI provider declined this Pipe under its safety policy` | `…declined this scheduled task…` |
| `chat-utils.ts` | `open pipes` | `open scheduled tasks` |
| `ai-presets-selector.tsx` | badge `pipes` | badge `tasks` |

Settings search also gains `pipes` as a keyword, so anyone still thinking in the old vocabulary finds the toggle.

## Deliberately NOT renamed

Renaming these would break existing installs, sync, or routing:

- `autoUpdatePipes` — persisted in `src-tauri/src/store.rs`, cross-device synced
- `id="auto-update-pipes-toggle"`, `pipeName`, `mutedPipes`
- `m.recommended_for?.includes('pipes')` — API value
- `/pipes` API paths, the `/pipes` slash-command token, `install-pipe` deeplink
- `pipe.md` / `pipe.md.bak` — real on-disk filenames

## Validation

- `tsc --noEmit`: **no errors in source.** Two errors exist in gitignored `.next/types` pointing at a deleted `app/mncopypreview` page — pre-existing, unrelated.
- `vitest components/settings`: **269/269 pass** across 33 files.
- `lib/__tests__/pipe-errors.test.ts` asserted the old copy; assertion updated in this commit and it now passes.
- 6 test files still fail (`free-plan-wall`, `free-wall`, `use-enterprise-policy`, `browser-log`, `acp-session-config`, `font-size`). **These are pre-existing and not from this change** — proved by checking out the parent commit and re-running: 42 failures there too. They fail on `Cannot read properties of undefined (reading 'invoke')` (Tauri API unavailable under vitest), none reference any module touched here, and the failing set varies run to run.
- No E2E spec asserts on any changed string.

## Visual

Copy-only change, so the before/after tables above are the diff. No layout, component, or behavior change — every edit is a string literal.

Not covered here: casing normalization (`Scheduled task` vs `scheduled task` appears mixed within single files) and the naming collision where the same object is called "My tasks", "scheduled tasks", "managed task", and "scheduled automations". Both are larger, more opinionated sweeps — happy to follow up if wanted.
