### PR TITLE
fix(card-ask): emit card_ask_shown once per opening

### DIFF
--- a/apps/screenpipe-app-tauri/components/__tests__/card-ask-modal.test.tsx
+++ b/apps/screenpipe-app-tauri/components/__tests__/card-ask-modal.test.tsx
@@ -165,3 +165,33 @@ describe("CardAskModal", () => {
     await waitFor(() => expect(openUrl).toHaveBeenCalledTimes(1));
   });
 });
+
+describe("CardAskModal shown-event idempotence", () => {
+  // Regression: `isFirstAsk` is derived from a mutable ref in useCardAsk and is
+  // in this effect's dependency array. On a user's second ask it flips
+  // true -> false, the deps change while the modal is still open, and the
+  // effect re-runs — emitting card_ask_shown twice for ONE modal.
+  //
+  // Observed in production: one user, trigger grant_expiry, two events at the
+  // same second from one machine. It inflates the exposure denominator, so
+  // every rate computed from card_ask_shown reads low.
+  it("emits card_ask_shown once per opening when isFirstAsk flips", () => {
+    const { rerender } = render(
+      <CardAskModal {...base} trigger="grant_expiry" isFirstAsk={true} />,
+    );
+    expect(names().filter((n) => n === "card_ask_shown")).toHaveLength(1);
+
+    // Same modal, still open, isFirstAsk recomputed to false.
+    rerender(<CardAskModal {...base} trigger="grant_expiry" isFirstAsk={false} />);
+    expect(names().filter((n) => n === "card_ask_shown")).toHaveLength(1);
+  });
+
+  it("still reports a genuinely new opening", () => {
+    const { rerender } = render(
+      <CardAskModal {...base} trigger="first_value" isFirstAsk={true} />,
+    );
+    rerender(<CardAskModal {...base} trigger={null} isFirstAsk={true} />);
+    rerender(<CardAskModal {...base} trigger="grant_expiry" isFirstAsk={false} />);
+    expect(names().filter((n) => n === "card_ask_shown")).toHaveLength(2);
+  });
+});

--- a/apps/screenpipe-app-tauri/components/card-ask-modal.tsx
+++ b/apps/screenpipe-app-tauri/components/card-ask-modal.tsx
@@ -76,11 +76,22 @@ export function CardAskModal({
   const [busy, setBusy] = useState(false);
   const open = trigger !== null && arm !== null;
 
+  // Which opening has already been reported. `isFirstAsk` is derived from a
+  // mutable ref in useCardAsk, so it can flip true -> false on a later render
+  // while this modal stays open — on a user's second ask it always does. That
+  // changes this effect's deps and re-runs it, emitting a second
+  // `card_ask_shown` for a single modal and inflating the exposure
+  // denominator every rate is computed from.
+  const reportedTriggerRef = useRef<CardAskTrigger | null>(null);
+
   useEffect(() => {
     if (!open || !trigger || !arm) {
       shownAtRef.current = null;
+      reportedTriggerRef.current = null;
       return;
     }
+    if (reportedTriggerRef.current === trigger) return;
+    reportedTriggerRef.current = trigger;
     shownAtRef.current = Date.now();
     cardAskEvents.shown({ arm, trigger, os, isFirstAsk });
   }, [open, trigger, arm, os, isFirstAsk]);


### PR DESCRIPTION
## one modal, two exposures

Found while monitoring the live experiment. A single user, trigger `grant_expiry`, **two `card_ask_shown` events at the same second from one machine**:

```
distinct_id  1aed2f45…  grant_expiry  n=2  first 21:48:28  last 21:48:28  machines=1
```

Same second, one machine, so not two asks. One modal reporting twice.

## cause

```tsx
// use-card-ask.tsx
const isFirstAsk = shownRef.current.length <= 1;   // derived from a mutable ref

// card-ask-modal.tsx
useEffect(() => {
  ...
  cardAskEvents.shown({ arm, trigger, os, isFirstAsk });
}, [open, trigger, arm, os, isFirstAsk]);          // ← isFirstAsk in deps
```

On a user's **second** ask, `markShown` pushes the trigger, `length` goes 1→2, and `isFirstAsk` flips `true`→`false` on a later render while the modal is still open. Deps changed, effect re-runs, second event fires.

## why it matters

`card_ask_shown` is the denominator of the primary exposure metric. This **inflates exposure and understates every rate derived from it** — the checkout-open rate being reported is a floor, not the real number.

It also grows over time. It triggers specifically on the second ask, and `grant_expiry` is only now starting to fire for the cardless grant holders this experiment exists to reach.

**No user impact.** The once-per-install guard is untouched, nobody saw a second modal, no extra ask was shown. Measurement only.

## fix

Track which opening has already been reported so the emit is idempotent per opening, regardless of dependency churn. `isFirstAsk` stays in the deps (removing it trips `exhaustive-deps`) and is now harmless.

## tests

Two new, and I wrote the failing one first:

```
✗ emits card_ask_shown once per opening when isFirstAsk flips   ← fails on parent, passes here
✓ still reports a genuinely new opening                          ← guards the over-correction
```

The second exists because the cheap fix (fire once ever) would silently stop reporting the `grant_expiry` ask entirely, which would be worse than double-counting. 79 pass across the card-ask suite. Typecheck and eslint clean.

## note on the numbers

Historical `card_ask_shown` counts are inflated by this for any user who reached a second ask. Small so far (one user), but exposure and rates from before this lands should be treated as approximate rather than recomputed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
