### PR TITLE
fix custom AI connection test streaming

### DIFF
--- a/apps/screenpipe-app-tauri/lib/utils/ai-preset-connection.test.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/ai-preset-connection.test.ts
@@ -35,6 +35,39 @@ describe("testAiPresetConnection", () => {
     expect(JSON.parse(request.mock.calls[0][1]!.body as string)).toMatchObject({
       model: "model-1",
       max_tokens: 50,
+      stream: false,
+    });
+  });
+
+  it("explicitly disables streaming for OpenAI-compatible gateways", async () => {
+    const request = vi.fn(async (_input: string, init?: RequestInit) => {
+      const body = JSON.parse(init?.body as string);
+      if (body.stream !== false) {
+        return new Response(
+          'data: {"choices":[{"delta":{"content":"hi"}}]}\n\n',
+          { status: 200, headers: { "Content-Type": "text/event-stream" } },
+        );
+      }
+      return new Response(
+        JSON.stringify({ choices: [{ message: { content: "hi" } }] }),
+        { status: 200 },
+      );
+    });
+
+    await expect(
+      testAiPresetConnection(
+        {
+          provider: "custom",
+          url: "https://gateway.example.com/v1",
+          model: "model-1",
+          apiKey: "secret",
+        },
+        { fetch: request },
+      ),
+    ).resolves.toMatchObject({ reply: "hi" });
+
+    expect(JSON.parse(request.mock.calls[0][1]!.body as string)).toMatchObject({
+      stream: false,
     });
   });
 
@@ -94,6 +127,7 @@ describe("testAiPresetConnection", () => {
     expect(JSON.parse(request.mock.calls[1][1]!.body as string)).toMatchObject({
       model: "gpt-5",
       max_completion_tokens: 50,
+      stream: false,
     });
   });
 });

--- a/apps/screenpipe-app-tauri/lib/utils/chat-test-body.test.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/chat-test-body.test.ts
@@ -15,6 +15,7 @@ describe("buildChatTestBody", () => {
     expect(body).toEqual({
       model: "gpt-4",
       messages: [{ role: "user", content: "say hi" }],
+      stream: false,
       max_tokens: 50,
     });
     expect(body.max_completion_tokens).toBeUndefined();
@@ -25,6 +26,7 @@ describe("buildChatTestBody", () => {
     expect(body).toEqual({
       model: "gpt-5",
       messages: [{ role: "user", content: "say hi" }],
+      stream: false,
       max_completion_tokens: 50,
     });
     expect(body.max_tokens).toBeUndefined();

--- a/apps/screenpipe-app-tauri/lib/utils/chat-test-body.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/chat-test-body.ts
@@ -21,6 +21,7 @@ export type ChatTokensField = "max_tokens" | "max_completion_tokens";
 export interface ChatTestBody {
   model: string;
   messages: Array<{ role: string; content: string }>;
+  stream: false;
   max_tokens?: number;
   max_completion_tokens?: number;
 }
@@ -37,6 +38,7 @@ export function buildChatTestBody(
   const body: ChatTestBody = {
     model,
     messages: [{ role: "user", content: prompt }],
+    stream: false,
   };
   if (tokensField === "max_tokens") {
     body.max_tokens = maxTokens;


### PR DESCRIPTION
## Summary

- explicitly set `stream: false` on custom AI connection-test chat requests
- preserve the existing token-field fallback behavior
- add focused regression coverage for gateways that return SSE when streaming is omitted

## Root cause

`buildChatTestBody()` omitted the `stream` field, while the connection test always parsed successful responses as JSON. Some OpenAI-compatible gateways default an omitted stream setting to SSE, causing `response.json()` to fail and blocking preset creation.

## User impact

Custom OpenAI-compatible providers such as omniroute now receive an explicitly non-streaming connection-test request, so their JSON response can be parsed successfully. Normal chat streaming behavior is unchanged.

Fixes #6196

Before

Not applicable: this is a request-body behavior fix. Live OmniRoute verification was not performed because the Windows OmniRoute installer fails during post-install.

After

The regression test simulates an OpenAI-compatible gateway that returns SSE unless stream: false is supplied. The connection test now sends stream: false and succeeds with a JSON response.

## Validation

- `bun x vitest run --config vitest.config.ts lib/utils/chat-test-body.test.ts lib/utils/ai-preset-connection.test.ts` (22 passed)
- `bun run typecheck`
- `git diff --check`
