### PR TITLE
fix(card-ask): gate on card-on-file, not plan label

### DIFF
--- a/apps/screenpipe-app-tauri/components/card-ask-modal.tsx
+++ b/apps/screenpipe-app-tauri/components/card-ask-modal.tsx
@@ -39,6 +39,13 @@ const COPY: Record<
     body: "A 7-day Business trial lifts the cap and keeps your pipes running. Cancel anytime before day 7 and you are not charged.",
     cta: "Start trial",
   },
+  // Someone already on a cardless grant is *in* a trial. Offering to "start"
+  // one is nonsense to them; the real ask is to keep what they already have.
+  grant_expiry: {
+    title: "Your trial ends soon",
+    body: "Add a card to keep hosted AI, pipes, and transcription running. Nothing is charged until your trial ends, and you can cancel before then.",
+    cta: "Keep Business",
+  },
 };
 
 type Props = {

--- a/apps/screenpipe-app-tauri/components/card-ask-provider.tsx
+++ b/apps/screenpipe-app-tauri/components/card-ask-provider.tsx
@@ -8,6 +8,9 @@ import { platform } from "@tauri-apps/plugin-os";
 import { CardAskModal } from "@/components/card-ask-modal";
 import { useCardAsk } from "@/lib/hooks/use-card-ask";
 import { emitCardAskTrigger } from "@/lib/card-ask/trigger-bus";
+import { isExpiringCardlessGrant } from "@/lib/card-ask/gating";
+import { useSettings } from "@/lib/hooks/use-settings";
+import type { AppUser } from "@/lib/app-entitlement";
 
 function normalizeOs(): string {
   try {
@@ -36,6 +39,7 @@ function normalizeOs(): string {
  */
 export function CardAskProvider() {
   const { activeTrigger, arm, isFirstAsk, dismiss, consume } = useCardAsk();
+  const { settings, isSettingsLoaded } = useSettings();
   const os = useMemo(normalizeOs, []);
 
   // Fire the login trigger once the arm has resolved. The controller's
@@ -44,6 +48,19 @@ export function CardAskProvider() {
     if (arm !== "at_login") return;
     emitCardAskTrigger("login");
   }, [arm]);
+
+  // Expiring cardless grant: the highest-intent moment in the funnel. The
+  // grant still works, the user is still active, and in a couple of days
+  // everything silently stops with no card to bill. Every non-control arm
+  // listens for this, and the controller still shows it at most once.
+  useEffect(() => {
+    if (!arm || arm === "control") return;
+    if (!isSettingsLoaded) return;
+    if (!isExpiringCardlessGrant(settings?.user as AppUser | null, Date.now())) {
+      return;
+    }
+    emitCardAskTrigger("grant_expiry");
+  }, [arm, isSettingsLoaded, settings?.user]);
 
   return (
     <CardAskModal

--- a/apps/screenpipe-app-tauri/lib/app-entitlement.ts
+++ b/apps/screenpipe-app-tauri/lib/app-entitlement.ts
@@ -59,6 +59,20 @@ export type AppUser = User & {
   plan_expires_at?: string | null;
   entitlement?: AppEntitlement | JsonValue | null;
   enterprise_account?: AppEnterpriseAccount | JsonValue | null;
+  /**
+   * Whether Stripe holds a payment method for this account. Server-derived
+   * from the entitlement source; see website `/api/user`.
+   *
+   * Distinct from "has a plan": a cardless signup grant reports
+   * `subscription_plan: "pro"` with no card on file. Never infer payment
+   * state from a plan label.
+   *
+   * Absent on older server responses — treat `undefined` as unknown, not
+   * false.
+   */
+  has_payment_method?: boolean | null;
+  /** Why the account has access. `manual` is the cardless signup grant. */
+  entitlement_source?: string | null;
 };
 
 export type LocalPlanPolicy = "verified-free" | "verified-paid" | "unknown";

--- a/apps/screenpipe-app-tauri/lib/card-ask/__tests__/gating.test.ts
+++ b/apps/screenpipe-app-tauri/lib/card-ask/__tests__/gating.test.ts
@@ -6,7 +6,9 @@ import { describe, expect, it } from "vitest";
 import type { AppUser } from "@/lib/app-entitlement";
 import {
   CARD_ASK_ARMS,
+  GRANT_EXPIRY_WINDOW_MS,
   isCardAskEligible,
+  isExpiringCardlessGrant,
   parseCardAskArm,
   parseShownTriggers,
   resolveStickyArm,
@@ -33,10 +35,19 @@ describe("parseCardAskArm", () => {
 });
 
 describe("triggersForArm", () => {
-  it("maps each arm to exactly its own trigger", () => {
-    expect(triggersForArm("at_login")).toEqual(["login"]);
-    expect(triggersForArm("at_first_value")).toEqual(["first_value"]);
-    expect(triggersForArm("at_limit")).toEqual(["limit"]);
+  it("maps each arm to its own trigger plus the shared expiry trigger", () => {
+    expect(triggersForArm("at_login")).toEqual(["login", "grant_expiry"]);
+    expect(triggersForArm("at_first_value")).toEqual([
+      "first_value",
+      "grant_expiry",
+    ]);
+    expect(triggersForArm("at_limit")).toEqual(["limit", "grant_expiry"]);
+  });
+
+  it("keeps control silent even at grant expiry", () => {
+    // Control is the counterfactual: what conversion looks like when we
+    // never ask. Leaking an expiry ask into it would destroy the baseline.
+    expect(triggersForArm("control")).not.toContain("grant_expiry");
   });
 
   it("gives control no triggers at all", () => {
@@ -239,5 +250,146 @@ describe("parseShownTriggers", () => {
     expect(
       parseShownTriggers(JSON.stringify(["login", "bogus", "limit"])),
     ).toEqual(["login", "limit"]);
+  });
+});
+
+const DAY = 24 * 60 * 60 * 1000;
+const NOW = Date.parse("2026-08-10T00:00:00.000Z");
+
+describe("isCardAskEligible — card on file, not plan label", () => {
+  const grantHolder = {
+    id: "u1",
+    email: "a@b.com",
+    // A cardless grant looks exactly like a paying Business customer by label.
+    subscription_plan: "pro",
+    app_entitled: true,
+    entitlement_source: "manual",
+    has_payment_method: false,
+  } as unknown as AppUser;
+
+  it("ASKS an active cardless grant holder despite a paid-looking plan", () => {
+    // The regression this whole change exists to fix. Before
+    // `has_payment_method`, the "pro" label suppressed the ask for exactly
+    // the users who cannot be billed.
+    expect(isCardAskEligible(grantHolder, true)).toBe(true);
+  });
+
+  it("does NOT ask anyone with a card on file", () => {
+    const withCard = {
+      ...grantHolder,
+      entitlement_source: "subscription",
+      has_payment_method: true,
+    } as AppUser;
+    expect(isCardAskEligible(withCard, true)).toBe(false);
+  });
+
+  it("does NOT ask a card-backed trial, which converts on its own", () => {
+    const cardTrial = {
+      id: "u1",
+      email: "a@b.com",
+      subscription_plan: "standard",
+      entitlement_source: "subscription",
+      has_payment_method: true,
+    } as unknown as AppUser;
+    expect(isCardAskEligible(cardTrial, true)).toBe(false);
+  });
+
+  it.each(["lifetime", "enterprise"])(
+    "does NOT ask %s even though it has no card",
+    (source) => {
+      // No recurring card, but nothing to sell: lifetime already owns the
+      // app, enterprise is billed to the org.
+      const user = {
+        id: "u1",
+        email: "a@b.com",
+        entitlement_source: source,
+        has_payment_method: false,
+      } as unknown as AppUser;
+      expect(isCardAskEligible(user, true)).toBe(false);
+    },
+  );
+
+  it("ASKS a free user with no card", () => {
+    const free = {
+      id: "u1",
+      email: "a@b.com",
+      entitlement_source: "none",
+      has_payment_method: false,
+    } as unknown as AppUser;
+    expect(isCardAskEligible(free, true)).toBe(true);
+  });
+
+  it("falls back to label rules when the server omits the field", () => {
+    // Older server: no has_payment_method. Under-ask rather than nag.
+    const legacyPaid = {
+      id: "u1",
+      email: "a@b.com",
+      subscription_plan: "pro",
+    } as unknown as AppUser;
+    const legacyFree = { id: "u1", email: "a@b.com" } as unknown as AppUser;
+    expect(isCardAskEligible(legacyPaid, true)).toBe(false);
+    expect(isCardAskEligible(legacyFree, true)).toBe(true);
+  });
+
+  it("still suppresses an enterprise account object regardless of card state", () => {
+    const ent = {
+      ...grantHolder,
+      enterprise_account: { org_name: "acme" },
+    } as unknown as AppUser;
+    expect(isCardAskEligible(ent, true)).toBe(false);
+  });
+});
+
+describe("isExpiringCardlessGrant", () => {
+  function grant(expiresInMs: number, extra: Record<string, unknown> = {}) {
+    return {
+      id: "u1",
+      email: "a@b.com",
+      entitlement_source: "manual",
+      has_payment_method: false,
+      plan_expires_at: new Date(NOW + expiresInMs).toISOString(),
+      ...extra,
+    } as unknown as AppUser;
+  }
+
+  it("fires inside the window", () => {
+    expect(isExpiringCardlessGrant(grant(DAY), NOW)).toBe(true);
+  });
+
+  it("does not fire while the grant is still far out", () => {
+    expect(isExpiringCardlessGrant(grant(5 * DAY), NOW)).toBe(false);
+  });
+
+  it("does not fire once already lapsed — that user is on the limit path", () => {
+    expect(isExpiringCardlessGrant(grant(-DAY), NOW)).toBe(false);
+  });
+
+  it("does not fire when a card is already on file", () => {
+    expect(
+      isExpiringCardlessGrant(grant(DAY, { has_payment_method: true }), NOW),
+    ).toBe(false);
+  });
+
+  it("does not fire for a Stripe subscription nearing renewal", () => {
+    // Renewal is not expiry — it bills itself.
+    expect(
+      isExpiringCardlessGrant(
+        grant(DAY, { entitlement_source: "subscription" }),
+        NOW,
+      ),
+    ).toBe(false);
+  });
+
+  it("tolerates a missing or malformed expiry without throwing", () => {
+    for (const bad of [null, undefined, "", "not-a-date"]) {
+      const user = grant(DAY, { plan_expires_at: bad });
+      expect(isExpiringCardlessGrant(user, NOW)).toBe(false);
+    }
+  });
+
+  it("uses a two-day window by default", () => {
+    expect(GRANT_EXPIRY_WINDOW_MS).toBe(2 * DAY);
+    expect(isExpiringCardlessGrant(grant(2 * DAY - 1000), NOW)).toBe(true);
+    expect(isExpiringCardlessGrant(grant(2 * DAY + 1000), NOW)).toBe(false);
   });
 });

--- a/apps/screenpipe-app-tauri/lib/card-ask/gating.ts
+++ b/apps/screenpipe-app-tauri/lib/card-ask/gating.ts
@@ -27,7 +27,11 @@ export const CARD_ASK_ARMS = [
 export type CardAskArm = (typeof CARD_ASK_ARMS)[number];
 
 /** The moment that fired the ask. One arm may own more than one trigger. */
-export type CardAskTrigger = "login" | "first_value" | "limit";
+export type CardAskTrigger =
+  | "login"
+  | "first_value"
+  | "limit"
+  | "grant_expiry";
 
 /** Local storage key holding the sticky arm assignment. */
 export const CARD_ASK_ARM_STORAGE_KEY = "screenpipe_card_ask_arm";
@@ -54,23 +58,34 @@ export function parseCardAskArm(flag: unknown): CardAskArm | null {
 export function triggersForArm(arm: CardAskArm): readonly CardAskTrigger[] {
   switch (arm) {
     case "at_login":
-      return ["login"];
+      return ["login", "grant_expiry"];
     case "at_first_value":
-      return ["first_value"];
+      return ["first_value", "grant_expiry"];
     case "at_limit":
-      return ["limit"];
+      return ["limit", "grant_expiry"];
     case "control":
+      // Control stays silent even at expiry. It is the counterfactual: what
+      // conversion looks like when we never ask.
       return [];
   }
 }
 
+/** Sources that mean someone else is paying, or there is nothing to sell. */
+const INELIGIBLE_SOURCES = new Set(["enterprise", "lifetime"]);
+
 /**
  * Is this user someone we may ask for a card at all?
  *
- * Deliberately conservative and symmetric with `shouldShowModelUpsell`: any
- * evidence of an existing paid, team, or enterprise relationship suppresses
- * the ask. Unknown or partially-hydrated entitlement also suppresses it, so a
- * token refresh can never flash a payment prompt at a paying customer.
+ * The question is **"is there a card on file?"**, not **"do they have a
+ * plan?"**. Those are different, and conflating them inverts the answer for
+ * the group that matters most: a cardless signup grant reports
+ * `subscription_plan: "pro"` while having no payment method at all. A
+ * plan-label rule reads that as "already paying" and stays silent — for
+ * precisely the users who will churn at expiry because nothing can bill them.
+ *
+ * Authoritative signal is the server's `has_payment_method`. It is absent on
+ * older builds, so when it is missing we fall back to plan labels and fail
+ * closed rather than guess.
  */
 export function isCardAskEligible(
   user: AppUser | null | undefined,
@@ -82,7 +97,13 @@ export function isCardAskEligible(
   // Signed-out users have no account to attach a subscription to.
   if (!user.id && !user.email) return false;
 
-  if (user.cloud_subscribed === true) return false;
+  // Someone else pays (enterprise seat), or there is no trial to sell
+  // (lifetime already owns the app).
+  const source =
+    typeof user.entitlement_source === "string"
+      ? user.entitlement_source.trim().toLowerCase()
+      : null;
+  if (source && INELIGIBLE_SOURCES.has(source)) return false;
 
   const enterpriseAccount = user.enterprise_account;
   if (
@@ -93,23 +114,59 @@ export function isCardAskEligible(
     return false;
   }
 
-  // Three independent paid signals. They catch different shapes and the
-  // polarity matters:
-  //
-  // `hasVerifiedPaidPlan` fails CLOSED — it demands a complete, fresh,
-  // self-consistent entitlement before granting access. That is right for
-  // unlocking features and wrong here. A user carrying a bare
-  // `subscription_plan: "pro"` with no hydrated entitlement fails that check,
-  // yet is exactly the person we must not show a payment prompt to.
-  //
-  // A payment prompt must fail OPEN: suppress on any *hint* of payment, and
-  // only ask when we positively believe the user has never paid.
+  // A card already on file: they convert on their own, or they are already
+  // paying. Either way asking is noise. This covers the card-backed trial,
+  // which looks like a trial but bills itself.
+  if (user.has_payment_method === true) return false;
+
+  // Authoritative "no card" from a server that knows. Grant holders and free
+  // users land here, and they are the population this exists for — even
+  // though a grant holder's plan label reads "pro".
+  if (user.has_payment_method === false) return true;
+
+  // Field absent: an older server. Fall back to the conservative label rule
+  // so we under-ask rather than nag a payer. This deliberately misses grant
+  // holders, which is the pre-existing behaviour, not a regression.
+  if (user.cloud_subscribed === true) return false;
   if (hasVerifiedPaidPlan(user)) return false;
   if (hasPersistedEntitlementEvidence(user)) return false;
   if (hasAnyPaidPlanHint(user)) return false;
 
   return true;
 }
+
+/**
+ * Is this an entitled user whose access is about to lapse with no card?
+ *
+ * The single highest-intent moment in the funnel: the grant still works, the
+ * user is still active, and in a couple of days everything silently stops.
+ */
+export function isExpiringCardlessGrant(
+  user: AppUser | null | undefined,
+  nowMs: number,
+  windowMs: number = GRANT_EXPIRY_WINDOW_MS,
+): boolean {
+  if (!user) return false;
+  if (user.has_payment_method !== false) return false;
+
+  const source =
+    typeof user.entitlement_source === "string"
+      ? user.entitlement_source.trim().toLowerCase()
+      : null;
+  if (source !== "manual") return false;
+
+  const expiresAt = user.plan_expires_at
+    ? Date.parse(user.plan_expires_at)
+    : NaN;
+  if (!Number.isFinite(expiresAt)) return false;
+
+  // Already lapsed is not "expiring" — that user is on the limit path now.
+  if (expiresAt <= nowMs) return false;
+  return expiresAt - nowMs <= windowMs;
+}
+
+/** How close to grant expiry the expiry ask becomes eligible. */
+export const GRANT_EXPIRY_WINDOW_MS = 2 * 24 * 60 * 60 * 1000;
 
 /**
  * Loose paid-plan detection for suppression only.
@@ -207,7 +264,12 @@ export function parseShownTriggers(raw: string | null): CardAskTrigger[] {
   try {
     const parsed = JSON.parse(raw);
     if (!Array.isArray(parsed)) return [];
-    const valid: CardAskTrigger[] = ["login", "first_value", "limit"];
+    const valid: CardAskTrigger[] = [
+      "login",
+      "first_value",
+      "limit",
+      "grant_expiry",
+    ];
     return parsed.filter((v): v is CardAskTrigger =>
       valid.includes(v as CardAskTrigger),
     );


### PR DESCRIPTION
## The bug

The eligibility rule I shipped in #6091 asks the wrong question.

It suppresses on **"has a paid plan"**. The actual decision is **"is there a card on file"** — and for the population this experiment exists to reach, those answers are *opposite*.

A cardless signup grant reports `subscription_plan: "pro"` with **no payment method**. The label rule reads that as "already paying" and stays silent. So the ~106-per-cohort grant users — the exact people who churn at expiry because nothing can bill them — were excluded from every arm.

The experiment as merged could not reach its own target population.

## The rule now

Gates on the server's `has_payment_method` (screenpipe/website#735):

| State | Card? | Ask? |
|---|---|---|
| Paying subscriber | Yes | No |
| **Card-backed trial** | **Yes** | **No** — converts at 65.8% unaided; asking is spam |
| **Cardless grant, active** | **No** | **Yes — primary target** |
| Cardless grant expired → free | No | Yes |
| Free, never paid | No | Yes |
| Lifetime | N/A | No — nothing to sell at trial tier |
| Enterprise / Team seat | Org pays | No |
| `has_payment_method` absent | Unknown | Fall back to the old label rule and under-ask |

The trial is not the discriminator. **The card is.**

## New: `grant_expiry` trigger

Fires ~2 days before a cardless grant lapses — the highest-intent moment in the funnel. Access still works, the user is still active, and it is about to stop silently with nothing on file to charge.

Every non-control arm listens for it. **Control stays silent even at expiry**, so the baseline remains a true counterfactual.

## New: grant-aware copy

"Start your 7-day Business trial" is nonsense to someone already on a trial. For them: *"Your trial ends soon — add a card to keep hosted AI, pipes, and transcription running."* CTA becomes **Keep Business**.

## Validation

| Gate | Result |
|---|---|
| gating tests | **49 pass** (16 new) |
| all card-ask suites | **70 pass** |
| Full vitest | 2916 passed / 62 failed |
| `origin/main` baseline | 62 failed — **identical**, 0 new |
| `test:bun` | 233 pass, 0 fail |
| typecheck / ESLint / coverage / diff | clean |

New cases pin the regression directly — *an active grant holder with plan `pro` is now eligible* — plus card-backed-trial suppression, lifetime/enterprise exclusion, legacy fallback, and expiry-window edges: already-lapsed, subscription-renewal (not expiry), and malformed dates.

## Ordering

Merge **screenpipe/website#735 first**. Until `has_payment_method` is deployed the field is absent, this falls back to the old label rule, and behaviour is unchanged — so merging in either order is safe, but the fix only takes effect once the API ships.

## Still open before enabling the flag

- Grant-conversion attribution in Supabase. Without it the D14 metric is unreadable.
- Stratify assignment by OS and read within-OS. Windows retains ~17pts better and cohort mix swung 34%→68% in three weeks.
- No dev override exists yet, so this cannot be exercised on a paid account — worth a follow-up mirroring `E2E_FORCE_BILLING_GATE_KEY`.