### PR TITLE
docs: prefer browser mocks for UI validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,10 +36,12 @@ Check CI after pushing.
 
 ## Testing
 
-Test your own work end to end before handing it over — review is the bottleneck,
-not writing code. Drive the real app when the change is user-visible. Put
-before/after visuals in every issue and PR body: screen recording, screenshots,
-HTML mockup screenshot, or ASCII.
+Test your work at the narrowest boundary that proves it — review is the
+bottleneck. For ordinary desktop React/layout changes, use the browser-mock loop
+documented in `apps/screenpipe-app-tauri/README.md`; do not build Tauri merely
+for UI validation. Drive the real app only when the change crosses a native
+boundary listed there. Put before/after visuals in every issue and PR body:
+screen recording, screenshots, HTML mockup screenshot, or ASCII.
 
 ## git
 


### PR DESCRIPTION
## Summary

- direct ordinary desktop React/layout validation to the existing browser-mock loop
- reserve real-app validation for native boundaries already defined in the desktop README
- preserve the requirement for before/after visual evidence

## Why

The root agent instruction previously said to drive the real app for every user-visible change. In cold probes, that blanket wording caused agents to schedule a Rust/Tauri compile even after finding `bun run dev:web`.

## Before / after

```text
before: any user-visible change -> real Tauri app
after:  React/layout -> browser mocks; native boundary -> real Tauri app
```

## Validation

- `git diff --check`
- three independent cold-agent probes after the edit all selected `bun run dev:web` and explicitly rejected a Tauri build for ordinary React/layout work
- existing mock-backed UI loop was manually verified against `/home` and `/settings?section=display`; UI rendered and interacted without console errors

No product code or runtime behavior changes.
