### PR TITLE
fix(usage): remove Cloudflare rule copy

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/__tests__/usage-section.limits.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/usage-section.limits.test.tsx
@@ -54,6 +54,7 @@ describe("HostedUsageLimits", () => {
     expect(screen.getByText("Weekly · all models")).toBeTruthy();
     expect(screen.getByText("42%")).toBeTruthy();
     expect(screen.getByText("9%")).toBeTruthy();
+    expect(screen.queryByText("each listed allowance applies independently.")).toBeNull();
     expect(document.body.textContent).not.toContain("$");
   });
 

--- a/apps/screenpipe-app-tauri/components/settings/usage-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/usage-section.tsx
@@ -219,9 +219,6 @@ export function HostedUsageLimits({ query }: { query: UsageStatusQuery }) {
         <div className="flex items-baseline justify-between gap-4 border-b border-border pb-4">
           <div>
             <h2 className="text-base font-medium lowercase">your usage limits</h2>
-            <p className="mt-1 text-xs text-muted-foreground">
-              each listed allowance applies independently.
-            </p>
           </div>
           {plan && (
             <span className="shrink-0 font-mono text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary
- removes the usage-panel sentence that exposed implementation details about Cloudflare rules
- adds a regression assertion that the sentence is not rendered
- audits rendered app copy: no equivalent per-meter/per-rule wording remains

## Visual
```text
before
┌ your usage limits ─────────── Business ┐
│ each listed allowance applies independently. │
│ 30-day limit                         42% │
└───────────────────────────────────────────┘

after
┌ your usage limits ─────────── Business ┐
│ 30-day limit                         42% │
└───────────────────────────────────────────┘
```

## Verification
- RED: focused `usage-section.limits.test.tsx` failed while the sentence still rendered
- GREEN: `/home/ezra/.bun/bin/bun x vitest run --config vitest.config.ts components/settings/__tests__/usage-section.limits.test.tsx` — 2 passed
- `PATH=/home/ezra/.bun/bin:$PATH bun run typecheck` — passed
- `git diff --check` — passed
- rendered-app-copy search found no equivalent per-meter/per-rule language and the exact reported wording is absent from the tracked tree

## Scope
Customer-facing copy only; no usage accounting behavior changed.