### PR TITLE
feat(overlay): meeting alerts come out of the pill, drag to pin it, hiding behind a remote flag

### DIFF
--- a/apps/screenpipe-app-tauri/app/shortcut-reminder/page.test.tsx
+++ b/apps/screenpipe-app-tauri/app/shortcut-reminder/page.test.tsx
@@ -191,29 +191,22 @@ describe("recording health hover detail", () => {
     expect(meetingDot.className).toContain("pointer-events-none");
   });
 
-  it("offers bounded snoozes from the gear without restoring the inbox", async () => {
+  it("cannot be hidden from the gear — it opens Display settings instead", async () => {
     mocks.getRecordingHealthState.mockResolvedValue("normal");
-    mocks.storeGet.mockResolvedValue({ showShortcutOverlay: true });
+    mocks.storeGet.mockResolvedValue({});
 
     render(<ShortcutReminderPage />);
 
     fireEvent.mouseEnter(await screen.findByTestId("shortcut-reminder-root"));
     fireEvent.click(await screen.findByTitle("Overlay settings"));
-    expect(screen.getByTitle("Hide for today")).toBeVisible();
-    expect(screen.getByTitle("Hide for a week")).toBeVisible();
-    expect(screen.getByTitle("Open overlay settings")).toBeVisible();
-    expect(screen.queryByTitle("notifications")).toBeNull();
 
-    fireEvent.click(screen.getByTitle("Hide for a week"));
-    await waitFor(() => expect(mocks.storeSet).toHaveBeenCalledTimes(1));
-    expect(mocks.storeSet).toHaveBeenCalledWith(
-      "settings",
-      expect.objectContaining({
-        showShortcutOverlay: true,
-        shortcutOverlaySnoozedUntil: expect.any(Number),
-      }),
-    );
-    expect(mocks.hideShortcutReminder).toHaveBeenCalledTimes(1);
+    // The overlay carries recording health, live meeting state and meeting
+    // alerts, so there is no longer any way for a user to dismiss it.
+    expect(screen.queryByTitle("Hide for today")).toBeNull();
+    expect(screen.queryByTitle("Hide for a week")).toBeNull();
+    expect(mocks.hideShortcutReminder).not.toHaveBeenCalled();
+    expect(mocks.storeSet).not.toHaveBeenCalled();
+    expect(mocks.showWindow).toHaveBeenCalledWith({ Home: { page: "display" } });
   });
 
   it("keeps recording health ahead of the meeting preview", async () => {

--- a/apps/screenpipe-app-tauri/app/shortcut-reminder/page.test.tsx
+++ b/apps/screenpipe-app-tauri/app/shortcut-reminder/page.test.tsx
@@ -200,8 +200,8 @@ describe("recording health hover detail", () => {
     fireEvent.mouseEnter(await screen.findByTestId("shortcut-reminder-root"));
     fireEvent.click(await screen.findByTitle("Overlay settings"));
 
-    // The overlay carries recording health, live meeting state and meeting
-    // alerts, so there is no longer any way for a user to dismiss it.
+    // The gear never hides the pill. Even when `overlay-hiding-control` grants
+    // the capability back, the switch lives in Display settings, not here.
     expect(screen.queryByTitle("Hide for today")).toBeNull();
     expect(screen.queryByTitle("Hide for a week")).toBeNull();
     expect(mocks.hideShortcutReminder).not.toHaveBeenCalled();

--- a/apps/screenpipe-app-tauri/app/shortcut-reminder/page.tsx
+++ b/apps/screenpipe-app-tauri/app/shortcut-reminder/page.tsx
@@ -10,7 +10,7 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import { LogicalPosition, LogicalSize } from "@tauri-apps/api/dpi";
 import posthog from "posthog-js";
 import { usePlatform } from "@/lib/hooks/use-platform";
-import { getStore, saveAndEncrypt } from "@/lib/hooks/use-settings";
+import { getStore } from "@/lib/hooks/use-settings";
 import { commands } from "@/lib/utils/tauri";
 import {
   CheckCircle2,
@@ -40,11 +40,8 @@ type RecordingHealthState = "normal" | "failure" | "fixing" | "recovered";
 
 const COLLAPSED_SIZE = { width: 22, height: 16 };
 const EXPANDED_SIZE = { width: 160, height: 62 };
-const SETTINGS_SIZE = { width: 164, height: 119 };
 const INCIDENT_SIZE = { width: 160, height: 40 };
 const MEETING_SIZE = { width: 280, height: 80 };
-const DAY_SECONDS = 24 * 60 * 60;
-const WEEK_SECONDS = 7 * DAY_SECONDS;
 
 export default function ShortcutReminderPage() {
   const { isMac, isLoading } = usePlatform();
@@ -58,7 +55,6 @@ export default function ShortcutReminderPage() {
   const [meetingHovering, setMeetingHovering] = useState(false);
   const [expanded, setExpanded] = useState(false);
   const [hoveredControl, setHoveredControl] = useState<string | null>(null);
-  const [settingsOpen, setSettingsOpen] = useState(false);
   const [overlayScale, setOverlayScale] = useState(1);
   const resizeQueue = useRef(Promise.resolve());
   const isMacRef = useRef(isMac);
@@ -145,7 +141,6 @@ export default function ShortcutReminderPage() {
     // Listen for explicit shortcut-reminder-update event (from Rust side)
     const unlistenShortcut = listen<string>("shortcut-reminder-update", () => {
       setExpanded(false);
-      setSettingsOpen(false);
       setHoveredControl(null);
       setMeetingHovering(false);
       loadShortcutsFromFile();
@@ -225,8 +220,6 @@ export default function ShortcutReminderPage() {
       resizeOverlay(INCIDENT_SIZE);
     } else if (meetingOverlay.active && meetingHovering) {
       resizeOverlay(MEETING_SIZE);
-    } else if (settingsOpen) {
-      resizeOverlay(SETTINGS_SIZE);
     } else if (expanded) {
       resizeOverlay(EXPANDED_SIZE);
     } else {
@@ -238,7 +231,6 @@ export default function ShortcutReminderPage() {
     meetingHovering,
     meetingOverlay.active,
     resizeOverlay,
-    settingsOpen,
   ]);
 
   const handleRestartRecording = useCallback(async (e: React.MouseEvent) => {
@@ -274,43 +266,9 @@ export default function ShortcutReminderPage() {
     }
   }, []);
 
-  const handleSnooze = useCallback(async (
-    e: React.MouseEvent,
-    scope: "today" | "week",
-  ) => {
-    e.preventDefault();
-    e.stopPropagation();
-
-    const snoozeSeconds = scope === "today" ? DAY_SECONDS : WEEK_SECONDS;
-    try {
-      const store = await getStore();
-      const settings = await store.get<Record<string, unknown>>("settings") || {};
-      await store.set("settings", {
-        ...settings,
-        showShortcutOverlay: true,
-        shortcutOverlaySnoozedUntil:
-          Math.floor(Date.now() / 1000) + snoozeSeconds,
-      });
-      await saveAndEncrypt(store);
-      posthog.capture("shortcut_reminder_dismissed", {
-        dismiss_scope: scope,
-        snooze_hours: snoozeSeconds / 3600,
-      });
-      await commands.hideShortcutReminder();
-    } catch (error) {
-      console.error("Failed to snooze shortcut reminder:", error);
-      try {
-        await getCurrentWindow().hide();
-      } catch {
-        // Ignore fallback hide errors.
-      }
-    }
-  }, []);
-
   const handleOpenSettings = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
     e.stopPropagation();
-    setSettingsOpen(false);
     posthog.capture("shortcut_reminder_overlay_settings_clicked");
     void commands.showWindow({ Home: { page: "display" } });
   }, []);
@@ -532,7 +490,7 @@ export default function ShortcutReminderPage() {
     posthog.capture("shortcut_reminder_timeline_clicked");
   };
 
-  if (!expanded && !settingsOpen) {
+  if (!expanded) {
     return (
       <div
         data-testid="shortcut-reminder-root"
@@ -596,7 +554,6 @@ export default function ShortcutReminderPage() {
       style={{ background: "transparent" }}
       onMouseLeave={() => {
         setExpanded(false);
-        setSettingsOpen(false);
         setHoveredControl(null);
       }}
     >
@@ -667,70 +624,30 @@ export default function ShortcutReminderPage() {
           style={dockButtonStyle}
           onMouseEnter={() => setHoveredControl("settings")}
           onMouseDown={(e) => e.stopPropagation()}
-          onClick={(e) => {
-            e.stopPropagation();
-            setSettingsOpen((open) => !open);
-          }}
+          onClick={handleOpenSettings}
         >
           <Settings style={{ width: `${12 * overlayScale}px`, height: `${12 * overlayScale}px` }} />
         </button>
       </div>
 
-      {settingsOpen ? (
-        <div
-          className="flex flex-col overflow-hidden border border-white/40 font-mono text-white/85"
-          style={{
-            width: `${164 * overlayScale}px`,
-            height: `${85 * overlayScale}px`,
-            marginTop: `${4 * overlayScale}px`,
-            background: "rgba(0, 0, 0, 0.96)",
-            borderRadius: `${4 * overlayScale}px`,
-            fontSize: `${fontPx}px`,
-          }}
-        >
-          <button
-            className="flex-1 px-2 text-left hover:bg-white/15"
-            title="Hide for today"
-            onClick={(e) => void handleSnooze(e, "today")}
-          >
-            hide for today
-          </button>
-          <button
-            className="flex-1 px-2 text-left hover:bg-white/15"
-            title="Hide for a week"
-            onClick={(e) => void handleSnooze(e, "week")}
-          >
-            hide for a week
-          </button>
-          <div className="mx-2 bg-white/20" style={{ height: "1px" }} />
-          <button
-            className="flex-1 px-2 text-left hover:bg-white/15"
-            title="Open overlay settings"
-            onClick={handleOpenSettings}
-          >
-            overlay settings
-          </button>
-        </div>
-      ) : (
-        <div
-          className="flex items-center justify-center border border-white/25 font-mono text-white/75"
-          style={{
-            width: `${160 * overlayScale}px`,
-            height: `${26 * overlayScale}px`,
-            marginTop: `${4 * overlayScale}px`,
-            background: "rgba(0, 0, 0, 0.9)",
-            borderRadius: `${4 * overlayScale}px`,
-            fontSize: `${fontPx}px`,
-          }}
-        >
-          {disclosure ? (
-            <span>
-              {disclosure[0]}
-              {disclosure[1] ? `  ${disclosure[1]}` : ""}
-            </span>
-          ) : null}
-        </div>
-      )}
+      <div
+        className="flex items-center justify-center border border-white/25 font-mono text-white/75"
+        style={{
+          width: `${160 * overlayScale}px`,
+          height: `${26 * overlayScale}px`,
+          marginTop: `${4 * overlayScale}px`,
+          background: "rgba(0, 0, 0, 0.9)",
+          borderRadius: `${4 * overlayScale}px`,
+          fontSize: `${fontPx}px`,
+        }}
+      >
+        {disclosure ? (
+          <span>
+            {disclosure[0]}
+            {disclosure[1] ? `  ${disclosure[1]}` : ""}
+          </span>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/apps/screenpipe-app-tauri/components/desktop-remote-control.tsx
+++ b/apps/screenpipe-app-tauri/components/desktop-remote-control.tsx
@@ -124,6 +124,11 @@ export function DesktopRemoteControl({ enabled }: { enabled: boolean }) {
               ),
               effective_aec_mode: effective.aecMode ?? "off",
               effective_auto_update: Boolean(effective.autoUpdate),
+              // No matching `preference_` field: this control's preference is
+              // pinned null, so it would report "unset" on every event.
+              effective_overlay_hiding: Boolean(
+                effective.allowHidingShortcutOverlay,
+              ),
               preference_semantic_context:
                 preferences.semanticContext === null
                   ? "unset"

--- a/apps/screenpipe-app-tauri/components/settings/display-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/display-section.tsx
@@ -556,17 +556,42 @@ export function DisplaySection() {
             opens the timeline — hide the whole section when the timeline is off. */}
         {!(settings?.disableTimeline ?? false) && (
         <>
+        {/* The overlay ships unhideable because it carries recording health,
+            live meeting state and meeting alerts. `overlay-hiding-control`
+            hands the switch back remotely if that proves too strict. */}
         <Card className="border-border bg-card">
           <CardContent className="px-3 py-2.5">
-            <div className="flex items-center space-x-2.5">
-              <Monitor className="h-4 w-4 text-muted-foreground shrink-0" />
-              <div>
-                <h3 className="text-sm font-medium text-foreground">Shortcut Reminder</h3>
-                <p className="text-xs text-muted-foreground">
-                  Always on screen. It carries recording health, live meeting state and meeting
-                  alerts. Drag it to pin it to any corner or edge.
-                </p>
+            <div className="flex items-center justify-between">
+              <div className="flex items-center space-x-2.5">
+                <Monitor className="h-4 w-4 text-muted-foreground shrink-0" />
+                <div>
+                  <h3 className="text-sm font-medium text-foreground">Shortcut Reminder</h3>
+                  {/* Only the "always on screen" claim depends on the flag.
+                      The drag hint is true either way and is the only place
+                      pinning is discoverable, so it stays in both. */}
+                  <p className="text-xs text-muted-foreground">
+                    {settings?.allowHidingShortcutOverlay
+                      ? "Carries recording health, live meeting state and meeting alerts. Drag it to pin it to any corner or edge."
+                      : "Always on screen. It carries recording health, live meeting state and meeting alerts. Drag it to pin it to any corner or edge."}
+                  </p>
+                </div>
               </div>
+              {settings?.allowHidingShortcutOverlay && (
+                <Switch
+                  id="shortcut-overlay"
+                  checked={settings?.showShortcutOverlay ?? true}
+                  onCheckedChange={async (checked) => {
+                    handleSettingsChange({ showShortcutOverlay: checked });
+                    try {
+                      if (checked) {
+                        await commands.showShortcutReminder(settings.showScreenpipeShortcut);
+                      } else {
+                        await commands.hideShortcutReminder();
+                      }
+                    } catch (e) {}
+                  }}
+                />
+              )}
             </div>
           </CardContent>
         </Card>

--- a/apps/screenpipe-app-tauri/components/settings/display-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/display-section.tsx
@@ -33,7 +33,7 @@ export const searchIndex: SettingsField[] = [
   { label: "Theme", keywords: ["dark", "light", "appearance"] },
   { label: "Font Size" },
   { label: "Chat Always on Top", keywords: ["pin", "window"] },
-  { label: "Show Shortcut Reminder" },
+  { label: "Shortcut Reminder", keywords: ["overlay", "pill", "pin", "drag", "position"] },
   { label: "Timeline / rewind", keywords: ["rewind", "timeline", "backend"] },
   { label: "Overlay Size" },
   { label: "Show Overlay in Screen Recording", keywords: ["capture", "obs", "screen share"] },
@@ -190,7 +190,7 @@ export function DisplaySection() {
                     try {
                       if (disabled) {
                         await commands.hideShortcutReminder();
-                      } else if (settings?.showShortcutOverlay) {
+                      } else {
                         await commands.showShortcutReminder(settings.showScreenpipeShortcut);
                       }
                     } catch {}
@@ -558,78 +558,63 @@ export function DisplaySection() {
         <>
         <Card className="border-border bg-card">
           <CardContent className="px-3 py-2.5">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center space-x-2.5">
-                <Monitor className="h-4 w-4 text-muted-foreground shrink-0" />
-                <div>
-                  <h3 className="text-sm font-medium text-foreground">Show Shortcut Reminder</h3>
-                  <p className="text-xs text-muted-foreground">Overlay showing the screenpipe shortcut</p>
-                </div>
+            <div className="flex items-center space-x-2.5">
+              <Monitor className="h-4 w-4 text-muted-foreground shrink-0" />
+              <div>
+                <h3 className="text-sm font-medium text-foreground">Shortcut Reminder</h3>
+                <p className="text-xs text-muted-foreground">
+                  Always on screen. It carries recording health, live meeting state and meeting
+                  alerts. Drag it to pin it to any corner or edge.
+                </p>
               </div>
-              <Switch
-                id="shortcut-overlay"
-                checked={settings?.showShortcutOverlay ?? false}
-                onCheckedChange={async (checked) => {
-                  handleSettingsChange({ showShortcutOverlay: checked });
-                  try {
-                    if (checked) {
-                      await commands.showShortcutReminder(settings.showScreenpipeShortcut);
-                    } else {
-                      await commands.hideShortcutReminder();
-                    }
-                  } catch (e) {}
-                }}
-              />
             </div>
           </CardContent>
         </Card>
 
-        {settings?.showShortcutOverlay && (
-          <Card className="border-border bg-card">
-            <CardContent className="px-3 py-2.5">
-              <div className="space-y-2.5">
-                <div className="flex items-center space-x-2.5">
-                  <Maximize2 className="h-4 w-4 text-muted-foreground shrink-0" />
-                  <div>
-                    <h3 className="text-sm font-medium text-foreground">Overlay Size</h3>
-                    <p className="text-xs text-muted-foreground">Size of the shortcut reminder overlay</p>
-                  </div>
-                </div>
-                <div className="flex gap-2 ml-[26px]">
-                  {([
-                    { value: "small", label: "Small" },
-                    { value: "medium", label: "Medium" },
-                    { value: "large", label: "Large" },
-                  ]).map((option) => {
-                    const isActive = (settings?.shortcutOverlaySize ?? "small") === option.value;
-                    return (
-                      <button
-                        key={option.value}
-                        onClick={async () => {
-                          handleSettingsChange({ shortcutOverlaySize: option.value });
-                          try {
-                            await commands.hideShortcutReminder();
-                            // Wait for store.bin to flush to disk before re-showing
-                            await new Promise(r => setTimeout(r, 500));
-                            await commands.showShortcutReminder(settings.showScreenpipeShortcut);
-                          } catch {}
-                        }}
-                        type="button"
-                        className={`flex-1 px-2.5 py-1.5 rounded-md border-2 transition-all text-center cursor-pointer ${
-                          isActive
-                            ? "border-primary bg-primary/5"
-                            : "border-border hover:border-muted-foreground/30"
-                        }`}
-                      >
-                        <div className="font-medium text-xs text-foreground">{option.label}</div>
-                      </button>
-                    );
-                  })}
+        <Card className="border-border bg-card">
+          <CardContent className="px-3 py-2.5">
+            <div className="space-y-2.5">
+              <div className="flex items-center space-x-2.5">
+                <Maximize2 className="h-4 w-4 text-muted-foreground shrink-0" />
+                <div>
+                  <h3 className="text-sm font-medium text-foreground">Overlay Size</h3>
+                  <p className="text-xs text-muted-foreground">Size of the shortcut reminder overlay</p>
                 </div>
               </div>
-            </CardContent>
-          </Card>
-        )}
+              <div className="flex gap-2 ml-[26px]">
+                {([
+                  { value: "small", label: "Small" },
+                  { value: "medium", label: "Medium" },
+                  { value: "large", label: "Large" },
+                ]).map((option) => {
+                  const isActive = (settings?.shortcutOverlaySize ?? "small") === option.value;
+                  return (
+                    <button
+                      key={option.value}
+                      onClick={async () => {
+                        handleSettingsChange({ shortcutOverlaySize: option.value });
+                        try {
+                          await commands.hideShortcutReminder();
+                          // Wait for store.bin to flush to disk before re-showing
+                          await new Promise(r => setTimeout(r, 500));
+                          await commands.showShortcutReminder(settings.showScreenpipeShortcut);
+                        } catch {}
+                      }}
+                      type="button"
+                      className={`flex-1 px-2.5 py-1.5 rounded-md border-2 transition-all text-center cursor-pointer ${
+                        isActive
+                          ? "border-primary bg-primary/5"
+                          : "border-border hover:border-muted-foreground/30"
+                      }`}
+                    >
+                      <div className="font-medium text-xs text-foreground">{option.label}</div>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
         </>
         )}
 

--- a/apps/screenpipe-app-tauri/components/settings/shortcut-row.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/shortcut-row.tsx
@@ -210,7 +210,7 @@ const ShortcutRow = ({
           }
 
           // Keep the visible reminder in sync when one of its displayed shortcuts changes.
-          if (settings.showShortcutOverlay && reminderShortcutKeys.has(shortcut)) {
+          if (reminderShortcutKeys.has(shortcut)) {
             try {
               await commands.showShortcutReminder(updatedShortcuts.showScreenpipeShortcut);
             } catch (e) {
@@ -262,7 +262,7 @@ const ShortcutRow = ({
       }
     }
 
-    if (settings.showShortcutOverlay && reminderShortcutKeys.has(shortcut)) {
+    if (reminderShortcutKeys.has(shortcut)) {
       try {
         await commands.showShortcutReminder(settings.showScreenpipeShortcut);
       } catch (e) {

--- a/apps/screenpipe-app-tauri/components/settings/shortcut-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/shortcut-section.tsx
@@ -63,9 +63,7 @@ const ShortcutSection = () => {
       );
 
       try { await commands.refreshTrayMenu(); } catch (_) {}
-      if (settings.showShortcutOverlay) {
-        try { await commands.showShortcutReminder(defaults.showScreenpipeShortcut); } catch (_) {}
-      }
+      try { await commands.showShortcutReminder(defaults.showScreenpipeShortcut); } catch (_) {}
 
       toast({
         title: "shortcuts restored",

--- a/apps/screenpipe-app-tauri/e2e/specs/windows-user-journey.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/windows-user-journey.spec.ts
@@ -661,7 +661,9 @@ describe("Windows user journey", function () {
     await displayNav.click();
 
     // The overlay carries recording health, live meeting state and meeting
-    // alerts, so Display no longer offers a way to turn it off — only a size.
+    // alerts, so it ships unhideable and Display offers only a size. The
+    // `overlay-hiding-control` remote flag can restore the switch, but it is
+    // off by default and E2E never initializes PostHog.
     await waitForBodyText(
       (bodyText) =>
         bodyText.includes("theme, windows, and overlay appearance") &&

--- a/apps/screenpipe-app-tauri/e2e/specs/windows-user-journey.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/windows-user-journey.spec.ts
@@ -647,7 +647,7 @@ describe("Windows user journey", function () {
     expect(existsSync(shortcutsScreenshot)).toBe(true);
   });
 
-  it("shows and hides the shortcut reminder overlay from Display settings", async function () {
+  it("keeps the shortcut reminder overlay on screen and drives its dock actions", async function () {
     if (!isWindows) this.skip();
 
     await openHomeWindow();
@@ -660,26 +660,18 @@ describe("Windows user journey", function () {
     await displayNav.waitForDisplayed({ timeout: t(15_000) });
     await displayNav.click();
 
+    // The overlay carries recording health, live meeting state and meeting
+    // alerts, so Display no longer offers a way to turn it off — only a size.
     await waitForBodyText(
       (bodyText) =>
         bodyText.includes("theme, windows, and overlay appearance") &&
-        bodyText.includes("show shortcut reminder") &&
-        bodyText.includes("overlay showing the screenpipe shortcut"),
+        bodyText.includes("shortcut reminder") &&
+        bodyText.includes("overlay size"),
       "Display settings did not show the shortcut reminder controls",
     );
-
-    const shortcutReminderSelector = "#shortcut-overlay";
-    const initiallyChecked = await switchIsChecked(shortcutReminderSelector);
+    expect(await $("#shortcut-overlay").isExisting()).toBe(false);
 
     try {
-      await setSwitchChecked(shortcutReminderSelector, false);
-      await expectShortcutReminderVisible(false, t(20_000));
-      await waitForBodyText(
-        (bodyText) => !bodyText.includes("overlay size"),
-        "Shortcut reminder size controls stayed visible after disabling the reminder",
-      );
-
-      await setSwitchChecked(shortcutReminderSelector, true);
       await expectShortcutReminderVisible(true, t(20_000));
       await waitForWindowHandle("shortcut-reminder", t(20_000));
 
@@ -795,32 +787,15 @@ describe("Windows user journey", function () {
       const overlaySettingsButton = await $('button[title="Overlay settings"]');
       await overlaySettingsButton.waitForDisplayed({ timeout: t(10_000) });
       await overlaySettingsButton.click();
-      const hideForTodayButton = await $('button[title="Hide for today"]');
-      await hideForTodayButton.waitForDisplayed({ timeout: t(10_000) });
-      await hideForTodayButton.click();
 
-      await expectShortcutReminderVisible(false, t(20_000));
-      await browser.switchToWindow("home");
-      await browser.waitUntil(
-        async () => await switchIsChecked(shortcutReminderSelector),
-        {
-          timeout: t(15_000),
-          interval: 250,
-          timeoutMsg: "A bounded overlay snooze unexpectedly disabled the Display setting",
-        },
-      );
+      // The gear opens Display settings; it must not offer to hide the pill,
+      // and the pill must still be on screen afterwards.
+      expect(await $('button[title="Hide for today"]').isExisting()).toBe(false);
+      expect(await $('button[title="Hide for a week"]').isExisting()).toBe(false);
+      await expectShortcutReminderVisible(true, t(20_000));
     } finally {
       if ((await browser.getWindowHandles()).includes("home")) {
         await browser.switchToWindow("home").catch(() => {});
-      }
-      // Toggling off then back on clears any bounded snooze through the
-      // explicit show command, leaving the user's original setting intact.
-      await setSwitchChecked(shortcutReminderSelector, false).catch(() => {});
-      if (initiallyChecked) {
-        await setSwitchChecked(shortcutReminderSelector, true).catch(() => {});
-      }
-      if (!initiallyChecked) {
-        await expectShortcutReminderVisible(false, t(10_000)).catch(() => {});
       }
     }
   });

--- a/apps/screenpipe-app-tauri/lib/desktop-remote-control.test.ts
+++ b/apps/screenpipe-app-tauri/lib/desktop-remote-control.test.ts
@@ -135,6 +135,7 @@ describe("desktop remote control", () => {
       prioritizeInputLatency: true,
       // Never chosen: stays null so the rollout default still applies.
       sidebarCustomization: null,
+      overlayHiding: null,
       aecMode: "screenpipe",
     });
 
@@ -190,6 +191,7 @@ describe("desktop remote control", () => {
           defaultEnabled: false,
           forceDisabled: false,
         },
+        overlayHiding: { defaultEnabled: false, forceDisabled: false },
       },
       autoUpdate: { forceEnabled: false },
     });
@@ -336,5 +338,71 @@ describe("desktop remote control", () => {
     expect(
       buildDesktopRemoteControlPatch(settings, policy).changedControls,
     ).toEqual([]);
+  });
+
+  it("ships the overlay unhideable and never seeds a local opt-in", () => {
+    // Shipped: the capability is off, so the Display toggle stays absent.
+    expect(
+      resolveBooleanRemoteControlValue(
+        "overlayHiding",
+        null,
+        LOCAL_DESKTOP_REMOTE_POLICY.boolean.overlayHiding,
+      ),
+    ).toBe(false);
+
+    // Remote grant: the toggle comes back without a release.
+    expect(
+      resolveBooleanRemoteControlValue("overlayHiding", null, {
+        defaultEnabled: true,
+        forceDisabled: false,
+      }),
+    ).toBe(true);
+
+    // Nothing lets a user grant themselves the capability, so the preference
+    // must stay null forever — a seeded value would make the flag a no-op.
+    expect(
+      normalizeDesktopRemotePreferences({
+        allowHidingShortcutOverlay: true,
+        remoteControlPreferences: {
+          ...NEW_INSTALL_REMOTE_CONTROL_PREFERENCES,
+          overlayHiding: true,
+        },
+      }).overlayHiding,
+    ).toBeNull();
+  });
+
+  it("grants overlay hiding without bouncing the recorder", () => {
+    const policy = normalizeDesktopRemotePolicySnapshot({
+      ...LOCAL_DESKTOP_REMOTE_POLICY,
+      boolean: {
+        ...LOCAL_DESKTOP_REMOTE_POLICY.boolean,
+        overlayHiding: { defaultEnabled: true, forceDisabled: false },
+      },
+    });
+
+    // Already sitting on every other shipped default, so `overlayHiding` is
+    // the only control that moves and the restart flag is attributable to it.
+    const result = buildDesktopRemoteControlPatch(
+      {
+        platform: "macos",
+        enableSemanticContext: false,
+        experimentalCoreaudioSystemAudio: true,
+        experimentalMeetingPiggyback: false,
+        filterMusic: true,
+        prioritizeInputLatency: false,
+        enableSidebarCustomization: false,
+        aecMode: "off",
+        screenpipeAecEnabled: false,
+        macosInputVpioEnabled: false,
+        windowsInputAecEnabled: false,
+        allowHidingShortcutOverlay: false,
+      },
+      policy,
+    );
+
+    expect(result.changedControls).toEqual(["overlayHiding"]);
+    expect(result.patch.allowHidingShortcutOverlay).toBe(true);
+    // Overlay visibility is not something the recorder reads.
+    expect(result.recorderRestartRequired).toBe(false);
   });
 });

--- a/apps/screenpipe-app-tauri/lib/desktop-remote-control.ts
+++ b/apps/screenpipe-app-tauri/lib/desktop-remote-control.ts
@@ -43,6 +43,15 @@ export const BOOLEAN_REMOTE_CONTROL_DEFINITIONS = {
     settingKey: "enableSidebarCustomization",
     shippedDefault: false,
   },
+  // Whether the user is allowed to hide the shortcut overlay at all. The
+  // overlay carries recording health, live meeting state and meeting alerts,
+  // so it ships unhideable; this is the remote escape hatch that gives the
+  // Display toggle back if that turns out to be too strict.
+  overlayHiding: {
+    flagKey: "overlay-hiding-control",
+    settingKey: "allowHidingShortcutOverlay",
+    shippedDefault: false,
+  },
 } as const satisfies Record<string, BooleanRemoteControlDefinition>;
 
 /**
@@ -51,7 +60,7 @@ export const BOOLEAN_REMOTE_CONTROL_DEFINITIONS = {
  */
 export const NON_RECORDER_REMOTE_CONTROLS = new Set<
   BooleanRemoteControlKey | "aecMode" | "autoUpdate"
->(["autoUpdate", "sidebarCustomization"]);
+>(["autoUpdate", "sidebarCustomization", "overlayHiding"]);
 
 export const AEC_MODE_CONTROL_FLAG_KEY = "aec-mode-control";
 export const AUTO_UPDATE_CONTROL_FLAG_KEY = "auto-update-control";
@@ -87,6 +96,7 @@ export type DesktopRemotePreferences = {
   filterMusic: boolean | null;
   prioritizeInputLatency: boolean | null;
   sidebarCustomization: boolean | null;
+  overlayHiding: boolean | null;
   aecMode: AecMode | null;
 };
 
@@ -103,6 +113,7 @@ export type RemoteControllableSettings = {
   filterMusic?: boolean;
   prioritizeInputLatency?: boolean;
   enableSidebarCustomization?: boolean;
+  allowHidingShortcutOverlay?: boolean;
   aecMode?: AecMode;
   screenpipeAecEnabled?: boolean;
   macosInputVpioEnabled?: boolean;
@@ -130,6 +141,7 @@ export const LOCAL_DESKTOP_REMOTE_POLICY: DesktopRemotePolicySnapshot = {
     filterMusic: localBooleanPolicy("filterMusic"),
     prioritizeInputLatency: localBooleanPolicy("prioritizeInputLatency"),
     sidebarCustomization: localBooleanPolicy("sidebarCustomization"),
+    overlayHiding: localBooleanPolicy("overlayHiding"),
   },
   aecMode: {
     defaultValue: "off",
@@ -148,6 +160,7 @@ export const NEW_INSTALL_REMOTE_CONTROL_PREFERENCES: DesktopRemotePreferences =
     filterMusic: null,
     prioritizeInputLatency: null,
     sidebarCustomization: null,
+    overlayHiding: null,
     aecMode: null,
   };
 
@@ -192,7 +205,7 @@ function isAutoUpdateRemotePolicy(
   );
 }
 
-function cloneLocalDesktopRemotePolicy(): DesktopRemotePolicySnapshot {
+export function cloneLocalDesktopRemotePolicy(): DesktopRemotePolicySnapshot {
   return {
     schemaVersion: 1,
     boolean: {
@@ -210,6 +223,7 @@ function cloneLocalDesktopRemotePolicy(): DesktopRemotePolicySnapshot {
       sidebarCustomization: {
         ...LOCAL_DESKTOP_REMOTE_POLICY.boolean.sidebarCustomization,
       },
+      overlayHiding: { ...LOCAL_DESKTOP_REMOTE_POLICY.boolean.overlayHiding },
     },
     aecMode: { ...LOCAL_DESKTOP_REMOTE_POLICY.aecMode },
     autoUpdate: { ...LOCAL_DESKTOP_REMOTE_POLICY.autoUpdate },
@@ -372,6 +386,12 @@ export function readDesktopRemotePolicySnapshot(
           BOOLEAN_REMOTE_CONTROL_DEFINITIONS.sidebarCustomization.flagKey,
         ),
       ),
+      overlayHiding: parseBooleanRemotePolicy(
+        "overlayHiding",
+        payloadForFlag(
+          BOOLEAN_REMOTE_CONTROL_DEFINITIONS.overlayHiding.flagKey,
+        ),
+      ),
     },
     aecMode: parseAecModeRemotePolicy(
       payloadForFlag(AEC_MODE_CONTROL_FLAG_KEY),
@@ -487,6 +507,10 @@ export function normalizeDesktopRemotePreferences(
       : // Existing installs never chose; leave them on the rollout default
         // instead of freezing today's (off) value as an explicit opt-out.
         null,
+    // Always null. Nothing lets a user grant themselves the ability to hide
+    // the overlay, so this control must track the remote default forever — a
+    // seeded `false` would make flipping the flag on a no-op.
+    overlayHiding: null,
     aecMode: validAecPreference(current?.aecMode)
       ? current.aecMode
       : normalizeAecModeForPlatform(
@@ -602,6 +626,13 @@ export function buildDesktopRemoteControlPatch(
       settings.platform,
       parseManagedBoolean(managed.enableSidebarCustomization),
     ),
+    overlayHiding: resolveBooleanRemoteControlValue(
+      "overlayHiding",
+      preferences.overlayHiding,
+      booleanPolicyOf(policy, "overlayHiding"),
+      settings.platform,
+      parseManagedBoolean(managed.allowHidingShortcutOverlay),
+    ),
     aecMode: resolveAecModeRemoteValue(
       preferences.aecMode,
       policy.aecMode,
@@ -660,6 +691,13 @@ export function buildDesktopRemoteControlPatch(
   ) {
     patch.enableSidebarCustomization = effective.sidebarCustomization;
     changedControls.push("sidebarCustomization");
+  }
+
+  if (
+    Boolean(settings.allowHidingShortcutOverlay) !== effective.overlayHiding
+  ) {
+    patch.allowHidingShortcutOverlay = effective.overlayHiding;
+    changedControls.push("overlayHiding");
   }
 
   const aecSettings = getAecModeSettings(effective.aecMode);

--- a/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -46,7 +46,7 @@ import {
 	type UserGoalCategory,
 } from "@/lib/live-views/onboarding-activation";
 import {
-	LOCAL_DESKTOP_REMOTE_POLICY,
+	cloneLocalDesktopRemotePolicy,
 	NEW_INSTALL_REMOTE_CONTROL_PREFERENCES,
 	normalizeDesktopRemotePolicySnapshot,
 	normalizeDesktopRemotePreferences,
@@ -755,31 +755,7 @@ let DEFAULT_SETTINGS: Settings = {
 			remoteControlPreferences: {
 				...NEW_INSTALL_REMOTE_CONTROL_PREFERENCES,
 			},
-			remoteControlPolicy: {
-				schemaVersion: 1,
-				boolean: {
-					semanticContext: {
-						...LOCAL_DESKTOP_REMOTE_POLICY.boolean.semanticContext,
-					},
-					coreAudioSystemAudio: {
-						...LOCAL_DESKTOP_REMOTE_POLICY.boolean.coreAudioSystemAudio,
-					},
-					smartRecording: {
-						...LOCAL_DESKTOP_REMOTE_POLICY.boolean.smartRecording,
-					},
-					filterMusic: {
-						...LOCAL_DESKTOP_REMOTE_POLICY.boolean.filterMusic,
-					},
-					prioritizeInputLatency: {
-						...LOCAL_DESKTOP_REMOTE_POLICY.boolean.prioritizeInputLatency,
-					},
-					sidebarCustomization: {
-						...LOCAL_DESKTOP_REMOTE_POLICY.boolean.sidebarCustomization,
-					},
-				},
-				aecMode: { ...LOCAL_DESKTOP_REMOTE_POLICY.aecMode },
-				autoUpdate: { ...LOCAL_DESKTOP_REMOTE_POLICY.autoUpdate },
-			},
+			remoteControlPolicy: cloneLocalDesktopRemotePolicy(),
 			semanticContextMode: "memory",
 			useAllMonitors: true,
 			chatHistory: {
@@ -800,6 +776,8 @@ let DEFAULT_SETTINGS: Settings = {
 			filterMusic: true,
 			prioritizeInputLatency: false,
 			enableSidebarCustomization: false,
+			allowHidingShortcutOverlay: false,
+			showShortcutOverlay: true,
 			sidebarNavLayout: { ...DEFAULT_SIDEBAR_NAV_LAYOUT },
 			ignoreIncognitoWindows: true,
 			enhancedIncognitoDetection: false,

--- a/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -782,7 +782,6 @@ let DEFAULT_SETTINGS: Settings = {
 			},
 			semanticContextMode: "memory",
 			useAllMonitors: true,
-			showShortcutOverlay: true,
 			chatHistory: {
 				conversations: [],
 				activeConversationId: null,

--- a/apps/screenpipe-app-tauri/lib/utils/tauri.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/tauri.ts
@@ -3694,11 +3694,15 @@ listenOnLan?: boolean }) &
  * that the Rust struct doesn't know about. Without this, `save()` would
  * serialize only known fields and silently wipe frontend-only data.
  */
-({ [key in string]: null | boolean | number | string | JsonValue[] | { [key in string]: JsonValue } }) & { aiPresets: AIPreset[]; isLoading: boolean; devMode: boolean; ocrEngine: string; dataDir: string; embeddedLLM: EmbeddedLLM; autoStartEnabled: boolean; platform: string; disabledShortcuts: string[]; user: User; showScreenpipeShortcut: string; startRecordingShortcut: string; stopRecordingShortcut: string; startAudioShortcut: string; stopAudioShortcut: string; showChatShortcut: string; searchShortcut: string; lockVaultShortcut?: string; showShortcutOverlay?: boolean;
+({ [key in string]: null | boolean | number | string | JsonValue[] | { [key in string]: JsonValue } }) & { aiPresets: AIPreset[]; isLoading: boolean; devMode: boolean; ocrEngine: string; dataDir: string; embeddedLLM: EmbeddedLLM; autoStartEnabled: boolean; platform: string; disabledShortcuts: string[]; user: User; showScreenpipeShortcut: string; startRecordingShortcut: string; stopRecordingShortcut: string; startAudioShortcut: string; stopAudioShortcut: string; showChatShortcut: string; searchShortcut: string; lockVaultShortcut?: string;
 /**
  * Overlay size: "small" (default), "medium" (1.5x), "large" (2x)
  */
 shortcutOverlaySize?: string;
+/**
+ * Where the user dragged the overlay: one of top/bottom x left/center/right.
+ */
+shortcutOverlayAnchor?: string;
 /**
  * Unique device ID for AI usage tracking (generated on first launch)
  */

--- a/apps/screenpipe-app-tauri/lib/utils/tauri.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/tauri.ts
@@ -3700,6 +3700,17 @@ listenOnLan?: boolean }) &
  */
 shortcutOverlaySize?: string;
 /**
+ * The user's choice, honored only while `allow_hiding_shortcut_overlay`
+ * is on. The overlay ships unhideable, so this is inert by default.
+ */
+showShortcutOverlay?: boolean;
+/**
+ * Remote-controlled capability (`overlay-hiding-control`), written by the
+ * desktop remote-control registry. False ships; flipping the flag on gives
+ * the Display toggle back without a release.
+ */
+allowHidingShortcutOverlay?: boolean;
+/**
  * Where the user dragged the overlay: one of top/bottom x left/center/right.
  */
 shortcutOverlayAnchor?: string;

--- a/apps/screenpipe-app-tauri/lib/utils/validation.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/validation.ts
@@ -134,7 +134,9 @@ export const settingsStoreSchema = z.object({
   startAudioShortcut: z.string(),
   stopAudioShortcut: z.string(),
   pipeShortcuts: z.record(z.string()),
-  
+  showShortcutOverlay: z.boolean().optional(),
+  allowHidingShortcutOverlay: z.boolean().optional(),
+
   // Other
   isLoading: z.boolean(),
   installedPipes: z.array(z.any()), // Define proper pipe schema if needed

--- a/apps/screenpipe-app-tauri/lib/utils/validation.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/validation.ts
@@ -134,7 +134,6 @@ export const settingsStoreSchema = z.object({
   startAudioShortcut: z.string(),
   stopAudioShortcut: z.string(),
   pipeShortcuts: z.record(z.string()),
-  showShortcutOverlay: z.boolean().optional(),
   
   // Other
   isLoading: z.boolean(),

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -52,8 +52,20 @@ mod tests {
         merge_enterprise_file_configs, persist_enterprise_device_config,
         persist_recovered_enterprise_device_config, read_enterprise_config_from_path,
         notification_belongs_to_overlay, recovery_anchor_license_key, save_enterprise_team_config,
-        scan_chat_entries_by_mtime, EnterpriseFileConfig, RecoveredEnterpriseDeviceConfig,
+        scan_chat_entries_by_mtime, shortcut_overlay_hidden_by_choice, EnterpriseFileConfig,
+        RecoveredEnterpriseDeviceConfig,
     };
+
+    /// The overlay ships unhideable. A stored `showShortcutOverlay: false` —
+    /// whether left over from before this shipped or set while the remote
+    /// capability was on — must stay inert until the flag grants it back.
+    #[test]
+    fn a_stored_hide_choice_only_counts_once_remote_policy_allows_it() {
+        assert!(!shortcut_overlay_hidden_by_choice(false, false));
+        assert!(!shortcut_overlay_hidden_by_choice(false, true));
+        assert!(shortcut_overlay_hidden_by_choice(true, false));
+        assert!(!shortcut_overlay_hidden_by_choice(true, true));
+    }
 
     #[test]
     fn only_meeting_alerts_are_routed_through_the_overlay() {
@@ -2826,13 +2838,33 @@ fn shortcut_reminder_payload(
     map
 }
 
-/// The overlay is the app's only always-on surface: it carries recording
-/// health, the live-meeting state and now meeting notifications, so it always
-/// comes up. Suppression is a system decision (timeline off, headless), never
+/// Whether a stored "keep the overlay hidden" choice may be honored at all.
+/// The overlay is the app's only always-on surface — it carries recording
+/// health, live meeting state and meeting notifications — so it ships
+/// unhideable and a stale stored `false` stays inert. `overlay-hiding-control`
+/// (see `lib/desktop-remote-control.ts`) can grant the capability back
+/// remotely, at which point the user's own choice starts counting again.
+pub(crate) fn shortcut_overlay_hidden_by_choice(
+    allow_hiding: bool,
+    show_overlay: bool,
+) -> bool {
+    allow_hiding && !show_overlay
+}
+
+/// Suppression is otherwise a system decision (timeline off, headless), never
 /// a stored dismissal.
 pub(crate) async fn maybe_show_shortcut_reminder_on_startup(
     app_handle: tauri::AppHandle,
 ) -> Result<(), String> {
+    let store = crate::store::SettingsStore::get(&app_handle)?.unwrap_or_default();
+    if shortcut_overlay_hidden_by_choice(
+        store.allow_hiding_shortcut_overlay,
+        store.show_shortcut_overlay,
+    ) {
+        info!("shortcut overlay stays hidden: remote policy allows it and the user turned it off");
+        return Ok(());
+    }
+
     show_shortcut_reminder_impl(app_handle, true, true).await
 }
 

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -50,49 +50,19 @@ mod tests {
         enterprise_license_key_sha256, fallback_local_api_config, is_login_callback_scheme,
         merge_enterprise_file_configs, persist_enterprise_device_config,
         persist_recovered_enterprise_device_config, read_enterprise_config_from_path,
-        recovery_anchor_license_key, save_enterprise_team_config, scan_chat_entries_by_mtime,
-        shortcut_overlay_startup_decision, EnterpriseFileConfig, RecoveredEnterpriseDeviceConfig,
-        SHORTCUT_OVERLAY_MINIMAL_RESHOW_VERSION,
+        notification_belongs_to_overlay, recovery_anchor_license_key, save_enterprise_team_config,
+        scan_chat_entries_by_mtime, EnterpriseFileConfig, RecoveredEnterpriseDeviceConfig,
     };
 
     #[test]
-    fn minimal_overlay_gets_one_bounded_reshow() {
-        let first = shortcut_overlay_startup_decision(false, 0, None, 100, true);
-        assert!(first.should_show);
-        assert!(first.consume_reshow);
-
-        let second = shortcut_overlay_startup_decision(
-            false,
-            SHORTCUT_OVERLAY_MINIMAL_RESHOW_VERSION,
-            None,
-            100,
-            true,
-        );
-        assert!(!second.should_show);
-        assert!(!second.consume_reshow);
-    }
-
-    #[test]
-    fn active_overlay_snooze_wins_over_reshow() {
-        let decision = shortcut_overlay_startup_decision(false, 0, Some(101), 100, true);
-        assert!(!decision.should_show);
-        assert!(!decision.consume_reshow);
-        assert!(!decision.clear_expired_snooze);
-    }
-
-    #[test]
-    fn expired_overlay_snooze_is_cleared_and_shown() {
-        let decision = shortcut_overlay_startup_decision(true, 0, Some(100), 100, true);
-        assert!(decision.should_show);
-        assert!(decision.consume_reshow);
-        assert!(decision.clear_expired_snooze);
-    }
-
-    #[test]
-    fn minimal_webview_overlay_gets_the_same_bounded_reshow() {
-        let decision = shortcut_overlay_startup_decision(false, 0, None, 100, true);
-        assert!(decision.should_show);
-        assert!(decision.consume_reshow);
+    fn only_meeting_alerts_are_routed_through_the_overlay() {
+        // The pill already shows live meeting state, so a meeting alert belongs
+        // there. Everything else keeps the standalone panel, which has room for
+        // long bodies and more than two actions.
+        assert!(notification_belongs_to_overlay(Some("meeting")));
+        assert!(!notification_belongs_to_overlay(Some("capture_stall")));
+        assert!(!notification_belongs_to_overlay(Some("pipe")));
+        assert!(!notification_belongs_to_overlay(None));
     }
 
     /// The whole point of SCR-300: `gateway_url` is the ONE name the server,
@@ -2857,69 +2827,20 @@ fn shortcut_reminder_payload(
         "shortcutOverlaySize".to_string(),
         serde_json::Value::String(settings.shortcut_overlay_size.clone()),
     );
+    map.insert(
+        "shortcutOverlayAnchor".to_string(),
+        serde_json::Value::String(settings.shortcut_overlay_anchor.clone()),
+    );
     map
 }
 
-const SHORTCUT_OVERLAY_MINIMAL_RESHOW_VERSION: u32 = 1;
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct ShortcutOverlayStartupDecision {
-    should_show: bool,
-    consume_reshow: bool,
-    clear_expired_snooze: bool,
-}
-
-fn shortcut_overlay_startup_decision(
-    setting_enabled: bool,
-    consumed_reshow_version: u32,
-    snoozed_until: Option<i64>,
-    now_unix: i64,
-    allow_minimal_reshow: bool,
-) -> ShortcutOverlayStartupDecision {
-    let snoozed = snoozed_until.is_some_and(|until| until > now_unix);
-    let reintroduce_minimal = allow_minimal_reshow
-        && !snoozed
-        && consumed_reshow_version < SHORTCUT_OVERLAY_MINIMAL_RESHOW_VERSION;
-    ShortcutOverlayStartupDecision {
-        should_show: !snoozed && (setting_enabled || reintroduce_minimal),
-        consume_reshow: reintroduce_minimal,
-        clear_expired_snooze: snoozed_until.is_some_and(|until| until <= now_unix),
-    }
-}
-
-/// Apply the simple startup policy for the minimal overlay on every platform.
-/// Existing dismissals get one bounded re-show; active snoozes always win.
+/// The overlay is the app's only always-on surface: it carries recording
+/// health, the live-meeting state and now meeting notifications, so it always
+/// comes up. Suppression is a system decision (timeline off, headless), never
+/// a stored dismissal.
 pub(crate) async fn maybe_show_shortcut_reminder_on_startup(
     app_handle: tauri::AppHandle,
 ) -> Result<(), String> {
-    let mut store = crate::store::SettingsStore::get(&app_handle)?.unwrap_or_default();
-    let decision = shortcut_overlay_startup_decision(
-        store.show_shortcut_overlay,
-        store.shortcut_overlay_minimal_reshow_version,
-        store.shortcut_overlay_snoozed_until,
-        chrono::Utc::now().timestamp(),
-        true,
-    );
-
-    let mut store_changed = false;
-    if decision.clear_expired_snooze {
-        store.shortcut_overlay_snoozed_until = None;
-        store_changed = true;
-    }
-    if decision.consume_reshow {
-        // Commit before rendering so a crash cannot turn this into a loop.
-        store.shortcut_overlay_minimal_reshow_version = SHORTCUT_OVERLAY_MINIMAL_RESHOW_VERSION;
-        store_changed = true;
-    }
-    if store_changed {
-        store.save(&app_handle)?;
-    }
-
-    if !decision.should_show {
-        info!("shortcut overlay suppressed by saved preference or active snooze");
-        return Ok(());
-    }
-
     show_shortcut_reminder_impl(app_handle, true, true).await
 }
 
@@ -2929,11 +2850,6 @@ pub async fn show_shortcut_reminder(
     app_handle: tauri::AppHandle,
     _shortcut: String,
 ) -> Result<(), String> {
-    if let Some(mut store) = crate::store::SettingsStore::get(&app_handle)? {
-        if store.shortcut_overlay_snoozed_until.take().is_some() {
-            store.save(&app_handle)?;
-        }
-    }
     show_shortcut_reminder_impl(app_handle, true, true).await
 }
 
@@ -3465,6 +3381,12 @@ pub async fn show_notification_inbox(app_handle: tauri::AppHandle) -> Result<(),
     Ok(())
 }
 
+/// Notification kinds the pill can host. Kept narrow on purpose: the overlay is
+/// a tiny surface and only earns notifications it already has context for.
+pub(crate) fn notification_belongs_to_overlay(notification_type: Option<&str>) -> bool {
+    matches!(notification_type, Some("meeting"))
+}
+
 #[tauri::command]
 #[specta::specta]
 pub async fn show_notification_panel(
@@ -3501,6 +3423,18 @@ pub async fn show_notification_panel(
     {
         // Store app handle for the action callback
         native_actions::install_notification_action_callback(&app_handle);
+
+        // A meeting alert is about the thing the overlay is already showing, so
+        // when the pill is on screen it speaks up itself instead of throwing a
+        // second window into the corner. Anything else — and the pill being
+        // hidden — keeps the standalone panel.
+        if notification_belongs_to_overlay(notification_type.as_deref())
+            && native_shortcut_reminder::show_notification(&payload)
+        {
+            info!("meeting notification rendered from the shortcut overlay");
+            let _ = app_handle.emit("native-notification-shown", &payload);
+            return Ok(());
+        }
 
         if native_notification::is_available() {
             info!("Using native SwiftUI notification panel");

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands/native_actions.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands/native_actions.rs
@@ -13,100 +13,44 @@ use tracing::{error, info, warn};
 /// Global app handle stored so native action callbacks can emit events.
 static GLOBAL_APP_HANDLE: std::sync::OnceLock<tauri::AppHandle> = std::sync::OnceLock::new();
 
-const SHORTCUT_OVERLAY_DAY_SNOOZE_SECONDS: i64 = 24 * 60 * 60;
-const SHORTCUT_OVERLAY_WEEK_SNOOZE_SECONDS: i64 = 7 * SHORTCUT_OVERLAY_DAY_SNOOZE_SECONDS;
+/// Anchors the overlay accepts, mirroring `OverlayAnchor` in
+/// `swift/shortcut_reminder.swift`. Anything else is ignored rather than
+/// persisted, so a bad payload can never strand the pill off screen.
+pub(crate) const SHORTCUT_OVERLAY_ANCHORS: [&str; 6] = [
+    "top-left",
+    "top-center",
+    "top-right",
+    "bottom-left",
+    "bottom-center",
+    "bottom-right",
+];
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum ShortcutOverlayDismissScope {
-    Today,
-    Week,
-    Persistent,
+pub(crate) fn parse_overlay_anchor(action: &str) -> Option<&str> {
+    let anchor = action.strip_prefix("set_overlay_anchor:")?;
+    SHORTCUT_OVERLAY_ANCHORS
+        .into_iter()
+        .find(|candidate| *candidate == anchor)
 }
 
-impl ShortcutOverlayDismissScope {
-    fn analytics_value(self) -> &'static str {
-        match self {
-            Self::Today => "today",
-            Self::Week => "week",
-            Self::Persistent => "persistent",
-        }
-    }
-
-    fn snooze_seconds(self) -> Option<i64> {
-        match self {
-            Self::Today => Some(SHORTCUT_OVERLAY_DAY_SNOOZE_SECONDS),
-            Self::Week => Some(SHORTCUT_OVERLAY_WEEK_SNOOZE_SECONDS),
-            Self::Persistent => None,
-        }
-    }
-}
-
-fn apply_shortcut_overlay_dismissal(
-    store: &mut SettingsStore,
-    scope: ShortcutOverlayDismissScope,
-    now_unix: i64,
-) {
-    if let Some(duration) = scope.snooze_seconds() {
-        store.show_shortcut_overlay = true;
-        store.shortcut_overlay_snoozed_until = Some(now_unix.saturating_add(duration));
-    } else {
-        store.show_shortcut_overlay = false;
-        store.shortcut_overlay_snoozed_until = None;
-    }
-}
-
-fn persist_shortcut_overlay_dismissal(
-    app: &tauri::AppHandle,
-    scope: ShortcutOverlayDismissScope,
-) -> bool {
+fn persist_shortcut_overlay_anchor(app: &tauri::AppHandle, anchor: &str) -> bool {
     match SettingsStore::get(app) {
         Ok(Some(mut store)) => {
-            apply_shortcut_overlay_dismissal(&mut store, scope, chrono::Utc::now().timestamp());
+            if store.shortcut_overlay_anchor == anchor {
+                return true;
+            }
+            store.shortcut_overlay_anchor = anchor.to_string();
             match store.save(app) {
                 Ok(()) => true,
                 Err(error) => {
-                    warn!("failed to persist shortcut overlay dismissal: {}", error);
+                    warn!("failed to persist shortcut overlay anchor: {}", error);
                     false
                 }
             }
         }
         Ok(None) => false,
         Err(error) => {
-            warn!("failed to read settings for overlay dismissal: {}", error);
+            warn!("failed to read settings for overlay anchor: {}", error);
             false
-        }
-    }
-}
-
-fn handle_shortcut_overlay_dismissal(
-    app: &tauri::AppHandle,
-    scope: ShortcutOverlayDismissScope,
-    open_display_settings: bool,
-) {
-    let persist_succeeded = persist_shortcut_overlay_dismissal(app, scope);
-    track_native_overlay_event(
-        app,
-        "shortcut_reminder_dismissed",
-        serde_json::json!({
-            "dismiss_scope": scope.analytics_value(),
-            "snooze_hours": scope.snooze_seconds().map(|seconds| seconds / 3_600),
-            "persist_succeeded": persist_succeeded,
-        }),
-    );
-    native_shortcut_reminder::hide();
-
-    if open_display_settings {
-        let app_for_show = app.clone();
-        if let Err(error) = app.run_on_main_thread(move || {
-            if let Err(error) = (ShowRewindWindow::Home {
-                page: Some("display".to_string()),
-            })
-            .show(&app_for_show)
-            {
-                warn!("failed to open Display settings after overlay turn-off: {error}");
-            }
-        }) {
-            warn!("failed to schedule Display settings after overlay turn-off: {error}");
         }
     }
 }
@@ -173,12 +117,6 @@ pub(crate) fn track_native_overlay_event(
     }
 }
 
-fn settings_menu_engagement_properties(action: &str) -> Option<serde_json::Value> {
-    let payload = action.strip_prefix("settings_menu_engaged:")?;
-    let properties: serde_json::Value = serde_json::from_str(payload).ok()?;
-    properties.is_object().then_some(properties)
-}
-
 fn native_notif_action_callback_inner(json_ptr: *const std::os::raw::c_char) {
     if json_ptr.is_null() {
         return;
@@ -186,6 +124,13 @@ fn native_notif_action_callback_inner(json_ptr: *const std::os::raw::c_char) {
     let json = unsafe { std::ffi::CStr::from_ptr(json_ptr) }
         .to_string_lossy()
         .to_string();
+    dispatch_notification_action(json);
+}
+
+/// Run one notification action. Shared by the standalone notification panel and
+/// by notifications the shortcut overlay renders itself, so a meeting alert
+/// behaves identically whichever surface showed it.
+pub(crate) fn dispatch_notification_action(json: String) {
     info!("native notification action: {}", json);
 
     let Some(app) = GLOBAL_APP_HANDLE.get() else {
@@ -761,15 +706,26 @@ fn native_shortcut_action_callback_inner(action_ptr: *const std::os::raw::c_char
         .to_string();
     info!("native shortcut action: {}", action);
 
+    // Notifications the pill rendered itself run the same dispatch as the
+    // standalone panel, on the same thread the panel callback uses.
+    if let Some(payload) = action.strip_prefix("notification_action:") {
+        dispatch_notification_action(payload.to_string());
+        return;
+    }
+
     if let Some(app) = GLOBAL_APP_HANDLE.get() {
         let app_clone = app.clone();
         std::thread::spawn(move || {
             let app_for_show = app_clone.clone();
-            if let Some(properties) = settings_menu_engagement_properties(&action) {
+            if let Some(anchor) = parse_overlay_anchor(&action) {
+                let persisted = persist_shortcut_overlay_anchor(&app_clone, anchor);
                 track_native_overlay_event(
                     &app_clone,
-                    "shortcut_reminder_settings_menu_engaged",
-                    properties,
+                    "shortcut_reminder_anchor_changed",
+                    serde_json::json!({
+                        "anchor": anchor,
+                        "persist_succeeded": persisted,
+                    }),
                 );
                 return;
             }
@@ -842,27 +798,6 @@ fn native_shortcut_action_callback_inner(action_ptr: *const std::os::raw::c_char
                             warn!("failed to open overlay settings: {error}");
                         }
                     });
-                }
-                "dismiss_today" => {
-                    handle_shortcut_overlay_dismissal(
-                        &app_clone,
-                        ShortcutOverlayDismissScope::Today,
-                        false,
-                    );
-                }
-                "dismiss_week" => {
-                    handle_shortcut_overlay_dismissal(
-                        &app_clone,
-                        ShortcutOverlayDismissScope::Week,
-                        false,
-                    );
-                }
-                "dismiss_persistent" => {
-                    handle_shortcut_overlay_dismissal(
-                        &app_clone,
-                        ShortcutOverlayDismissScope::Persistent,
-                        true,
-                    );
                 }
                 "restart_recording" => {
                     // Recording-health overlay: restart the engine in place.
@@ -945,55 +880,29 @@ fn native_shortcut_action_callback_inner(action_ptr: *const std::os::raw::c_char
 #[cfg(test)]
 mod tests {
     use super::{
-        apply_shortcut_overlay_dismissal, native_overlay_meeting_note_id, notification_copy_value,
-        notification_source_url, parse_meeting_deeplink, settings_menu_engagement_properties,
-        ShortcutOverlayDismissScope, SHORTCUT_OVERLAY_DAY_SNOOZE_SECONDS,
-        SHORTCUT_OVERLAY_WEEK_SNOOZE_SECONDS,
+        native_overlay_meeting_note_id, notification_copy_value, notification_source_url,
+        parse_meeting_deeplink, parse_overlay_anchor, SHORTCUT_OVERLAY_ANCHORS,
     };
-    use crate::store::SettingsStore;
     use serde_json::json;
 
     #[test]
-    fn temporary_overlay_dismissals_keep_the_feature_enabled() {
-        for (scope, expected_until) in [
-            (
-                ShortcutOverlayDismissScope::Today,
-                100 + SHORTCUT_OVERLAY_DAY_SNOOZE_SECONDS,
-            ),
-            (
-                ShortcutOverlayDismissScope::Week,
-                100 + SHORTCUT_OVERLAY_WEEK_SNOOZE_SECONDS,
-            ),
-        ] {
-            let mut store = SettingsStore::default();
-            store.show_shortcut_overlay = false;
-            apply_shortcut_overlay_dismissal(&mut store, scope, 100);
-            assert!(store.show_shortcut_overlay);
-            assert_eq!(store.shortcut_overlay_snoozed_until, Some(expected_until));
+    fn accepts_every_anchor_the_overlay_can_report() {
+        for anchor in SHORTCUT_OVERLAY_ANCHORS {
+            assert_eq!(
+                parse_overlay_anchor(&format!("set_overlay_anchor:{anchor}")),
+                Some(anchor),
+            );
         }
     }
 
     #[test]
-    fn permanent_overlay_dismissal_clears_any_snooze() {
-        let mut store = SettingsStore::default();
-        store.shortcut_overlay_snoozed_until = Some(1_000);
-        apply_shortcut_overlay_dismissal(&mut store, ShortcutOverlayDismissScope::Persistent, 100);
-        assert!(!store.show_shortcut_overlay);
-        assert_eq!(store.shortcut_overlay_snoozed_until, None);
-    }
-
-    #[test]
-    fn parses_settings_menu_engagement_summary() {
-        let action = concat!(
-            "settings_menu_engaged:",
-            r#"{"hovered_items":["today","week"],"revisit_count":1,"longest_hover_ms":1400}"#
-        );
-        let properties = settings_menu_engagement_properties(action).expect("valid summary");
-        assert_eq!(properties["hovered_items"], json!(["today", "week"]));
-        assert_eq!(properties["revisit_count"], 1);
-        assert_eq!(properties["longest_hover_ms"], 1400);
-        assert!(settings_menu_engagement_properties("settings_menu_engaged:[]").is_none());
-        assert!(settings_menu_engagement_properties("settings_menu_opened").is_none());
+    fn rejects_anchors_that_would_strand_the_pill() {
+        // An unknown or malformed anchor must not be persisted — the pill would
+        // come back somewhere the positioning code cannot reason about.
+        assert_eq!(parse_overlay_anchor("set_overlay_anchor:middle"), None);
+        assert_eq!(parse_overlay_anchor("set_overlay_anchor:"), None);
+        assert_eq!(parse_overlay_anchor("set_overlay_anchor:top-left "), None);
+        assert_eq!(parse_overlay_anchor("open_timeline"), None);
     }
 
     #[test]

--- a/apps/screenpipe-app-tauri/src-tauri/src/native_shortcut_reminder.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/native_shortcut_reminder.rs
@@ -32,6 +32,7 @@ mod ffi {
         pub fn shortcut_is_available() -> c_int;
         pub fn shortcut_show(json: *const c_char) -> c_int;
         pub fn shortcut_hide() -> c_int;
+        pub fn shortcut_show_notification(json: *const c_char) -> c_int;
         pub fn shortcut_set_meeting_active(active: c_int);
         pub fn shortcut_set_meeting_stop_result(succeeded: c_int);
         pub fn shortcut_set_health_state(state: *const c_char) -> c_int;
@@ -71,6 +72,19 @@ mod ffi {
             super::NATIVE_REMINDER_VISIBLE.store(false, Ordering::SeqCst);
         }
         hidden
+    }
+
+    /// Render a notification attached to the pill. False when the pill is not
+    /// on screen or cannot represent the payload, so the caller falls back to
+    /// the standalone notification panel.
+    pub fn show_notification(json: &str) -> bool {
+        if !super::is_reminder_visible() {
+            return false;
+        }
+        match CString::new(json) {
+            Ok(c) => unsafe { shortcut_show_notification(c.as_ptr()) == 0 },
+            Err(_) => false,
+        }
     }
 
     pub fn set_meeting_active(active: bool) {
@@ -121,6 +135,9 @@ mod ffi {
         false
     }
     pub fn hide() -> bool {
+        false
+    }
+    pub fn show_notification(_json: &str) -> bool {
         false
     }
     pub fn set_meeting_active(_active: bool) {}

--- a/apps/screenpipe-app-tauri/src-tauri/src/overlay_health.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/overlay_health.rs
@@ -572,23 +572,19 @@ fn overlay_visible(app: &tauri::AppHandle) -> bool {
         .unwrap_or(false)
 }
 
-/// Briefly reveal the overlay for a confirmed incident even when the user has
-/// it hidden (issue #5127: "if hidden — show whatever visible"). Recovery puts
-/// it back via the `auto_revealed` flag.
+/// Briefly reveal the overlay for a confirmed incident even when it is off
+/// screen (issue #5127: "if hidden — show whatever visible"). Recovery puts it
+/// back via the `auto_revealed` flag.
 async fn reveal_overlay_if_hidden(app: &tauri::AppHandle) {
     if overlay_visible(app) {
         return;
     }
-    // Only take responsibility for re-hiding after recovery when the user's
-    // preference is actually "hidden". If the pref is on and we merely beat
-    // the startup show (incident 1s into boot), the overlay should stay.
-    let user_wants_hidden = crate::store::SettingsStore::get(app)
-        .ok()
-        .flatten()
-        .map(|s| !s.show_shortcut_overlay)
-        .unwrap_or(false);
+    // The overlay can no longer be dismissed, so anything hiding it now is a
+    // system decision (timeline disabled, headless, or the startup show has not
+    // landed yet). Leave it up after recovery rather than re-hiding it: if the
+    // startup show was simply slow, hiding it again would fight that.
     if let Ok(mut inner) = INNER.lock() {
-        inner.auto_revealed = user_wants_hidden;
+        inner.auto_revealed = false;
     }
     info!("overlay health: revealing hidden shortcut overlay for incident");
     // Skip the disable_timeline gate and the wait-for-server handshake — the

--- a/apps/screenpipe-app-tauri/src-tauri/src/store.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/store.rs
@@ -951,17 +951,12 @@ pub struct SettingsStore {
     pub search_shortcut: String,
     #[serde(rename = "lockVaultShortcut", default)]
     pub lock_vault_shortcut: String,
-    #[serde(rename = "showShortcutOverlay", default = "default_true")]
-    pub show_shortcut_overlay: bool,
-    /// Unix timestamp until which the user asked to hide the shortcut overlay.
-    #[serde(rename = "shortcutOverlaySnoozedUntil", default)]
-    pub shortcut_overlay_snoozed_until: Option<i64>,
-    /// Version marker for the bounded re-show of the smaller overlay design.
-    #[serde(rename = "shortcutOverlayMinimalReshowVersion", default)]
-    pub shortcut_overlay_minimal_reshow_version: u32,
     /// Overlay size: "small" (default), "medium" (1.5x), "large" (2x)
     #[serde(rename = "shortcutOverlaySize", default = "default_overlay_size")]
     pub shortcut_overlay_size: String,
+    /// Where the user dragged the overlay: one of top/bottom x left/center/right.
+    #[serde(rename = "shortcutOverlayAnchor", default = "default_overlay_anchor")]
+    pub shortcut_overlay_anchor: String,
     /// Unique device ID for AI usage tracking (generated on first launch)
     #[serde(rename = "deviceId", default = "generate_device_id")]
     pub device_id: String,
@@ -1060,6 +1055,10 @@ fn default_true() -> bool {
 
 fn default_overlay_size() -> String {
     "small".to_string()
+}
+
+fn default_overlay_anchor() -> String {
+    "top-center".to_string()
 }
 
 fn default_ui_theme() -> String {
@@ -1549,10 +1548,8 @@ Rules:
             lock_vault_shortcut: "Ctrl+Shift+L".to_string(),
             #[cfg(not(target_os = "windows"))]
             lock_vault_shortcut: "Super+Shift+L".to_string(),
-            show_shortcut_overlay: true,
-            shortcut_overlay_snoozed_until: None,
-            shortcut_overlay_minimal_reshow_version: 0,
             shortcut_overlay_size: "small".to_string(),
+            shortcut_overlay_anchor: default_overlay_anchor(),
             device_id: uuid::Uuid::new_v4().to_string(),
             auto_update: true,
             auto_update_pipes: true,
@@ -2430,17 +2427,29 @@ mod tests {
     }
 
     #[test]
-    fn shortcut_overlay_snooze_and_reshow_state_default_cleanly() {
-        let defaults = SettingsStore::default();
-        assert_eq!(defaults.shortcut_overlay_snoozed_until, None);
-        assert_eq!(defaults.shortcut_overlay_minimal_reshow_version, 0);
+    fn shortcut_overlay_anchor_defaults_to_top_center() {
+        assert_eq!(SettingsStore::default().shortcut_overlay_anchor, "top-center");
 
+        // Settings written before the pill could be pinned have no anchor key.
         let missing: SettingsStore = serde_json::from_value(json!({
             "aiPresets": []
         }))
         .unwrap();
-        assert_eq!(missing.shortcut_overlay_snoozed_until, None);
-        assert_eq!(missing.shortcut_overlay_minimal_reshow_version, 0);
+        assert_eq!(missing.shortcut_overlay_anchor, "top-center");
+    }
+
+    /// Stored dismissals from before the overlay became permanent must not
+    /// resurrect: the keys are gone, and an old file carrying them still loads.
+    #[test]
+    fn retired_overlay_dismissal_keys_are_ignored() {
+        let legacy: SettingsStore = serde_json::from_value(json!({
+            "aiPresets": [],
+            "showShortcutOverlay": false,
+            "shortcutOverlaySnoozedUntil": 4_102_444_800_i64,
+            "shortcutOverlayMinimalReshowVersion": 1,
+        }))
+        .unwrap();
+        assert_eq!(legacy.shortcut_overlay_anchor, "top-center");
     }
 
     #[test]

--- a/apps/screenpipe-app-tauri/src-tauri/src/store.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/store.rs
@@ -954,6 +954,15 @@ pub struct SettingsStore {
     /// Overlay size: "small" (default), "medium" (1.5x), "large" (2x)
     #[serde(rename = "shortcutOverlaySize", default = "default_overlay_size")]
     pub shortcut_overlay_size: String,
+    /// The user's choice, honored only while `allow_hiding_shortcut_overlay`
+    /// is on. The overlay ships unhideable, so this is inert by default.
+    #[serde(rename = "showShortcutOverlay", default = "default_true")]
+    pub show_shortcut_overlay: bool,
+    /// Remote-controlled capability (`overlay-hiding-control`), written by the
+    /// desktop remote-control registry. False ships; flipping the flag on gives
+    /// the Display toggle back without a release.
+    #[serde(rename = "allowHidingShortcutOverlay", default)]
+    pub allow_hiding_shortcut_overlay: bool,
     /// Where the user dragged the overlay: one of top/bottom x left/center/right.
     #[serde(rename = "shortcutOverlayAnchor", default = "default_overlay_anchor")]
     pub shortcut_overlay_anchor: String,
@@ -1550,6 +1559,8 @@ Rules:
             lock_vault_shortcut: "Super+Shift+L".to_string(),
             shortcut_overlay_size: "small".to_string(),
             shortcut_overlay_anchor: default_overlay_anchor(),
+            show_shortcut_overlay: true,
+            allow_hiding_shortcut_overlay: false,
             device_id: uuid::Uuid::new_v4().to_string(),
             auto_update: true,
             auto_update_pipes: true,

--- a/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder.swift
+++ b/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder.swift
@@ -73,24 +73,72 @@ final class OverlayMetrics: ObservableObject {
     @Published var forceExpanded: Bool = false
     /// Progressive disclosure opens away from the nearest screen edge.
     @Published var disclosureDown: Bool = true
+    /// Side of the fixed-width panel the pill and dock hug, so a pill pinned to
+    /// a corner sits on the corner instead of ~70pt inside it.
+    @Published var horizontal: OverlayHorizontal = .center
     /// Control under the pointer in the expanded dock.
     @Published var hoveredControl: String? = nil
 }
 
-@available(macOS 13.0, *)
-private final class OverlayMenuState: ObservableObject {
-    @Published var hoveredItem: String?
+/// One clickable button on a notification shown from the pill.
+struct OverlayNotificationAction: Identifiable, Equatable {
+    /// Opaque payload handed back to Rust verbatim so the pill reuses the same
+    /// action dispatch as the standalone notification panel.
+    let id: String
+    let label: String
+    let primary: Bool
+    let payload: String
 }
 
-private struct SettingsMenuAnalyticsSession {
-    let openedAt: TimeInterval
-    var currentItem: String?
-    var currentItemEnteredAt: TimeInterval?
-    var hoverSequence: [String] = []
-    var hoverMilliseconds: [String: Int] = [:]
-    var longestHoverMilliseconds = 0
-    var longestHoverItem: String?
-    var revisitCount = 0
+/// A notification rendered as an extension of the pill rather than as a
+/// separate top-right panel. Only used while the pill is actually on screen.
+struct OverlayNotification: Equatable {
+    let id: String
+    let title: String
+    let body: String
+    let actions: [OverlayNotificationAction]
+    let autoDismissMs: Int?
+
+    static func parse(_ json: String) -> OverlayNotification? {
+        guard let data = json.data(using: .utf8),
+              let root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+              let id = root["id"] as? String,
+              let title = root["title"] as? String
+        else { return nil }
+
+        let rawActions = (root["actions"] as? [[String: Any]]) ?? []
+        let actions: [OverlayNotificationAction] = rawActions.compactMap { action in
+            guard let label = action["label"] as? String, !label.isEmpty else { return nil }
+            let actionId = (action["id"] as? String)
+                ?? (action["action"] as? String)
+                ?? label
+            guard let payloadData = try? JSONSerialization.data(withJSONObject: action),
+                  let payload = String(data: payloadData, encoding: .utf8)
+            else { return nil }
+            return OverlayNotificationAction(
+                id: actionId,
+                label: label,
+                primary: (action["primary"] as? Bool) ?? false,
+                payload: payload
+            )
+        }
+
+        // Two buttons is the most this row can show. Rather than silently drop
+        // the rest, refuse the payload so the caller falls back to the
+        // standalone panel, which has room for all of them.
+        guard actions.count == rawActions.count, actions.count <= 2 else { return nil }
+
+        let autoDismiss = (root["autoDismissMs"] as? Int)
+            ?? (root["autoDismissMs"] as? NSNumber)?.intValue
+
+        return OverlayNotification(
+            id: id,
+            title: title,
+            body: (root["body"] as? String) ?? "",
+            actions: actions,
+            autoDismissMs: autoDismiss
+        )
+    }
 }
 
 struct MeetingOverlayTranscriptItem: Identifiable, Equatable {
@@ -341,11 +389,8 @@ private let kBaseDisclosureH: CGFloat = 26
 private let kBaseDisclosureGap: CGFloat = 4
 private let kBaseTranscriptW: CGFloat = 280
 private let kBaseTranscriptH: CGFloat = 142
-private let kBaseSettingsMenuW: CGFloat = 116
-private let kBaseSettingsMenuH: CGFloat = 30
-private let kBaseOverlaySubmenuW: CGFloat = 164
-private let kBaseOverlaySubmenuRowH: CGFloat = 28
-private let kBaseOverlaySubmenuH: CGFloat = 85
+private let kBaseNotificationW: CGFloat = 340
+private let kBaseNotificationH: CGFloat = 44
 private let kRestingOpacity: Double = 0.50
 private let kAnimDur: Double = 0.2
 private let kDockControls = ["search", "chat", "timeline", "audio", "settings"]
@@ -380,17 +425,109 @@ func prettifyShortcut(_ raw: String) -> String {
     return (canonicalModifiers + keys).joined(separator: "+")
 }
 
+/// Which side of the panel the pill and its dock hug. The panel stays a fixed
+/// wide rectangle (resizing a nonactivating panel breaks mouse routing), so the
+/// pill is placed inside it instead.
+enum OverlayHorizontal {
+    case leading
+    case center
+    case trailing
+}
+
+/// Discrete places the pill can be pinned to. A floating control that lands
+/// wherever the pointer let go looks dropped; landing on a corner or an edge
+/// centre looks placed.
+enum OverlayAnchor: String, CaseIterable {
+    case topLeft = "top-left"
+    case topCenter = "top-center"
+    case topRight = "top-right"
+    case bottomLeft = "bottom-left"
+    case bottomCenter = "bottom-center"
+    case bottomRight = "bottom-right"
+
+    /// Top anchors keep the pill at the panel top so the disclosure, dock menu
+    /// and notification all have room to open downward, and vice versa.
+    var pillAtPanelTop: Bool {
+        switch self {
+        case .topLeft, .topCenter, .topRight: return true
+        case .bottomLeft, .bottomCenter, .bottomRight: return false
+        }
+    }
+
+    var horizontal: OverlayHorizontal {
+        switch self {
+        case .topLeft, .bottomLeft: return .leading
+        case .topCenter, .bottomCenter: return .center
+        case .topRight, .bottomRight: return .trailing
+        }
+    }
+}
+
+/// Gap between the pinned pill and the screen edge.
+let kAnchorMargin: CGFloat = 4
+
+/// Where the resting pill should sit on screen for a given anchor.
+func anchorPillCenter(
+    _ anchor: OverlayAnchor,
+    in visible: NSRect,
+    pillSize: NSSize
+) -> NSPoint {
+    let halfW = pillSize.width / 2
+    let halfH = pillSize.height / 2
+    let x: CGFloat
+    switch anchor.horizontal {
+    case .leading: x = visible.minX + kAnchorMargin + halfW
+    case .center: x = visible.midX
+    case .trailing: x = visible.maxX - kAnchorMargin - halfW
+    }
+    let y = anchor.pillAtPanelTop
+        ? visible.maxY - kAnchorMargin - halfH
+        : visible.minY + kAnchorMargin + halfH
+    return NSPoint(x: x, y: y)
+}
+
+/// Anchor whose resting spot is closest to where the pill was dropped. Ties go
+/// to the current anchor so a stray nudge never re-pins the pill.
+func nearestAnchor(
+    to pillCenter: NSPoint,
+    in visible: NSRect,
+    pillSize: NSSize,
+    current: OverlayAnchor
+) -> OverlayAnchor {
+    func distance(_ anchor: OverlayAnchor) -> CGFloat {
+        let target = anchorPillCenter(anchor, in: visible, pillSize: pillSize)
+        return hypot(target.x - pillCenter.x, target.y - pillCenter.y)
+    }
+    var best = current
+    var bestDistance = distance(current)
+    for candidate in OverlayAnchor.allCases where candidate != current {
+        let candidateDistance = distance(candidate)
+        if candidateDistance < bestDistance {
+            bestDistance = candidateDistance
+            best = candidate
+        }
+    }
+    return best
+}
+
 func overlayHoverRect(
     in bounds: NSRect,
     expanded: Bool,
     disclosureDown: Bool,
+    horizontal: OverlayHorizontal,
     scale: CGFloat
 ) -> NSRect {
     let collapsedScale = 1 + (scale - 1) * 0.2
     let width = expanded ? kBaseExpandedW * scale : kBaseCollapsedW * collapsedScale
     let height = expanded ? kBaseDockH * scale : kBaseCollapsedH * collapsedScale
+    let x: CGFloat
+    switch horizontal {
+    case .leading: x = bounds.minX
+    case .center: x = bounds.midX - width / 2
+    case .trailing: x = bounds.maxX - width
+    }
     return NSRect(
-        x: bounds.midX - width / 2,
+        x: x,
         y: disclosureDown ? bounds.maxY - height : bounds.minY,
         width: width,
         height: height
@@ -488,7 +625,16 @@ struct ShortcutReminderView: View {
 
     private var panelAlignment: Alignment {
         guard metrics.healthState == "normal" else { return .center }
-        return metrics.disclosureDown ? .top : .bottom
+        let horizontal: HorizontalAlignment
+        switch metrics.horizontal {
+        case .leading: horizontal = .leading
+        case .center: horizontal = .center
+        case .trailing: horizontal = .trailing
+        }
+        return Alignment(
+            horizontal: horizontal,
+            vertical: metrics.disclosureDown ? .top : .bottom
+        )
     }
 
     var body: some View {
@@ -728,7 +874,7 @@ struct ShortcutReminderView: View {
             Rectangle().fill(.white.opacity(0.28)).frame(width: 1).padding(.vertical, s(4))
 
             DockIconButton(icon: "gearshape", active: metrics.hoveredControl == "settings", scale: scale) {
-                onAction("show_settings_menu")
+                onAction("open_overlay_settings")
             }
         }
         .frame(width: kBaseExpandedW * scale, height: kBaseDockH * scale)
@@ -898,79 +1044,80 @@ private struct DockStatusCell<Content: View>: View {
     }
 }
 
+/// Notification rendered as an extension of the pill. Deliberately shaped like
+/// the pill's other surfaces (transcript preview, disclosure) rather than the
+/// standalone notification panel, so it reads as the overlay speaking up.
 @available(macOS 13.0, *)
-private struct OverlaySettingsMenuView: View {
+private struct OverlayNotificationView: View {
+    let notification: OverlayNotification
     let scale: CGFloat
-    let onOpenOverlayMenu: () -> Void
+    let onAction: (OverlayNotificationAction) -> Void
+    let onDismiss: () -> Void
 
     private func s(_ value: CGFloat) -> CGFloat { value * scale }
 
-    var body: some View {
-        Button(action: onOpenOverlayMenu) {
-            HStack(spacing: s(7)) {
-                Image(systemName: "rectangle.inset.filled")
-                    .font(.system(size: 9 * scale, weight: .medium))
-                Text("overlay")
-                    .font(Brand.swiftUIMonoFont(size: 9 * scale, weight: .medium))
-                Spacer(minLength: s(8))
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 8 * scale, weight: .semibold))
-            }
-            .foregroundColor(.white.opacity(0.88))
-            .padding(.horizontal, s(9))
-            .frame(
-                width: kBaseSettingsMenuW * scale,
-                height: kBaseSettingsMenuH * scale
-            )
-            .background(Color.white.opacity(0.08))
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .background(Color.black)
-        .overlay(Rectangle().stroke(Color.white.opacity(0.42), lineWidth: 1))
+    /// Ordered so the primary action lands closest to the right edge, where the
+    /// pointer already is after reading the title.
+    private var orderedActions: [OverlayNotificationAction] {
+        notification.actions.sorted { !$0.primary && $1.primary }
     }
-}
-
-@available(macOS 13.0, *)
-private struct OverlaySettingsSubmenuView: View {
-    @ObservedObject var menuState: OverlayMenuState
-    let scale: CGFloat
-    let onHideToday: () -> Void
-    let onHideWeek: () -> Void
-    let onOpenSettings: () -> Void
-
-    private func s(_ value: CGFloat) -> CGFloat { value * scale }
 
     var body: some View {
-        VStack(spacing: 0) {
-            menuRow("hide for today", id: "today", action: onHideToday)
-            menuRow("hide for a week", id: "week", action: onHideWeek)
-            Rectangle()
-                .fill(Color.white.opacity(0.18))
-                .frame(height: 1)
-                .padding(.horizontal, s(8))
-            menuRow("overlay settings", id: "settings", action: onOpenSettings)
+        HStack(spacing: s(8)) {
+            Image(systemName: "video.fill")
+                .font(.system(size: 10 * scale, weight: .medium))
+                .foregroundColor(.white.opacity(0.75))
+
+            VStack(alignment: .leading, spacing: s(1)) {
+                Text(notification.title)
+                    .font(Brand.swiftUIMonoFont(size: 10 * scale, weight: .semibold))
+                    .foregroundColor(.white.opacity(0.95))
+                    .lineLimit(1)
+                if !notification.body.isEmpty {
+                    Text(notification.body)
+                        .font(Brand.swiftUIMonoFont(size: 8.5 * scale, weight: .regular))
+                        .foregroundColor(.white.opacity(0.60))
+                        .lineLimit(1)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            ForEach(orderedActions) { action in
+                Button(action: { onAction(action) }) {
+                    Text(action.label)
+                        .font(Brand.swiftUIMonoFont(size: 9 * scale, weight: .medium))
+                        .foregroundColor(action.primary ? .black : .white.opacity(0.88))
+                        .lineLimit(1)
+                        .padding(.horizontal, s(8))
+                        .frame(height: s(22))
+                        .background(
+                            action.primary
+                                ? Color.white.opacity(0.92)
+                                : Color.white.opacity(0.10)
+                        )
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .fixedSize()
+            }
+
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 8 * scale, weight: .semibold))
+                    .foregroundColor(.white.opacity(0.55))
+                    .frame(width: s(14), height: s(22))
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("dismiss notification")
         }
+        .padding(.horizontal, s(10))
         .frame(
-            width: kBaseOverlaySubmenuW * scale,
-            height: kBaseOverlaySubmenuH * scale
+            width: kBaseNotificationW * scale,
+            height: kBaseNotificationH * scale
         )
         .background(Color.black)
         .overlay(Rectangle().stroke(Color.white.opacity(0.42), lineWidth: 1))
-    }
-
-    private func menuRow(_ title: String, id: String, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            Text(title)
-                .font(Brand.swiftUIMonoFont(size: 9 * scale, weight: .medium))
-                .foregroundColor(.white.opacity(0.88))
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, s(10))
-                .frame(height: kBaseOverlaySubmenuRowH * scale)
-                .background(menuState.hoveredItem == id ? Color.white.opacity(0.14) : Color.clear)
-                .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
     }
 }
 
@@ -1019,20 +1166,12 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
     private var trackingView: ReminderTrackingView?
     private var disclosurePanel: NSPanel?
     private var transcriptPanel: NSPanel?
-    private var settingsMenuPanel: NSPanel?
-    private var overlaySubmenuPanel: NSPanel?
     private var transcriptHostingView: NSHostingView<AnyView>?
     private var transcriptTrackingView: ReminderTrackingView?
     private var pillHovering = false
     private var transcriptHovering = false
-    private var settingsMenuHovering = false
-    private var overlaySubmenuHovering = false
     private var hoverHideWorkItem: DispatchWorkItem?
-    private var settingsMenuHideWorkItem: DispatchWorkItem?
     private var meetingStopTimeoutWorkItem: DispatchWorkItem?
-    private var settingsMenuOpen = false
-    private var settingsMenuAnalyticsSession: SettingsMenuAnalyticsSession?
-    private let overlayMenuState = OverlayMenuState()
 
     private var overlayShortcut = "Cmd+Ctrl+S"
     private var chatShortcut = "Cmd+Ctrl+L"
@@ -1046,6 +1185,21 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
     private var metricsWsUrl = "ws://127.0.0.1:3030/ws/metrics"
     private var eventsWsUrl = "ws://127.0.0.1:3030/ws/meeting-overlay"
     private var isVisible = false
+
+    /// Where the pill is pinned. Rust supplies the persisted value on show and
+    /// stores whatever the user drags it to.
+    private var overlayAnchor: OverlayAnchor = .topCenter
+    private var snapHintPanel: NSPanel?
+    private var snapHintAnchor: OverlayAnchor?
+    private var isDraggingPill = false
+    private var notificationPanel: NSPanel?
+    private var notificationHostingView: NSHostingView<AnyView>?
+    private var notificationTrackingView: ReminderTrackingView?
+    private var notificationHovering = false
+    private var notificationDismissWorkItem: DispatchWorkItem?
+    /// Notification currently shown from the pill. Held here rather than on
+    /// `metrics` so showing one does not re-render the pill itself.
+    private var activeNotification: OverlayNotification?
 
     private var healthToolTip: String? {
         guard metrics.healthState == "failure" else { return nil }
@@ -1068,18 +1222,12 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
                 parseShortcuts(shortcuts)
             }
             if panel == nil || prevScale != gOverlayScale {
-                emitSettingsMenuEngagement(selectedItem: nil)
-                settingsMenuHideWorkItem?.cancel()
-                settingsMenuHideWorkItem = nil
-                settingsMenuOpen = false
-                settingsMenuHovering = false
-                overlaySubmenuHovering = false
-                overlayMenuState.hoveredItem = nil
+                dismissOverlayNotification()
+                hideSnapHint()
+                isDraggingPill = false
                 panel?.orderOut(nil)
                 disclosurePanel?.orderOut(nil)
                 transcriptPanel?.orderOut(nil)
-                settingsMenuPanel?.orderOut(nil)
-                overlaySubmenuPanel?.orderOut(nil)
                 panel = nil
                 hostingView = nil
                 trackingView = nil
@@ -1087,8 +1235,12 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
                 transcriptPanel = nil
                 transcriptHostingView = nil
                 transcriptTrackingView = nil
-                settingsMenuPanel = nil
-                overlaySubmenuPanel = nil
+                // Every child panel is sized from gOverlayScale at creation, so
+                // they have to be rebuilt too when the scale changes.
+                snapHintPanel = nil
+                notificationPanel = nil
+                notificationHostingView = nil
+                notificationTrackingView = nil
                 createPanel()
             }
             updateContent()
@@ -1106,29 +1258,23 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
     func hide() {
         DispatchQueue.main.async { [self] in
             isVisible = false
-            emitSettingsMenuEngagement(selectedItem: nil)
             hoverHideWorkItem?.cancel()
             hoverHideWorkItem = nil
-            settingsMenuHideWorkItem?.cancel()
-            settingsMenuHideWorkItem = nil
             meetingStopTimeoutWorkItem?.cancel()
             meetingStopTimeoutWorkItem = nil
             pillHovering = false
             transcriptHovering = false
-            settingsMenuHovering = false
-            overlaySubmenuHovering = false
             metrics.isHovering = false
             metrics.forceExpanded = false
             metrics.hoveredControl = nil
-            overlayMenuState.hoveredItem = nil
-            settingsMenuOpen = false
+            isDraggingPill = false
+            dismissOverlayNotification()
+            hideSnapHint()
             AnimationTick.shared.setVisible(false, hasActiveSignal: false)
             disconnectWebSocket()
             disconnectMeetingEventsWebSocket()
             disclosurePanel?.orderOut(nil)
             transcriptPanel?.orderOut(nil)
-            settingsMenuPanel?.orderOut(nil)
-            overlaySubmenuPanel?.orderOut(nil)
             panel?.orderOut(nil)
         }
     }
@@ -1413,7 +1559,6 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
                 if state != "normal" {
                     self.metrics.hoveredControl = nil
                     self.disclosurePanel?.orderOut(nil)
-                    self.closeSettingsMenu(scheduleCollapse: false)
                 }
                 // Normal states are trailing-anchored, health states centred —
                 // the window origin differs, so re-place it on that boundary.
@@ -1434,6 +1579,9 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
         if let s = dict["chat"] { chatShortcut = prettifyShortcut(s) }
         if let s = dict["search"] { searchShortcut = prettifyShortcut(s) }
         if let s = dict["shortcutOverlaySize"] { setOverlayScale(s) }
+        if let s = dict["shortcutOverlayAnchor"], let anchor = OverlayAnchor(rawValue: s) {
+            overlayAnchor = anchor
+        }
         if let s = dict["metrics_ws_url"] { metricsWsUrl = s }
         if let s = dict["events_ws_url"] { eventsWsUrl = s }
     }
@@ -1477,6 +1625,7 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
                 in: bounds,
                 expanded: self.metrics.isHovering || self.metrics.forceExpanded,
                 disclosureDown: self.metrics.disclosureDown,
+                horizontal: self.metrics.horizontal,
                 scale: gOverlayScale
             )
         }
@@ -1515,15 +1664,6 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
         guard pointerIsInDock else { return }
         let index = min(kDockControls.count - 1, max(0, Int(point.x / cellWidth)))
         let control = kDockControls[index]
-        if control == "settings" {
-            metrics.hoveredControl = control
-            disclosurePanel?.orderOut(nil)
-            showSettingsMenu()
-            return
-        }
-        if settingsMenuOpen {
-            closeSettingsMenu(scheduleCollapse: false)
-        }
         if metrics.hoveredControl != control {
             metrics.hoveredControl = control
             showDisclosurePanel(for: control, index: index)
@@ -1622,7 +1762,7 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
             guard let self = self,
                   !self.pillHovering,
                   !self.transcriptHovering,
-                  !self.settingsMenuOpen else { return }
+                  !self.notificationHovering else { return }
             self.metrics.isHovering = false
             self.metrics.forceExpanded = false
             self.metrics.hoveredControl = nil
@@ -1720,47 +1860,221 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
         transcriptPanel.setFrameOrigin(NSPoint(x: x, y: y))
     }
 
+    /// Disclosure direction follows the pinned anchor rather than the live
+    /// frame, so it stays put while the pill is being dragged and only flips
+    /// once the drag lands somewhere new.
     private func updateDisclosureDirection() {
-        guard let panel = panel else { return }
-        let visible = panel.screen?.visibleFrame ?? NSScreen.main?.visibleFrame ?? panel.frame
-        let disclosureDown = panel.frame.midY >= visible.midY
-        if metrics.disclosureDown != disclosureDown {
-            metrics.disclosureDown = disclosureDown
-            positionDisclosurePanel()
-            if settingsMenuOpen {
-                positionSettingsMenuPanels()
-            }
-            if transcriptPanel?.isVisible == true {
-                positionTranscriptPanel()
-            }
+        let disclosureDown = overlayAnchor.pillAtPanelTop
+        let horizontal = overlayAnchor.horizontal
+        guard metrics.disclosureDown != disclosureDown || metrics.horizontal != horizontal else {
+            return
+        }
+        metrics.disclosureDown = disclosureDown
+        metrics.horizontal = horizontal
+        positionDisclosurePanel()
+        if transcriptPanel?.isVisible == true {
+            positionTranscriptPanel()
+        }
+        if notificationPanel?.isVisible == true {
+            positionNotificationPanel()
         }
     }
 
-    /// Keep the fixed-width panel centred so both the resting icon and expanded
-    /// dock share one midpoint and expansion grows evenly in both directions.
-    private func centeredOriginX(on screen: NSScreen) -> CGFloat {
-        let expanded = kBaseExpandedW * gOverlayScale
-        return screen.frame.origin.x
-            + (screen.frame.size.width - expanded) / 2
+    /// Footprint of the resting pill, which is much smaller than the panel that
+    /// hosts it. Pinning positions this, not the panel.
+    private func collapsedPillSize() -> NSSize {
+        let collapsedScale = 1 + (gOverlayScale - 1) * 0.2
+        return NSSize(
+            width: kBaseCollapsedW * collapsedScale,
+            height: kBaseCollapsedH * collapsedScale
+        )
     }
 
-    private func positionPanel() {
-        guard let panel = panel else { return }
+    private func screenUnderCursor() -> NSScreen? {
         let mouseLocation = NSEvent.mouseLocation
-        for screen in NSScreen.screens {
-            if NSMouseInRect(mouseLocation, screen.frame, false) {
-                let visible = screen.visibleFrame
-                let h = kBaseExpandedH * gOverlayScale
-                let x = max(visible.minX, centeredOriginX(on: screen))
-                let y = visible.origin.y + visible.size.height - h - 4
-                panel.setFrameOrigin(NSPoint(x: x, y: y))
-                updateDisclosureDirection()
-                if transcriptPanel?.isVisible == true {
-                    positionTranscriptPanel()
-                }
-                break
-            }
+        return NSScreen.screens.first { NSMouseInRect(mouseLocation, $0.frame, false) }
+    }
+
+    /// Screen a dropped pill belongs to. Falls back to the panel's screen so a
+    /// drop into a gap between displays still lands somewhere real.
+    private func screenContaining(_ point: NSPoint) -> NSScreen? {
+        NSScreen.screens.first { NSMouseInRect(point, $0.frame, false) }
+            ?? panel?.screen
+            ?? NSScreen.main
+    }
+
+    /// Panel origin that puts the resting pill exactly on `anchor`. The pill is
+    /// aligned inside the panel by `metrics.horizontal` / `disclosureDown`, so
+    /// this is the inverse of that placement.
+    private func anchoredPanelOrigin(for anchor: OverlayAnchor, on screen: NSScreen) -> NSPoint {
+        let visible = screen.visibleFrame
+        let panelW = kBaseExpandedW * gOverlayScale
+        let panelH = kBaseExpandedH * gOverlayScale
+        let pill = collapsedPillSize()
+        let center = anchorPillCenter(anchor, in: visible, pillSize: pill)
+
+        let x: CGFloat
+        switch anchor.horizontal {
+        case .leading: x = center.x - pill.width / 2
+        case .center: x = center.x - panelW / 2
+        case .trailing: x = center.x + pill.width / 2 - panelW
         }
+        let y = anchor.pillAtPanelTop
+            ? center.y + pill.height / 2 - panelH
+            : center.y - pill.height / 2
+        return NSPoint(x: x, y: y)
+    }
+
+    /// Screen point the resting pill currently occupies, used to decide which
+    /// anchor a drag landed on.
+    private func currentPillCenter() -> NSPoint? {
+        guard let panel = panel else { return nil }
+        let rect = overlayHoverRect(
+            in: panel.frame,
+            expanded: false,
+            disclosureDown: metrics.disclosureDown,
+            horizontal: metrics.horizontal,
+            scale: gOverlayScale
+        )
+        return NSPoint(x: rect.midX, y: rect.midY)
+    }
+
+    private func positionPanel(animated: Bool = false, on targetScreen: NSScreen? = nil) {
+        guard let panel = panel else { return }
+        guard let screen = targetScreen ?? screenUnderCursor() ?? panel.screen ?? NSScreen.main
+        else { return }
+
+        // The anchor is the single source of truth for both the panel origin
+        // and where the pill sits inside it, so they can never disagree.
+        metrics.horizontal = overlayAnchor.horizontal
+        metrics.disclosureDown = overlayAnchor.pillAtPanelTop
+        let origin = anchoredPanelOrigin(for: overlayAnchor, on: screen)
+
+        if animated {
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = kAnimDur
+                context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+                panel.animator().setFrameOrigin(origin)
+            }
+        } else {
+            panel.setFrameOrigin(origin)
+        }
+
+        positionDisclosurePanel()
+        if transcriptPanel?.isVisible == true {
+            positionTranscriptPanel()
+        }
+        if notificationPanel?.isVisible == true {
+            positionNotificationPanel()
+        }
+    }
+
+    // MARK: - Drag to pin
+
+    private func beginPillDrag() {
+        isDraggingPill = true
+        metrics.isHovering = false
+        metrics.forceExpanded = false
+        metrics.hoveredControl = nil
+        disclosurePanel?.orderOut(nil)
+        updateSnapHint()
+    }
+
+    /// Snap to the nearest anchor, persist it, and let the panel settle there.
+    private func endPillDrag() {
+        isDraggingPill = false
+        hideSnapHint()
+        guard let (landed, screen) = droppedAnchor() else { return }
+
+        let changed = landed != overlayAnchor
+        overlayAnchor = landed
+        // Re-place on the screen the pill was dropped on, which is not always
+        // the one under the cursor at release.
+        positionPanel(animated: true, on: screen)
+        if changed {
+            sendAction("set_overlay_anchor:\(landed.rawValue)")
+        }
+    }
+
+    /// Anchor the pill would land on right now, with the screen it belongs to.
+    private func droppedAnchor() -> (OverlayAnchor, NSScreen)? {
+        guard let center = currentPillCenter(),
+              let screen = screenContaining(center) else { return nil }
+        let landed = nearestAnchor(
+            to: center,
+            in: screen.visibleFrame,
+            pillSize: collapsedPillSize(),
+            current: overlayAnchor
+        )
+        return (landed, screen)
+    }
+
+    private func snapHintTarget() -> (OverlayAnchor, NSRect)? {
+        guard let (candidate, screen) = droppedAnchor() else { return nil }
+        let pill = collapsedPillSize()
+        let target = anchorPillCenter(candidate, in: screen.visibleFrame, pillSize: pill)
+        // Pad the hint so it reads as a landing pad rather than a second pill.
+        let pad: CGFloat = 5 * gOverlayScale
+        let rect = NSRect(
+            x: target.x - pill.width / 2 - pad,
+            y: target.y - pill.height / 2 - pad,
+            width: pill.width + pad * 2,
+            height: pill.height + pad * 2
+        )
+        return (candidate, rect)
+    }
+
+    private func updateSnapHint() {
+        guard isDraggingPill, let (candidate, rect) = snapHintTarget() else {
+            hideSnapHint()
+            return
+        }
+        let hint = ensureSnapHintPanel()
+        hint.setFrame(rect, display: false)
+        if snapHintAnchor != candidate {
+            snapHintAnchor = candidate
+        }
+        if !hint.isVisible {
+            hint.orderFront(nil)
+        }
+    }
+
+    private func hideSnapHint() {
+        snapHintAnchor = nil
+        snapHintPanel?.orderOut(nil)
+    }
+
+    private func ensureSnapHintPanel() -> NSPanel {
+        if let existing = snapHintPanel { return existing }
+        let hint = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 40, height: 30),
+            styleMask: [.nonactivatingPanel, .borderless],
+            backing: .buffered,
+            defer: false
+        )
+        hint.isFloatingPanel = true
+        hint.level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.floatingWindow)) + 1)
+        hint.collectionBehavior = [.canJoinAllSpaces, .ignoresCycle, .fullScreenAuxiliary]
+        hint.isOpaque = false
+        hint.backgroundColor = .clear
+        hint.hasShadow = false
+        hint.hidesOnDeactivate = false
+        hint.isReleasedWhenClosed = false
+        hint.sharingType = .readOnly
+        hint.ignoresMouseEvents = true
+
+        let content = NSView(frame: hint.contentView?.bounds ?? .zero)
+        content.wantsLayer = true
+        content.autoresizingMask = [.width, .height]
+        if let layer = content.layer {
+            layer.cornerRadius = kBaseCollapsedCornerRadius * gOverlayScale
+            layer.borderWidth = 1
+            layer.borderColor = NSColor.white.withAlphaComponent(0.55).cgColor
+            layer.backgroundColor = NSColor.white.withAlphaComponent(0.10).cgColor
+        }
+        hint.contentView = content
+        snapHintPanel = hint
+        return hint
     }
 
     private func updateContent() {
@@ -1772,12 +2086,7 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
             metrics: metrics,
             scale: gOverlayScale,
             onAction: { [weak self] action in
-                if action == "show_settings_menu" {
-                    self?.showSettingsMenu()
-                } else {
-                    self?.closeSettingsMenu(scheduleCollapse: false)
-                    self?.sendAction(action)
-                }
+                self?.sendAction(action)
             }
         )
         let contentView = panel.contentView!
@@ -1788,12 +2097,11 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
             hosting.onDragStarted = { [weak self] in
                 self?.pillHovering = false
                 self?.transcriptHovering = false
-                self?.metrics.isHovering = false
-                self?.metrics.forceExpanded = false
-                self?.metrics.hoveredControl = nil
-                self?.disclosurePanel?.orderOut(nil)
                 self?.transcriptPanel?.orderOut(nil)
-                self?.closeSettingsMenu(scheduleCollapse: false)
+                self?.beginPillDrag()
+            }
+            hosting.onDragEnded = { [weak self] in
+                self?.endPillDrag()
             }
             hosting.frame = contentView.bounds
             hosting.autoresizingMask = [.width, .height]
@@ -1803,293 +2111,177 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
         updateHealthToolTip()
     }
 
-    private func showSettingsMenu() {
-        guard !settingsMenuOpen else { return }
-        settingsMenuAnalyticsSession = SettingsMenuAnalyticsSession(
-            openedAt: ProcessInfo.processInfo.systemUptime
-        )
-        hoverHideWorkItem?.cancel()
-        hoverHideWorkItem = nil
-        settingsMenuHideWorkItem?.cancel()
-        settingsMenuHideWorkItem = nil
-        settingsMenuOpen = true
-        metrics.forceExpanded = true
-        metrics.hoveredControl = "settings"
-        disclosurePanel?.orderOut(nil)
-        transcriptPanel?.orderOut(nil)
 
-        ensureSettingsMenuPanels()
-        positionSettingsMenuPanels()
-        overlaySubmenuPanel?.orderOut(nil)
-        settingsMenuPanel?.orderFrontRegardless()
-    }
+    // MARK: - Notification shown from the pill
 
-    private func ensureSettingsMenuPanels() {
-        guard let panel = panel else { return }
-
-        if settingsMenuPanel == nil {
-            let size = NSSize(
-                width: kBaseSettingsMenuW * gOverlayScale,
-                height: kBaseSettingsMenuH * gOverlayScale
-            )
-            let (menu, tracking) = makeSettingsMenuPanel(
-                size: size,
-                level: NSWindow.Level(rawValue: panel.level.rawValue + 1)
-            )
-            tracking.onHoverChanged = { [weak self] hovering in
-                self?.setSettingsMenuHovering(hovering)
-            }
-            let view = OverlaySettingsMenuView(
-                scale: gOverlayScale,
-                onOpenOverlayMenu: { [weak self] in self?.showOverlaySubmenu() }
-            )
-            let hosting = OverlayMenuHostingView(rootView: AnyView(view))
-            hosting.frame = tracking.bounds
-            hosting.autoresizingMask = [.width, .height]
-            tracking.addSubview(hosting)
-            settingsMenuPanel = menu
+    /// Render a notification next to the pill. Returns false when the pill is
+    /// not on screen so Rust can fall back to the standalone panel.
+    func showNotification(_ json: String) -> Bool {
+        guard isVisible, panel != nil else { return false }
+        guard let parsed = OverlayNotification.parse(json) else { return false }
+        DispatchQueue.main.async { [self] in
+            notificationDismissWorkItem?.cancel()
+            notificationDismissWorkItem = nil
+            activeNotification = parsed
+            ensureNotificationPanel()
+            updateNotificationContent()
+            positionNotificationPanel()
+            presentNotificationPanel()
+            scheduleNotificationDismiss()
         }
-
-        if overlaySubmenuPanel == nil {
-            let size = NSSize(
-                width: kBaseOverlaySubmenuW * gOverlayScale,
-                height: kBaseOverlaySubmenuH * gOverlayScale
-            )
-            let (submenu, tracking) = makeSettingsMenuPanel(
-                size: size,
-                level: NSWindow.Level(rawValue: panel.level.rawValue + 2)
-            )
-            tracking.onHoverChanged = { [weak self] hovering in
-                self?.setOverlaySubmenuHovering(hovering)
-            }
-            tracking.onPointerMoved = { [weak self] point in
-                self?.updateOverlaySubmenuHover(at: point)
-            }
-            let view = OverlaySettingsSubmenuView(
-                menuState: overlayMenuState,
-                scale: gOverlayScale,
-                onHideToday: { [weak self] in self?.selectOverlayDismissal("dismiss_today") },
-                onHideWeek: { [weak self] in self?.selectOverlayDismissal("dismiss_week") },
-                onOpenSettings: { [weak self] in self?.openOverlaySettings() }
-            )
-            let hosting = OverlayMenuHostingView(rootView: AnyView(view))
-            hosting.frame = tracking.bounds
-            hosting.autoresizingMask = [.width, .height]
-            tracking.addSubview(hosting)
-            overlaySubmenuPanel = submenu
-        }
+        return true
     }
 
-    private func makeSettingsMenuPanel(
-        size: NSSize,
-        level: NSWindow.Level
-    ) -> (NSPanel, ReminderTrackingView) {
-        let menu = NSPanel(
-            contentRect: NSRect(origin: .zero, size: size),
-            styleMask: [.nonactivatingPanel, .borderless],
-            backing: .buffered,
-            defer: false
-        )
-        menu.isFloatingPanel = true
-        menu.level = level
-        menu.collectionBehavior = [.canJoinAllSpaces, .ignoresCycle, .fullScreenAuxiliary]
-        menu.isOpaque = false
-        menu.backgroundColor = .clear
-        menu.hasShadow = false
-        menu.hidesOnDeactivate = false
-        menu.acceptsMouseMovedEvents = true
-        menu.isReleasedWhenClosed = false
-        menu.sharingType = panel?.sharingType ?? .readOnly
-
-        let tracking = ReminderTrackingView(frame: NSRect(origin: .zero, size: size))
-        tracking.autoresizingMask = [.width, .height]
-        menu.contentView = tracking
-        return (menu, tracking)
+    func dismissOverlayNotification() {
+        notificationDismissWorkItem?.cancel()
+        notificationDismissWorkItem = nil
+        notificationHovering = false
+        activeNotification = nil
+        notificationPanel?.orderOut(nil)
     }
 
-    private func setSettingsMenuHovering(_ hovering: Bool) {
-        settingsMenuHovering = hovering
+    /// Reading the notification holds it open and holds the pill expanded.
+    /// Leaving restarts both timers rather than stranding either state.
+    private func setNotificationHovering(_ hovering: Bool) {
+        notificationHovering = hovering
         if hovering {
-            settingsMenuHideWorkItem?.cancel()
-            settingsMenuHideWorkItem = nil
-            showOverlaySubmenu()
+            hoverHideWorkItem?.cancel()
+            hoverHideWorkItem = nil
+            notificationDismissWorkItem?.cancel()
+            notificationDismissWorkItem = nil
         } else {
-            scheduleSettingsMenuExit()
-        }
-    }
-
-    private func setOverlaySubmenuHovering(_ hovering: Bool) {
-        overlaySubmenuHovering = hovering
-        if hovering {
-            settingsMenuHideWorkItem?.cancel()
-            settingsMenuHideWorkItem = nil
-        } else {
-            overlayMenuState.hoveredItem = nil
-            updateSettingsMenuAnalyticsHover(nil)
-            scheduleSettingsMenuExit()
-        }
-    }
-
-    private func showOverlaySubmenu() {
-        guard settingsMenuOpen else { return }
-        positionSettingsMenuPanels()
-        overlaySubmenuPanel?.orderFrontRegardless()
-    }
-
-    private func updateOverlaySubmenuHover(at point: NSPoint?) {
-        guard let point = point else {
-            overlayMenuState.hoveredItem = nil
-            updateSettingsMenuAnalyticsHover(nil)
-            return
-        }
-        let height = kBaseOverlaySubmenuH * gOverlayScale
-        let rowHeight = kBaseOverlaySubmenuRowH * gOverlayScale
-        let index = min(2, max(0, Int((height - point.y) / rowHeight)))
-        let item = ["today", "week", "settings"][index]
-        overlayMenuState.hoveredItem = item
-        updateSettingsMenuAnalyticsHover(item)
-    }
-
-    private func updateSettingsMenuAnalyticsHover(_ item: String?) {
-        guard var session = settingsMenuAnalyticsSession,
-              session.currentItem != item else { return }
-        let now = ProcessInfo.processInfo.systemUptime
-
-        if let currentItem = session.currentItem,
-           let enteredAt = session.currentItemEnteredAt {
-            let elapsed = max(0, Int(((now - enteredAt) * 1_000).rounded()))
-            session.hoverMilliseconds[currentItem, default: 0] += elapsed
-            if elapsed > session.longestHoverMilliseconds {
-                session.longestHoverMilliseconds = elapsed
-                session.longestHoverItem = currentItem
-            }
-        }
-
-        session.currentItem = nil
-        session.currentItemEnteredAt = nil
-        if let item = item {
-            if session.hoverSequence.contains(item) {
-                session.revisitCount += 1
-            }
-            session.hoverSequence.append(item)
-            session.currentItem = item
-            session.currentItemEnteredAt = now
-        }
-        settingsMenuAnalyticsSession = session
-    }
-
-    private func emitSettingsMenuEngagement(selectedItem: String?) {
-        updateSettingsMenuAnalyticsHover(nil)
-        guard let session = settingsMenuAnalyticsSession else { return }
-        settingsMenuAnalyticsSession = nil
-        guard !session.hoverSequence.isEmpty || selectedItem != nil else { return }
-
-        var hoveredItems: [String] = []
-        for item in session.hoverSequence where !hoveredItems.contains(item) {
-            hoveredItems.append(item)
-        }
-        let openMilliseconds = max(
-            0,
-            Int(((ProcessInfo.processInfo.systemUptime - session.openedAt) * 1_000).rounded())
-        )
-        let properties: [String: Any] = [
-            "hovered_items": hoveredItems,
-            "hover_sequence": session.hoverSequence,
-            "hover_transition_count": max(0, session.hoverSequence.count - 1),
-            "revisit_count": session.revisitCount,
-            "menu_open_ms": openMilliseconds,
-            "today_hover_ms": session.hoverMilliseconds["today", default: 0],
-            "week_hover_ms": session.hoverMilliseconds["week", default: 0],
-            "settings_hover_ms": session.hoverMilliseconds["settings", default: 0],
-            "longest_hover_ms": session.longestHoverMilliseconds,
-            "longest_hover_item": session.longestHoverItem ?? NSNull(),
-            "dwell_over_one_second": session.longestHoverMilliseconds >= 1_000,
-            "selected_item": selectedItem ?? NSNull(),
-            "outcome": selectedItem == nil ? "closed" : "selected",
-        ]
-        guard let data = try? JSONSerialization.data(withJSONObject: properties),
-              let json = String(data: data, encoding: .utf8) else { return }
-        sendAction("settings_menu_engaged:\(json)")
-    }
-
-    private func scheduleSettingsMenuExit() {
-        settingsMenuHideWorkItem?.cancel()
-        let work = DispatchWorkItem { [weak self] in
-            guard let self = self,
-                  !self.pillHovering,
-                  !self.settingsMenuHovering,
-                  !self.overlaySubmenuHovering else { return }
-            self.closeSettingsMenu()
-        }
-        settingsMenuHideWorkItem = work
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.18, execute: work)
-    }
-
-    private func closeSettingsMenu(
-        scheduleCollapse: Bool = true,
-        selectedItem: String? = nil
-    ) {
-        emitSettingsMenuEngagement(selectedItem: selectedItem)
-        settingsMenuHideWorkItem?.cancel()
-        settingsMenuHideWorkItem = nil
-        settingsMenuOpen = false
-        settingsMenuHovering = false
-        overlaySubmenuHovering = false
-        overlayMenuState.hoveredItem = nil
-        settingsMenuPanel?.orderOut(nil)
-        overlaySubmenuPanel?.orderOut(nil)
-        if scheduleCollapse && !pillHovering && !transcriptHovering {
+            scheduleNotificationDismiss()
             scheduleHoverExit()
         }
     }
 
-    private func positionSettingsMenuPanels() {
-        guard let panel = panel,
-              let menu = settingsMenuPanel,
-              let submenu = overlaySubmenuPanel else { return }
+    /// Arm the auto-dismiss for the notification currently on screen.
+    private func scheduleNotificationDismiss() {
+        notificationDismissWorkItem?.cancel()
+        notificationDismissWorkItem = nil
+        guard let autoDismissMs = activeNotification?.autoDismissMs, autoDismissMs > 0 else {
+            return
+        }
+        let work = DispatchWorkItem { [weak self] in
+            guard let self = self, !self.notificationHovering else { return }
+            self.dismissOverlayNotification()
+        }
+        notificationDismissWorkItem = work
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + .milliseconds(autoDismissMs),
+            execute: work
+        )
+    }
+
+    private func ensureNotificationPanel() {
+        guard notificationPanel == nil else { return }
+        let w = kBaseNotificationW * gOverlayScale
+        let h = kBaseNotificationH * gOverlayScale
+        let toast = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: Int(w), height: Int(h)),
+            styleMask: [.nonactivatingPanel, .borderless],
+            backing: .buffered,
+            defer: false
+        )
+        toast.isFloatingPanel = true
+        toast.level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.floatingWindow)) + 2)
+        toast.collectionBehavior = [.canJoinAllSpaces, .ignoresCycle, .fullScreenAuxiliary]
+        toast.isOpaque = false
+        toast.backgroundColor = .clear
+        toast.hasShadow = false
+        toast.hidesOnDeactivate = false
+        toast.acceptsMouseMovedEvents = true
+        toast.isReleasedWhenClosed = false
+        toast.sharingType = .readOnly
+
+        let tracking = ReminderTrackingView(
+            frame: NSRect(x: 0, y: 0, width: Int(w), height: Int(h))
+        )
+        tracking.autoresizingMask = [.width, .height]
+        tracking.onHoverChanged = { [weak self] hovering in
+            self?.setNotificationHovering(hovering)
+        }
+        toast.contentView = tracking
+        notificationPanel = toast
+        notificationTrackingView = tracking
+    }
+
+    private func updateNotificationContent() {
+        guard let contentView = notificationPanel?.contentView,
+              let notification = activeNotification else { return }
+        let view = OverlayNotificationView(
+            notification: notification,
+            scale: gOverlayScale,
+            onAction: { [weak self] action in
+                self?.dismissOverlayNotification()
+                self?.sendAction("notification_action:\(action.payload)")
+            },
+            onDismiss: { [weak self] in self?.dismissOverlayNotification() }
+        )
+        if let hosting = notificationHostingView {
+            hosting.rootView = AnyView(view)
+        } else {
+            let hosting = NSHostingView(rootView: AnyView(view))
+            hosting.frame = contentView.bounds
+            hosting.autoresizingMask = [.width, .height]
+            contentView.addSubview(hosting)
+            notificationHostingView = hosting
+        }
+    }
+
+    /// Sit the notification against the pill on the side the disclosure opens,
+    /// aligned to the pill's edge so it visibly belongs to it.
+    private func positionNotificationPanel() {
+        guard let panel = panel, let toast = notificationPanel else { return }
         let visible = panel.screen?.visibleFrame ?? NSScreen.main?.visibleFrame ?? panel.frame
-        let gap = kBaseDisclosureGap * gOverlayScale
-        let dockHeight = kBaseDockH * gOverlayScale
-        let rootSize = menu.frame.size
-        let submenuSize = submenu.frame.size
+        let width = toast.frame.width
+        let height = toast.frame.height
+        let pill = overlayHoverRect(
+            in: panel.frame,
+            expanded: false,
+            disclosureDown: metrics.disclosureDown,
+            horizontal: metrics.horizontal,
+            scale: gOverlayScale
+        )
 
-        let rootX = min(
-            max(panel.frame.maxX - rootSize.width, visible.minX),
-            visible.maxX - rootSize.width
-        )
-        let preferredRootY = metrics.disclosureDown
-            ? panel.frame.maxY - dockHeight - gap - rootSize.height
-            : panel.frame.minY + dockHeight + gap
-        let rootY = min(
-            max(preferredRootY, visible.minY),
-            visible.maxY - rootSize.height
-        )
-        menu.setFrameOrigin(NSPoint(x: rootX, y: rootY))
-
-        let rightX = menu.frame.maxX + gap
-        let leftX = menu.frame.minX - gap - submenuSize.width
-        let submenuX = rightX + submenuSize.width <= visible.maxX
-            ? rightX
-            : max(visible.minX, leftX)
-        let preferredSubmenuY = metrics.disclosureDown
-            ? menu.frame.maxY - submenuSize.height
-            : menu.frame.minY
-        let submenuY = min(
-            max(preferredSubmenuY, visible.minY),
-            visible.maxY - submenuSize.height
-        )
-        submenu.setFrameOrigin(NSPoint(x: submenuX, y: submenuY))
+        let preferredX: CGFloat
+        switch metrics.horizontal {
+        case .leading: preferredX = pill.minX
+        case .center: preferredX = pill.midX - width / 2
+        case .trailing: preferredX = pill.maxX - width
+        }
+        let x = min(max(preferredX, visible.minX + kAnchorMargin), visible.maxX - width - kAnchorMargin)
+        let preferredY = metrics.disclosureDown
+            ? panel.frame.minY - height - kAnchorMargin
+            : panel.frame.maxY + kAnchorMargin
+        let y = min(max(preferredY, visible.minY + kAnchorMargin), visible.maxY - height - kAnchorMargin)
+        toast.setFrameOrigin(NSPoint(x: x, y: y))
     }
 
-    private func selectOverlayDismissal(_ action: String) {
-        let selectedItem = action == "dismiss_today" ? "today" : "week"
-        closeSettingsMenu(scheduleCollapse: false, selectedItem: selectedItem)
-        sendAction(action)
-    }
-
-    private func openOverlaySettings() {
-        closeSettingsMenu(selectedItem: "settings")
-        sendAction("open_overlay_settings")
+    /// Grow out of the pill instead of appearing on top of it.
+    private func presentNotificationPanel() {
+        guard let toast = notificationPanel else { return }
+        let destination = toast.frame
+        guard let pill = panelFrameIfVisible() else {
+            toast.alphaValue = 1
+            toast.orderFrontRegardless()
+            return
+        }
+        let start = NSRect(
+            x: pill.midX - destination.width / 2,
+            y: metrics.disclosureDown ? destination.maxY - 1 : destination.minY + 1,
+            width: destination.width,
+            height: 1
+        )
+        toast.setFrame(start, display: false)
+        toast.alphaValue = 0
+        toast.orderFrontRegardless()
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = kAnimDur
+            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            toast.animator().setFrame(destination, display: true)
+            toast.animator().alphaValue = 1
+        }
     }
 
     private func sendAction(_ action: String) {
@@ -2106,10 +2298,15 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
         guard metrics.healthState == "normal",
               !metrics.isHovering,
               !metrics.forceExpanded else { return frame }
-        let collapsedScale = 1 + (gOverlayScale - 1) * 0.2
-        let collapsed = min(kBaseCollapsedW * collapsedScale, frame.width)
+        let collapsed = min(collapsedPillSize().width, frame.width)
+        let x: CGFloat
+        switch metrics.horizontal {
+        case .leading: x = frame.minX
+        case .center: x = frame.midX - collapsed / 2
+        case .trailing: x = frame.maxX - collapsed
+        }
         return NSRect(
-            x: frame.midX - collapsed / 2,
+            x: x,
             y: frame.minY,
             width: collapsed,
             height: frame.height
@@ -2119,8 +2316,13 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
     func windowDidMove(_ notification: Notification) {
         updateDisclosureDirection()
         positionDisclosurePanel()
-        if settingsMenuOpen {
-            positionSettingsMenuPanels()
+        if notificationPanel?.isVisible == true {
+            positionNotificationPanel()
+        }
+        // performDrag runs its own tracking loop, so this is the only signal
+        // that the pill moved while the user is still holding it.
+        if isDraggingPill {
+            updateSnapHint()
         }
     }
 }
@@ -2206,6 +2408,8 @@ private class ReminderTrackingView: NSView {
 private class DraggableHostingView<Content: View>: NSHostingView<Content> {
     /// Called when a drag begins — lets the controller collapse the pill.
     var onDragStarted: (() -> Void)?
+    /// Called once the user releases, so the controller can snap and persist.
+    var onDragEnded: (() -> Void)?
 
     private var dragMonitor: Any?
     private var dragStartLocation: NSPoint = .zero
@@ -2262,6 +2466,7 @@ private class DraggableHostingView<Content: View>: NSHostingView<Content> {
                     // alive to catch and swallow the final mouseUp.
                     self.swallowNextMouseUp = true
                     window.performDrag(with: event)
+                    self.onDragEnded?()
                     return nil
                 }
                 return event
@@ -2289,6 +2494,22 @@ public func shortcutHide() -> Int32 {
     if #available(macOS 13.0, *) {
         ShortcutReminderController.shared.hide()
         return 0
+    }
+    return -2
+}
+
+/// Show a notification attached to the pill. Returns 0 when the pill rendered
+/// it, -1 when it could not (hidden, or a payload the pill cannot represent) so
+/// the caller can fall back to the standalone notification panel.
+@_cdecl("shortcut_show_notification")
+public func shortcutShowNotification(_ jsonPtr: UnsafePointer<CChar>?) -> Int32 {
+    guard let jsonPtr = jsonPtr else { return -1 }
+    let json = String(cString: jsonPtr)
+    if #available(macOS 13.0, *) {
+        var shown = false
+        let work = { shown = ShortcutReminderController.shared.showNotification(json) }
+        if Thread.isMainThread { work() } else { DispatchQueue.main.sync(execute: work) }
+        return shown ? 0 : -1
     }
     return -2
 }

--- a/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder_preview.swift
+++ b/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder_preview.swift
@@ -17,14 +17,21 @@ struct ShortcutReminderPreview {
             exit(1)
         }
 
+        // Line-buffer stdout so `--once` runs still report what happened when
+        // their output is redirected to a file.
+        setvbuf(stdout, nil, _IOLBF, 0)
+
         let arguments = Array(CommandLine.arguments.dropFirst())
         if arguments.contains("--help") || arguments.contains("-h") {
-            print("usage: preview-shortcut-overlay.sh [--once] [--expanded] [--meeting] [--size small|medium|large]")
-            print("hover the resting icon to inspect the expanded native dock; press Ctrl-C to quit")
+            print("usage: preview-shortcut-overlay.sh [--once] [--expanded] [--meeting] [--notification]")
+            print("       [--size small|medium|large] [--anchor top-left|top-center|...|bottom-right]")
+            print("hover the resting icon to inspect the expanded native dock; drag it to re-pin it")
+            print("press Ctrl-C to quit")
             return
         }
 
         let size = requestedSize(from: arguments)
+        let anchor = requestedAnchor(from: arguments)
         let app = NSApplication.shared
         app.setActivationPolicy(.accessory)
 
@@ -40,6 +47,7 @@ struct ShortcutReminderPreview {
             "chat": "Cmd+Ctrl+L",
             "search": "Cmd+Ctrl+K",
             "shortcutOverlaySize": size,
+            "shortcutOverlayAnchor": anchor,
         ]
         guard let payloadData = try? JSONSerialization.data(withJSONObject: payload),
               let payloadJSON = String(data: payloadData, encoding: .utf8) else {
@@ -56,8 +64,60 @@ struct ShortcutReminderPreview {
             ShortcutReminderController.shared.setPreviewExpanded(true)
         }
 
-        print("native shortcut overlay preview running at size '\(size)' — press Ctrl-C to quit")
+        if arguments.contains("--notification") {
+            // Same shape `/notify` sends for a detected meeting, so the preview
+            // exercises the real parse and action plumbing.
+            let notification: [String: Any] = [
+                "id": "preview-meeting",
+                "title": "meeting detected",
+                "body": "screenpipe is saving this meeting for transcription: weekly sync",
+                "type": "meeting",
+                "autoDismissMs": 30_000,
+                "actions": [
+                    [
+                        "id": "open-live-notes",
+                        "action": "open-live-notes",
+                        "label": "open note",
+                        "type": "deeplink",
+                        "url": "screenpipe://meeting/1",
+                        "primary": true,
+                    ],
+                    [
+                        "id": "record-hd",
+                        "action": "record-hd",
+                        "label": "+ HD",
+                        "type": "api",
+                        "url": "/capture/hd/start",
+                        "method": "POST",
+                    ],
+                ],
+            ]
+            if let data = try? JSONSerialization.data(withJSONObject: notification),
+               let json = String(data: data, encoding: .utf8) {
+                // `shortcutShow` queues its work on the main queue, which has not
+                // drained yet — post behind it so the pill exists first, exactly
+                // as it does in the app.
+                DispatchQueue.main.async {
+                    let shown = json.withCString { pointer in
+                        shortcutShowNotification(pointer)
+                    }
+                    print("preview notification shown: \(shown == 0)")
+                }
+            }
+        }
+
+        print("native shortcut overlay preview running at size '\(size)', anchored '\(anchor)' — press Ctrl-C to quit")
         app.run()
+    }
+
+    private static func requestedAnchor(from arguments: [String]) -> String {
+        guard let anchorFlag = arguments.firstIndex(of: "--anchor"),
+              arguments.indices.contains(anchorFlag + 1),
+              let anchor = OverlayAnchor(rawValue: arguments[anchorFlag + 1])
+        else {
+            return OverlayAnchor.topCenter.rawValue
+        }
+        return anchor.rawValue
     }
 
     private static func requestedSize(from arguments: [String]) -> String {


### PR DESCRIPTION
# overlay: meeting alerts come out of the pill, drag it to pin it, and hiding is off by default behind a remote flag

## After

The meeting notification, rendered by the pill it belongs to instead of as a second window in another corner:

![meeting notification from the pinned pill](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/overlay-meeting-notification/01-notification-from-corner-pill.png)

Dropped on the bottom-right corner and pinned there:

![pill pinned to the bottom-right corner](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/overlay-meeting-notification/02-pill-pinned-bottom-right.png)

Pinned top-left, with the dock expanding inward instead of off-screen:

![dock pinned to the top-left corner](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/overlay-meeting-notification/03-dock-pinned-top-left.png)

Before: the pill was always top-centre, a drag was thrown away on the next show, and the meeting alert always opened the standalone panel in the top-right.

All three shots are the real native panel, captured from `scripts/preview-shortcut-overlay.sh` (which now takes `--anchor` and `--notification`). They live on the image-only branch `assets/overlay-meeting-notification` at `c4a5c5c` rather than being committed here.

## Problem

Three problems with the same surface, the shortcut overlay.

**1. The meeting notification ignores the overlay.** When screenpipe detects a meeting, `meeting_live_notes.rs` posts to `/notify`, which always lands in the standalone notification panel in the top-right corner. Meanwhile the pill is already on screen showing live-meeting state (red dot, transcript preview). Two surfaces talk about the same meeting at the same time, in different corners.

**2. Dragging the pill does nothing durable.** `DraggableHostingView` calls `window.performDrag`, so the pill moves, but nothing records where it went. `positionPanel()` recomputes top-centre of the screen under the cursor, so the next show, scale change or health transition throws the drag away. There is no way to keep the pill somewhere you want it.

**3. The overlay can be hidden, and it should not be by default.** `hide for today` / `hide for a week` in the gear submenu, plus the `showShortcutOverlay` switch in Display, could take the pill off screen. That surface now carries recording health, live meeting state and (with this PR) meeting alerts, so hiding it hides the app's only always-on signal. It should ship unhideable — but that is a strong enough product call that it needs to be reversible without shipping a build.

## Where found

- Notification path: `meeting_live_notes.rs:342` → `notifications/routes.rs:317` → `commands.rs::show_notification_panel`, which goes straight to `native_notification::show`, never consulting the overlay.
- Drag: `shortcut_reminder.swift` `DraggableHostingView.mouseDown` had `onDragStarted` but no drag-end hook; `positionPanel()` hard-coded `y = visible.maxY - h - 4` and a centred x.
- Hiding: `native_actions.rs` `dismiss_today` / `dismiss_week` / `dismiss_persistent`, and `display-section.tsx` `#shortcut-overlay`.

## Design notes

**Discrete anchors, not free placement.** A floating control dropped wherever the pointer let go looks dropped; one that lands on a corner or an edge centre looks placed. Discrete anchors are also the only thing that survives a monitor change or a resolution change without arithmetic that can strand the pill off screen.

**A separate hint panel, not a fullscreen drag layer.** The obvious way to show landing zones is to expand the pill's window to cover the display while dragging. Our panel is a nonactivating `NSPanel`, and `setFrame` on one breaks its mouse routing — that is the "dead-click pill" the existing code comments already warn about, which is why the panel is created at expanded size and never resized. A small separate hint panel gets the same affordance without touching the pill's frame.

**One source of truth.** Panel origin, which side of the panel the pill hugs, and which way the disclosure opens all derive from the anchor. Before, disclosure direction was recomputed from the live frame, which would have flipped mid-drag.

## Fix

### Meeting notification comes out of the pill

`show_notification_panel` now checks `notification_belongs_to_overlay(type)` (only `meeting`) and, when the pill is actually on screen, hands the payload to it. If the pill is hidden, unavailable, or the payload cannot be represented, it falls through to the existing panel unchanged — so nothing changes on a machine where the overlay is not up.

The pill renders it as a single row (icon, title, one-line body, actions, dismiss) anchored to the pill on the side the disclosure opens, animating out of the pill rather than appearing over it. Actions carry their original JSON back through `notification_action:<payload>` and run through `dispatch_notification_action`, the same function the standalone panel uses, so `open note` and `+ HD` behave identically on both surfaces. `autoDismissMs` is honoured, and hovering holds it open.

### Drag to pin

Six anchors (`top-left` … `bottom-right`). On drag start the pill collapses and a landing-pad hint appears at the nearest anchor, following the pill as it moves. On release it snaps there, persists via `set_overlay_anchor:<slot>` into `shortcutOverlayAnchor`, and is restored on the next show.

The anchor is the single source of truth for panel origin, which side of the panel the pill hugs (`metrics.horizontal`) and which way the disclosure opens. Corner anchors put the pill on the corner, and the dock now expands inward instead of off-screen.

### Unhideable by default, reversible remotely

Removed `hide for today` / `hide for a week` / the persistent off switch and the snooze/reshow settings they wrote. The gear now opens Display settings directly, which deleted the whole two-level settings-menu subsystem in Swift (two panels, hover bridging, and its analytics session — about 350 lines) and the matching menu in the webview overlay. System suppression paths are untouched: timeline disabled, headless, and the health incident reveal all still work.

The Display switch is not deleted, it is gated. `overlayHiding` joins the typed registry in `lib/desktop-remote-control.ts` as `overlay-hiding-control`, `shippedDefault: false`. While the capability is off the switch is not rendered and a stored `showShortcutOverlay: false` stays inert, so anyone who had hidden the pill before this gets it back. Setting the flag payload to `{"defaultEnabled": true, "forceDisabled": false}` restores the switch and starts honouring the stored choice again — no release needed.

Three details worth checking in review:

- **The preference is pinned to `null`.** Nothing lets a user grant themselves the capability, so `normalizeDesktopRemotePreferences` never seeds a local value for it. A seeded `false` would win over `defaultEnabled` and make flipping the flag a silent no-op — the same trap `sidebarCustomization` documents.
- **It is non-recorder-affecting.** Added to `NON_RECORDER_REMOTE_CONTROLS` so granting or revoking it never bounces capture.
- **Rust owns the startup decision**, before any webview exists, so it reads the resolved capability out of settings rather than PostHog: `shortcut_overlay_hidden_by_choice(allow_hiding, show_overlay)` is the single predicate, and it is unit-tested across all four combinations.

Enterprise managed policy can also set `allowHidingShortcutOverlay`, matching every other control in the registry.

## Validation

Ran locally on macOS:

- `swiftc -typecheck` clean in library mode, and the `-DOVERLAY_PREVIEW` preview binary compiles and runs.
- `cargo check` clean.
- `cargo test` — new tests: every anchor round-trips through `parse_overlay_anchor`, malformed anchors are rejected rather than persisted, only `meeting` routes to the overlay, a stored hide choice stays inert until the remote capability allows it, and the anchor/legacy-dismissal store defaults hold.
- `bunx vitest run lib/desktop-remote-control.test.ts components/desktop-remote-control.test.tsx` — 18 passed, including two new ones: the capability ships off and never seeds a local preference, and granting it changes only that control without requiring a recorder restart.
- `bun run typecheck` clean. `bun run bindings:check` clean after regenerating `lib/utils/tauri.ts` for the store change.
- `bunx vitest run app/shortcut-reminder/` — 12 passed. The old snooze test is replaced by one asserting the gear cannot hide the pill and opens Display instead.
- `bunx vitest run components/settings/__tests__/ app/onboarding/page.test.tsx components/theme-provider.test.tsx` — 247 passed. The 4 failures are the pre-existing `localStorage.clear()` jsdom shim gap in `theme-provider.test.tsx`, which this PR does not touch.
- Real native panel driven through the preview harness at several anchors, with and without a notification; the screenshots above are from that.

Not run here:

- Windows E2E. `windows-user-journey.spec.ts` is updated to assert the Display switch is gone, the pill stays visible, and the gear offers no hide rows, but it needs Windows CI to actually execute.
- No packaged-app run. The notification path is exercised through the same `shortcut_show_notification` FFI the app calls, but end to end from a real `meeting_started` event is CI/manual territory.

## One thing worth deciding separately

Removing the hide options makes an existing gap matter more: the native overlay panels hardcode `sharingType = .readOnly`, so they are *visible* in screen recordings and shares. `hideAppInScreenShare` defaults on and is applied to webview windows through `set_content_protected` (`window/capture_protection.rs`), but it never reaches the Swift panels. That was already true before this PR, and the two new panels here follow the same convention as the pill they belong to rather than diverging. With hiding gone, "screenpipe's pill is in my screen share and I can't turn it off" becomes reachable. Worth a follow-up that pushes the preference into the Swift panels; I left it out of this PR to keep the diff to the three things asked for.

## Not covered

- Pinning is macOS-native only. The Windows/Linux webview overlay keeps its current fixed placement; it has no drag today either.
- The meeting notification also routes only on the native path. The webview overlay keeps using the standalone panel.
- Existing snooze values in `store.bin` are ignored rather than migrated, and `showShortcutOverlay: false` stays inert while the capability is off. That is the intent — the overlay comes back for anyone who had hidden it, and their old choice is honoured again if the flag is ever granted.
- The in-overlay gear does not regain hide rows when the capability is granted. Hiding lives in Display settings only, so there is one place for it rather than two.
- Revoking the capability while a user has the pill hidden brings it back on next launch, not mid-session. The startup predicate is the only place the stored choice is read, so the state self-heals rather than needing a live watcher.
