### PR TITLE
fix(onboarding): collect payment only when missing

### DIFF
--- a/apps/screenpipe-app-tauri/app/onboarding/page.test.tsx
+++ b/apps/screenpipe-app-tauri/app/onboarding/page.test.tsx
@@ -24,7 +24,10 @@ const mocks = vi.hoisted(() => ({
   isSettingLocked: vi.fn((_key: string) => false),
   settings: {
     deviceTier: "low" as string | null | undefined,
-    user: null as null | { cloud_subscribed?: boolean },
+    user: null as null | {
+      cloud_subscribed?: boolean;
+      has_payment_method?: boolean;
+    },
   },
   isSettingsLoaded: true,
 }));
@@ -278,9 +281,27 @@ describe("enterprise onboarding authentication", () => {
     expect(screen.queryByText("plan selection")).not.toBeInTheDocument();
   });
 
-  it("does not show pricing to an existing paid consumer", async () => {
+  it("collects payment during a cardless trial", async () => {
     mocks.enterprisePolicy.isManagedDeployment = false;
-    mocks.settings.user = { cloud_subscribed: true };
+    mocks.settings.user = {
+      cloud_subscribed: true,
+      has_payment_method: false,
+    };
+    onboardingData.currentStep = "engine";
+
+    render(<OnboardingPage />);
+    fireEvent.click(await screen.findByRole("button", { name: "finish engine" }));
+
+    expect(await screen.findByText("plan selection")).toBeInTheDocument();
+    expect(mocks.completeOnboarding).not.toHaveBeenCalled();
+  });
+
+  it("does not collect payment when the account already has a payment method", async () => {
+    mocks.enterprisePolicy.isManagedDeployment = false;
+    mocks.settings.user = {
+      cloud_subscribed: true,
+      has_payment_method: true,
+    };
     onboardingData.currentStep = "engine";
 
     render(<OnboardingPage />);

--- a/apps/screenpipe-app-tauri/app/onboarding/page.tsx
+++ b/apps/screenpipe-app-tauri/app/onboarding/page.tsx
@@ -19,6 +19,7 @@ import { EnterpriseLicensePrompt } from "@/components/enterprise-license-prompt"
 import posthog from "posthog-js";
 import { commands } from "@/lib/utils/tauri";
 import { onboardingFunnel } from "@/lib/analytics/onboarding-funnel";
+import type { AppUser } from "@/lib/app-entitlement";
 
 type SlideKey =
   | "login"
@@ -127,6 +128,7 @@ export default function OnboardingPage() {
   );
   const { onboardingData, isLoading, completeOnboarding } = useOnboarding();
   const { settings, isSettingsLoaded } = useSettings();
+  const user = settings.user as AppUser | null | undefined;
   const completedForHiddenUiRef = React.useRef(false);
   const transitioningRef = React.useRef(false);
   const funnelStartedRef = React.useRef(false);
@@ -162,7 +164,7 @@ export default function OnboardingPage() {
       ? settings.deviceTier
       : "unknown";
   const shouldShowPlanSelection =
-    !isManagedDeployment && settings.user?.cloud_subscribed !== true;
+    !isManagedDeployment && user?.has_payment_method !== true;
   const visibleOrder = useMemo(
     () =>
       SLIDE_ORDER.filter(

--- a/apps/screenpipe-app-tauri/components/onboarding/plan-selection-step.test.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/plan-selection-step.test.tsx
@@ -10,13 +10,19 @@ const mocks = vi.hoisted(() => ({
   loadUser: vi.fn(async () => undefined),
   capture: vi.fn(),
   fetch: vi.fn(),
+  settings: {
+    user: {
+      token: "token-1",
+      cloud_subscribed: true,
+      has_payment_method: false,
+      subscription_plan: "pro",
+    },
+  },
 }));
 
 vi.mock("@/lib/hooks/use-settings", () => ({
   useSettings: () => ({
-    settings: {
-      user: { token: "token-1", cloud_subscribed: false },
-    },
+    settings: mocks.settings,
     loadUser: mocks.loadUser,
   }),
 }));
@@ -29,6 +35,12 @@ import PlanSelectionStep from "./plan-selection-step";
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.settings.user = {
+    token: "token-1",
+    cloud_subscribed: true,
+    has_payment_method: false,
+    subscription_plan: "pro",
+  };
   vi.stubGlobal("fetch", mocks.fetch);
   mocks.fetch.mockImplementation(async (input: RequestInfo | URL) => ({
     ok: true,
@@ -40,6 +52,22 @@ beforeEach(() => {
 });
 
 describe("onboarding card capture", () => {
+  it("waits for a payment method even when the trial already has cloud access", async () => {
+    const next = vi.fn();
+    const view = render(<PlanSelectionStep handleNextSlide={next} />);
+
+    await waitFor(() => expect(mocks.fetch).toHaveBeenCalledOnce());
+    expect(next).not.toHaveBeenCalled();
+
+    mocks.settings.user = {
+      ...mocks.settings.user,
+      has_payment_method: true,
+    };
+    view.rerender(<PlanSelectionStep handleNextSlide={next} />);
+
+    await waitFor(() => expect(next).toHaveBeenCalledOnce());
+  });
+
   it("replaces plan cards with an embedded annual Business checkout", async () => {
     render(<PlanSelectionStep handleNextSlide={vi.fn()} />);
 

--- a/apps/screenpipe-app-tauri/components/onboarding/plan-selection-step.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/plan-selection-step.tsx
@@ -8,6 +8,7 @@ import { useEffect, useRef, useState } from "react";
 import posthog from "posthog-js";
 import { useSettings } from "@/lib/hooks/use-settings";
 import { screenpipeWebUrl } from "@/lib/web-url";
+import type { AppUser } from "@/lib/app-entitlement";
 
 const CHECKOUT_URL = screenpipeWebUrl(
   "/api/subscription/checkout",
@@ -30,6 +31,7 @@ export default function PlanSelectionStep({
   handleNextSlide: () => void | Promise<void>;
 }) {
   const { settings, loadUser } = useSettings();
+  const user = settings.user as AppUser | null | undefined;
   const [interval, setInterval] = useState<BillingInterval>("year");
   const [frameUrl, setFrameUrl] = useState<string | null>(null);
   const [busy, setBusy] = useState(true);
@@ -41,7 +43,7 @@ export default function PlanSelectionStep({
   const requestRef = useRef(0);
   const advancedRef = useRef(false);
   const loadUserRef = useRef(loadUser);
-  const userToken = settings.user?.token;
+  const userToken = user?.token;
   loadUserRef.current = loadUser;
 
   useEffect(() => {
@@ -150,17 +152,17 @@ export default function PlanSelectionStep({
 
   useEffect(() => {
     if (
-      settings.user?.cloud_subscribed !== true ||
+      user?.has_payment_method !== true ||
       advancedRef.current
     ) {
       return;
     }
     advancedRef.current = true;
     posthog.capture("onboarding_plan_activated", {
-      plan: settings.user.subscription_plan || "unknown",
+      plan: user.subscription_plan || "unknown",
     });
     void handleNextSlide();
-  }, [handleNextSlide, settings.user]);
+  }, [handleNextSlide, user?.has_payment_method, user?.subscription_plan]);
 
   const continueWithoutCard = async () => {
     if (!userToken || startingCardlessTrial) return;


### PR DESCRIPTION
## Summary

- show the onboarding payment step when the signed-in account has no saved payment method, including an active 7-day Business trial
- skip payment collection when `has_payment_method` is already true
- preserve the managed-enterprise onboarding bypass
- advance after checkout only when the refreshed account reports a saved payment method

## Before / after

```text
before: sign up -> trial starts -> cloud access skips card collection -> app
after:  sign up -> trial starts -> collect card if missing -> app
                              \-> skip if already saved
```

## Usage audit

- `app/onboarding/page.tsx` -> same defect: slide visibility used `cloud_subscribed`; fixed to use `has_payment_method`
- `components/onboarding/plan-selection-step.tsx` -> same defect: checkout completion used `cloud_subscribed`; fixed to wait for `has_payment_method`
- `components/onboarding/engine-startup.tsx` -> safe: `cloud_subscribed` selects Pro engine behavior, not card collection
- `lib/card-ask/gating.ts` -> already correct: separate post-onboarding card ask uses the authoritative payment-method signal
- other `cloud_subscribed` usages -> safe: entitlement, upsell, and settings behavior outside onboarding payment collection

## Validation

- `bun x vitest run --config vitest.config.ts app/onboarding/page.test.tsx components/onboarding/plan-selection-step.test.tsx`
- 2 test files passed, 40 tests passed
- `git diff --check upstream/main...HEAD`