### PR TITLE
fix(auth): send onboarding intent to login

### DIFF
--- a/apps/screenpipe-app-tauri/components/app-entitlement-gate.test.tsx
+++ b/apps/screenpipe-app-tauri/components/app-entitlement-gate.test.tsx
@@ -802,7 +802,7 @@ describe("AppEntitlementGate", () => {
     );
     expect(mocks.setCloudToken).toHaveBeenCalledWith(null);
     expect(mocks.piUpdateConfig).toHaveBeenCalledWith(null, null);
-    expect(mocks.openLoginWindow).toHaveBeenCalledWith(true);
+    expect(mocks.openLoginWindow).toHaveBeenCalledWith(true, null);
   });
 
   it("does not route enterprise members away when they also have a consumer app subscription", () => {

--- a/apps/screenpipe-app-tauri/components/app-entitlement-gate.tsx
+++ b/apps/screenpipe-app-tauri/components/app-entitlement-gate.tsx
@@ -420,7 +420,7 @@ export function AppEntitlementGate({
 
   const openLogin = useCallback(() => {
     posthog.capture("app_entitlement_login_clicked");
-    commands.openLoginWindow(null);
+    commands.openLoginWindow(null, null);
   }, []);
 
   const refreshUser = useCallback(async () => {
@@ -453,7 +453,7 @@ export function AppEntitlementGate({
     } catch (e) {
       console.warn("failed to clear pi config before switching accounts:", e);
     }
-    commands.openLoginWindow(true);
+    commands.openLoginWindow(true, null);
   }, [updateSettings]);
 
   const downloadEnterpriseApp = useCallback(() => {

--- a/apps/screenpipe-app-tauri/components/login-dialog.tsx
+++ b/apps/screenpipe-app-tauri/components/login-dialog.tsx
@@ -26,7 +26,7 @@ export function LoginDialog() {
           <Button
             variant="default"
             onClick={() => {
-              commands.openLoginWindow(null);
+              commands.openLoginWindow(null, null);
               setIsOpen(false);
             }}
           >

--- a/apps/screenpipe-app-tauri/components/onboarding/login-gate.test.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/login-gate.test.tsx
@@ -235,6 +235,18 @@ describe("onboarding login gate", () => {
     expect(screen.getByTestId("login-cta-icon")).toBeInTheDocument();
   });
 
+  it("opens account creation directly for consumer onboarding", async () => {
+    mocks.settings = { user: null };
+    mocks.openLoginWindow.mockResolvedValue({ status: "ok", data: "" });
+
+    render(<OnboardingLogin handleNextSlide={vi.fn()} />);
+    fireEvent.click(screen.getByTestId("login-cta"));
+
+    await waitFor(() =>
+      expect(mocks.openLoginWindow).toHaveBeenCalledWith(null, "sign-up"),
+    );
+  });
+
   // Everyone reaching this slide on a consumer build is a fresh install with
   // no account. Labelling the only affordance "sign in" tells them the app is
   // for people who already have one, and nothing on the slide offered to
@@ -264,6 +276,18 @@ describe("onboarding login gate", () => {
     expect(screen.getByText(/^sign in$/i)).toBeInTheDocument();
     expect(screen.queryByText(/^get started$/i)).toBeNull();
     expect(screen.queryByText(/create a free account/i)).toBeNull();
+  });
+
+  it("opens sign in directly for managed enterprise onboarding", async () => {
+    mocks.settings = { user: null };
+    mocks.openLoginWindow.mockResolvedValue({ status: "ok", data: "" });
+
+    render(<OnboardingLogin handleNextSlide={vi.fn()} suppressAutoAdvance />);
+    fireEvent.click(screen.getByTestId("login-cta"));
+
+    await waitFor(() =>
+      expect(mocks.openLoginWindow).toHaveBeenCalledWith(null, "sign-in"),
+    );
   });
 
   it("labels sign-in as the enterprise-account option during enterprise onboarding", () => {
@@ -342,7 +366,7 @@ describe("onboarding login gate", () => {
 
     // `true` requests the isolated-profile WebView, the one path that still
     // works when the default browser is unusable.
-    expect(mocks.openLoginWindow).toHaveBeenCalledWith(true);
+    expect(mocks.openLoginWindow).toHaveBeenCalledWith(true, "sign-up");
     expect(mocks.capture).toHaveBeenCalledWith(
       "onboarding_login_webview_fallback_clicked",
     );
@@ -386,6 +410,6 @@ describe("onboarding login gate", () => {
     await waitFor(() =>
       expect(screen.queryByTestId("login-browser-failure")).toBeNull(),
     );
-    expect(mocks.openLoginWindow).toHaveBeenCalledWith(null);
+    expect(mocks.openLoginWindow).toHaveBeenCalledWith(null, "sign-up");
   });
 });

--- a/apps/screenpipe-app-tauri/components/onboarding/login-gate.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/login-gate.tsx
@@ -289,14 +289,15 @@ const OnboardingLogin: React.FC<OnboardingLoginProps> = ({
     // already have with Google/etc. is reused instead of asking them to
     // re-type credentials into a cold embedded WebView. Either way the token
     // comes back on the screenpipe:// deep link; nothing is typed by hand.
+    const authMode = suppressAutoAdvance ? "sign-in" : "sign-up";
     void commands
-      .openLoginWindow(null)
+      .openLoginWindow(null, authMode)
       .then((result) => {
         if (result.status === "ok") setAwaitingBrowser(true);
         else setBrowserFailure("failed");
       })
       .catch(() => setBrowserFailure("failed"));
-  }, []);
+  }, [suppressAutoAdvance]);
 
   // Escape hatch when the default browser is unusable or the user never
   // returns to it — falls back to the in-app WebView.
@@ -304,8 +305,9 @@ const OnboardingLogin: React.FC<OnboardingLoginProps> = ({
     posthog.capture("onboarding_login_webview_fallback_clicked");
     setAwaitingBrowser(false);
     setBrowserFailure(null);
-    void commands.openLoginWindow(true);
-  }, []);
+    const authMode = suppressAutoAdvance ? "sign-in" : "sign-up";
+    void commands.openLoginWindow(true, authMode);
+  }, [suppressAutoAdvance]);
 
   const handleSkip = useCallback(() => {
     posthog.capture("onboarding_login_skipped_dev");

--- a/apps/screenpipe-app-tauri/components/settings/account-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/account-section.tsx
@@ -322,7 +322,7 @@ export function AccountSection() {
         offer_version: selection.offerVersion,
         pricing_experiment_variant: selection.experimentVariant,
       });
-      await commands.openLoginWindow(null);
+      await commands.openLoginWindow(null, null);
       return;
     }
 
@@ -501,7 +501,7 @@ export function AccountSection() {
             <Button
               variant="outline"
               size="sm"
-              onClick={() => commands.openLoginWindow(null)}
+              onClick={() => commands.openLoginWindow(null, null)}
             >
               login <ExternalLinkIcon className="w-3.5 h-3.5 ml-1.5" />
             </Button>
@@ -808,7 +808,7 @@ export function AccountSection() {
             <Button
               className="w-full max-w-xs bg-foreground text-background hover:bg-background hover:text-foreground transition-colors duration-150"
               size="lg"
-              onClick={() => commands.openLoginWindow(null)}
+              onClick={() => commands.openLoginWindow(null, null)}
             >
               Log in
               <ExternalLinkIcon className="w-4 h-4 ml-2" />

--- a/apps/screenpipe-app-tauri/components/settings/referral-card.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/referral-card.test.tsx
@@ -167,6 +167,6 @@ describe("ReferralCard", () => {
     render(<ReferralCard />);
 
     fireEvent.click(screen.getByRole("button", { name: /^sign in$/i }));
-    expect(mocks.openLoginWindow).toHaveBeenCalledWith(null);
+    expect(mocks.openLoginWindow).toHaveBeenCalledWith(null, null);
   });
 });

--- a/apps/screenpipe-app-tauri/components/settings/referral-card.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/referral-card.tsx
@@ -102,7 +102,7 @@ export function ReferralCard() {
         <Button
           variant="outline"
           size="sm"
-          onClick={() => commands.openLoginWindow(null)}
+          onClick={() => commands.openLoginWindow(null, null)}
         >
           sign in
         </Button>

--- a/apps/screenpipe-app-tauri/components/standalone-chat.tsx
+++ b/apps/screenpipe-app-tauri/components/standalone-chat.tsx
@@ -630,7 +630,7 @@ export function StandaloneChat({
     });
 
     try {
-      await commands.openLoginWindow(null);
+      await commands.openLoginWindow(null, null);
     } catch (e) {
       console.warn("failed to open login after Pi auth error:", e);
     }
@@ -2071,7 +2071,7 @@ export function StandaloneChat({
         hasValidModel={hasValidModel}
         needsLogin={needsLogin}
         onOpenLogin={async () => {
-          await commands.openLoginWindow(null);
+          await commands.openLoginWindow(null, null);
         }}
         onOpenSettings={async () => {
           await commands.showWindow({ Home: { page: null } });

--- a/apps/screenpipe-app-tauri/lib/utils/tauri.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/tauri.ts
@@ -1184,9 +1184,9 @@ async openGoogleCalendarAuthWindow(authUrl: string) : Promise<Result<null, strin
  * taught onboarding to show one; every other login surface silently opened a
  * browser asking for a code nothing displayed.
  */
-async openLoginWindow(freshSession: boolean | null) : Promise<Result<string, string>> {
+async openLoginWindow(freshSession: boolean | null, authMode: LoginMode | null) : Promise<Result<string, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("open_login_window", { freshSession }) };
+    return { status: "ok", data: await TAURI_INVOKE("open_login_window", { freshSession, authMode }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -2915,6 +2915,7 @@ export type JobEvent = { kind: "started"; jobId: string; label: string; message:
 export type JsonValue = null | boolean | number | string | JsonValue[] | { [key in string]: JsonValue }
 export type KeychainStatus = { state: string }
 export type LogFile = { name: string; path: string; modified_at: number }
+export type LoginMode = "sign-in" | "sign-up"
 /**
  * Stable low-disk safety values shared with the settings UI.
  *

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -1623,6 +1623,81 @@ fn login_url() -> String {
     crate::web_base::screenpipe_web_url("/login")
 }
 
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, specta::Type, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum LoginMode {
+    SignIn,
+    SignUp,
+}
+
+impl LoginMode {
+    fn as_query_value(self) -> &'static str {
+        match self {
+            Self::SignIn => "sign-in",
+            Self::SignUp => "sign-up",
+        }
+    }
+}
+
+fn login_url_with_intent(
+    auth_mode: Option<LoginMode>,
+    return_scheme: Option<&str>,
+) -> Result<String, String> {
+    let mut url: tauri::Url = login_url()
+        .parse()
+        .map_err(|error| format!("invalid login URL: {error}"))?;
+    {
+        let mut query = url.query_pairs_mut();
+        if let Some(mode) = auth_mode {
+            query.append_pair("mode", mode.as_query_value());
+        }
+        if let Some(scheme) = return_scheme {
+            query.append_pair("return_scheme", scheme);
+        }
+    }
+    Ok(url.to_string())
+}
+
+#[cfg(test)]
+mod login_url_intent_tests {
+    use super::{login_url_with_intent, LoginMode};
+
+    #[test]
+    fn carries_explicit_signup_intent_and_return_scheme() {
+        let login_url = login_url_with_intent(Some(LoginMode::SignUp), Some("screenpipe"))
+            .expect("valid login URL");
+        let parsed: tauri::Url = login_url.parse().expect("parse generated login URL");
+        let pairs = parsed
+            .query_pairs()
+            .collect::<std::collections::HashMap<_, _>>();
+
+        assert_eq!(
+            pairs.get("mode").map(|value| value.as_ref()),
+            Some("sign-up")
+        );
+        assert_eq!(
+            pairs.get("return_scheme").map(|value| value.as_ref()),
+            Some("screenpipe")
+        );
+    }
+
+    #[test]
+    fn keeps_neutral_login_urls_free_of_mode() {
+        let login_url =
+            login_url_with_intent(None, Some("screenpipe-enterprise")).expect("valid login URL");
+        let parsed: tauri::Url = login_url.parse().expect("parse generated login URL");
+        let pairs = parsed
+            .query_pairs()
+            .collect::<std::collections::HashMap<_, _>>();
+
+        assert!(!pairs.contains_key("mode"));
+        assert_eq!(
+            pairs.get("return_scheme").map(|value| value.as_ref()),
+            Some("screenpipe-enterprise")
+        );
+    }
+}
+
 /// The custom URL scheme this build registers for deep links. The enterprise
 /// build uses a distinct scheme so it does not collide with the consumer app's
 /// `screenpipe://` on machines that have both installed (see #3890). Login
@@ -1678,6 +1753,7 @@ fn reset_existing_login_window<R: tauri::Runtime>(
 pub async fn open_login_window(
     app_handle: tauri::AppHandle,
     fresh_session: Option<bool>,
+    auth_mode: Option<LoginMode>,
 ) -> Result<String, String> {
     let fresh_session = fresh_session.unwrap_or(false);
     #[cfg(target_os = "macos")]
@@ -1687,7 +1763,7 @@ pub async fn open_login_window(
         // with another installed build here (#3890) and stays correct until
         // the website honours `return_scheme`.
         let callback_url = match crate::auth_session::start_session(
-            login_url(),
+            login_url_with_intent(auth_mode, None)?,
             "screenpipe".to_string(),
             fresh_session,
         )
@@ -1735,7 +1811,7 @@ pub async fn open_login_window(
             // from the default browser, so none of that is necessary: the
             // deep-link handler (mounted outside the entitlement gate) receives
             // the token exactly as it does today.
-            let login_url = format!("{}?return_scheme={}", login_url(), deep_link_scheme());
+            let login_url = login_url_with_intent(auth_mode, Some(deep_link_scheme()))?;
             match app_handle
                 .opener()
                 .open_url(login_url.as_str(), None::<&str>)
@@ -1762,7 +1838,7 @@ pub async fn open_login_window(
             "login-browser".to_string()
         };
 
-        let login_url = format!("{}?return_scheme={}", login_url(), deep_link_scheme());
+        let login_url = login_url_with_intent(auth_mode, Some(deep_link_scheme()))?;
         let parsed_login_url = login_url
             .parse()
             .map_err(|e| format!("invalid login URL: {e}"))?;


### PR DESCRIPTION
## what changed

- extend the typed Tauri login command with an allowlisted `sign-up` / `sign-in` intent
- open account creation directly for consumer onboarding
- open sign-in directly for managed enterprise onboarding
- keep account recovery, referral, entitlement, and chat login surfaces neutral
- encode query parameters through `Url` rather than string concatenation
- regenerate and verify the checked-in Tauri TypeScript bindings

This pairs with screenpipe/website#748. Direct `/login` visits still show the explicit chooser; only callers that know the user's intent skip it.

## verification

- `bunx vitest run components/onboarding/login-gate.test.tsx components/app-entitlement-gate.test.tsx components/settings/referral-card.test.tsx` (63 tests pass)
- `cargo test -p screenpipe-app login_url_intent_tests --manifest-path src-tauri/Cargo.toml -- --nocapture` (2 tests pass)
- `bun run bindings:check` passes
- `bunx tsc --noEmit` passes
- `git diff --cached --check` passes
