### PR TITLE
fix(onboarding): one window size for every setup step

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -32,15 +32,15 @@ results and `cargo llvm-cov` data on top when judging release confidence.
 
 - Mapped suites: 32
 - Mapped Rust files: 321
-- Active test blocks: 3062
+- Active test blocks: 3064
 - Ignored/manual test blocks: 137
-- Weighted coverage points: 2519.7
+- Weighted coverage points: 2521.1
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 2931 | 132 | 2459.7 | 21 | 11 | 100% |
-| macos | 29 | 2984 | 112 | 2470.1 | 22 | 11 | 100% |
-| linux | 25 | 2617 | 105 | 2176.5 | 20 | 11 | 100% |
+| windows | 29 | 2933 | 132 | 2461.1 | 21 | 11 | 100% |
+| macos | 29 | 2986 | 112 | 2471.5 | 22 | 11 | 100% |
+| linux | 25 | 2619 | 105 | 2177.9 | 20 | 11 | 100% |
 
 ## Refresh
 

--- a/apps/screenpipe-app-tauri/app/onboarding/page.test.tsx
+++ b/apps/screenpipe-app-tauri/app/onboarding/page.test.tsx
@@ -237,11 +237,31 @@ describe("enterprise onboarding authentication", () => {
     render(<OnboardingPage />);
 
     await waitFor(() =>
-      expect(mocks.setWindowSize).toHaveBeenCalledWith("Onboarding", 500, 620),
+      expect(mocks.setWindowSize).toHaveBeenCalledWith("Onboarding", 500, 680),
     );
     expect(screen.getByTestId("onboarding-scroll-region")).toHaveClass(
       "overflow-y-auto",
     );
+  });
+
+  // Per-slide sizes made the window jump on every step and blew up to 760x720
+  // on the payment slide. One size, applied once, for the whole flow.
+  it("sizes the window once instead of resizing per slide", async () => {
+    mocks.enterprisePolicy.isManagedDeployment = false;
+    mocks.settings.user = { has_payment_method: false, token: "tok" };
+    onboardingData.currentStep = "engine";
+
+    render(<OnboardingPage />);
+    await waitFor(() =>
+      expect(mocks.setWindowSize).toHaveBeenCalledWith("Onboarding", 500, 680),
+    );
+
+    // Advancing onto the payment slide, the step that used to widen the window
+    // to 760x720, must not resize it again.
+    fireEvent.click(await screen.findByRole("button", { name: "finish engine" }));
+    expect(await screen.findByText("plan selection")).toBeInTheDocument();
+
+    expect(mocks.setWindowSize).toHaveBeenCalledTimes(1);
   });
 
   it("managed onboarding completes from engine without consumer pricing", async () => {

--- a/apps/screenpipe-app-tauri/app/onboarding/page.tsx
+++ b/apps/screenpipe-app-tauri/app/onboarding/page.tsx
@@ -29,19 +29,18 @@ type SlideKey =
   | "engine"
   | "plan";
 
-const SLIDE_WINDOW_SIZES: Record<SlideKey, { width: number; height: number }> =
-  {
-    login: { width: 500, height: 480 },
-    acquisition: { width: 500, height: 560 },
-    // Taller than the other 560 slides: the wheel now sits under the data dir
-    // chip and above the pause note, and at 560 the note was clipped by the
-    // window edge (caught by the trust-affordance E2E screenshot, which is why
-    // that spec asserts the note is inside the viewport).
-    permissions: { width: 500, height: 660 },
-    timeline: { width: 500, height: 680 },
-    engine: { width: 500, height: 620 },
-    plan: { width: 760, height: 720 },
-  };
+// One size for the whole flow. Per-slide sizes made the window jump on every
+// step, worst on "plan", which widened to 760 even though the content column is
+// capped at max-w-lg — 124px of dead margin per side — and was still 42px too
+// short to show the free-plan link. 680 is the tallest any slide previously
+// asked for (timeline), so every other step only gains slack: the permissions
+// wheel and its pause note, which the trust-affordance E2E asserts stay inside
+// the viewport, still fit. Steps that need less stay centered by the wrapper's
+// justify-center, and anything taller still scrolls.
+//
+// Must match the inner_size the Rust side creates the window at, in
+// window/show.rs, so opening onboarding doesn't resize on first paint.
+const ONBOARDING_WINDOW_SIZE = { width: 500, height: 680 };
 
 // When shown, the timeline choice sits before "engine" so disableTimeline is
 // persisted before the engine spawns and reads it — no restart needed.
@@ -108,9 +107,12 @@ const EndowedProgress = ({
   </div>
 );
 
-const setWindowSizeForSlide = async (slide: SlideKey) => {
+// Corrective only: Rust already builds the window at this size. It still runs
+// so a window left at an old per-slide size — an install that upgraded midway
+// through onboarding — snaps back to the shared size instead of staying wide.
+const applyOnboardingWindowSize = async () => {
   try {
-    const { width, height } = SLIDE_WINDOW_SIZES[slide];
+    const { width, height } = ONBOARDING_WINDOW_SIZE;
     await commands.setWindowSize("Onboarding", width, height);
   } catch {
     // non-critical
@@ -280,9 +282,13 @@ export default function OnboardingPage() {
     onboardingData.isCompleted,
   ]);
 
-  // Set window size + track view when slide changes
+  // The window is sized once, not per slide, so stepping through setup no
+  // longer resizes it under the user.
   useEffect(() => {
-    setWindowSizeForSlide(currentSlide);
+    void applyOnboardingWindowSize();
+  }, []);
+
+  useEffect(() => {
     setIsVisible(true);
     posthog.capture(`onboarding_${currentSlide}_viewed`);
   }, [currentSlide]);

--- a/apps/screenpipe-app-tauri/components/onboarding/plan-selection-step.test.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/plan-selection-step.test.tsx
@@ -91,6 +91,22 @@ describe("onboarding card capture", () => {
     );
   });
 
+  // The step used to hard-code a 520px iframe inside a 460px box, which forced
+  // the onboarding window wider and taller than every other slide and still cut
+  // off the free-plan link. It now fills whatever the shared window leaves.
+  it("fills the available height instead of forcing a fixed iframe size", async () => {
+    render(<PlanSelectionStep handleNextSlide={vi.fn()} />);
+
+    const root = screen.getByTestId("onboarding-card-capture");
+    expect(root.className).toContain("flex-1");
+    expect(root.className).not.toMatch(/max-w-/);
+
+    const frame = await screen.findByTestId("onboarding-card-frame");
+    expect(frame.className).toContain("h-full");
+    expect(frame.className).not.toMatch(/h-\[\d+px\]/);
+    expect(frame.parentElement?.className).toContain("flex-1");
+  });
+
   it("recreates embedded checkout with monthly billing when switched", async () => {
     render(<PlanSelectionStep handleNextSlide={vi.fn()} />);
     await waitFor(() => expect(mocks.fetch).toHaveBeenCalledOnce());

--- a/apps/screenpipe-app-tauri/components/onboarding/plan-selection-step.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/plan-selection-step.tsx
@@ -212,8 +212,12 @@ export default function PlanSelectionStep({
   };
 
   return (
+    // Grows into whatever the shared onboarding window leaves after the heading
+    // and interval toggle, so the checkout box never overflows the window the
+    // way the old fixed 520px iframe did. max-w-2xl was dead: the onboarding
+    // page wraps every slide in max-w-lg.
     <div
-      className="mx-auto w-full max-w-2xl"
+      className="mx-auto flex min-h-0 w-full flex-1 flex-col"
       data-testid="onboarding-card-capture"
     >
       <div className="mb-4 text-center">
@@ -239,7 +243,7 @@ export default function PlanSelectionStep({
         </button>
       </div>
 
-      <div className="relative min-h-[460px] border bg-white">
+      <div className="relative min-h-[360px] flex-1 border bg-white">
         {busy && (
           <div className="absolute inset-0 flex items-center justify-center font-mono text-[11px] text-muted-foreground">
             loading secure payment form
@@ -251,7 +255,10 @@ export default function PlanSelectionStep({
             src={frameUrl}
             title="secure Stripe payment form"
             allow="payment"
-            className="h-[520px] w-full border-0"
+            // Fills the box exactly. A percentage height would not resolve
+            // against a flex-grown parent for a replaced element, leaving the
+            // iframe at its 150px intrinsic default.
+            className="absolute inset-0 h-full w-full border-0"
             data-testid="onboarding-card-frame"
           />
         )}

--- a/apps/screenpipe-app-tauri/src-tauri/src/window/show.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/window/show.rs
@@ -1541,13 +1541,16 @@ impl ShowRewindWindow {
                     return ShowRewindWindow::Home { page: None }.show(app);
                 }
 
-                // Clamp onboarding window size to primary monitor to prevent min > max panic
+                // One size for every onboarding slide (see ONBOARDING_WINDOW_SIZE in
+                // app/onboarding/page.tsx) so stepping through setup never resizes
+                // the window. Still clamped to the primary monitor to prevent a
+                // min > max panic on small displays; slides scroll when clamped.
                 let (width, height) = if let Ok(Some(monitor)) = app.primary_monitor() {
                     let logical: tauri::LogicalSize<f64> =
                         monitor.size().to_logical(monitor.scale_factor());
-                    (500.0_f64.min(logical.width), 560.0_f64.min(logical.height))
+                    (500.0_f64.min(logical.width), 680.0_f64.min(logical.height))
                 } else {
-                    (500.0, 560.0)
+                    (500.0, 680.0)
                 };
                 let min = self.id().min_size().unwrap_or((0.0, 0.0));
                 let clamped_min = (min.0.min(width), min.1.min(height));

--- a/docs/coverage/CORE.md
+++ b/docs/coverage/CORE.md
@@ -9,10 +9,10 @@ confidence, and criticality.
 - Tracked crates: screenpipe-engine, screenpipe-db, screenpipe-sqlite-coordinator, screenpipe-audio, screenpipe-screen, screenpipe-a11y
 - Mapped suites: 32
 - Mapped Rust files: 321
-- Active test blocks: 3062
+- Active test blocks: 3064
 - Ignored/manual test blocks: 137
-- Declared test blocks: 3199
-- Weighted coverage points: 2519.7
+- Declared test blocks: 3201
+- Weighted coverage points: 2521.1
 
 Confidence weights: strong=1.0, partial=0.7, conditional=0.4, smoke=0.3.
 Criticality weights: high=1.0, medium=0.7, low=0.4.
@@ -23,15 +23,15 @@ are explicitly enabled in a runtime lane.
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 2931 | 132 | 2459.7 | 21 | 11 | 100% |
-| macos | 29 | 2984 | 112 | 2470.1 | 22 | 11 | 100% |
-| linux | 25 | 2617 | 105 | 2176.5 | 20 | 11 | 100% |
+| windows | 29 | 2933 | 132 | 2461.1 | 21 | 11 | 100% |
+| macos | 29 | 2986 | 112 | 2471.5 | 22 | 11 | 100% |
+| linux | 25 | 2619 | 105 | 2177.9 | 20 | 11 | 100% |
 
 ## Crate Summary
 
 | Crate | Suites | Integration files | Source unit files | Active tests | Ignored tests | Weighted points | Flows |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| screenpipe-engine | 10 | 18 | 102 | 1440 | 42 | 1103.9 | 10 |
+| screenpipe-engine | 10 | 18 | 102 | 1442 | 42 | 1105.3 | 10 |
 | screenpipe-db | 5 | 52 | 14 | 447 | 16 | 424.2 | 9 |
 | screenpipe-sqlite-coordinator | 1 | 0 | 2 | 16 | 0 | 16.0 | 2 |
 | screenpipe-audio | 6 | 25 | 51 | 584 | 43 | 510.4 | 5 |
@@ -72,17 +72,17 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | meeting | 6 suites / 1401 active / 19 ignored / 1144.2 pts | 6 suites / 1401 active / 19 ignored / 1144.2 pts | 4 suites / 1123 active / 15 ignored / 888.7 pts |
 | ocr | 4 suites / 124 active / 7 ignored / 118.3 pts | 4 suites / 128 active / 7 ignored / 123.8 pts | 3 suites / 119 active / 6 ignored / 114.8 pts |
 | os-integration | 1 suites / 6 active / 0 ignored / 1.7 pts | 1 suites / 6 active / 0 ignored / 1.7 pts | - |
-| performance | 13 suites / 1370 active / 67 ignored / 1208.8 pts | 14 suites / 1468 active / 70 ignored / 1248.0 pts | 13 suites / 1370 active / 67 ignored / 1208.8 pts |
+| performance | 13 suites / 1372 active / 67 ignored / 1210.2 pts | 14 suites / 1470 active / 70 ignored / 1249.4 pts | 13 suites / 1372 active / 67 ignored / 1210.2 pts |
 | pipes | 1 suites / 462 active / 3 ignored / 323.4 pts | 1 suites / 462 active / 3 ignored / 323.4 pts | 1 suites / 462 active / 3 ignored / 323.4 pts |
 | privacy | 5 suites / 871 active / 36 ignored / 707.5 pts | 5 suites / 920 active / 16 ignored / 712.4 pts | 5 suites / 846 active / 14 ignored / 685.0 pts |
 | real-app | - | 1 suites / 98 active / 3 ignored / 39.2 pts | - |
 | speaker | 2 suites / 342 active / 8 ignored / 342.0 pts | 2 suites / 342 active / 8 ignored / 342.0 pts | 2 suites / 342 active / 8 ignored / 342.0 pts |
-| storage | 3 suites / 471 active / 29 ignored / 382.2 pts | 3 suites / 471 active / 29 ignored / 382.2 pts | 3 suites / 471 active / 29 ignored / 382.2 pts |
+| storage | 3 suites / 473 active / 29 ignored / 383.6 pts | 3 suites / 473 active / 29 ignored / 383.6 pts | 3 suites / 473 active / 29 ignored / 383.6 pts |
 | sync | 1 suites / 462 active / 3 ignored / 323.4 pts | 1 suites / 462 active / 3 ignored / 323.4 pts | 1 suites / 462 active / 3 ignored / 323.4 pts |
-| timeline | 4 suites / 929 active / 33 ignored / 755.9 pts | 4 suites / 929 active / 33 ignored / 755.9 pts | 4 suites / 929 active / 33 ignored / 755.9 pts |
+| timeline | 4 suites / 931 active / 33 ignored / 757.3 pts | 4 suites / 931 active / 33 ignored / 757.3 pts | 4 suites / 931 active / 33 ignored / 757.3 pts |
 | transcription | 5 suites / 692 active / 40 ignored / 545.2 pts | 5 suites / 692 active / 40 ignored / 545.2 pts | 5 suites / 692 active / 40 ignored / 545.2 pts |
 | ui-events | 4 suites / 701 active / 28 ignored / 533.9 pts | 3 suites / 652 active / 5 ignored / 499.6 pts | 3 suites / 652 active / 5 ignored / 499.6 pts |
-| vision-capture | 5 suites / 490 active / 32 ignored / 388.5 pts | 5 suites / 494 active / 32 ignored / 394.0 pts | 4 suites / 485 active / 31 ignored / 385.0 pts |
+| vision-capture | 5 suites / 492 active / 32 ignored / 389.9 pts | 5 suites / 496 active / 32 ignored / 395.4 pts | 4 suites / 487 active / 31 ignored / 386.4 pts |
 
 ## Critical Flow Matrix
 
@@ -134,7 +134,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | db-search-indexing | screenpipe-db | windows, macos, linux | db-search, ocr, accessibility, performance | local-api-search, capture-ocr-pipeline, accessibility-ui-events, performance-liveness | high | strong | mixed | 13 | 105 | 4 | FTS, tokenizer, OCR snapshot search, query planning, ordering, accessibility search, and contention coverage. |
 | db-timeline-frames | screenpipe-db | windows, macos, linux | database, timeline, storage, performance | timeline-streaming, performance-liveness | high | strong | mixed | 18 | 175 | 3 | Frame/audio joins, timeline query shape, suggestions frames, write queue, DB primitives (src/db.rs split into src/db/ modules), feedback record upserts, media eviction anti-join regressions, SAF output registry, semantic storage, and timeline performance. |
 | engine-api-routes | screenpipe-engine | windows, macos, linux | local-api, timeline, meeting, transcription | local-api-search, timeline-streaming, meeting-live-notes, audio-record-transcribe | high | partial | mixed | 31 | 319 | 4 | Route/unit coverage for search, health, streaming, meetings, time/timezone, and transcription. Legacy endpoint/websocket tests require local data and remain ignored. |
-| engine-capture-timeline | screenpipe-engine | windows, macos, linux | vision-capture, timeline, storage, performance | capture-ocr-pipeline, timeline-streaming, performance-liveness | high | partial | mixed | 23 | 258 | 26 | Covers capture trigger logic, frame/audio linking, hot cache, timeline refresh regressions, fragmented MP4 extraction, and HD-mode control. Several real-data tests are intentionally ignored by default. |
+| engine-capture-timeline | screenpipe-engine | windows, macos, linux | vision-capture, timeline, storage, performance | capture-ocr-pipeline, timeline-streaming, performance-liveness | high | partial | mixed | 23 | 260 | 26 | Covers capture trigger logic, frame/audio linking, hot cache, timeline refresh regressions, fragmented MP4 extraction, and HD-mode control. Several real-data tests are intentionally ignored by default. |
 | engine-config-lifecycle | screenpipe-engine | windows, macos, linux | configuration, engine-lifecycle, performance | settings-to-engine-config, engine-health-lifecycle, performance-liveness | high | strong | mixed | 11 | 111 | 1 | Fast logic coverage for the config bridge, tray health debounce, sleep/power policies, and queue backpressure. |
 | engine-db-recovery-cli | screenpipe-engine | windows, macos, linux | database, engine-lifecycle | engine-health-lifecycle, performance-liveness | high | strong | unit | 1 | 8 | 0 | Exact DB/WAL/SHM working-copy preservation, rollback on archive failure, and restart repair for crashes during the multi-file generation swap. |
 | engine-focus-os | screenpipe-engine | windows, macos | engine-lifecycle, os-integration | engine-health-lifecycle, performance-liveness | medium | conditional | unit | 3 | 6 | 0 | Platform focus-tracker parsing/helpers. These files are cfg-gated and only execute on their target OS. |


### PR DESCRIPTION
## Problem

The payment step resized the onboarding window to **760x720** while every other step is 500 wide, so the window jumps on the last step of setup.

![before/after](https://raw.githubusercontent.com/screenpipe/screenpipe/assets-onboarding-window-size/plan-window-size.png)

## Where found

`SLIDE_WINDOW_SIZES` in `app/onboarding/page.tsx` sized the window per slide: `login` 480, `acquisition` 560, `permissions` 660, `timeline` 680, `engine` 620 — all 500 wide — and `plan` at `760x720`.

## Reproduction and pre-fix failure

Rendering the plan slide at its own 760x720, measured on the live component:

| | before (760x720) | after (500x680) |
|---|---|---|
| content column | 512px | 452px |
| dead margin per side | **124px** | 24px |
| content clipped below the fold | **34px** | **0px** |
| "continue with limited free plan" visible | **no** | **yes** |

Two things, not one. The extra width bought nothing — the onboarding page wraps every slide in `max-w-lg`, so the content column stayed 512px no matter how wide the window got. And the window was still too short for its own content: the free-plan link sat below the fold behind a scroll.

## Root cause

- Width: the plan step asked for `max-w-2xl` (672px) and the window was sized to match, but the page wrapper caps every slide at `max-w-lg` (512px). The `max-w-2xl` was dead code and the extra 248px of window was pure margin.
- Height: the checkout box hard-coded a **520px** iframe inside a `min-h-[460px]` box. Total content came to 722px against a 720px window.

## Fix

- One `ONBOARDING_WINDOW_SIZE` of `500x680` for the whole flow, applied **once on mount** instead of on every slide change. 680 is the tallest any slide previously asked for (`timeline`), so every other step only gains slack — including the permissions wheel and its pause note, which the trust-affordance E2E asserts stay inside the viewport. Shorter steps stay centered by the wrapper's `justify-center`.
- `window/show.rs` builds the onboarding window at the same size, so opening onboarding no longer resizes on first paint. Still clamped to the primary monitor.
- The payment box now grows into whatever the window leaves (`flex-1`, floor `min-h-[360px]`) instead of hard-coding a height, so it can't overflow the window again if the heading wraps to a different number of lines. The iframe fills it with `absolute inset-0` — a percentage height does not resolve against a flex-grown parent for a replaced element and would leave the iframe at its 150px intrinsic default.

The frontend `setWindowSize` call is kept as a corrective so a window left at an old per-slide size — an install that upgraded midway through onboarding — snaps back instead of staying wide.

The checkout box goes from 520px to 421px at the shared size. Stripe's embedded checkout is responsive and scrolls inside its own frame; the whole form is visible in the after shot above, and the outer chrome strictly improves (before, the free-plan link was unreachable without scrolling).

## Validation

- `vitest app/onboarding/page.test.tsx components/onboarding/plan-selection-step.test.tsx` — 43 passed, including two new regressions: the window is sized exactly once across an engine→plan transition, and the plan step carries no fixed iframe height or stale `max-w-*`.
- Full `vitest run`: 3233 passed. The 62 failures across 8 files are the pre-existing local jsdom `localStorage` baseline plus one module missing from this worktree's `node_modules`; all are untouched files and reproduce on `main`.
- `tsc --noEmit`: clean apart from a `@radix-ui/react-hover-card` resolution error that is a local `node_modules` gap (the dep is declared in `package.json`), not a code error.
- `next lint` clean; `eslint --config eslint.effects.config.mjs` 0 errors.
- `cargo check -p screenpipe-app` clean.
- Geometry numbers above measured in a headless render of the real chrome and the real step classes at both sizes.

Not run: the packaged wdio E2E (`onboarding-first-run.spec.ts` covers this screen and will exercise it in CI).
