### PR TITLE
copy: drop "hosted" from user-facing AI limit wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ Screen frames, audio, transcripts, and the search index are stored locally by de
 
 - Product analytics is enabled by default through PostHog. It uses a stable installation identifier and, when you sign in, may associate account details such as your email with app, hostname, operating-system, hardware, and other device or feature metadata.
 - Sentry receives crash and error diagnostics while telemetry is enabled.
-- If you choose cloud transcription, hosted AI, or cloud sync, the audio, prompts and selected context, or synced data needed for that feature is processed remotely by the configured service.
+- If you choose cloud transcription, screenpipe cloud AI, or cloud sync, the audio, prompts and selected context, or synced data needed for that feature is processed remotely by the configured service.
 
 You can disable telemetry in **Settings → Privacy → Analytics**, then apply the settings change. To keep capture and AI processing local, leave cloud sync off and select local transcription and a local AI provider such as Ollama.
 

--- a/apps/screenpipe-app-tauri/components/advisory-overlay.test.tsx
+++ b/apps/screenpipe-app-tauri/components/advisory-overlay.test.tsx
@@ -19,7 +19,7 @@ describe("AdvisoryOverlay", () => {
         {
           id: "pipe:summary",
           title: "27 scheduled tasks couldn't run",
-          body: "daily hosted AI allowance reached",
+          body: "daily AI allowance reached",
           severity: "warn",
           details: {
             label: "view 27 affected scheduled tasks",

--- a/apps/screenpipe-app-tauri/components/card-ask-modal.tsx
+++ b/apps/screenpipe-app-tauri/components/card-ask-modal.tsx
@@ -26,12 +26,12 @@ const COPY: Record<
 > = {
   login: {
     title: "Start your 7-day Business trial",
-    body: "Full access to hosted AI, unlimited pipes, and cloud transcription. Cancel anytime before day 7 and you are not charged.",
+    body: "Full access to AI, unlimited pipes, and cloud transcription. Cancel anytime before day 7 and you are not charged.",
     cta: "Start trial",
   },
   first_value: {
     title: "Keep this running",
-    body: "You just got your first result. A 7-day Business trial keeps hosted AI, pipes, and transcription running at full capacity. Cancel anytime before day 7 and you are not charged.",
+    body: "You just got your first result. A 7-day Business trial keeps AI, pipes, and transcription running at full capacity. Cancel anytime before day 7 and you are not charged.",
     cta: "Start trial",
   },
   limit: {
@@ -43,7 +43,7 @@ const COPY: Record<
   // one is nonsense to them; the real ask is to keep what they already have.
   grant_expiry: {
     title: "Your trial ends soon",
-    body: "Add a card to keep hosted AI, pipes, and transcription running. Nothing is charged until your trial ends, and you can cancel before then.",
+    body: "Add a card to keep AI, pipes, and transcription running. Nothing is charged until your trial ends, and you can cancel before then.",
     cta: "Keep Business",
   },
 };

--- a/apps/screenpipe-app-tauri/components/chat/standalone/upgrade-quota-banner.test.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/upgrade-quota-banner.test.tsx
@@ -147,7 +147,7 @@ describe("UpgradeQuotaBanner", () => {
     render(<UpgradeQuotaBanner />);
 
     expect(screen.getByTestId("hosted-ai-allowance-banner")).toBeTruthy();
-    expect(screen.getByText("Weekly hosted AI limit reached")).toBeTruthy();
+    expect(screen.getByText("Weekly AI limit reached")).toBeTruthy();
     expect(screen.getByText(/100% used this week/i)).toBeTruthy();
     expect(screen.getByText(/resets Aug 17, 5:00 PM/i)).toBeTruthy();
     expect(screen.getByText(/Switch to Auto or upgrade/i)).toBeTruthy();
@@ -302,7 +302,7 @@ describe("UpgradeQuotaBanner", () => {
 
     render(<UpgradeQuotaBanner />);
     expect(screen.getByTestId("cost-limit-upgrade-banner")).toBeTruthy();
-    expect(screen.getByText(/hosted AI usage limit reached/i)).toBeTruthy();
+    expect(screen.getByText(/AI usage limit reached/i)).toBeTruthy();
     expect(
       screen.getByText(/resets 5:00 PM/i),
     ).toBeTruthy();

--- a/apps/screenpipe-app-tauri/components/chat/standalone/upgrade-quota-banner.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/upgrade-quota-banner.tsx
@@ -125,8 +125,8 @@ export function UpgradeQuotaBanner() {
   const weeklyAllowance =
     cloudflareBlocked && cloudflareAllowance.window_seconds === 7 * 86_400;
   const blockedTitle = weeklyAllowance
-    ? "Weekly hosted AI limit reached"
-    : "Hosted AI usage limit reached";
+    ? "Weekly AI limit reached"
+    : "AI usage limit reached";
 
   return (
     <>
@@ -162,7 +162,7 @@ export function UpgradeQuotaBanner() {
               ) : legacyCostBlocked ? (
                 activeUpgrade ? (
                   <>
-                    Upgrade to {requiredPlanProse} for a higher hosted AI allowance,
+                    Upgrade to {requiredPlanProse} for a higher AI allowance,
                     or switch to a local or own-key AI preset.
                   </>
                 ) : (

--- a/apps/screenpipe-app-tauri/components/settings/__tests__/brain-overview.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/brain-overview.test.tsx
@@ -912,7 +912,7 @@ describe("BrainOverview", () => {
       "live-view-ai-prompt",
     )) as HTMLTextAreaElement;
     expect(prompt).toBeDisabled();
-    expect(prompt.placeholder).toBe("Hosted AI limit reached");
+    expect(prompt.placeholder).toBe("AI limit reached");
     expect(screen.getByTestId("live-view-ai-options")).toHaveAttribute(
       "aria-hidden",
       "true",

--- a/apps/screenpipe-app-tauri/components/settings/live-view-ai-composer.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/live-view-ai-composer.tsx
@@ -219,7 +219,7 @@ export function LiveViewAiComposer({
           }
           placeholder={
             hostedUsageExhausted
-              ? "Hosted AI limit reached"
+              ? "AI limit reached"
               : compact
                 ? "Ask AI to change this Live View..."
                 : "For example: show how I spend my time and what changed this week"

--- a/apps/screenpipe-app-tauri/e2e/specs/chat-cost-limit-upgrade.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/chat-cost-limit-upgrade.spec.ts
@@ -162,7 +162,7 @@ describe("Hosted AI usage-limit Business Max recovery", function () {
       error: JSON.stringify({
         error: "daily_limit_exceeded",
         message:
-          "You've used your daily hosted AI allowance. Background scheduled tasks share this allowance.",
+          "You've used your daily AI allowance. Background scheduled tasks share this allowance.",
         resets_at: "2026-08-02T00:00:00.000Z",
         plan: "business",
         required_plan: "business_max",
@@ -189,7 +189,7 @@ describe("Hosted AI usage-limit Business Max recovery", function () {
 
     const banner = await $('[data-testid="cost-limit-upgrade-banner"]');
     await banner.waitForDisplayed({ timeout: t(10_000) });
-    expect(await banner.getText()).toContain("Hosted AI usage limit reached");
+    expect(await banner.getText()).toContain("AI usage limit reached");
     expect(await banner.getText()).toContain("Resets");
 
     // The recovery action lives inline on the banner — no blocking dialog.

--- a/apps/screenpipe-app-tauri/e2e/specs/chat-hosted-retry-feedback.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/chat-hosted-retry-feedback.spec.ts
@@ -152,7 +152,7 @@ describe("Hosted AI retry feedback and follow-up queue", function () {
       async () => {
         const text = await assistant.getText();
         return (
-          text.includes("Another hosted AI request is finishing") &&
+          text.includes("Another AI request is finishing") &&
           text.includes("Retrying in")
         );
       },

--- a/apps/screenpipe-app-tauri/lib/__tests__/pipe-advisories.test.ts
+++ b/apps/screenpipe-app-tauri/lib/__tests__/pipe-advisories.test.ts
@@ -11,7 +11,7 @@ import {
 const DAILY_LIMIT = JSON.stringify({
   error: "daily_cost_limit_exceeded",
   message:
-    "You've used your daily hosted AI allowance. Background scheduled tasks share this allowance.",
+    "You've used your daily AI allowance. Background scheduled tasks share this allowance.",
 });
 
 function failingPipe(name: string, lastError = DAILY_LIMIT): PipeAdvisoryRow {
@@ -39,7 +39,7 @@ describe("buildPipeAdvisories", () => {
       id: "pipe:summary",
       title: "27 scheduled tasks couldn't run",
       body:
-        "You've used your daily hosted AI allowance. Background scheduled tasks share this allowance.",
+        "You've used your daily AI allowance. Background scheduled tasks share this allowance.",
       details: { label: "view 27 affected scheduled tasks" },
       action: { label: "upgrade" },
     });
@@ -57,7 +57,7 @@ describe("buildPipeAdvisories", () => {
         id: "pipe:summary",
         title: 'scheduled task "meeting-prep" couldn\'t run',
         body:
-          "You've used your daily hosted AI allowance. Background scheduled tasks share this allowance.",
+          "You've used your daily AI allowance. Background scheduled tasks share this allowance.",
         severity: "warn",
       },
     ]);
@@ -83,7 +83,7 @@ describe("buildPipeAdvisories", () => {
     expect(advisory.title).toBe("2 scheduled tasks couldn't run");
     expect(advisory.body).toBe("2 issues are blocking these background scheduled tasks.");
     expect(advisory.details?.items).toEqual([
-      `meeting-prep — You've used your daily hosted AI allowance. Background scheduled tasks share this allowance.`,
+      `meeting-prep — You've used your daily AI allowance. Background scheduled tasks share this allowance.`,
       "support-triage — uses a model that needs business — switch to a free model (auto) or upgrade",
     ]);
     expect(advisory.action).toBeUndefined();

--- a/apps/screenpipe-app-tauri/lib/chat/__tests__/provider-errors.test.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/__tests__/provider-errors.test.ts
@@ -113,7 +113,7 @@ describe("provider error copy", () => {
       '{"error":"free_chat_limit_exceeded","limit":2}',
       { provider: "screenpipe-cloud", model: "auto" },
     );
-    expect(msg).toContain("2 free hosted AI messages");
+    expect(msg).toContain("2 free AI messages");
     expect(msg).toContain("tomorrow");
     expect(msg).toContain("upgrade");
     expect(msg).toContain("Ollama");

--- a/apps/screenpipe-app-tauri/lib/chat/__tests__/quota-errors.test.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/__tests__/quota-errors.test.ts
@@ -95,7 +95,7 @@ describe("buildDailyLimitMessage", () => {
       '{"error":{"code":"hosted_ai_allowance_exceeded"},"allowance":{"lane":"auto","plan":"basic","managed_by":"cloudflare"}}',
     );
     expect(message).toBe(
-      "Your hosted AI usage limit is reached. Switch to Auto.",
+      "Your AI usage limit is reached. Switch to Auto.",
     );
     expect(message).not.toContain("explicit");
     expect(message).not.toMatch(/\$\d/);
@@ -106,7 +106,7 @@ describe("buildDailyLimitMessage", () => {
       '{"error":{"code":"hosted_ai_allowance_exceeded"},"allowance":{"lane":"explicit","plan":"business","managed_by":"cloudflare"},"required_plan":"business_max","upgrade_url":"https://screenpipe.com/account/billing?target_plan=pro_max&interval=month"}',
     );
     expect(message).toBe(
-      "Your hosted AI usage limit is reached. Switch to Auto or upgrade.",
+      "Your AI usage limit is reached. Switch to Auto or upgrade.",
     );
     expect(message).not.toContain("explicit");
   });
@@ -120,7 +120,7 @@ describe("buildDailyLimitMessage", () => {
 
   it("shows the daily free message wall without immediate retry copy", () => {
     const message = buildDailyLimitMessage("free_chat_limit_exceeded");
-    expect(message).toContain("2 free hosted AI messages");
+    expect(message).toContain("2 free AI messages");
     expect(message).toContain("tomorrow");
     expect(message).toContain("Claude");
     expect(message).toContain("Codex");
@@ -245,7 +245,7 @@ describe("buildDailyLimitMessage", () => {
     });
     expect(parseQuotaUpgradeAction(error)?.requiredPlan).toBe("business_max");
     expect(buildDailyLimitMessage(error)).toBe(
-      "Your hosted AI usage limit is reached. Switch to Auto or upgrade.",
+      "Your AI usage limit is reached. Switch to Auto or upgrade.",
     );
   });
 
@@ -378,7 +378,7 @@ describe("presentQuotaError", () => {
     );
     expect(presented.kind).toBe("daily");
     expect(presented.message).toBe(
-      "Your hosted AI usage limit is reached. Switch to Auto.",
+      "Your AI usage limit is reached. Switch to Auto.",
     );
     expect(presented.message).not.toContain("explicit");
   });

--- a/apps/screenpipe-app-tauri/lib/chat/provider-errors.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/provider-errors.ts
@@ -287,16 +287,16 @@ function buildGenericProviderErrorMessage(
 
   if (isHostedScreenpipeProvider(provider)) {
     if (normalized.includes("free_chat_limit_exceeded")) {
-      return "You've used today's 2 free hosted AI messages. Try again tomorrow, upgrade, or switch your AI preset to Ollama, Claude, Codex, or your own provider key.";
+      return "You've used today's 2 free AI messages. Try again tomorrow, upgrade, or switch your AI preset to Ollama, Claude, Codex, or your own provider key.";
     }
     if (normalized.includes("free_chat_turn_request_limit_exceeded")) {
       return "This free message reached its 8-step agent limit. Upgrade for longer agent runs, or switch your AI preset to your own provider.";
     }
     if (normalized.includes("free_plan_hosted_background_disabled")) {
-      return "Hosted AI for background scheduled tasks requires a paid plan. You can still run this scheduled task with Ollama or your own provider key.";
+      return "screenpipe cloud AI for background scheduled tasks requires a paid plan. You can still run this scheduled task with Ollama or your own provider key.";
     }
     if (normalized.includes("free_chat_client_update_required")) {
-      return "Update screenpipe to use your 2 daily free hosted AI messages.";
+      return "Update screenpipe to use your 2 daily free AI messages.";
     }
     if (normalized.includes("not allowed")) {
       return `Model is restricted on your current plan. Please switch to a free model or upgrade your account.`;

--- a/apps/screenpipe-app-tauri/lib/chat/quota-errors.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/quota-errors.ts
@@ -99,17 +99,17 @@ function costLimitReason(window: CostLimitWindow, errorStr: string): string {
   const shared = "Background scheduled tasks share this budget.";
   switch (window) {
     case "trial":
-      return `you've used the hosted AI allowance included with your trial. It doesn't refill during the trial. ${shared}`;
+      return `you've used the AI allowance included with your trial. It doesn't refill during the trial. ${shared}`;
     case "month":
       return resetTime
-        ? `you've used this month's hosted AI usage limit. It resets ${resetTime}. ${shared}`
-        : `you've used this month's hosted AI usage limit. It resets at the start of next month. ${shared}`;
+        ? `you've used this month's AI usage limit. It resets ${resetTime}. ${shared}`
+        : `you've used this month's AI usage limit. It resets at the start of next month. ${shared}`;
     case "day":
       return resetTime
-        ? `you've used today's hosted AI usage limit. It resets ${resetTime}. ${shared}`
-        : `you've used today's hosted AI usage limit. It resets tomorrow. ${shared}`;
+        ? `you've used today's AI usage limit. It resets ${resetTime}. ${shared}`
+        : `you've used today's AI usage limit. It resets tomorrow. ${shared}`;
     default:
-      return `your plan's hosted AI usage limit is reached. ${shared}`;
+      return `your plan's AI usage limit is reached. ${shared}`;
   }
 }
 
@@ -161,11 +161,11 @@ export function buildDailyLimitMessage(errorStr: string): string {
     const normalized = errorStr.toLowerCase();
     if (normalized.includes("hosted_ai_allowance_exceeded")) {
       return parseQuotaUpgradeAction(errorStr)
-        ? "Your hosted AI usage limit is reached. Switch to Auto or upgrade."
-        : "Your hosted AI usage limit is reached. Switch to Auto.";
+        ? "Your AI usage limit is reached. Switch to Auto or upgrade."
+        : "Your AI usage limit is reached. Switch to Auto.";
     }
     if (normalized.includes("free_chat_limit_exceeded")) {
-      return "You've used today's 2 free hosted AI messages. Try again tomorrow, upgrade, or switch your AI preset to Ollama, Claude, Codex, or your own provider key.";
+      return "You've used today's 2 free AI messages. Try again tomorrow, upgrade, or switch your AI preset to Ollama, Claude, Codex, or your own provider key.";
     }
     if (normalized.includes("free_chat_turn_request_limit_exceeded")) {
       return "This free message reached its 8-step agent limit. Upgrade for longer agent runs, or switch your AI preset to your own provider.";
@@ -188,7 +188,7 @@ export function buildDailyLimitMessage(errorStr: string): string {
         ? // The persistent recovery panel owns the explanation and actions.
           "Choose a recovery option below."
         : "Switch to a local model or your own provider key to keep working.";
-      return `Hosted AI didn't run this request because ${costLimitReason(window, errorStr)} ${recovery}`;
+      return `This request didn't run because ${costLimitReason(window, errorStr)} ${recovery}`;
     }
 
     if (isRateLimit) {
@@ -196,7 +196,7 @@ export function buildDailyLimitMessage(errorStr: string): string {
     }
 
     if (parseQuotaUpgradeAction(errorStr)) {
-      return "Hosted AI didn't run this request because your plan's usage limit is reached. Choose a recovery option below.";
+      return "This request didn't run because your plan's usage limit is reached. Choose a recovery option below.";
     }
 
     const tierMatch = errorStr.match(/"tier":\s*"([^"]+)"/);
@@ -320,7 +320,7 @@ export function presentQuotaError(errorStr: string): QuotaErrorPresentation {
       const message = buildDailyLimitMessage(errorStr).endsWith(
         "Choose a recovery option below.",
       )
-        ? "Your plan's hosted AI usage limit is reached. Upgrade for a higher limit, or switch to a local model or your own provider key."
+        ? "Your plan's AI usage limit is reached. Upgrade for a higher limit, or switch to a local model or your own provider key."
         : buildDailyLimitMessage(errorStr);
       return { kind, message, upgrade };
     }
@@ -334,7 +334,7 @@ export function presentQuotaError(errorStr: string): QuotaErrorPresentation {
 }
 
 export function buildHostedBusyMessage(): string {
-  return "Another hosted AI request is finishing. Retrying automatically… You can keep typing — new messages will be queued.";
+  return "Another AI request is finishing. Retrying automatically… You can keep typing — new messages will be queued.";
 }
 
 export function buildHostedBusyRetryMessage(
@@ -343,11 +343,11 @@ export function buildHostedBusyRetryMessage(
   delayMs: number,
 ): string {
   const waitSeconds = Math.max(1, Math.ceil(delayMs / 1000));
-  return `Another hosted AI request is finishing. Retrying in ${waitSeconds}s… (${attempt}/${maxAttempts}) You can keep typing — new messages will be queued.`;
+  return `Another AI request is finishing. Retrying in ${waitSeconds}s… (${attempt}/${maxAttempts}) You can keep typing — new messages will be queued.`;
 }
 
 export function buildHostedBusyFinalMessage(): string {
-  return "Hosted AI stayed busy with another request, so this reply could not start. Try again in a moment.";
+  return "AI stayed busy with another request, so this reply could not start. Try again in a moment.";
 }
 
 export function buildRateLimitMessage(errorStr: string): string {

--- a/apps/screenpipe-app-tauri/lib/pi-extension-catalog.ts
+++ b/apps/screenpipe-app-tauri/lib/pi-extension-catalog.ts
@@ -66,7 +66,7 @@ export const PI_EXTENSION_CATALOG: PiExtensionCatalogItem[] = [
     details: "Useful for review, scouting, parallel audits, and implementation tasks that benefit from separate context windows.",
     modelFit: "cloud-preferred",
     modelFitLabel: "Cloud model recommended",
-    modelFitCopy: "Subagents amplify planning mistakes. Use a strong hosted model first; small local models may over-spawn or lose tool boundaries.",
+    modelFitCopy: "Subagents amplify planning mistakes. Use a strong cloud model first; small local models may over-spawn or lose tool boundaries.",
     risk: "Runs extra Pi sessions locally and can multiply tool calls.",
     npmUrl: "https://www.npmjs.com/package/pi-subagents",
     sourceUrl: "https://github.com/nicobailon/pi-subagents",

--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -4609,7 +4609,7 @@ mod tests {
         assert_eq!(parse_rate_limit_reset_secs("model not found"), None);
 
         // hosted_ai_capacity_reserved uses "retry_after_seconds", not "reset_in".
-        let capacity_reserved = r#"429 {"error":"hosted_ai_capacity_reserved","message":"Other hosted AI chats are still running. Wait for one to finish, then retry.","retry_after_seconds":5}"#;
+        let capacity_reserved = r#"429 {"error":"hosted_ai_capacity_reserved","message":"Other AI chats are still running. Wait for one to finish, then retry.","retry_after_seconds":5}"#;
         assert_eq!(parse_rate_limit_reset_secs(capacity_reserved), Some(5));
     }
 
@@ -4853,7 +4853,7 @@ mod tests {
     #[test]
     fn test_next_rate_limit_retry_capacity_reserved_outlasts_fixed_retry_cap() {
         // Real gateway payload for contention on the shared hosted-AI slot.
-        let stderr = r#"429 {"error":"hosted_ai_capacity_reserved","message":"Other hosted AI chats are still running. Wait for one to finish, then retry.","retry_after_seconds":5}"#;
+        let stderr = r#"429 {"error":"hosted_ai_capacity_reserved","message":"Other AI chats are still running. Wait for one to finish, then retry.","retry_after_seconds":5}"#;
 
         // Simulate holding capacity for 35s (7 retries at 5s each) — longer
         // than the fixed MAX_RATE_LIMIT_RETRIES=3 a generic rate limit gets.
@@ -4964,7 +4964,7 @@ mod tests {
     ) {
         // Simulate the shared hosted-AI slot staying busy for 4 attempts —
         // one more than MAX_RATE_LIMIT_RETRIES=3 — before it frees up.
-        let capacity_stderr = r#"429 {"error":"hosted_ai_capacity_reserved","message":"Other hosted AI chats are still running. Wait for one to finish, then retry.","retry_after_seconds":5}"#;
+        let capacity_stderr = r#"429 {"error":"hosted_ai_capacity_reserved","message":"Other AI chats are still running. Wait for one to finish, then retry.","retry_after_seconds":5}"#;
         let calls = std::cell::RefCell::new(0u32);
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
 

--- a/docs/mintlify/docs-mintlify-mig-tmp/changelog.mdx
+++ b/docs/mintlify/docs-mintlify-mig-tmp/changelog.mdx
@@ -13,7 +13,7 @@ icon: "newspaper"
 
 ### updates
 
-- **See your hosted AI usage in Settings** — the Usage tab in app settings now shows how much of your hosted AI allowance you've used, with a per-lane progress bar for auto and manual model traffic (or a single "all models" bar when your plan doesn't split them). Each meter includes your plan label, the window type, the next reset time, and turns yellow under 30% remaining and red when exhausted, with an upgrade link when one applies. See [connections](/connections).
+- **See your AI usage in Settings** — the Usage tab in app settings now shows how much of your AI allowance you've used, with a per-lane progress bar for auto and manual model traffic (or a single "all models" bar when your plan doesn't split them). Each meter includes your plan label, the window type, the next reset time, and turns yellow under 30% remaining and red when exhausted, with an upgrade link when one applies. See [connections](/connections).
 
 ## week of july 28, 2026
 
@@ -67,13 +67,13 @@ icon: "newspaper"
 ### updates
 
 - **CLI auto-connects every detected AI tool on startup** — when the screenpipe CLI starts, it now scans for every supported AI coding tool installed on your machine (Claude Code, Cursor, Cline, Continue, Copilot CLI, Gemini CLI, opencode, and more) and wires them up to screenpipe over MCP in one shot, instead of asking you to connect each one by hand. Existing custom MCP servers you've already configured (including Hermes) are preserved untouched, so previously wired-up tools keep their settings. See [MCP server](/mcp-server) and [connections](/connections).
-- **hosted AI catalog cleaned up and modernized** — the hosted chat gateway and desktop model picker no longer list retired options (Google Open MaaS, Gemini 3, selectable Gemma 4, GPT‑OSS/OpenRouter‑era choices, Claude Haiku, and older Sonnet families). Saved presets that pointed at any of those IDs are now transparently upgraded: hosted Claude legacy IDs move to GPT‑5.6 Luna, and direct Anthropic BYOK legacy IDs move to Claude Sonnet 5. Paid Auto and outage fallback now flow through Luna → Sonnet 5 → GPT‑5.4 mini (the free preview stays bounded to Luna → GPT‑5.4 mini). Existing chats and pipes keep working — you'll just be routed to a current model instead of a decommissioned one. See [connections](/connections).
+- **screenpipe cloud AI catalog cleaned up and modernized** — the hosted chat gateway and desktop model picker no longer list retired options (Google Open MaaS, Gemini 3, selectable Gemma 4, GPT‑OSS/OpenRouter‑era choices, Claude Haiku, and older Sonnet families). Saved presets that pointed at any of those IDs are now transparently upgraded: hosted Claude legacy IDs move to GPT‑5.6 Luna, and direct Anthropic BYOK legacy IDs move to Claude Sonnet 5. Paid Auto and outage fallback now flow through Luna → Sonnet 5 → GPT‑5.4 mini (the free preview stays bounded to Luna → GPT‑5.4 mini). Existing chats and pipes keep working — you'll just be routed to a current model instead of a decommissioned one. See [connections](/connections).
 
 ### bug fixes
 
 - **Electron apps get the full accessibility walk** — VS Code, Discord, Slack, and other Electron apps sometimes had their content indexing cut off partway through the accessibility tree, so screen text from those apps could be missing from search results. The depth counter now resets at `AXWebArea` boundaries, giving Electron apps the full walk budget and restoring complete text capture. See [search screen history](/search-screen-history).
 - **USB audio devices no longer drop into silence on macOS** — USB microphones and interfaces whose native sample rate did not match the system's could silently stop delivering audio mid-session on macOS. Sample-rate mismatches are now handled correctly, so USB capture keeps flowing throughout the recording. See [troubleshooting](/troubleshooting).
-- **free hosted chat accepts one verbose tool** — the free hosted chat gateway previously rejected requests containing a single tool with a long description or a large parameter schema. The size cap now applies to the combined byte size of all tool definitions in a request instead of each tool individually, so one verbose tool goes through as long as the aggregate stays under the limit. Pi and pipes that ship a rich schema for a single tool no longer see spurious `free_chat_tools_too_large` errors. See [pipes](/pipes).
+- **free AI chat accepts one verbose tool** — the free AI chat gateway previously rejected requests containing a single tool with a long description or a large parameter schema. The size cap now applies to the combined byte size of all tool definitions in a request instead of each tool individually, so one verbose tool goes through as long as the aggregate stays under the limit. Pi and pipes that ship a rich schema for a single tool no longer see spurious `free_chat_tools_too_large` errors. See [pipes](/pipes).
 
 ## week of july 17, 2026
 

--- a/packages/ai-gateway/src/handlers/chat.ts
+++ b/packages/ai-gateway/src/handlers/chat.ts
@@ -751,8 +751,8 @@ function errorResponse(body: RequestBody, status: number, message: string): Resp
 
 function allowanceMessage(canUpgrade: boolean): string {
   return canUpgrade
-    ? 'Your hosted AI usage limit is reached. Switch to Auto or upgrade.'
-    : 'Your hosted AI usage limit is reached. Switch to Auto.';
+    ? 'Your AI usage limit is reached. Switch to Auto or upgrade.'
+    : 'Your AI usage limit is reached. Switch to Auto.';
 }
 
 /** Render the stable terminal contract Pi uses to avoid generic 429 retries. */

--- a/packages/ai-gateway/src/index.ts
+++ b/packages/ai-gateway/src/index.ts
@@ -423,7 +423,7 @@ export async function handleRequest(request: Request, env: Env, ctx: ExecutionCo
 				console.error('usage cost control configuration unavailable', error);
 				return addCorsHeaders(createErrorResponse(503, JSON.stringify({
 					error: 'cost_control_unavailable',
-					message: 'Hosted AI usage controls are temporarily unavailable. Try again shortly.',
+					message: 'AI usage controls are temporarily unavailable. Try again shortly.',
 				})));
 			}
 			let monthlyCost: number | null = null;
@@ -503,7 +503,7 @@ export async function handleRequest(request: Request, env: Env, ctx: ExecutionCo
 				return freeChatErrorResponse({
 					status: 401,
 					code: 'authentication_required',
-					message: 'Sign in to use screenpipe hosted AI.',
+					message: 'Sign in to use screenpipe AI.',
 				});
 			}
 			if (!hasPaidHostedAiPlan(authResult) && authResult.accountPlan !== 'free') {
@@ -524,7 +524,7 @@ export async function handleRequest(request: Request, env: Env, ctx: ExecutionCo
 							return freeChatErrorResponse({
 								status: 413,
 								code: 'free_chat_request_too_large',
-								message: `Free hosted chat requests are limited to ${FREE_CHAT_MAX_REQUEST_BYTES} bytes.`,
+								message: `Free AI chat requests are limited to ${FREE_CHAT_MAX_REQUEST_BYTES} bytes.`,
 							});
 						}
 						throw new Error('invalid JSON');
@@ -650,7 +650,7 @@ export async function handleRequest(request: Request, env: Env, ctx: ExecutionCo
 						},
 						subscribe: {
 							url: 'https://screenpi.pe/onboarding',
-							benefit: 'Frontier Claude and GPT models, higher hosted AI limits, and encrypted sync',
+							benefit: 'Frontier Claude and GPT models, higher AI limits, and encrypted sync',
 							price: '$29/mo',
 						},
 					},
@@ -1000,13 +1000,13 @@ export async function handleRequest(request: Request, env: Env, ctx: ExecutionCo
 				console.error('transcription cost control unavailable', error);
 				return addCorsHeaders(createErrorResponse(503, JSON.stringify({
 					error: 'cost_control_unavailable',
-					message: 'Hosted transcription controls are temporarily unavailable. Local transcription still works.',
+					message: 'Cloud transcription controls are temporarily unavailable. Local transcription still works.',
 				})));
 			}
 			if (dailyCost >= maxCost) {
 				return addCorsHeaders(createErrorResponse(429, JSON.stringify({
 					error: 'daily_cost_limit_exceeded',
-					message: "You've reached today's hosted transcription allowance. Audio will be transcribed locally until tomorrow.",
+					message: "You've reached today's cloud transcription allowance. Audio will be transcribed locally until tomorrow.",
 				})));
 			}
 
@@ -1048,14 +1048,14 @@ export async function handleRequest(request: Request, env: Env, ctx: ExecutionCo
 				if (dailyCost >= maxCost) {
 					return addCorsHeaders(createErrorResponse(429, JSON.stringify({
 						error: 'daily_cost_limit_exceeded',
-						message: "You've reached today's hosted transcription allowance. Use local transcription or try again tomorrow.",
+						message: "You've reached today's cloud transcription allowance. Use local transcription or try again tomorrow.",
 					})));
 				}
 			} catch (error) {
 				console.error('realtime transcription cost control unavailable', error);
 				return addCorsHeaders(createErrorResponse(503, JSON.stringify({
 					error: 'cost_control_unavailable',
-					message: 'Hosted transcription controls are temporarily unavailable. Local transcription still works.',
+					message: 'Cloud transcription controls are temporarily unavailable. Local transcription still works.',
 				})));
 			}
 			return await handleRealtimeTranscriptionUpgrade(request, env, ctx, authResult);

--- a/packages/ai-gateway/src/services/cost-cap.ts
+++ b/packages/ai-gateway/src/services/cost-cap.ts
@@ -241,10 +241,10 @@ function capResponse(accountPlan: AccountPlan, period: 'request' | 'day' | 'mont
 					? 'trial_cost_limit_exceeded'
 					: 'monthly_cost_limit_exceeded',
 		message: period === 'request'
-			? 'This request is too large for your hosted AI plan. Shorten the context, use a local model, or use your own provider key.'
+			? 'This request is too large for your AI plan. Shorten the context, use a local model, or use your own provider key.'
 			: period === 'trial'
-				? "You've used the hosted AI allowance for this trial. Upgrade, use a local model, or use your own provider key."
-				: `You've used your ${period === 'day' ? 'daily' : 'monthly'} hosted AI allowance. Background pipes share this allowance.`,
+				? "You've used the AI allowance for this trial. Upgrade, use a local model, or use your own provider key."
+				: `You've used your ${period === 'day' ? 'daily' : 'monthly'} AI allowance. Background pipes share this allowance.`,
 		resets_at: period === 'request' || period === 'trial' ? null : resetsAt.toISOString(),
 		plan: accountPlan,
 		required_plan: upgrade?.requiredPlan ?? null,
@@ -268,7 +268,7 @@ function backgroundCapResponse(
 	const periodLabel = period === 'month' ? 'monthly' : period === 'trial' ? 'trial' : 'daily';
 	return addCorsHeaders(createErrorResponse(429, JSON.stringify({
 		error: 'background_cost_limit_exceeded',
-		message: `Scheduled pipes reached their ${periodLabel} hosted AI budget. Foreground chat remains available.`,
+		message: `Scheduled pipes reached their ${periodLabel} AI budget. Foreground chat remains available.`,
 		resets_at: period === 'trial' ? null : resetsAt.toISOString(),
 		plan: accountPlan,
 		required_plan: null,
@@ -281,7 +281,7 @@ function backgroundCapResponse(
 function globalCapResponse(period: 'hour' | 'day'): Response {
 	const response = addCorsHeaders(createErrorResponse(503, JSON.stringify({
 		error: 'hosted_ai_global_spend_limit',
-		message: 'Hosted AI is temporarily paused by the global spend safety limit. Local models and your own provider keys still work.',
+		message: 'screenpipe cloud AI is temporarily paused by the global spend safety limit. Local models and your own provider keys still work.',
 		period,
 		retry_after_seconds: period === 'hour' ? 300 : 900,
 	})));
@@ -292,7 +292,7 @@ function globalCapResponse(period: 'hour' | 'day'): Response {
 function unavailableResponse(): Response {
 	return addCorsHeaders(createErrorResponse(503, JSON.stringify({
 		error: 'cost_control_unavailable',
-		message: 'Hosted AI spend controls are temporarily unavailable. Try again shortly or use a local model or your own provider key.',
+		message: 'AI spend controls are temporarily unavailable. Try again shortly or use a local model or your own provider key.',
 	})));
 }
 
@@ -300,8 +300,8 @@ function capacityResponse(tier: string, lane: DailyCostLane): Response {
 	const response = addCorsHeaders(createErrorResponse(429, JSON.stringify({
 		error: 'hosted_ai_capacity_reserved',
 		message: lane === 'background'
-			? 'Other hosted AI background requests are still running. Wait for one to finish, then retry.'
-			: 'Other hosted AI chats are still running. Wait for one to finish, then retry.',
+			? 'Other AI background requests are still running. Wait for one to finish, then retry.'
+			: 'Other AI chats are still running. Wait for one to finish, then retry.',
 		tier,
 		retry_after_seconds: 5,
 	})));

--- a/packages/ai-gateway/src/services/free-chat-limit.test.ts
+++ b/packages/ai-gateway/src/services/free-chat-limit.test.ts
@@ -705,7 +705,7 @@ describe('reserveFreeChatTurn', () => {
 		expect(results.filter((result) => !result.allowed)).toHaveLength(1);
 	});
 
-	it('fails closed for free hosted chat when D1 is unavailable', async () => {
+	it('fails closed for free AI chat when D1 is unavailable', async () => {
 		const db = new FakeD1();
 		db.fail = true;
 

--- a/packages/ai-gateway/src/services/free-chat-limit.ts
+++ b/packages/ai-gateway/src/services/free-chat-limit.ts
@@ -213,7 +213,7 @@ export function validateFreeChatRequestBodyLimits(
 		return {
 			status: 400,
 			code: 'free_chat_structure_too_deep',
-			message: `Free hosted chat JSON structures are limited to ${FREE_CHAT_MAX_STRUCTURE_DEPTH} nested levels.`,
+			message: `Free AI chat JSON structures are limited to ${FREE_CHAT_MAX_STRUCTURE_DEPTH} nested levels.`,
 		};
 	}
 
@@ -221,7 +221,7 @@ export function validateFreeChatRequestBodyLimits(
 	try {
 		serializedBytes = jsonByteLength(body);
 	} catch {
-		return { status: 400, code: 'invalid_free_chat_request', message: 'Free hosted chat requires a JSON request body.' };
+		return { status: 400, code: 'invalid_free_chat_request', message: 'Free AI chat requires a JSON request body.' };
 	}
 	if (
 		serializedBytes > FREE_CHAT_MAX_REQUEST_BYTES
@@ -229,12 +229,12 @@ export function validateFreeChatRequestBodyLimits(
 	) {
 		return requestTooLarge(
 			'free_chat_request_too_large',
-			`Free hosted chat requests are limited to ${FREE_CHAT_MAX_REQUEST_BYTES} bytes.`,
+			`Free AI chat requests are limited to ${FREE_CHAT_MAX_REQUEST_BYTES} bytes.`,
 		);
 	}
 
 	if (!Array.isArray(body.messages)) {
-		return { status: 400, code: 'invalid_free_chat_messages', message: 'Free hosted chat requires a messages array.' };
+		return { status: 400, code: 'invalid_free_chat_messages', message: 'Free AI chat requires a messages array.' };
 	}
 
 	let imageCount = 0;
@@ -248,7 +248,7 @@ export function validateFreeChatRequestBodyLimits(
 				return {
 					status: 400,
 					code: 'invalid_free_chat_tool_calls',
-					message: 'Free hosted chat tool calls must be an array.',
+					message: 'Free AI chat tool calls must be an array.',
 				};
 			}
 			if (toolCalls.some((toolCall) => (
@@ -257,7 +257,7 @@ export function validateFreeChatRequestBodyLimits(
 				return {
 					status: 400,
 					code: 'invalid_free_chat_tool_call',
-					message: 'Every free hosted chat tool call must be an object.',
+					message: 'Every free AI chat tool call must be an object.',
 				};
 			}
 		}
@@ -265,7 +265,7 @@ export function validateFreeChatRequestBodyLimits(
 		if (messageBytes > FREE_CHAT_MAX_MESSAGE_BYTES) {
 			return requestTooLarge(
 				'free_chat_message_too_large',
-				`Each free hosted chat message is limited to ${FREE_CHAT_MAX_MESSAGE_BYTES} bytes.`,
+				`Each free AI chat message is limited to ${FREE_CHAT_MAX_MESSAGE_BYTES} bytes.`,
 			);
 		}
 
@@ -276,7 +276,7 @@ export function validateFreeChatRequestBodyLimits(
 					return {
 						status: 400,
 						code: 'invalid_free_chat_content_part',
-						message: 'Every free hosted chat content part must be an object.',
+						message: 'Every free AI chat content part must be an object.',
 					};
 				}
 				if (isImagePart(part)) {
@@ -285,13 +285,13 @@ export function validateFreeChatRequestBodyLimits(
 						return {
 							status: 400,
 							code: 'free_chat_image_unverifiable',
-							message: 'Free hosted chat images must use an inline base64 image payload so their type and size can be verified.',
+							message: 'Free AI chat images must use an inline base64 image payload so their type and size can be verified.',
 						};
 					}
 					if (jsonByteLength(part) > FREE_CHAT_MAX_IMAGE_BYTES) {
 						return requestTooLarge(
 							'free_chat_image_too_large',
-							`Each free hosted chat image is limited to ${FREE_CHAT_MAX_IMAGE_BYTES} encoded bytes.`,
+							`Each free AI chat image is limited to ${FREE_CHAT_MAX_IMAGE_BYTES} encoded bytes.`,
 						);
 					}
 				}
@@ -302,31 +302,31 @@ export function validateFreeChatRequestBodyLimits(
 	if (imageCount > FREE_CHAT_MAX_IMAGES) {
 		return requestTooLarge(
 			'free_chat_too_many_images',
-			`Free hosted chat supports at most ${FREE_CHAT_MAX_IMAGES} images per request.`,
+			`Free AI chat supports at most ${FREE_CHAT_MAX_IMAGES} images per request.`,
 		);
 	}
 
 	if (body.tools !== undefined && !Array.isArray(body.tools)) {
-		return { status: 400, code: 'invalid_free_chat_tools', message: 'Free hosted chat tools must be an array.' };
+		return { status: 400, code: 'invalid_free_chat_tools', message: 'Free AI chat tools must be an array.' };
 	}
 	const tools = body.tools ?? [];
 	if (tools.some((tool) => !tool || typeof tool !== 'object' || Array.isArray(tool))) {
 		return {
 			status: 400,
 			code: 'invalid_free_chat_tool',
-			message: 'Every free hosted chat tool definition must be an object.',
+			message: 'Every free AI chat tool definition must be an object.',
 		};
 	}
 	if (tools.length > FREE_CHAT_MAX_TOOLS) {
 		return requestTooLarge(
 			'free_chat_too_many_tools',
-			`Free hosted chat supports at most ${FREE_CHAT_MAX_TOOLS} tools per request.`,
+			`Free AI chat supports at most ${FREE_CHAT_MAX_TOOLS} tools per request.`,
 		);
 	}
 	if (jsonByteLength(tools) > FREE_CHAT_MAX_TOOLS_BYTES) {
 		return requestTooLarge(
 			'free_chat_tools_too_large',
-			`Free hosted chat tool definitions are limited to ${FREE_CHAT_MAX_TOOLS_BYTES} bytes per request.`,
+			`Free AI chat tool definitions are limited to ${FREE_CHAT_MAX_TOOLS_BYTES} bytes per request.`,
 		);
 	}
 	if (
@@ -335,7 +335,7 @@ export function validateFreeChatRequestBodyLimits(
 	) {
 		return requestTooLarge(
 			'free_chat_response_format_too_large',
-			`Free hosted chat response schemas are limited to ${FREE_CHAT_MAX_RESPONSE_FORMAT_BYTES} bytes.`,
+			`Free AI chat response schemas are limited to ${FREE_CHAT_MAX_RESPONSE_FORMAT_BYTES} bytes.`,
 		);
 	}
 
@@ -394,7 +394,7 @@ export async function prepareFreeChatTurn(
 		return blocked(
 			401,
 			'authentication_required',
-			'Sign in to use screenpipe hosted AI.',
+			'Sign in to use screenpipe AI.',
 		);
 	}
 
@@ -418,7 +418,7 @@ export async function prepareFreeChatTurn(
 		return blocked(
 			403,
 			'free_plan_hosted_background_disabled',
-			'Hosted AI for background pipes is available on a paid plan. Use a local model or your own provider key on the free plan.',
+			'screenpipe cloud AI for background pipes is available on a paid plan. Use a local model or your own provider key on the free plan.',
 		);
 	}
 
@@ -427,7 +427,7 @@ export async function prepareFreeChatTurn(
 		return blocked(
 			426,
 			'free_chat_client_update_required',
-			'Update screenpipe to use the free hosted chat allowance.',
+			'Update screenpipe to use the free AI chat allowance.',
 		);
 	}
 
@@ -458,7 +458,7 @@ export async function prepareFreeChatTurn(
 		return blocked(
 			400,
 			'invalid_free_chat_turn',
-			'A hosted chat request must contain a user message.',
+			'An AI chat request must contain a user message.',
 		);
 	}
 
@@ -590,7 +590,7 @@ export async function reserveFreeChatTurn(
 			error: {
 				status: 429,
 				code: 'free_chat_limit_exceeded',
-				message: `You've used today's ${FREE_CHAT_MESSAGE_LIMIT} free hosted AI messages. Try again tomorrow, upgrade, or use your own AI provider.`,
+				message: `You've used today's ${FREE_CHAT_MESSAGE_LIMIT} free AI messages. Try again tomorrow, upgrade, or use your own AI provider.`,
 			},
 		};
 	} catch (error) {
@@ -600,7 +600,7 @@ export async function reserveFreeChatTurn(
 			error: {
 				status: 503,
 				code: 'free_chat_control_unavailable',
-				message: 'Free hosted AI controls are temporarily unavailable. Try again shortly or use your own AI provider.',
+				message: 'Free AI controls are temporarily unavailable. Try again shortly or use your own AI provider.',
 			},
 		};
 	}
@@ -680,7 +680,7 @@ export async function acquireFreeChatLease(
 				error: {
 					status: 429,
 					code: 'free_chat_request_in_flight',
-					message: 'Another free hosted chat request is still running. Wait for it to finish before continuing.',
+					message: 'Another free AI chat request is still running. Wait for it to finish before continuing.',
 				},
 			};
 		}
@@ -692,7 +692,7 @@ export async function acquireFreeChatLease(
 			error: {
 				status: 503,
 				code: 'free_chat_control_unavailable',
-				message: 'Free hosted AI controls are temporarily unavailable. Try again shortly or use your own AI provider.',
+				message: 'Free AI controls are temporarily unavailable. Try again shortly or use your own AI provider.',
 			},
 		};
 	}
@@ -753,7 +753,7 @@ export async function reserveFreeChatBudget(
 				error: {
 					status: 429,
 					code: 'free_chat_daily_budget_exceeded',
-					message: "Today's free hosted AI budget has been used. Try again tomorrow, upgrade, or use your own AI provider.",
+					message: "Today's free AI budget has been used. Try again tomorrow, upgrade, or use your own AI provider.",
 				},
 			};
 		}
@@ -766,7 +766,7 @@ export async function reserveFreeChatBudget(
 			error: {
 				status: 503,
 				code: 'free_chat_budget_unavailable',
-				message: 'Free hosted AI controls are temporarily unavailable. Try again shortly or use your own AI provider.',
+				message: 'Free AI controls are temporarily unavailable. Try again shortly or use your own AI provider.',
 			},
 		};
 	}

--- a/packages/ai-gateway/src/services/hosted-ai-errors.ts
+++ b/packages/ai-gateway/src/services/hosted-ai-errors.ts
@@ -40,7 +40,7 @@ export function modelNotAllowedResponse(auth: AuthResult, model: string): Respon
 		error: 'model_not_allowed',
 		message: requiredPlan
 			? `Model "${model}" requires ${requiredPlan === 'basic' ? 'Basic' : 'Business'}. Choose an included model or upgrade.`
-			: `Model "${model}" is not available through hosted AI. Choose another model or use your own provider key.`,
+			: `Model "${model}" is not available through screenpipe cloud. Choose another model or use your own provider key.`,
 		plan: currentPlan ?? 'unknown',
 		required_plan: requiredPlan,
 		allowed_models: allowedModels,
@@ -64,7 +64,7 @@ export function paidHostedAiRouteError(auth: AuthResult): Response | null {
 			? 'authentication_required'
 			: 'free_plan_alternate_hosted_ai_disabled',
 		message: auth.tier === 'anonymous'
-			? 'Sign in to use screenpipe hosted AI.'
+			? 'Sign in to use screenpipe AI.'
 			: 'The daily two-message free allowance is available in screenpipe chat. Use your own Claude, Codex, Ollama, or provider credentials for unlimited local/BYOK use.',
 	});
 }
@@ -72,7 +72,7 @@ export function paidHostedAiRouteError(auth: AuthResult): Response | null {
 export function internalServerErrorResponse(errorId: string): Response {
 	return addCorsHeaders(createErrorResponse(500, JSON.stringify({
 		error: 'internal_error',
-		message: 'The hosted AI request failed unexpectedly. Try again shortly.',
+		message: 'The AI request failed unexpectedly. Try again shortly.',
 		request_id: errorId,
 	})));
 }

--- a/packages/ai-gateway/src/test/cloudflare-chat-routing.unit.test.ts
+++ b/packages/ai-gateway/src/test/cloudflare-chat-routing.unit.test.ts
@@ -140,8 +140,8 @@ describe('Cloudflare hosted-chat routing', () => {
 			expect(json.required_plan).toBe(requiredPlan);
 			expect(json.upgrade_url).toBe(upgradeUrl);
 			expect(json.error.message).toBe(requiredPlan
-				? 'Your hosted AI usage limit is reached. Switch to Auto or upgrade.'
-				: 'Your hosted AI usage limit is reached. Switch to Auto.');
+				? 'Your AI usage limit is reached. Switch to Auto or upgrade.'
+				: 'Your AI usage limit is reached. Switch to Auto.');
 			expect(json.error.message).not.toMatch(/explicit|allowance for Auto/i);
 			expect(JSON.stringify(json)).not.toMatch(/usd|dollar|amount/i);
 


### PR DESCRIPTION
## Problem

"Hosted AI" is internal vocabulary that leaked into shipped product copy. Users don't care where inference runs — they see "AI". The desktop chat banner read **"Weekly hosted AI limit reached"**, and the same phrasing repeated across ~40 strings in the app, the gateway responses that render verbatim in the app, and the docs.

## Where found

Louis flagged the chat quota banner. A sweep found the same term across five surfaces:

| surface | file |
|---|---|
| chat quota banner | `components/chat/standalone/upgrade-quota-banner.tsx` |
| chat/pipe error copy | `lib/chat/quota-errors.ts`, `lib/chat/provider-errors.ts` |
| Live View composer, trial modal | `live-view-ai-composer.tsx`, `card-ask-modal.tsx` |
| gateway 4xx/5xx `message` bodies | `packages/ai-gateway/src/{index,handlers/chat,services/*}.ts` |
| docs | `README.md`, `changelog.mdx` |

## Before / after

```
BEFORE                                                   AFTER
──────────────────────────────────────────────────────   ──────────────────────────────────────────────────
┌────────────────────────────────────────────┐           ┌────────────────────────────────────────────┐
│ ⚡ Weekly hosted AI limit reached           │           │ ⚡ Weekly AI limit reached                   │
│    92% used this week. Resets on Aug 17.   │           │    92% used this week. Resets on Aug 17.    │
│    Switch to Auto or upgrade.              │           │    Switch to Auto or upgrade.               │
└────────────────────────────────────────────┘           └────────────────────────────────────────────┘

"Hosted AI usage limit reached"                       →  "AI usage limit reached"
"Your hosted AI usage limit is reached. Switch to     →  "Your AI usage limit is reached. Switch to
 Auto or upgrade."                                        Auto or upgrade."
"Hosted AI didn't run this request because you've     →  "This request didn't run because you've used
 used today's hosted AI usage limit."                     today's AI usage limit."
"Another hosted AI request is finishing…"             →  "Another AI request is finishing…"
"Hosted AI limit reached"  (composer placeholder)     →  "AI limit reached"
"Full access to hosted AI, unlimited pipes…"          →  "Full access to AI, unlimited pipes…"
"You've used today's 2 free hosted AI messages."      →  "You've used today's 2 free AI messages."
```

Where the sentence is genuinely contrasting our inference with local/BYOK, it names the product instead of the hosting model:

```
"Hosted AI for background pipes is available on a     →  "screenpipe cloud AI for background pipes is
 paid plan. Use a local model or your own key."           available on a paid plan. Use a local model…"
"Hosted AI is temporarily paused by the global        →  "screenpipe cloud AI is temporarily paused by
 spend safety limit."                                     the global spend safety limit."
"Model X is not available through hosted AI."         →  "Model X is not available through screenpipe cloud."
```

Same retired word, swept for consistency: `hosted transcription` → `cloud transcription` (the app already says "cloud transcription" elsewhere), `Free hosted chat …` validation messages → `Free AI chat …`.

## Root cause

Copy drift — the gateway's internal `hosted_ai_*` naming was mirrored into display strings.

## Fix — what is and is not renamed

Display strings only. **Unchanged**, so the desktop↔gateway contract is byte-identical:

- machine error codes: `hosted_ai_allowance_exceeded`, `hosted_ai_capacity_reserved`, `free_plan_hosted_background_disabled`, …
- API fields (`usage.hosted_ai`), TS types (`HostedAiAllowance`), filenames, `data-testid`s, react-query keys
- `console.*` logs, internal `throw new Error(...)` config messages, code comments

Verified no runtime code branches on the display text — `classifyQuotaError` / `presentQuotaError` match on the machine codes above, never on prose. Three `pi.rs` test fixtures that embed a gateway `message` were updated so they stay a faithful copy of the payload; they assert on `retry_after_seconds`, so parsing is unaffected.

## Validation

| gate | result |
|---|---|
| `packages/ai-gateway` `bun test` | **942 pass, 0 fail** |
| app `bun run test:vitest` | **315 files pass** |
| app `bun run test:bun` | **233 pass, 0 fail** |
| `cargo test -p screenpipe-core --lib capacity` | **6/6 pass** (the tests over the edited fixtures) |
| `rustfmt --check pi.rs` | clean |
| `bun run e2e:coverage:check` | up to date |
| `git diff --check` | clean |

Test assertions on the old copy were updated in the same commit (`quota-errors`, `provider-errors`, `pipe-advisories`, `upgrade-quota-banner`, `brain-overview`, `advisory-overlay`, `cloudflare-chat-routing`, `free-chat-limit`).

**Not green, both pre-existing and unrelated:**
- `pi.rs` `test_ensure_pi_config_adds_ollama_provider` fails at `pi.rs:5136` on an Ollama provider count (`left: 2, right: 1`) — untouched code path.
- The Vitest suite needs `NODE_OPTIONS=--localstorage-file=…`; without it 7 untouched files fail in `beforeEach` on `localStorage.clear()`. With it, all 315 pass.

No app was launched — this is copy with no behavioural surface beyond the rendered strings, each covered by the unit tests above.

## Open question for review

`docs/mintlify/.../changelog.mdx` entries were reworded too, so docs match the shipped UI. Say the word if you'd rather leave historical changelog entries verbatim and I'll revert just those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)