### PR TITLE
fix(pi): bump managed runtime to v0.84.1

### DIFF
--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -16,8 +16,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing::{debug, error, info, warn};
 
-pub const PI_PACKAGE: &str = "@earendil-works/pi-coding-agent@0.83.0";
-pub const PI_AI_PACKAGE: &str = "@earendil-works/pi-ai@0.83.0";
+pub const PI_PACKAGE: &str = "@earendil-works/pi-coding-agent@0.84.1";
+pub const PI_AI_PACKAGE: &str = "@earendil-works/pi-ai@0.84.1";
 pub const PI_NAMESPACE_DIR: &str = "@earendil-works";
 pub const SCREENPIPE_API_URL: &str = "https://api.screenpipe.com/v1";
 const PI_INSTALL_ARGS: [&str; 5] = [


### PR DESCRIPTION
## Summary

- bump the managed `@earendil-works/pi-coding-agent` runtime from `0.83.0` to `0.84.1`
- bump the directly pinned `@earendil-works/pi-ai` runtime in lockstep
- pick up Pi's upstream malformed-package-manifest fix ([earendil-works/pi#7187](https://github.com/earendil-works/pi/issues/7187)), instead of maintaining a Screenpipe-side manifest rewriter

```text
Screenpipe managed Pi
0.83.0  ──▶  0.84.1
                └─ validates malformed `pi` resource arrays before package resolution
```

## Compatibility

Pi v0.84.0 changed RPC `message_update` events by removing cumulative message/partial fields. Screenpipe consumes the retained `assistantMessageEvent` deltas and authoritative `message_end.message`, and does not reference `assistantMessageEvent.partial`, so the managed desktop RPC path remains compatible.

## Verification

- RED/GREEN pin assertion: failed against `0.83.0`, then passed for both `0.84.1` pins
- npm registry artifact checks: HTTP 200 for both exact `0.84.1` packages
- `cargo fmt --all -- --check`
- `cargo test -p screenpipe-core agents::pi --lib` — 47 passed, 0 failed, 1 ignored
- `git diff --check`
