### PR TITLE
fix(capture): bump sck-rs off an unmerged branch head onto main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8216,7 +8216,7 @@ dependencies = [
 [[package]]
 name = "sck-rs"
 version = "0.1.0"
-source = "git+https://github.com/screenpipe/sck-rs?rev=6deefba79619c2763f24cfbaaf4e08fa7e8302e0#6deefba79619c2763f24cfbaaf4e08fa7e8302e0"
+source = "git+https://github.com/screenpipe/sck-rs?rev=e3ec9f6bb2f08b7747a2bd2edc003c1b674d0c9a#e3ec9f6bb2f08b7747a2bd2edc003c1b674d0c9a"
 dependencies = [
  "cidre 0.16.1 (git+https://github.com/yury/cidre.git?rev=9c20f5ee5abaad4598843a33e13d6e48822d1f30)",
  "image",

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -11075,7 +11075,7 @@ dependencies = [
 [[package]]
 name = "sck-rs"
 version = "0.1.0"
-source = "git+https://github.com/screenpipe/sck-rs?rev=6deefba79619c2763f24cfbaaf4e08fa7e8302e0#6deefba79619c2763f24cfbaaf4e08fa7e8302e0"
+source = "git+https://github.com/screenpipe/sck-rs?rev=e3ec9f6bb2f08b7747a2bd2edc003c1b674d0c9a#e3ec9f6bb2f08b7747a2bd2edc003c1b674d0c9a"
 dependencies = [
  "cidre 0.16.1 (git+https://github.com/yury/cidre.git?rev=9c20f5ee5abaad4598843a33e13d6e48822d1f30)",
  "image 0.25.10",

--- a/crates/screenpipe-screen/Cargo.toml
+++ b/crates/screenpipe-screen/Cargo.toml
@@ -77,7 +77,7 @@ harness = false
 
 # macOS: sck-rs for 12.3+ (ScreenCaptureKit), xcap as fallback for older versions
 [target.'cfg(target_os = "macos")'.dependencies]
-sck-rs = { git = "https://github.com/screenpipe/sck-rs" , rev = "6deefba79619c2763f24cfbaaf4e08fa7e8302e0"}
+sck-rs = { git = "https://github.com/screenpipe/sck-rs" , rev = "e3ec9f6bb2f08b7747a2bd2edc003c1b674d0c9a"}
 xcap = { workspace = true }
 libc = { workspace = true }
 cidre = { git = "https://github.com/yury/cidre.git", rev = "8481f3f0dc7dd39bb5be80d9424bfac0cad3801a", features = ["vn", "cv", "cg", "app"] }

--- a/packages/sdk/Cargo.lock
+++ b/packages/sdk/Cargo.lock
@@ -6721,7 +6721,7 @@ dependencies = [
 [[package]]
 name = "sck-rs"
 version = "0.1.0"
-source = "git+https://github.com/screenpipe/sck-rs?rev=6deefba79619c2763f24cfbaaf4e08fa7e8302e0#6deefba79619c2763f24cfbaaf4e08fa7e8302e0"
+source = "git+https://github.com/screenpipe/sck-rs?rev=e3ec9f6bb2f08b7747a2bd2edc003c1b674d0c9a#e3ec9f6bb2f08b7747a2bd2edc003c1b674d0c9a"
 dependencies = [
  "cidre 0.16.1 (git+https://github.com/yury/cidre.git?rev=9c20f5ee5abaad4598843a33e13d6e48822d1f30)",
  "image",

--- a/packages/sdk/examples/tauri-app/src-tauri/Cargo.lock
+++ b/packages/sdk/examples/tauri-app/src-tauri/Cargo.lock
@@ -6847,7 +6847,7 @@ dependencies = [
 [[package]]
 name = "sck-rs"
 version = "0.1.0"
-source = "git+https://github.com/screenpipe/sck-rs?rev=6deefba79619c2763f24cfbaaf4e08fa7e8302e0#6deefba79619c2763f24cfbaaf4e08fa7e8302e0"
+source = "git+https://github.com/screenpipe/sck-rs?rev=e3ec9f6bb2f08b7747a2bd2edc003c1b674d0c9a#e3ec9f6bb2f08b7747a2bd2edc003c1b674d0c9a"
 dependencies = [
  "cidre 0.16.1 (git+https://github.com/yury/cidre.git?rev=9c20f5ee5abaad4598843a33e13d6e48822d1f30)",
  "image",


### PR DESCRIPTION
## Problem

`crates/screenpipe-screen/Cargo.toml` pinned sck-rs to `6deefba79619c2763f24cfbaaf4e08fa7e8302e0`.

That SHA is the **branch head of sck-rs PR #17** (`codex/hd-backpressure-before-rgba`). Upstream squash-merged that PR as `63cdddc`, so the pinned commit is **not an ancestor of sck-rs main**:

```
$ git merge-base --is-ancestor 6deefba origin/main ; echo $?
1
$ git branch -a --contains 6deefba
  remotes/origin/codex/hd-backpressure-before-rgba
```

Consequence: every sck-rs fix merged after #17 has been invisible to screenpipe since 2026-07-29. Two of them are exactly the failures we are seeing in production.

## What the bump picks up

**`7a923e3` — #18, bound concurrent ScreenCaptureKit calls so the leak guard actually holds**

Admission was `WEDGED_SCK_CALLS.load()` at entry, with `fetch_add()` only seconds later when the call missed its deadline. A burst of callers all observe zero wedged calls and all spawn; every one of them then wedges. The cap was advisory.

Observed on a macOS machine here:
```
abandoning worker (5 wedged)   × 5
abandoning worker (6 wedged)   × 2      ← MAX_WEDGED_SCK_CALLS = 4
```
Upstream replaces it with a CAS reservation (`try_reserve_live_call`, `MAX_LIVE_SCK_CALLS = 6`) taken **before** the thread spawns, sized above normal concurrency so healthy bursts are never rejected.

**`e3ec9f6` — #19, make the wedged-call gate recoverable instead of permanent**

Once the cap was reached, the only decrement was a wedged call eventually returning. When the daemon never answers — the exact scenario the guard exists for — the gate stayed shut for the life of the process and capture never returned. A reporter's log shows 463 consecutive `already wedged` skips with zero recoveries.

Upstream adds a half-open probe (`evaluate_wedge_gate`, one probe caller per interval), a breaker reset on any completion, and a `MAX_LEAKED_SCK_THREADS = 32` hard ceiling.

## Scope

```
 src/capture.rs | 414 ++++++++++++++++++++++++++++++++++-
 1 file changed, 409 insertions(+), 5 deletions(-)
```

**No public API change** — `git diff` over `src/` produces zero `pub fn` / `pub struct` / `pub enum` / `pub const` signature changes, so this is a drop-in.

The pin moves to a full SHA on main rather than a branch head, so this cannot silently drift again.

## Validation

- `cargo check -p screenpipe-screen` against the new rev: clean
- `cargo test -p screenpipe-screen`: **221 passed, 0 failed** across 11 suites
- `./scripts/regenerate-locks.sh`: all four workspace lockfiles updated; every `Cargo.lock` references the new rev and none references the old one
- `cargo metadata --locked --no-deps` passes at the workspace root **and** in `apps/screenpipe-app-tauri/src-tauri` (the hard CI gate)

**Not verified on affected hardware.** Upstream owns the tests for #18/#19; what this PR proves is that screenpipe builds and passes against the new rev. The behavioural proof is the reporter's `already wedged` streak ending and the wedge count no longer exceeding its cap.

## Related

- #6121 — tray preview stops driving ~2.5 SCK stream creations/sec
- #6122 — monitor lookups served from a recent enumeration

Those two reduce the *call volume* into sck-rs. This PR fixes what sck-rs does when the daemon is slow anyway. They are independent and complementary; this one is the smallest of the three and arguably the highest leverage, since it also restores recovery without an app restart.
