### PR TITLE
fix(meetings): don't auto-end a live meeting when our own audio capture was invalidated

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -32,15 +32,15 @@ results and `cargo llvm-cov` data on top when judging release confidence.
 
 - Mapped suites: 32
 - Mapped Rust files: 321
-- Active test blocks: 3064
+- Active test blocks: 3071
 - Ignored/manual test blocks: 137
-- Weighted coverage points: 2521.1
+- Weighted coverage points: 2528.1
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 2933 | 132 | 2461.1 | 21 | 11 | 100% |
-| macos | 29 | 2986 | 112 | 2471.5 | 22 | 11 | 100% |
-| linux | 25 | 2619 | 105 | 2177.9 | 20 | 11 | 100% |
+| windows | 29 | 2940 | 132 | 2468.1 | 21 | 11 | 100% |
+| macos | 29 | 2993 | 112 | 2478.5 | 22 | 11 | 100% |
+| linux | 25 | 2626 | 105 | 2184.9 | 20 | 11 | 100% |
 
 ## Refresh
 

--- a/crates/screenpipe-audio/src/lib.rs
+++ b/crates/screenpipe-audio/src/lib.rs
@@ -59,12 +59,23 @@ pub(crate) mod test_support {
 /// consumed by the device monitor loop so that audio devices are force-cycled
 /// (stop + restart) to recover from silent CoreAudio stream failures.
 pub mod stream_invalidation {
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
     static NEEDS_INVALIDATION: AtomicBool = AtomicBool::new(false);
+    /// Monotonic count of invalidation requests.
+    ///
+    /// The `NEEDS_INVALIDATION` flag is consume-once: whoever calls `take()`
+    /// first (the device monitor) clears it for everyone else. Observers that
+    /// only need to *know a disruption happened* — without stealing the
+    /// restart from the device monitor — watermark this counter instead and
+    /// compare it on their own schedule.
+    static GENERATION: AtomicU64 = AtomicU64::new(0);
 
     /// Request that all audio streams be invalidated and restarted.
     /// Safe to call from any thread (including CFNotification callbacks).
     pub fn request() {
+        // Bump the generation before setting the flag so an observer that
+        // sees the flag can never read a stale generation.
+        GENERATION.fetch_add(1, Ordering::SeqCst);
         NEEDS_INVALIDATION.store(true, Ordering::SeqCst);
     }
 
@@ -74,19 +85,43 @@ pub mod stream_invalidation {
         NEEDS_INVALIDATION.swap(false, Ordering::SeqCst)
     }
 
+    /// Non-consuming read of the invalidation counter.
+    ///
+    /// Every `request()` increments this exactly once, and nothing ever
+    /// decrements or clears it, so multiple independent observers can each
+    /// hold their own watermark without interfering with `take()` or with
+    /// each other.
+    pub fn generation() -> u64 {
+        GENERATION.load(Ordering::SeqCst)
+    }
+
     #[cfg(test)]
     mod tests {
         use super::*;
+        use std::sync::{Mutex, MutexGuard};
+
+        // These tests all drive the same process-global flag, so cargo's
+        // parallel test threads let one test's `take()` consume another's
+        // `request()`. Serialize them. Poisoning is ignored: a panic in one
+        // test must fail that test, not cascade into every other one.
+        static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+        fn serial() -> MutexGuard<'static, ()> {
+            let guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            // Start from a known state regardless of what ran before.
+            let _ = take();
+            guard
+        }
 
         #[test]
         fn take_returns_false_when_no_request() {
-            // Clear any leftover state from other tests
-            let _ = take();
+            let _guard = serial();
             assert!(!take());
         }
 
         #[test]
         fn request_then_take_returns_true_once() {
+            let _guard = serial();
             request();
             assert!(take(), "first take after request should return true");
             assert!(!take(), "second take should return false (flag cleared)");
@@ -94,11 +129,35 @@ pub mod stream_invalidation {
 
         #[test]
         fn multiple_requests_coalesce() {
+            let _guard = serial();
             request();
             request();
             request();
             assert!(take(), "take should return true");
             assert!(!take(), "flag should be cleared after single take");
+        }
+
+        /// The generation counter is the whole point of the split: an
+        /// observer must be able to see that a disruption happened without
+        /// consuming the device monitor's restart signal.
+        #[test]
+        fn generation_advances_per_request_and_survives_take() {
+            let _guard = serial();
+            let before = generation();
+            request();
+            request();
+            assert_eq!(
+                generation(),
+                before + 2,
+                "each request must increment the generation exactly once"
+            );
+
+            assert!(take(), "take still consumes the flag");
+            assert_eq!(
+                generation(),
+                before + 2,
+                "take must not reset or decrement the generation"
+            );
         }
     }
 }

--- a/crates/screenpipe-audio/src/meeting_streaming/controller.rs
+++ b/crates/screenpipe-audio/src/meeting_streaming/controller.rs
@@ -54,6 +54,15 @@ const STALL_NOTIFY_THRESHOLD: Duration = Duration::from_secs(60);
 /// audio landing anywhere between two checks still counts — otherwise the
 /// notification would depend on where the tick happened to fall.
 const STALL_VOICED_AUDIO_RECENCY: Duration = Duration::from_secs(45);
+/// How many times one session may rebase its inactivity clock because our own
+/// capture stack was disrupted (sleep/wake, display reconfiguration).
+///
+/// Each rebase buys another full `LIVE_NO_AUDIO_ACTIVITY_TIMEOUT`, so this is
+/// deliberately small: a genuinely dead capture path must still end the
+/// meeting rather than hold an empty session open forever. Four rebases caps
+/// the extension at roughly an hour, and `LIVE_MAX_SESSION_DURATION` remains
+/// the hard ceiling regardless.
+const MAX_CAPTURE_DISRUPTION_REBASES: u32 = 4;
 
 #[derive(Debug)]
 struct ActiveMeetingStream {
@@ -75,6 +84,13 @@ struct ActiveMeetingStream {
     last_live_transcript_at: Option<Instant>,
     notified_audio_stall: bool,
     notified_transcript_stall: bool,
+    // Watermark into `stream_invalidation::generation()`. Advancing means
+    // sleep/wake or a display reconfiguration forced every audio stream to be
+    // rebuilt, so any silence that follows is ours, not the meeting's.
+    capture_invalidation_watermark: u64,
+    // How many times this session has already rebased its inactivity clock
+    // for that reason. Bounded by `MAX_CAPTURE_DISRUPTION_REBASES`.
+    capture_disruption_rebases: u32,
     device_senders: HashMap<String, mpsc::Sender<MeetingAudioFrame>>,
     device_retry_after: HashMap<String, Instant>,
 }
@@ -309,6 +325,21 @@ pub fn start_meeting_streaming_loop(
                 }
                 _ = inactivity_tick.tick() => {
                     if let Some(session) = active.as_mut() {
+                        // Before judging silence, discount any of it that our
+                        // own capture teardown caused.
+                        if apply_capture_disruption_grace(
+                            session,
+                            crate::stream_invalidation::generation(),
+                            Instant::now(),
+                        ) {
+                            warn!(
+                                "meeting streaming: audio streams were invalidated (sleep/wake or \
+                                 display change) — rebasing inactivity clock ({}/{}, meeting_id={})",
+                                session.capture_disruption_rebases,
+                                MAX_CAPTURE_DISRUPTION_REBASES,
+                                session.meeting_id,
+                            );
+                        }
                         check_and_emit_stall_notifications(session, Instant::now());
                     }
                     if let Some(reason) = active
@@ -399,6 +430,8 @@ async fn start_streaming_session(
         last_live_transcript_at: None,
         notified_audio_stall: false,
         notified_transcript_stall: false,
+        capture_invalidation_watermark: crate::stream_invalidation::generation(),
+        capture_disruption_rebases: 0,
         device_senders: HashMap::new(),
         device_retry_after: HashMap::new(),
     });
@@ -774,6 +807,50 @@ fn should_request_auto_end_for_inactivity(session: &ActiveMeetingStream, now: In
         && now.duration_since(session.last_audio_activity_at) >= LIVE_NO_AUDIO_ACTIVITY_TIMEOUT
 }
 
+/// Rebase the inactivity clock when our own capture stack was torn down.
+///
+/// `LIVE_NO_AUDIO_ACTIVITY_TIMEOUT` answers "has this meeting gone quiet?",
+/// but it reads that from one signal: audio frames arriving. Sleep/wake and
+/// display reconfiguration invalidate every audio stream, and CoreAudio can
+/// come back silent without ever raising an error — so the frames stop while
+/// the meeting is still very much running. Left alone, the session ends
+/// itself mid-call and the user finds a truncated note.
+///
+/// Rather than suppress auto-end for a fixed window (the outage routinely
+/// outlives any window worth choosing), this treats the disruption as making
+/// the elapsed silence *unattributable* and restarts the clock from it. If
+/// capture recovers, frames advance the clock normally and the rebase costs
+/// nothing. If it never recovers, the next full timeout still ends the
+/// session — just from the disruption rather than through it.
+///
+/// Bounded by `MAX_CAPTURE_DISRUPTION_REBASES` so a permanently broken
+/// capture path cannot hold a session open indefinitely.
+///
+/// Returns `true` when the clock was rebased, for logging.
+fn apply_capture_disruption_grace(
+    session: &mut ActiveMeetingStream,
+    current_generation: u64,
+    now: Instant,
+) -> bool {
+    if current_generation <= session.capture_invalidation_watermark {
+        return false;
+    }
+    // Always take the watermark, even when the budget is spent. Otherwise a
+    // single stale generation would re-trigger on every subsequent tick.
+    session.capture_invalidation_watermark = current_generation;
+
+    if !session.live_transcription_enabled {
+        return false;
+    }
+    if session.capture_disruption_rebases >= MAX_CAPTURE_DISRUPTION_REBASES {
+        return false;
+    }
+
+    session.capture_disruption_rebases += 1;
+    session.last_audio_activity_at = now;
+    true
+}
+
 /// Fire at most one "audio stall" and one "transcript stall" event per
 /// session, when the live note has clearly failed to start streaming.
 ///
@@ -985,6 +1062,8 @@ mod tests {
             last_live_transcript_at: None,
             notified_audio_stall: false,
             notified_transcript_stall: false,
+            capture_invalidation_watermark: 0,
+            capture_disruption_rebases: 0,
             device_senders: HashMap::new(),
             device_retry_after: HashMap::new(),
         }
@@ -1257,6 +1336,123 @@ mod tests {
         assert_eq!(
             auto_end_reason(&session, now),
             Some(AutoEndReason::MaxDuration)
+        );
+    }
+
+    /// The regression this exists for: the machine sleeps (or the display
+    /// layout changes) mid-meeting, audio streams are invalidated, frames
+    /// stop, and the session ends itself while the user is still talking.
+    #[test]
+    fn capture_invalidation_prevents_auto_end_during_a_silent_stream_outage() {
+        let now = Instant::now();
+        let mut session = test_session(now, true);
+        session.capture_invalidation_watermark = 7;
+        // Frames stopped a full timeout ago — without the grace this ends.
+        session.last_audio_activity_at =
+            now - LIVE_NO_AUDIO_ACTIVITY_TIMEOUT - Duration::from_secs(1);
+        assert!(
+            should_request_auto_end_for_inactivity(&session, now),
+            "precondition: this session would otherwise auto-end"
+        );
+
+        assert!(apply_capture_disruption_grace(&mut session, 8, now));
+
+        assert!(
+            !should_request_auto_end_for_inactivity(&session, now),
+            "an invalidated capture stack must not read as a quiet meeting"
+        );
+        assert_eq!(session.capture_disruption_rebases, 1);
+    }
+
+    #[test]
+    fn capture_grace_is_bounded_so_a_dead_capture_still_ends_the_session() {
+        let now = Instant::now();
+        let mut session = test_session(now, true);
+
+        for i in 0..MAX_CAPTURE_DISRUPTION_REBASES {
+            assert!(
+                apply_capture_disruption_grace(&mut session, u64::from(i) + 1, now),
+                "rebase {i} should be granted"
+            );
+        }
+
+        assert!(
+            !apply_capture_disruption_grace(
+                &mut session,
+                u64::from(MAX_CAPTURE_DISRUPTION_REBASES) + 1,
+                now
+            ),
+            "budget is spent, further disruptions must not extend the session"
+        );
+
+        session.last_audio_activity_at =
+            now - LIVE_NO_AUDIO_ACTIVITY_TIMEOUT - Duration::from_secs(1);
+        assert!(
+            should_request_auto_end_for_inactivity(&session, now),
+            "a permanently dead capture path must still terminate the meeting"
+        );
+    }
+
+    /// Without taking the watermark on every advance, one stale generation
+    /// would re-trigger on each 30s tick and spend the whole budget.
+    #[test]
+    fn capture_grace_consumes_the_watermark_even_when_budget_is_spent() {
+        let now = Instant::now();
+        let mut session = test_session(now, true);
+        session.capture_disruption_rebases = MAX_CAPTURE_DISRUPTION_REBASES;
+
+        assert!(!apply_capture_disruption_grace(&mut session, 5, now));
+        assert_eq!(
+            session.capture_invalidation_watermark, 5,
+            "watermark must advance so the same generation cannot re-fire"
+        );
+    }
+
+    #[test]
+    fn capture_grace_is_inert_without_a_new_invalidation() {
+        let now = Instant::now();
+        let mut session = test_session(now, true);
+        session.capture_invalidation_watermark = 3;
+        let baseline = now - LIVE_NO_AUDIO_ACTIVITY_TIMEOUT - Duration::from_secs(1);
+        session.last_audio_activity_at = baseline;
+
+        assert!(!apply_capture_disruption_grace(&mut session, 3, now));
+
+        assert_eq!(
+            session.last_audio_activity_at, baseline,
+            "an unchanged generation must not touch the inactivity clock"
+        );
+        assert_eq!(session.capture_disruption_rebases, 0);
+    }
+
+    /// Background-only sessions have an inactive audio tap by design, so they
+    /// never auto-end for inactivity and must not burn rebase budget either.
+    #[test]
+    fn capture_grace_skips_background_only_sessions() {
+        let now = Instant::now();
+        let mut session = test_session(now, false);
+
+        assert!(!apply_capture_disruption_grace(&mut session, 1, now));
+        assert_eq!(session.capture_disruption_rebases, 0);
+        assert_eq!(
+            session.capture_invalidation_watermark, 1,
+            "watermark still advances so the session stays in step"
+        );
+    }
+
+    /// Max duration is the hard ceiling: capture grace must not defeat it.
+    #[test]
+    fn capture_grace_does_not_extend_past_max_session_duration() {
+        let now = Instant::now();
+        let mut session = test_session(now, true);
+        session.started_at = now - LIVE_MAX_SESSION_DURATION - Duration::from_secs(1);
+
+        assert!(apply_capture_disruption_grace(&mut session, 1, now));
+
+        assert_eq!(
+            auto_end_reason(&session, now),
+            Some(AutoEndReason::MaxDuration),
+            "the 2h ceiling still applies after a rebase"
         );
     }
 

--- a/docs/coverage/CORE.md
+++ b/docs/coverage/CORE.md
@@ -9,10 +9,10 @@ confidence, and criticality.
 - Tracked crates: screenpipe-engine, screenpipe-db, screenpipe-sqlite-coordinator, screenpipe-audio, screenpipe-screen, screenpipe-a11y
 - Mapped suites: 32
 - Mapped Rust files: 321
-- Active test blocks: 3064
+- Active test blocks: 3071
 - Ignored/manual test blocks: 137
-- Declared test blocks: 3201
-- Weighted coverage points: 2521.1
+- Declared test blocks: 3208
+- Weighted coverage points: 2528.1
 
 Confidence weights: strong=1.0, partial=0.7, conditional=0.4, smoke=0.3.
 Criticality weights: high=1.0, medium=0.7, low=0.4.
@@ -23,9 +23,9 @@ are explicitly enabled in a runtime lane.
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 2933 | 132 | 2461.1 | 21 | 11 | 100% |
-| macos | 29 | 2986 | 112 | 2471.5 | 22 | 11 | 100% |
-| linux | 25 | 2619 | 105 | 2177.9 | 20 | 11 | 100% |
+| windows | 29 | 2940 | 132 | 2468.1 | 21 | 11 | 100% |
+| macos | 29 | 2993 | 112 | 2478.5 | 22 | 11 | 100% |
+| linux | 25 | 2626 | 105 | 2184.9 | 20 | 11 | 100% |
 
 ## Crate Summary
 
@@ -34,7 +34,7 @@ are explicitly enabled in a runtime lane.
 | screenpipe-engine | 10 | 18 | 102 | 1442 | 42 | 1105.3 | 10 |
 | screenpipe-db | 5 | 52 | 14 | 447 | 16 | 424.2 | 9 |
 | screenpipe-sqlite-coordinator | 1 | 0 | 2 | 16 | 0 | 16.0 | 2 |
-| screenpipe-audio | 6 | 25 | 51 | 584 | 43 | 510.4 | 5 |
+| screenpipe-audio | 6 | 25 | 51 | 591 | 43 | 517.4 | 5 |
 | screenpipe-screen | 6 | 9 | 18 | 241 | 9 | 216.9 | 4 |
 | screenpipe-a11y | 4 | 2 | 28 | 334 | 27 | 248.3 | 3 |
 
@@ -62,25 +62,25 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | Layer | windows | macos | linux |
 | --- | --- | --- | --- |
 | accessibility | 4 suites / 344 active / 29 ignored / 315.5 pts | 4 suites / 393 active / 9 ignored / 320.4 pts | 4 suites / 319 active / 7 ignored / 293.0 pts |
-| audio | 7 suites / 694 active / 44 ignored / 620.4 pts | 7 suites / 694 active / 44 ignored / 620.4 pts | 6 suites / 619 active / 43 ignored / 567.9 pts |
-| audio-device | 2 suites / 211 active / 7 ignored / 188.5 pts | 2 suites / 211 active / 7 ignored / 188.5 pts | 1 suites / 136 active / 6 ignored / 136.0 pts |
+| audio | 7 suites / 701 active / 44 ignored / 627.4 pts | 7 suites / 701 active / 44 ignored / 627.4 pts | 6 suites / 626 active / 43 ignored / 574.9 pts |
+| audio-device | 2 suites / 212 active / 7 ignored / 189.5 pts | 2 suites / 212 active / 7 ignored / 189.5 pts | 1 suites / 137 active / 6 ignored / 137.0 pts |
 | configuration | 2 suites / 138 active / 3 ignored / 124.2 pts | 2 suites / 138 active / 3 ignored / 124.2 pts | 2 suites / 138 active / 3 ignored / 124.2 pts |
 | database | 6 suites / 366 active / 12 ignored / 343.2 pts | 6 suites / 366 active / 12 ignored / 343.2 pts | 6 suites / 366 active / 12 ignored / 343.2 pts |
 | db-search | 2 suites / 111 active / 9 ignored / 111.0 pts | 2 suites / 111 active / 9 ignored / 111.0 pts | 2 suites / 111 active / 9 ignored / 111.0 pts |
 | engine-lifecycle | 6 suites / 208 active / 1 ignored / 183.6 pts | 6 suites / 208 active / 1 ignored / 183.6 pts | 5 suites / 202 active / 1 ignored / 181.9 pts |
 | local-api | 2 suites / 325 active / 9 ignored / 229.3 pts | 2 suites / 325 active / 9 ignored / 229.3 pts | 2 suites / 325 active / 9 ignored / 229.3 pts |
-| meeting | 6 suites / 1401 active / 19 ignored / 1144.2 pts | 6 suites / 1401 active / 19 ignored / 1144.2 pts | 4 suites / 1123 active / 15 ignored / 888.7 pts |
+| meeting | 6 suites / 1407 active / 19 ignored / 1150.2 pts | 6 suites / 1407 active / 19 ignored / 1150.2 pts | 4 suites / 1129 active / 15 ignored / 894.7 pts |
 | ocr | 4 suites / 124 active / 7 ignored / 118.3 pts | 4 suites / 128 active / 7 ignored / 123.8 pts | 3 suites / 119 active / 6 ignored / 114.8 pts |
 | os-integration | 1 suites / 6 active / 0 ignored / 1.7 pts | 1 suites / 6 active / 0 ignored / 1.7 pts | - |
-| performance | 13 suites / 1372 active / 67 ignored / 1210.2 pts | 14 suites / 1470 active / 70 ignored / 1249.4 pts | 13 suites / 1372 active / 67 ignored / 1210.2 pts |
+| performance | 13 suites / 1373 active / 67 ignored / 1211.2 pts | 14 suites / 1471 active / 70 ignored / 1250.4 pts | 13 suites / 1373 active / 67 ignored / 1211.2 pts |
 | pipes | 1 suites / 462 active / 3 ignored / 323.4 pts | 1 suites / 462 active / 3 ignored / 323.4 pts | 1 suites / 462 active / 3 ignored / 323.4 pts |
 | privacy | 5 suites / 871 active / 36 ignored / 707.5 pts | 5 suites / 920 active / 16 ignored / 712.4 pts | 5 suites / 846 active / 14 ignored / 685.0 pts |
 | real-app | - | 1 suites / 98 active / 3 ignored / 39.2 pts | - |
-| speaker | 2 suites / 342 active / 8 ignored / 342.0 pts | 2 suites / 342 active / 8 ignored / 342.0 pts | 2 suites / 342 active / 8 ignored / 342.0 pts |
+| speaker | 2 suites / 348 active / 8 ignored / 348.0 pts | 2 suites / 348 active / 8 ignored / 348.0 pts | 2 suites / 348 active / 8 ignored / 348.0 pts |
 | storage | 3 suites / 473 active / 29 ignored / 383.6 pts | 3 suites / 473 active / 29 ignored / 383.6 pts | 3 suites / 473 active / 29 ignored / 383.6 pts |
 | sync | 1 suites / 462 active / 3 ignored / 323.4 pts | 1 suites / 462 active / 3 ignored / 323.4 pts | 1 suites / 462 active / 3 ignored / 323.4 pts |
 | timeline | 4 suites / 931 active / 33 ignored / 757.3 pts | 4 suites / 931 active / 33 ignored / 757.3 pts | 4 suites / 931 active / 33 ignored / 757.3 pts |
-| transcription | 5 suites / 692 active / 40 ignored / 545.2 pts | 5 suites / 692 active / 40 ignored / 545.2 pts | 5 suites / 692 active / 40 ignored / 545.2 pts |
+| transcription | 5 suites / 698 active / 40 ignored / 551.2 pts | 5 suites / 698 active / 40 ignored / 551.2 pts | 5 suites / 698 active / 40 ignored / 551.2 pts |
 | ui-events | 4 suites / 701 active / 28 ignored / 533.9 pts | 3 suites / 652 active / 5 ignored / 499.6 pts | 3 suites / 652 active / 5 ignored / 499.6 pts |
 | vision-capture | 5 suites / 492 active / 32 ignored / 389.9 pts | 5 suites / 496 active / 32 ignored / 395.4 pts | 4 suites / 487 active / 31 ignored / 386.4 pts |
 
@@ -122,8 +122,8 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | a11y-linux-tree | screenpipe-a11y | linux | accessibility, privacy | accessibility-ui-events, privacy-and-redaction | medium | partial | unit | 4 | 24 | 1 | Linux-specific accessibility/incognito normalization tests. |
 | a11y-macos-tree | screenpipe-a11y | macos | accessibility, privacy, real-app, performance | accessibility-ui-events, privacy-and-redaction, performance-liveness | high | conditional | mixed | 6 | 98 | 3 | macOS AX unit coverage plus real TextEdit/Finder/Obsidian probes. Obsidian tests are ignored by default because they require a local app install and AX permission. |
 | a11y-windows-tree | screenpipe-a11y | windows | accessibility, privacy, ui-events | accessibility-ui-events, privacy-and-redaction | high | partial | unit | 6 | 49 | 23 | Windows UIA/accessibility parsing and privacy matching; some UIA tests are ignored where they require a live desktop. |
-| audio-device-stream-health | screenpipe-audio | windows, macos, linux | audio-device, audio, performance | audio-device-health, audio-record-transcribe, performance-liveness | high | strong | mixed | 14 | 136 | 6 | Device monitor, device manager, stream buffering, source lag, audio metrics, Bluetooth gap/hallucination regressions, and cross-platform process-tap watchdog counters (process_tap.rs split into src/core/process_tap/ modules). |
-| audio-meetings-speakers-dedup | screenpipe-audio | windows, macos, linux | audio, meeting, speaker, transcription | audio-record-transcribe, meeting-live-notes, performance-liveness | high | strong | mixed | 26 | 232 | 7 | Meeting streaming config/controller logic, speaker embedding state, cross-device dedupe simulations, and overlap cleanup coverage. |
+| audio-device-stream-health | screenpipe-audio | windows, macos, linux | audio-device, audio, performance | audio-device-health, audio-record-transcribe, performance-liveness | high | strong | mixed | 14 | 137 | 6 | Device monitor, device manager, stream buffering, source lag, audio metrics, Bluetooth gap/hallucination regressions, and cross-platform process-tap watchdog counters (process_tap.rs split into src/core/process_tap/ modules). |
+| audio-meetings-speakers-dedup | screenpipe-audio | windows, macos, linux | audio, meeting, speaker, transcription | audio-record-transcribe, meeting-live-notes, performance-liveness | high | strong | mixed | 26 | 238 | 7 | Meeting streaming config/controller logic, speaker embedding state, cross-device dedupe simulations, and overlap cleanup coverage. |
 | audio-models-filtering | screenpipe-audio | windows, macos, linux | audio, transcription, privacy | audio-record-transcribe, privacy-and-redaction | medium | partial | mixed | 6 | 20 | 10 | Model-download/TLS guards, ONNX startup smoke, and music-versus-speech filtering. |
 | audio-pipeline-benchmarks | screenpipe-audio | windows, macos, linux | audio, transcription, performance | audio-record-transcribe, meeting-live-notes, performance-liveness | medium | partial | benchmark | 8 | 22 | 12 | Benchmark-backed regression probes for VAD, smart mode, meeting audio, quality, cross-device, and end-to-end pipeline timing. |
 | audio-platform-output-capture | screenpipe-audio | windows, macos | audio-device, audio, meeting | audio-device-health, audio-record-transcribe, meeting-live-notes | high | partial | unit | 7 | 75 | 1 | OS-specific output/system-audio capture: CoreAudio process tap and SCK output watchdog plus VPIO health policy on macOS, per-process meeting audio taps on both platforms, and the Windows follow-the-audio output watchdog. Platform impl files are cfg-gated to their target OS. |
@@ -208,11 +208,11 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | audio-device-stream-health | screenpipe-audio | src/device/device_manager.rs | source | 6 | 0 | 6 |
 | audio-platform-output-capture | screenpipe-audio | src/device/vpio_health.rs | source | 5 | 0 | 5 |
 | audio-device-stream-health | screenpipe-audio | src/idle_detector.rs | source | 4 | 0 | 4 |
-| audio-device-stream-health | screenpipe-audio | src/lib.rs | source | 3 | 0 | 3 |
+| audio-device-stream-health | screenpipe-audio | src/lib.rs | source | 4 | 0 | 4 |
 | audio-meetings-speakers-dedup | screenpipe-audio | src/meeting_detector.rs | source | 11 | 0 | 11 |
 | audio-meetings-speakers-dedup | screenpipe-audio | src/meeting_processes.rs | source | 16 | 1 | 17 |
 | audio-meetings-speakers-dedup | screenpipe-audio | src/meeting_streaming/config.rs | source | 12 | 0 | 12 |
-| audio-meetings-speakers-dedup | screenpipe-audio | src/meeting_streaming/controller.rs | source | 14 | 0 | 14 |
+| audio-meetings-speakers-dedup | screenpipe-audio | src/meeting_streaming/controller.rs | source | 20 | 0 | 20 |
 | audio-meetings-speakers-dedup | screenpipe-audio | src/meeting_streaming/deepgram_live.rs | source | 6 | 0 | 6 |
 | audio-meetings-speakers-dedup | screenpipe-audio | src/meeting_streaming/selected_engine.rs | source | 3 | 0 | 3 |
 | audio-device-stream-health | screenpipe-audio | src/metrics.rs | source | 2 | 0 | 2 |


### PR DESCRIPTION
## Expected experience

![live meeting overlay before and after a capture invalidation](https://raw.githubusercontent.com/screenpipe/screenpipe/8f9415e73/docs/assets/pr/6185-meeting-overlay-capture-disruption.png)

There is no new UI in this PR — the change is behavioural, so the user-visible difference is that the overlay's meeting panel *survives* a sleep/wake instead of vanishing. Same sequence in both lanes; only the outcome at t+17m differs.

> Mockup, not a device capture. Panel geometry, colours and controls are taken from `src-tauri/swift/shortcut_reminder.swift`; IBM Plex Mono is not installed on the rendering machine so type falls back to the system monospace. The greyed liveness dot marks the outage for the reader and is **not** a state this PR adds.

---

## Problem

The live meeting inactivity check answers *"has this meeting gone quiet?"* from exactly one signal: audio frames arriving.

```rust
fn should_request_auto_end_for_inactivity(session: &ActiveMeetingStream, now: Instant) -> bool {
    session.live_transcription_enabled
        && now.duration_since(session.last_audio_activity_at) >= LIVE_NO_AUDIO_ACTIVITY_TIMEOUT
}
```

Sleep/wake and display reconfiguration invalidate **every** audio stream, and CoreAudio can come back silent without ever raising an error — that is precisely why `sleep_monitor::on_did_wake` calls `screenpipe_audio::stream_invalidation::request()` to force-cycle devices. During that outage the frames stop, so a broken capture stack is indistinguishable from an empty room.

After 15 minutes the session ends itself **while the user is still in the meeting**, and they come back to a truncated note.

## Where found

Competitive teardown of Wispr Flow 1.6.492. Their auto-end is a confidence policy, not a timer: losing the meeting signal produces a drop classified high / ambiguous / suppressed, with named holdoffs for post-wake, CoreAudio service restart, input-device change, helper-ready and a flap cooldown, all behind a remotely tunable preset. We have two end reasons and no suppression at all. This PR ports the single most load-bearing piece of that.

## Reproduction

```
t+0m    meeting starts, live transcription on, frames flowing
t+2m    laptop sleeps / display layout changes
        -> sleep_monitor calls stream_invalidation::request()
        -> audio streams torn down, CoreAudio returns silent
t+2m..  no frames arrive; last_audio_activity_at frozen at t+2m
t+17m   now - last_audio_activity_at >= 15m
        -> AutoEndReason::Inactive -> "meeting_auto_end_requested"
        -> meeting ends, user is still talking
```

Encoded as the failing-before test `capture_invalidation_prevents_auto_end_during_a_silent_stream_outage`, which asserts the precondition (this session *would* auto-end) before applying the grace.

## Root cause

`last_audio_activity_at` only ever advances on a received frame. Nothing distinguishes "nobody is speaking" from "we tore our own capture down and it came back mute."

## Fix

**Before**

```
inactivity tick --> silence >= 15m? --> end meeting
                    (silence cause unknown)
```

**After**

```
inactivity tick
      |
      +--> capture invalidated since last tick?     generation() > watermark
      |        |
      |        +- yes, budget left --> rebase clock, log     --+
      |        +- yes, budget spent -> take watermark only     |
      |        +- no ----------------> unchanged               |
      |                                                        |
      +--> silence >= 15m? --> end meeting  <------------------+
                               (silence now attributable)
```

Rebasing rather than suppressing for a fixed window is deliberate: the outage routinely outlives any window worth choosing, and a fixed suppression that expires before the timeout fires changes nothing. Rebasing means:

- capture recovers -> frames advance the clock normally, the rebase cost nothing
- capture never recovers -> the next full timeout still ends the session, measured *from* the disruption instead of *through* it

`stream_invalidation`'s flag is consume-once — the device monitor calls `take()` and clears it for everyone — so this adds a **non-consuming monotonic `generation()`** beside it. Observers watermark the counter instead of stealing the device monitor's restart. `take()` semantics are unchanged.

Bounded by `MAX_CAPTURE_DISRUPTION_REBASES = 4` so a permanently dead capture path still terminates the meeting; `LIVE_MAX_SESSION_DURATION` (2h) remains the hard ceiling and is asserted as such.

## Also fixed

The `stream_invalidation` tests share a process-global flag and cargo runs them in parallel, so one test's `take()` can consume another's `request()`. Latent before this change; adding a fourth test made it reproduce. Now serialized behind a mutex that also normalizes starting state, with poisoning ignored so one panicking test can't cascade.

## Validation

| Gate | Result |
|---|---|
| `cargo test -p screenpipe-audio --lib` | **452 passed**, 0 failed, 8 ignored |
| New tests | 6 in `controller`, 1 in `stream_invalidation` |
| Race fix | `stream_invalidation` filter run 3x consecutively, stable |
| `cargo clippy -p screenpipe-audio --lib` | no new warnings in changed files (the `too many arguments` hit on `start_streaming_session` is pre-existing, verified against a clean tree) |
| `rustfmt --check` on both changed files | clean |
| `bun run coverage:all:check` | up to date (regenerated: +7 blocks, exactly the 7 tests added) |
| `Cargo.lock` | untouched — no dependency change |

New test coverage, one per branch:

- `capture_invalidation_prevents_auto_end_during_a_silent_stream_outage` — the regression
- `capture_grace_is_bounded_so_a_dead_capture_still_ends_the_session`
- `capture_grace_consumes_the_watermark_even_when_budget_is_spent` — otherwise one stale generation re-fires every 30s tick and drains the budget
- `capture_grace_is_inert_without_a_new_invalidation`
- `capture_grace_skips_background_only_sessions` — background sessions never auto-end for inactivity and must not burn budget
- `capture_grace_does_not_extend_past_max_session_duration`
- `generation_advances_per_request_and_survives_take`

## Not covered

No packaged runtime canary — reproducing this end to end needs a real sleep/wake during a live meeting on a signed build. The logic is pure and fully unit-tested, but the wiring from an actual `on_did_wake` through to a rebase has not been exercised on device. Worth one manual pass before release.

Scope is deliberately narrow: only `stream_invalidation` (sleep/wake, display reconfig) grants grace. Explicitly **not** wired to `audio_device_status_changed` — a user pausing a device on purpose should not silently extend their meeting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

