### PR TITLE
chore(deps): bump sck-rs to the wedge-recovery fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8216,7 +8216,7 @@ dependencies = [
 [[package]]
 name = "sck-rs"
 version = "0.1.0"
-source = "git+https://github.com/screenpipe/sck-rs?rev=e3ec9f6bb2f08b7747a2bd2edc003c1b674d0c9a#e3ec9f6bb2f08b7747a2bd2edc003c1b674d0c9a"
+source = "git+https://github.com/screenpipe/sck-rs?rev=8f0c74ef35737463c9c05fcdff375633dc143788#8f0c74ef35737463c9c05fcdff375633dc143788"
 dependencies = [
  "cidre 0.16.1 (git+https://github.com/yury/cidre.git?rev=9c20f5ee5abaad4598843a33e13d6e48822d1f30)",
  "image",

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -11075,7 +11075,7 @@ dependencies = [
 [[package]]
 name = "sck-rs"
 version = "0.1.0"
-source = "git+https://github.com/screenpipe/sck-rs?rev=e3ec9f6bb2f08b7747a2bd2edc003c1b674d0c9a#e3ec9f6bb2f08b7747a2bd2edc003c1b674d0c9a"
+source = "git+https://github.com/screenpipe/sck-rs?rev=8f0c74ef35737463c9c05fcdff375633dc143788#8f0c74ef35737463c9c05fcdff375633dc143788"
 dependencies = [
  "cidre 0.16.1 (git+https://github.com/yury/cidre.git?rev=9c20f5ee5abaad4598843a33e13d6e48822d1f30)",
  "image 0.25.10",

--- a/crates/screenpipe-screen/Cargo.toml
+++ b/crates/screenpipe-screen/Cargo.toml
@@ -77,7 +77,7 @@ harness = false
 
 # macOS: sck-rs for 12.3+ (ScreenCaptureKit), xcap as fallback for older versions
 [target.'cfg(target_os = "macos")'.dependencies]
-sck-rs = { git = "https://github.com/screenpipe/sck-rs" , rev = "e3ec9f6bb2f08b7747a2bd2edc003c1b674d0c9a"}
+sck-rs = { git = "https://github.com/screenpipe/sck-rs" , rev = "8f0c74ef35737463c9c05fcdff375633dc143788"}
 xcap = { workspace = true }
 libc = { workspace = true }
 cidre = { git = "https://github.com/yury/cidre.git", rev = "8481f3f0dc7dd39bb5be80d9424bfac0cad3801a", features = ["vn", "cv", "cg", "app"] }

--- a/packages/sdk/Cargo.lock
+++ b/packages/sdk/Cargo.lock
@@ -6721,7 +6721,7 @@ dependencies = [
 [[package]]
 name = "sck-rs"
 version = "0.1.0"
-source = "git+https://github.com/screenpipe/sck-rs?rev=e3ec9f6bb2f08b7747a2bd2edc003c1b674d0c9a#e3ec9f6bb2f08b7747a2bd2edc003c1b674d0c9a"
+source = "git+https://github.com/screenpipe/sck-rs?rev=8f0c74ef35737463c9c05fcdff375633dc143788#8f0c74ef35737463c9c05fcdff375633dc143788"
 dependencies = [
  "cidre 0.16.1 (git+https://github.com/yury/cidre.git?rev=9c20f5ee5abaad4598843a33e13d6e48822d1f30)",
  "image",

--- a/packages/sdk/examples/tauri-app/src-tauri/Cargo.lock
+++ b/packages/sdk/examples/tauri-app/src-tauri/Cargo.lock
@@ -6847,7 +6847,7 @@ dependencies = [
 [[package]]
 name = "sck-rs"
 version = "0.1.0"
-source = "git+https://github.com/screenpipe/sck-rs?rev=e3ec9f6bb2f08b7747a2bd2edc003c1b674d0c9a#e3ec9f6bb2f08b7747a2bd2edc003c1b674d0c9a"
+source = "git+https://github.com/screenpipe/sck-rs?rev=8f0c74ef35737463c9c05fcdff375633dc143788#8f0c74ef35737463c9c05fcdff375633dc143788"
 dependencies = [
  "cidre 0.16.1 (git+https://github.com/yury/cidre.git?rev=9c20f5ee5abaad4598843a33e13d6e48822d1f30)",
  "image",


### PR DESCRIPTION
Picks up **screenpipe/sck-rs#20** (merged as `8f0c74e`). Without this bump the pin stays on `e3ec9f6` and none of that fix reaches users — the merge alone is inert.

## What it unblocks

A wedged ScreenCaptureKit daemon currently ends capture for the life of the process. Three defects, each one making the next unreachable:

| # | defect | effect |
|---|---|---|
| 1 | the half-open recovery probe was refused by the live-call cap | the gate could never reopen |
| 2 | a parked worker was charged to *both* `LIVE_SCK_CALLS` and `LEAKED_SCK_THREADS` | a probe cleared the breaker and ordinary capture was **still** refused |
| 3 | `reset_wedge_breaker()` zeroes the counter while workers are parked; a late completion decremented past zero | wrapped to `usize::MAX`, read as "over the cap", shut capture permanently |

Observed on macOS 2.6.10: six parked `sck-shareable-content` threads, monitor enumeration falling back to CoreGraphics 89 times in one hour, vision frames not landing for hours across four in-process `VisionManager` restarts. Only relaunching recovered it.

## Change

```
-rev = "e3ec9f6bb2f08b7747a2bd2edc003c1b674d0c9a"
+rev = "8f0c74ef35737463c9c05fcdff375633dc143788"
```

All four workspace lockfiles regenerated with `scripts/regenerate-locks.sh`:

- `Cargo.lock`
- `apps/screenpipe-app-tauri/src-tauri/Cargo.lock`
- `packages/sdk/Cargo.lock`
- `packages/sdk/examples/tauri-app/src-tauri/Cargo.lock`

## Verification

- `cargo check -p screenpipe-screen` clean against the new rev
- `cargo metadata --locked` passes for both the workspace root and the Tauri app (the lockfile-freshness CI gate)
- `cargo test -p screenpipe-screen --lib monitor::` 22 passed
- upstream: 36/36 tests, stable across 6 consecutive parallel runs, each new behaviour verified to fail without its fix

## Related

**#6170** cuts the SCK call volume that makes hitting the wedge likely in the first place (720+/hour to 60). This PR makes the wedge recoverable when it does happen. Independent — either order.