### PR TITLE
fix(onboarding): stop live view follow-up retrying a permanent failure forever

### DIFF
--- a/apps/screenpipe-app-tauri/lib/analytics/onboarding-h1-follow-up.ts
+++ b/apps/screenpipe-app-tauri/lib/analytics/onboarding-h1-follow-up.ts
@@ -10,7 +10,8 @@ type Stage =
   | "delivery_attempted"
   | "notification_accepted"
   | "delivery_skipped"
-  | "retry_scheduled";
+  | "retry_scheduled"
+  | "retry_exhausted";
 type Reason =
   | "none"
   | "view_missing"

--- a/apps/screenpipe-app-tauri/lib/live-views/__tests__/onboarding-follow-up.test.ts
+++ b/apps/screenpipe-app-tauri/lib/live-views/__tests__/onboarding-follow-up.test.ts
@@ -206,4 +206,54 @@ describe("onboarding Live View follow-up", () => {
       retryAt: "2026-07-30T20:05:00.000Z",
     });
   });
+
+  it("backs off and gives up after the attempt cap instead of looping forever", async () => {
+    const engineFetch = vi.fn().mockResolvedValue({ ok: false } as Response);
+    const notificationFetch = vi.fn().mockResolvedValue(okResponse());
+
+    let clock = now.getTime();
+    const delaysMin: number[] = [];
+    let lastStatus = "";
+    for (let i = 0; i < 20; i++) {
+      const runNow = new Date(clock);
+      const result = await runDueOnboardingLiveViewFollowUp({
+        now: () => runNow,
+        listViews: async () => [dashboard],
+        engineFetch,
+        notificationFetch,
+      });
+      lastStatus = result.status;
+      if (result.status !== "retry_scheduled") break;
+      const followUp = getOnboardingLiveViewActivation("first-dashboard")!
+        .followUp!;
+      delaysMin.push(Math.round((Date.parse(followUp.retryAt!) - clock) / 60_000));
+      clock = Date.parse(followUp.retryAt!);
+    }
+
+    expect(delaysMin).toEqual([5, 10, 20, 40, 60]);
+    expect(lastStatus).toBe("retries_exhausted");
+    expect(notificationFetch).not.toHaveBeenCalled();
+    expect(
+      getOnboardingLiveViewActivation("first-dashboard")?.followUp,
+    ).toMatchObject({ status: "failed", retryAt: null });
+
+    // A failed follow-up is terminal: no timer, and no further runs.
+    expect(
+      nextOnboardingLiveViewFollowUpAt(clock + 60 * 60 * 1_000),
+    ).toBeNull();
+    await expect(
+      runDueOnboardingLiveViewFollowUp({
+        now: () => new Date(clock + 60 * 60 * 1_000),
+        listViews: async () => [dashboard],
+        engineFetch,
+        notificationFetch,
+      }),
+    ).resolves.toEqual({ status: "idle" });
+    expect(
+      capture.mock.calls.some(
+        ([, props]: [string, { stage?: string }]) =>
+          props.stage === "retry_exhausted",
+      ),
+    ).toBe(true);
+  });
 });

