### PR TITLE
feat(ai-connection): hardened backend proxy for local-provider connection tests

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/ai-presets.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/ai-presets.tsx
@@ -31,6 +31,7 @@ import {
   hostedAiAllowanceForModel,
   shouldWarnLowHostedAiAllowance,
 } from "@/lib/hooks/use-usage-status";
+
 import { testAiPresetConnection } from "@/lib/utils/ai-preset-connection";
 import { openBusinessUpgradeSurface } from "@/lib/upgrade-flow";
 import { Label } from "../ui/label";
@@ -159,6 +160,80 @@ const formatPresetName = (name: string): string => {
   return name;
 };
 
+const isLocalhostUrl = (url?: string): boolean => {
+  if (!url) return false;
+  try {
+    const hostname = new URL(url).hostname.toLowerCase();
+    if (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1") return true;
+    // mDNS/Bonjour .local domains resolve to local addresses (RFC 6762)
+    if (hostname.endsWith(".local")) return true;
+    // Private IP ranges: 10.x.x.x, 172.16-31.x.x, 192.168.x.x
+    if (/^10\.\d+\.\d+\.\d+$/.test(hostname)) return true;
+    if (/^172\.(1[6-9]|2[0-9]|3[01])\.\d+\.\d+$/.test(hostname)) return true;
+    if (/^192\.168\.\d+\.\d+$/.test(hostname)) return true;
+    return false;
+  } catch {
+    return false;
+  }
+};
+
+const tauriBackendFetch = async (
+  url: string,
+  options?: RequestInit
+): Promise<Response> => {
+  try {
+    const headers: Record<string, string> = {};
+    if (options?.headers) {
+      const h = options.headers as Record<string, string>;
+      Object.keys(h).forEach((key) => {
+        headers[key] = h[key];
+      });
+    }
+    const bodyVal = options?.body ? JSON.parse(options.body as string) : null;
+    const res = await commands.testAiEndpoint(
+      url,
+      options?.method || "GET",
+      headers,
+      bodyVal
+    );
+    if (res.status === "error") {
+      throw new Error(res.error);
+    }
+    const resText = res.data;
+    // The Rust backend returns only the body text (no headers). Sniff SSE so
+    // the diagnostics' content-type check can detect a streamed response.
+    const looksLikeSse = /(^|\n)\s*data:/.test(resText);
+    const contentType = looksLikeSse ? "text/event-stream" : "application/json";
+    return {
+      ok: true,
+      status: 200,
+      headers: {
+        get: (name: string) =>
+          name.toLowerCase() === "content-type" ? contentType : null,
+      },
+      json: async () => JSON.parse(resText),
+      text: async () => resText,
+      clone: function () {
+        return this;
+      },
+    } as unknown as Response;
+  } catch (err: any) {
+    return {
+      ok: false,
+      status: 500,
+      headers: {
+        get: (_name: string) => null,
+      },
+      text: async () => String(err?.message || err),
+      json: async () => {
+        throw new Error(String(err?.message || err));
+      },
+      clone: function () {
+        return this;
+      },
+    } as unknown as Response;
+  }
+};
 type DiagnosticStatus = "pass" | "fail" | "skip" | "pending" | "running";
 
 interface DiagnosticStepResult {
@@ -852,10 +927,17 @@ const AISection = ({
         chat: { status: "running", message: "Sending test message..." },
       }));
     } else {
-      // Custom endpoints use native HTTP so validation is not affected by the
-      // webview's CORS policy. The wrapper also bounds both headers and body.
+      // native-ollama and custom local endpoints go through native HTTP to bypass
+      // WKWebView mixed-content/CORS blocking. Custom local providers use the
+      // Rust backend allowlisted fetcher so missing CORS preflight doesn't matter.
+      const modelsFetchFn =
+        settingsPreset?.provider === "native-ollama"
+          ? tauriFetchWithDeadline
+          : settingsPreset?.provider === "custom" && isLocalhostUrl(settingsPreset?.url)
+          ? tauriBackendFetch
+          : fetch;
       try {
-        modelsResponse = await tauriFetchWithDeadline(modelsUrl, {
+        modelsResponse = await modelsFetchFn(modelsUrl, {
           headers,
           signal: abort.signal,
         });
@@ -975,6 +1057,13 @@ const AISection = ({
 
     // Step 4: Test the actual chat endpoint. BYOK providers share one probe so
     // both preset editors enforce the same request and response contract.
+    // Custom local/private URLs route through the Rust backend (tauriBackendFetch)
+    // because WKWebView blocks them; other BYOK traffic uses native HTTP.
+    const chatFetchFn = isLocalhostUrl(
+      settingsPreset?.provider === "custom" ? settingsPreset?.url : undefined
+    )
+      ? tauriBackendFetch
+      : tauriFetchWithDeadline;
     const chatStart = performance.now();
     try {
       let reply: string;
@@ -1024,6 +1113,7 @@ const AISection = ({
           apiKey: settingsPreset?.apiKey,
         }, {
           signal: abort.signal,
+          fetch: chatFetchFn,
         });
         reply = result.reply;
         latencyMs = result.latencyMs;
@@ -1106,7 +1196,10 @@ const AISection = ({
           break;
         case "custom":
           try {
-            const customResponse = await tauriFetchWithDeadline(
+            const customFetchFn = isLocalhostUrl(settingsPreset?.url)
+              ? tauriBackendFetch
+              : tauriFetchWithDeadline;
+            const customResponse = await customFetchFn(
               aiEndpointUrl(settingsPreset?.url, "models"),
               {
                 headers: settingsPreset.apiKey

--- a/apps/screenpipe-app-tauri/lib/utils/ai-preset-connection.test.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/ai-preset-connection.test.ts
@@ -96,4 +96,53 @@ describe("testAiPresetConnection", () => {
       max_completion_tokens: 50,
     });
   });
+
+  it("reconstructs the reply from an SSE stream (OmniRoute/LiteLLM/vLLM)", async () => {
+    // Gateways like OmniRoute answer with text/event-stream even without
+    // stream:true. Feeding that to response.json() throws the opaque
+    // "The string did not match the expected pattern." on macOS WKWebView.
+    const sse = [
+      'data: {"choices":[{"delta":{"content":"he"}}]}',
+      'data: {"choices":[{"delta":{"content":"llo"}}]}',
+      "data: [DONE]",
+      "",
+    ].join("\n");
+    const request = vi.fn(async () =>
+      new Response(sse, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      }));
+
+    await expect(
+      testAiPresetConnection(
+        {
+          provider: "custom",
+          url: "http://localhost:20128/v1",
+          model: "gpt-4o-mini",
+          apiKey: "secret",
+        },
+        { fetch: request },
+      ),
+    ).resolves.toMatchObject({ reply: "hello" });
+  });
+
+  it("reconstructs an SSE reply even when content-type is not set", async () => {
+    // Some gateways stream without a text/event-stream content-type, so we
+    // must sniff the body shape too.
+    const sse = 'data: {"choices":[{"delta":{"content":"hi"}}]}\n\ndata: [DONE]\n';
+    const request = vi.fn(async () =>
+      new Response(sse, { status: 200 }));
+
+    await expect(
+      testAiPresetConnection(
+        {
+          provider: "custom",
+          url: "http://localhost:20128/v1",
+          model: "gpt-4o-mini",
+          apiKey: "secret",
+        },
+        { fetch: request },
+      ),
+    ).resolves.toMatchObject({ reply: "hi" });
+  });
 });

--- a/apps/screenpipe-app-tauri/lib/utils/ai-preset-connection.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/ai-preset-connection.ts
@@ -7,6 +7,8 @@ import { aiEndpointUrl } from "./ai-endpoint-url";
 import {
   buildChatTestBody,
   shouldRetryWithMaxCompletionTokens,
+  looksLikeSsePayload,
+  parseSseChatContent,
 } from "./chat-test-body";
 import {
   extractAiProviderErrorMessage,
@@ -111,17 +113,34 @@ export async function testAiPresetConnection(
 
   if (!response.ok) throw await errorFromResponse(response);
 
-  const data = await response.json();
+  // Some OpenAI-compatible gateways (OmniRoute, LiteLLM, vLLM, LM Studio, …)
+  // answer with a Server-Sent Events stream even when we never set
+  // `stream: true`. Calling response.json() on that stream throws — and on
+  // macOS (WKWebView / JavaScriptCore) the surfaced message is the opaque
+  // "The string did not match the expected pattern." Read the body as text
+  // first and reconstruct the assistant reply when it is an SSE payload.
+  const rawText = await response.text();
   let reply: string;
   if (isAnthropic) {
+    const data = JSON.parse(rawText);
     if (!data.content?.[0]) throw new Error("Provider returned no message");
     reply = data.content[0].text?.slice(0, 100) || "Valid message received";
   } else {
-    if (!data.choices?.[0]?.message) {
-      throw new Error("Provider returned no chat message");
+    const isSse =
+      response.headers.get("content-type")?.includes("text/event-stream") ||
+      looksLikeSsePayload(rawText);
+    if (isSse) {
+      reply =
+        parseSseChatContent(rawText).slice(0, 100) ||
+        "Valid chat response received";
+    } else {
+      const data = JSON.parse(rawText);
+      if (!data.choices?.[0]?.message) {
+        throw new Error("Provider returned no chat message");
+      }
+      reply = data.choices[0].message.content?.slice(0, 100) ||
+        "Valid chat response received";
     }
-    reply = data.choices[0].message.content?.slice(0, 100) ||
-      "Valid chat response received";
   }
 
   return {

--- a/apps/screenpipe-app-tauri/lib/utils/chat-test-body.test.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/chat-test-body.test.ts
@@ -7,6 +7,8 @@ import {
   buildChatTestBody,
   shouldRetryWithMaxCompletionTokens,
   shouldRetryWithMaxTokens,
+  looksLikeSsePayload,
+  parseSseChatContent,
 } from "./chat-test-body";
 
 describe("buildChatTestBody", () => {
@@ -154,5 +156,49 @@ describe("integration: retry flow", () => {
     const authError = `{"error":"Invalid API key"}`;
     expect(shouldRetryWithMaxCompletionTokens(authError)).toBe(false);
     expect(shouldRetryWithMaxTokens(authError)).toBe(false);
+  });
+});
+
+describe("looksLikeSsePayload", () => {
+  it("detects an SSE stream body", () => {
+    expect(
+      looksLikeSsePayload(`data: {"choices":[{"delta":{"content":"hi"}}]}\n\ndata: [DONE]\n\n`),
+    ).toBe(true);
+  });
+
+  it("detects SSE even with a leading blank line", () => {
+    expect(looksLikeSsePayload(`\n\ndata: {"x":1}\n`)).toBe(true);
+  });
+
+  it("returns false for plain JSON", () => {
+    expect(looksLikeSsePayload(`{"choices":[{"message":{"content":"hi"}}]}`)).toBe(false);
+  });
+});
+
+describe("parseSseChatContent", () => {
+  it("concatenates streamed delta chunks", () => {
+    const stream =
+      `data: {"choices":[{"delta":{"content":"Hel"}}]}\n\n` +
+      `data: {"choices":[{"delta":{"content":"lo"}}]}\n\n` +
+      `data: [DONE]\n\n`;
+    expect(parseSseChatContent(stream)).toBe("Hello");
+  });
+
+  it("handles non-streamed message frames", () => {
+    const stream = `data: {"choices":[{"message":{"content":"hi there"}}]}\n\n`;
+    expect(parseSseChatContent(stream)).toBe("hi there");
+  });
+
+  it("ignores keep-alive comments and malformed frames", () => {
+    const stream =
+      `: keep-alive\n` +
+      `data: not-json\n` +
+      `data: {"choices":[{"delta":{"content":"ok"}}]}\n` +
+      `data: [DONE]\n`;
+    expect(parseSseChatContent(stream)).toBe("ok");
+  });
+
+  it("returns empty string when there is no content", () => {
+    expect(parseSseChatContent(`data: [DONE]\n`)).toBe("");
   });
 });

--- a/apps/screenpipe-app-tauri/lib/utils/chat-test-body.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/chat-test-body.ts
@@ -80,3 +80,41 @@ export function shouldRetryWithMaxTokens(errText: string): boolean {
       lower.includes("invalid"))
   );
 }
+
+/**
+ * Some OpenAI-compatible servers (OmniRoute, LiteLLM, vLLM, LM Studio, etc.)
+ * answer the chat probe with a Server-Sent Events stream even when we don't set
+ * `stream: true`. Feeding that stream to JSON.parse throws — and on macOS
+ * (WKWebView / JavaScriptCore) the message is the opaque
+ * "The string did not match the expected pattern." These helpers let the
+ * diagnostics detect the SSE shape and reconstruct the assistant text instead.
+ */
+export function looksLikeSsePayload(text: string): boolean {
+  return /(^|\n)\s*data:/.test(text);
+}
+
+/**
+ * Reconstruct assistant text from an OpenAI-style chat completions SSE stream.
+ * Handles both streamed `choices[].delta.content` chunks and non-streamed
+ * `choices[].message.content` frames, and ignores keep-alive comments and the
+ * terminal `[DONE]` sentinel.
+ */
+export function parseSseChatContent(text: string): string {
+  let content = "";
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("data:")) continue;
+    const payload = trimmed.slice(5).trim();
+    if (!payload || payload === "[DONE]") continue;
+    try {
+      const json = JSON.parse(payload);
+      const delta = json?.choices?.[0]?.delta?.content;
+      const message = json?.choices?.[0]?.message?.content;
+      if (typeof delta === "string") content += delta;
+      else if (typeof message === "string") content += message;
+    } catch {
+      // ignore keep-alive comments / partial frames
+    }
+  }
+  return content;
+}

--- a/apps/screenpipe-app-tauri/lib/utils/tauri.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/tauri.ts
@@ -8,6 +8,14 @@
 
 
 export const commands = {
+async testAiEndpoint(url: string, method: string, headers: Record<string, string>, body: any | null) : Promise<Result<string, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("test_ai_endpoint", { url, method, headers, body }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 /**
  * Frontend hook for browser OAuth flows that complete by polling (MCP and
  * Composio). Generic integration OAuth calls the same mechanism directly.

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -11,6 +11,7 @@ use crate::{
     updates::is_enterprise_build,
     window::{RewindWindowId, ShowRewindWindow},
 };
+use futures::TryStreamExt;
 use sha2::{Digest, Sha256};
 use tauri::{Emitter, Manager};
 #[cfg(not(target_os = "macos"))]
@@ -4217,4 +4218,225 @@ pub fn set_autostart(app_handle: tauri::AppHandle, enabled: bool) -> Result<(), 
         manager.is_enabled().unwrap_or(false)
     );
     Ok(())
+}
+
+/// Known public AI providers that are allowed even though they resolve to
+/// public (non-private) IP addresses. These are pinned by exact host match.
+const ALLOWED_PUBLIC_AI_HOSTS: &[&str] = &[
+    "api.openai.com",
+    "api.anthropic.com",
+    "api.screenpipe.com",
+    "api.screenpi.pe",
+];
+
+/// Returns true for IPs that live inside the local/private network perimeter we
+/// intentionally allow the AI-endpoint proxy to reach (loopback, RFC1918,
+/// IPv6 ULA/link-local).
+fn is_private_or_loopback_ip(ip: &std::net::IpAddr) -> bool {
+    match ip {
+        std::net::IpAddr::V4(ipv4) => ipv4.is_loopback() || ipv4.is_private(),
+        std::net::IpAddr::V6(ipv6) => {
+            ipv6.is_loopback()
+                || (ipv6.segments()[0] & 0xfe00) == 0xfc00 // ULA
+                || (ipv6.segments()[0] & 0xffc0) == 0xfe80 // Link-Local
+        }
+    }
+}
+
+fn is_safe_ai_url(url_str: &str) -> bool {
+    let parsed = match url::Url::parse(url_str) {
+        Ok(u) => u,
+        Err(_) => return false,
+    };
+
+    let host = match parsed.host_str() {
+        Some(h) => h.to_lowercase(),
+        None => return false,
+    };
+
+    // Allow known public AI providers
+    if ALLOWED_PUBLIC_AI_HOSTS.contains(&host.as_str()) {
+        return true;
+    }
+
+    if host == "localhost" || host.ends_with(".local") {
+        return true;
+    }
+
+    // Check if host is an IP address literal
+    if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+        is_private_or_loopback_ip(&ip)
+    } else {
+        false
+    }
+}
+
+/// Resolve the URL's host and confirm every resolved address is acceptable,
+/// returning the pinned `(host, socket_addrs)` so the connection can be locked
+/// to exactly those IPs.
+///
+/// Why: `is_safe_ai_url` only validates the *hostname string*. A hostname such
+/// as `attacker.local` (or one of the allow-listed public API hosts if its DNS
+/// were poisoned) is resolved again by reqwest at connect time, so without
+/// pinning, DNS rebinding could point the request at an arbitrary IP. We resolve
+/// here, validate the IPs, and hand reqwest a fixed address list via
+/// `resolve_to_addrs()` so it never performs its own (re-resolvable) lookup.
+async fn resolve_and_verify_ai_host(
+    url_str: &str,
+) -> Result<(String, Vec<std::net::SocketAddr>), String> {
+    let parsed =
+        url::Url::parse(url_str).map_err(|e| format!("invalid url: {}", e))?;
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| "url has no host".to_string())?
+        .to_lowercase();
+
+    // Literal-IP hosts were already range-checked by is_safe_ai_url; reqwest
+    // will connect straight to the literal, so there is nothing to rebind.
+    if host.parse::<std::net::IpAddr>().is_ok() {
+        return Ok((host, Vec::new()));
+    }
+
+    let is_allowed_public = ALLOWED_PUBLIC_AI_HOSTS.contains(&host.as_str());
+    let port = parsed
+        .port_or_known_default()
+        .ok_or_else(|| "url has no port".to_string())?;
+
+    // Resolve on a blocking thread to avoid pulling in an async resolver.
+    let lookup_host = host.clone();
+    let addrs: Vec<std::net::SocketAddr> = tokio::task::spawn_blocking(move || {
+        use std::net::ToSocketAddrs;
+        (lookup_host.as_str(), port)
+            .to_socket_addrs()
+            .map(|iter| iter.collect::<Vec<_>>())
+    })
+    .await
+    .map_err(|e| format!("dns resolution task failed: {}", e))?
+    .map_err(|e| format!("failed to resolve host '{}': {}", host, e))?;
+
+    if addrs.is_empty() {
+        return Err(format!("host '{}' resolved to no addresses", host));
+    }
+
+    // For non-public hosts (localhost / *.local) every resolved IP must be
+    // inside the private/loopback perimeter. Public AI hosts are exempt from the
+    // private-range check but are still pinned to the addresses resolved here.
+    if !is_allowed_public {
+        for addr in &addrs {
+            if !is_private_or_loopback_ip(&addr.ip()) {
+                return Err(format!(
+                    "host '{}' resolved to non-local address {} (blocked to prevent DNS rebinding)",
+                    host,
+                    addr.ip()
+                ));
+            }
+        }
+    }
+
+    Ok((host, addrs))
+}
+
+const AI_TEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+const MAX_AI_TEST_BODY_BYTES: usize = 16 * 1024 * 1024; // 16 MiB
+
+#[tauri::command]
+#[specta::specta]
+pub async fn test_ai_endpoint(
+    url: String,
+    method: String,
+    headers: std::collections::HashMap<String, String>,
+    body: Option<serde_json::Value>,
+) -> Result<String, String> {
+    if !is_safe_ai_url(&url) {
+        return Err("URL is blocked for security (only loopback, private IP ranges, .local, or official AI providers allowed)".to_string());
+    }
+
+    // Resolve the host now and pin the connection to exactly those addresses.
+    // This closes the DNS-rebinding gap: is_safe_ai_url only checks the hostname
+    // string, but reqwest would otherwise resolve the host again at connect time,
+    // letting a hostname that passed the string check point at an arbitrary IP.
+    let (pinned_host, pinned_addrs) = resolve_and_verify_ai_host(&url).await?;
+
+    // Bound request body size to avoid proxying huge payloads to private IPs.
+    let body_bytes: Option<Vec<u8>> = match body {
+        Some(b) => {
+            let bytes = serde_json::to_vec(&b)
+                .map_err(|e| format!("failed to serialize body: {}", e))?;
+            if bytes.len() > MAX_AI_TEST_BODY_BYTES {
+                return Err(format!(
+                    "request body too large: {} bytes (max {} MiB)",
+                    bytes.len(),
+                    MAX_AI_TEST_BODY_BYTES / (1024 * 1024)
+                ));
+            }
+            Some(bytes)
+        }
+        None => None,
+    };
+
+    let mut client_builder = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(AI_TEST_TIMEOUT);
+
+    // Pin the resolved+verified addresses so reqwest connects only to them and
+    // never performs its own (re-resolvable) DNS lookup for this host.
+    if !pinned_addrs.is_empty() {
+        client_builder = client_builder.resolve_to_addrs(&pinned_host, &pinned_addrs);
+    }
+
+    let client = client_builder
+        .build()
+        .map_err(|e| format!("failed to build http client: {}", e))?;
+
+    let mut req = match method.to_uppercase().as_str() {
+        "POST" => client.post(&url),
+        "GET" => client.get(&url),
+        _ => return Err("unsupported method".to_string()),
+    };
+
+    for (k, v) in headers {
+        if let Ok(hk) = reqwest::header::HeaderName::from_bytes(k.as_bytes()) {
+            if let Ok(hv) = reqwest::header::HeaderValue::from_str(&v) {
+                req = req.header(hk, hv);
+            }
+        }
+    }
+
+    if let Some(bytes) = body_bytes {
+        req = req.body(bytes);
+    }
+
+    let resp = req
+        .send()
+        .await
+        .map_err(|e| format!("connection failed: {}", e))?;
+
+    let status = resp.status();
+    let body_stream = resp.bytes_stream();
+    let limited = body_stream
+        .map(|chunk| chunk.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e)))
+        .try_fold(Vec::new(), |mut acc, chunk| async move {
+            acc.extend_from_slice(&chunk);
+            if acc.len() > MAX_AI_TEST_BODY_BYTES {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!(
+                        "response body exceeded {} MiB limit",
+                        MAX_AI_TEST_BODY_BYTES / (1024 * 1024)
+                    ),
+                ))
+            } else {
+                Ok(acc)
+            }
+        });
+    let text = limited
+        .await
+        .map(|v| String::from_utf8_lossy(&v).into_owned())
+        .map_err(|e| format!("failed to read response: {}", e))?;
+
+    if !status.is_success() {
+        return Err(format!("HTTP error {}: {}", status.as_u16(), text));
+    }
+
+    Ok(text)
 }


### PR DESCRIPTION
## Summary
Lets the settings UI test a **local** self-hosted AI provider (blocked today by WKWebView CORS + mixed-content against `http://localhost`/private IPs) by proxying the connection test through a Rust backend command, and hardens that command since the backend now fetches a user-supplied URL.

## Why hardening is needed
The moment the backend makes an outbound request to a user-provided URL, it's an SSRF surface. So `test_ai_endpoint`:
- Restricts targets to loopback, private IP ranges, `*.local`, and official AI hosts (`is_safe_ai_url`).
- Disables redirects (`Policy::none`), applies a 60s timeout, caps request/response bodies at 16 MiB.
- **Closes the DNS-rebinding gap:** resolves the host up front, verifies every resolved address is inside the private/loopback perimeter (official public hosts exempt from the range check but still pinned), and pins reqwest to those exact IPs via `resolve_to_addrs` so it never re-resolves at connect time.

Frontend routes custom local/private URLs through this backend fetcher for both the models list and the chat probe; public providers keep native `fetch`.

## Testing
- `tsc --noEmit` clean; frontend unit tests pass.
- `tauri.ts` binding regenerated for `test_ai_endpoint` (no bindings drift).

## Scope / stacking
Second of two PRs split out from #6001. **Builds on #6110** (SSE handling) — review/merge #6110 first. Together they restore the local-provider connection test end to end.