--- a/apps/screenpipe-app-tauri/lib/live-views/onboarding-activation.ts
+++ b/apps/screenpipe-app-tauri/lib/live-views/onboarding-activation.ts
@@ -48,7 +48,8 @@ export type OnboardingLiveViewActivation = {
 
 export type OnboardingLiveViewFollowUp = {
   dueAt: string;
-  status: "scheduled" | "running" | "sent";
+  status: "scheduled" | "running" | "sent" | "failed";
+  attempts: number;
   retryAt: string | null;
   startedAt: string | null;
   sentAt: string | null;
@@ -88,6 +89,7 @@ function normalizeFollowUp(value: unknown): OnboardingLiveViewFollowUp | null {
   const status =
     followUp.status === "running" ||
     followUp.status === "sent" ||
+    followUp.status === "failed" ||
     followUp.status === "scheduled"
       ? followUp.status
       : "scheduled";
@@ -99,6 +101,10 @@ function normalizeFollowUp(value: unknown): OnboardingLiveViewFollowUp | null {
   return {
     dueAt: followUp.dueAt,
     status: runningIsStale ? "scheduled" : status,
+    attempts:
+      typeof followUp.attempts === "number" && Number.isFinite(followUp.attempts)
+        ? followUp.attempts
+        : 0,
     retryAt: runningIsStale ? null : (followUp.retryAt ?? null),
     startedAt: runningIsStale ? null : (followUp.startedAt ?? null),
     sentAt: followUp.sentAt ?? null,
@@ -278,6 +284,7 @@ export function markOnboardingLiveViewSetupReady(
     followUp: current.followUp ?? {
       dueAt: new Date(Date.now() + 60 * 60 * 1_000).toISOString(),
       status: "scheduled",
+      attempts: 0,
       retryAt: null,
       startedAt: null,
       sentAt: null,

--- a/apps/screenpipe-app-tauri/lib/live-views/onboarding-follow-up.ts
+++ b/apps/screenpipe-app-tauri/lib/live-views/onboarding-follow-up.ts
@@ -13,7 +13,14 @@ import { buildLiveViewTimeContext } from "@/lib/live-views/time-range";
 import { appServerFetch } from "@/lib/notifications/app-server";
 import { commands, type BrainViewDefinition } from "@/lib/utils/tauri";
 
-const FOLLOW_UP_RETRY_DELAY_MS = 5 * 60 * 1_000;
+const FOLLOW_UP_RETRY_BASE_MS = 5 * 60 * 1_000;
+const FOLLOW_UP_RETRY_MAX_MS = 60 * 60 * 1_000;
+const MAX_FOLLOW_UP_ATTEMPTS = 6;
+
+type FollowUpRetryReason =
+  | "no_pipe_started"
+  | "notification_rejected"
+  | "unexpected_failure";
 
 type FollowUpDependencies = {
   now?: () => Date;
@@ -26,6 +33,7 @@ export type OnboardingLiveViewFollowUpResult =
   | { status: "idle" }
   | { status: "notified"; viewId: string; pipeCount: number }
   | { status: "retry_scheduled"; viewId: string }
+  | { status: "retries_exhausted"; viewId: string }
   | { status: "view_missing"; viewId: string };
 
 function dueAt(activation: OnboardingLiveViewActivation): number | null {
@@ -63,13 +71,47 @@ function claimDueFollowUp(now: Date): OnboardingLiveViewActivation | null {
   return claimed?.followUp?.startedAt === startedAt ? claimed : null;
 }
 
-function scheduleRetry(viewId: string, now: Date): void {
+function retryDelayMs(attempts: number): number {
+  const backoff = FOLLOW_UP_RETRY_BASE_MS * 2 ** Math.max(0, attempts - 1);
+  return Math.min(backoff, FOLLOW_UP_RETRY_MAX_MS);
+}
+
+function scheduleRetry(viewId: string, now: Date, attempts: number): void {
   updateOnboardingLiveViewFollowUp(viewId, (followUp) => ({
     ...followUp,
     status: "scheduled",
-    retryAt: new Date(now.getTime() + FOLLOW_UP_RETRY_DELAY_MS).toISOString(),
+    attempts,
+    retryAt: new Date(now.getTime() + retryDelayMs(attempts)).toISOString(),
     startedAt: null,
   }));
+}
+
+function markFollowUpFailed(viewId: string, attempts: number): void {
+  updateOnboardingLiveViewFollowUp(viewId, (followUp) => ({
+    ...followUp,
+    status: "failed",
+    attempts,
+    retryAt: null,
+    startedAt: null,
+  }));
+}
+
+// A failed attempt schedules a backed-off retry until the cap, then gives up so
+// a permanently failing activation stops re-running every few minutes forever.
+function retryOrGiveUp(
+  activation: OnboardingLiveViewActivation,
+  now: Date,
+  reason: FollowUpRetryReason,
+): OnboardingLiveViewFollowUpResult {
+  const attempts = (activation.followUp?.attempts ?? 0) + 1;
+  if (attempts >= MAX_FOLLOW_UP_ATTEMPTS) {
+    markFollowUpFailed(activation.viewId, attempts);
+    captureOnboardingH1FollowUp("retry_exhausted", activation.goalCategory, reason);
+    return { status: "retries_exhausted", viewId: activation.viewId };
+  }
+  scheduleRetry(activation.viewId, now, attempts);
+  captureOnboardingH1FollowUp("retry_scheduled", activation.goalCategory, reason);
+  return { status: "retry_scheduled", viewId: activation.viewId };
 }
 
 function markFollowUpSent(viewId: string, now: Date): void {
@@ -224,13 +266,7 @@ export async function runDueOnboardingLiveViewFollowUp(
 
     const pipeCount = await startDashboardPipes(view, engineFetch);
     if (pipeCount === 0) {
-      scheduleRetry(activation.viewId, now);
-      captureOnboardingH1FollowUp(
-        "retry_scheduled",
-        activation.goalCategory,
-        "no_pipe_started",
-      );
-      return { status: "retry_scheduled", viewId: activation.viewId };
+      return retryOrGiveUp(activation, now, "no_pipe_started");
     }
 
     const notification = await notificationFetch("/notify", {
@@ -239,13 +275,7 @@ export async function runDueOnboardingLiveViewFollowUp(
       body: JSON.stringify(followUpNotification(view, activation)),
     });
     if (!notification.ok) {
-      scheduleRetry(activation.viewId, now);
-      captureOnboardingH1FollowUp(
-        "retry_scheduled",
-        activation.goalCategory,
-        "notification_rejected",
-      );
-      return { status: "retry_scheduled", viewId: activation.viewId };
+      return retryOrGiveUp(activation, now, "notification_rejected");
     }
 
     markFollowUpSent(activation.viewId, now);
@@ -255,12 +285,6 @@ export async function runDueOnboardingLiveViewFollowUp(
     );
     return { status: "notified", viewId: activation.viewId, pipeCount };
   } catch {
-    scheduleRetry(activation.viewId, now);
-    captureOnboardingH1FollowUp(
-      "retry_scheduled",
-      activation.goalCategory,
-      "unexpected_failure",
-    );
-    return { status: "retry_scheduled", viewId: activation.viewId };
+    return retryOrGiveUp(activation, now, "unexpected_failure");
   }
 }


### PR DESCRIPTION
the post-onboarding live view follow-up retried every 5 minutes with no cap, backoff, or deadline. an activation that can never start its dashboard pipe (permanent no_pipe_started) looped for the life of the install and never sent the notification.

now each failed attempt backs off (5, 10, 20, 40, 60 min) and after 6 attempts it stops and marks the follow-up failed, with a retry_exhausted analytics stage.

before: retryAt = now + 5min, forever
after:  bounded backoff, terminal after the cap

added a test covering the backoff sequence and give-up.

fixes #6117