### PR TITLE
fix(account): show Business Max and Ultra in the plan picker

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/__tests__/account-section.subscription-gate.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/account-section.subscription-gate.test.tsx
@@ -189,8 +189,9 @@ describe("AccountSection subscription/login gating", () => {
     expect(mocks.openUrl).toHaveBeenCalledWith("https://screenpipe.com/account");
   });
 
-  it("shows one quiet next-tier action and opens the exact Max billing target", () => {
-    vi.stubEnv("NEXT_PUBLIC_BUSINESS_POWER_PLANS_ENABLED", "true");
+  it("shows Max and Ultra as plans and opens the exact Max billing target", () => {
+    // These cards replace a strip that shipped behind
+    // NEXT_PUBLIC_BUSINESS_POWER_PLANS_ENABLED, an env var no build ever set.
     mocks.state.user = {
       id: "u1",
       email: "pro@screenpipe.test",
@@ -200,10 +201,19 @@ describe("AccountSection subscription/login gating", () => {
     };
 
     render(<AccountSection />);
-    const upgrade = screen.getByTestId("account-capacity-upgrade");
-    expect(within(upgrade).getByText("need more AI capacity?")).toBeInTheDocument();
-    expect(within(upgrade).getByText(/higher query and request-rate limits/i)).toBeInTheDocument();
-    fireEvent.click(screen.getByTestId("account-capacity-upgrade-button"));
+    const options = screen.getByTestId("account-plan-options");
+    expect(within(options).getByText("business max")).toBeInTheDocument();
+    expect(within(options).getByText("business ultra")).toBeInTheDocument();
+    expect(within(options).getByText("$100")).toBeInTheDocument();
+    expect(within(options).getByText("$200")).toBeInTheDocument();
+    // Business is the current plan, so Max is the immediate next step.
+    expect(
+      within(screen.getByTestId("account-plan-pro_max")).getByTestId(
+        "account-plan-next-step",
+      ),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("account-plan-choose-pro_max"));
 
     expect(mocks.openUrl).toHaveBeenCalledWith(
       "https://screenpipe.com/account/billing?target_plan=pro_max&interval=month",
@@ -214,25 +224,39 @@ describe("AccountSection subscription/login gating", () => {
     );
   });
 
-  it("does not show power-plan promotion while the rollout flag is off", () => {
+  it("marks the capacity level a Max account actually pays for", () => {
+    // The Max card used to be the Business card wearing Max's name and price,
+    // which cost the ladder its rungs and claimed "higher monthly AI credit
+    // allowance" — the gateway grants Max the same 400 credits as Business.
     mocks.state.user = {
       id: "u1",
-      email: "pro@screenpipe.test",
+      email: "max@screenpipe.test",
       token: "tok",
       cloud_subscribed: true,
-      subscription_plan: "pro",
+      subscription_plan: "pro_max",
     };
 
     render(<AccountSection />);
-    expect(screen.queryByTestId("account-capacity-upgrade")).not.toBeInTheDocument();
+    const max = screen.getByTestId("account-plan-pro_max");
+    expect(max).toHaveAttribute("data-current", "true");
+    expect(within(max).getByText("$100")).toBeInTheDocument();
+    expect(within(max).getByText("your plan")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("account-plan-pro"),
+    ).not.toHaveAttribute("data-current");
   });
 
-  it("routes Max to Ultra and never promotes Ultra or org plans", () => {
-    vi.stubEnv("NEXT_PUBLIC_BUSINESS_POWER_PLANS_ENABLED", "true");
-    mocks.state.user = { id: "u1", email: "max@screenpipe.test", token: "tok", cloud_subscribed: true, subscription_plan: "pro_max" };
+  it("routes Max to Ultra and recommends nothing above Ultra or off-ladder", () => {
+    mocks.state.user = {
+      id: "u1",
+      email: "max@screenpipe.test",
+      token: "tok",
+      cloud_subscribed: true,
+      subscription_plan: "pro_max",
+    };
 
     const { rerender } = render(<AccountSection />);
-    fireEvent.click(screen.getByTestId("account-capacity-upgrade-button"));
+    fireEvent.click(screen.getByTestId("account-plan-choose-pro_ultra"));
     expect(mocks.openUrl).toHaveBeenLastCalledWith(
       "https://screenpipe.com/account/billing?target_plan=pro_ultra&interval=month",
     );
@@ -240,7 +264,9 @@ describe("AccountSection subscription/login gating", () => {
     for (const plan of ["pro_ultra", "team", "enterprise"]) {
       mocks.state.user = { ...mocks.state.user, subscription_plan: plan };
       rerender(<AccountSection />);
-      expect(screen.queryByTestId("account-capacity-upgrade")).not.toBeInTheDocument();
+      expect(
+        screen.queryByTestId("account-plan-next-step"),
+      ).not.toBeInTheDocument();
     }
   });
 

--- a/apps/screenpipe-app-tauri/components/settings/account-plan-options.test.ts
+++ b/apps/screenpipe-app-tauri/components/settings/account-plan-options.test.ts
@@ -6,49 +6,80 @@ import { describe, expect, it } from "vitest";
 import {
   ACCOUNT_PLANS,
   accountPlanForEntitlement,
-  businessCapacityTier,
+  recommendedCapacityCard,
 } from "./account-plan-options";
 
 describe("account plan options", () => {
-  it("offers Free, Basic and Business — the app could only sell Business", () => {
+  it("offers every self-serve plan, including the capacity levels", () => {
+    // Max and Ultra existed in code since #5681 but sat behind an env flag no
+    // build ever set, so the picker only ever rendered three cards.
     expect(ACCOUNT_PLANS.map((plan) => plan.id)).toEqual([
       "free",
       "standard",
       "pro",
+      "pro_max",
+      "pro_ultra",
     ]);
   });
 
   it("quotes the same monthly prices as the pricing page", () => {
-    expect(ACCOUNT_PLANS[0].monthly).toBe(0);
-    expect(ACCOUNT_PLANS[1].monthly).toBe(25);
-    expect(ACCOUNT_PLANS[2].monthly).toBe(50);
+    expect(ACCOUNT_PLANS.map((plan) => plan.monthly)).toEqual([
+      0, 25, 50, 100, 200,
+    ]);
   });
 
   describe("business capacity levels", () => {
-    it("states Max and Ultra's own price, not the $50 Business seat", () => {
-      // A Business Max account used to read "$50 / seat / month" under a
-      // "your plan" badge while actually paying $100.
-      expect(businessCapacityTier("pro_max")).toEqual({
-        name: "business max",
-        monthly: 100,
+    it("sells Max and Ultra through web billing, not the in-app checkout", () => {
+      // Both change an existing subscription, so they need proration on the
+      // web. Only Basic and Business can start a checkout in the app.
+      const byId = Object.fromEntries(ACCOUNT_PLANS.map((p) => [p.id, p]));
+      expect(byId.pro_max.purchase).toEqual({
+        kind: "billing",
+        targetPlan: "pro_max",
       });
-      expect(businessCapacityTier("pro_ultra")).toEqual({
-        name: "business ultra",
-        monthly: 200,
+      expect(byId.pro_ultra.purchase).toEqual({
+        kind: "billing",
+        targetPlan: "pro_ultra",
       });
+      expect(byId.standard.purchase).toEqual({
+        kind: "checkout",
+        plan: "standard",
+      });
+      expect(byId.pro.purchase).toEqual({ kind: "checkout", plan: "pro" });
+      expect(byId.free.purchase).toBeNull();
     });
 
-    it("accepts the business_* aliases and is case-insensitive", () => {
-      expect(businessCapacityTier("business_max")?.monthly).toBe(100);
-      expect(businessCapacityTier("BUSINESS_ULTRA")?.monthly).toBe(200);
-      expect(businessCapacityTier("  pro_max  ")?.monthly).toBe(100);
+    it("does not promise more credits or models than the gateway grants", () => {
+      // getHostedAiPlan collapses every business tier to the same 400 credits
+      // and the same frontier catalog. Max and Ultra buy throughput only.
+      const capacity = ACCOUNT_PLANS.filter((p) =>
+        ["pro_max", "pro_ultra"].includes(p.id),
+      );
+      expect(capacity).toHaveLength(2);
+      for (const plan of capacity) {
+        expect(plan.points.join(" ")).toContain("same 400 credits");
+        expect(plan.points.join(" ")).not.toMatch(/\b(800|1600|1,600)\b/);
+      }
     });
 
-    it("leaves every plan the business card already describes correctly", () => {
-      // These must stay null or the base card would restate itself.
+    it("states the capacity multipliers the usage tracker actually applies", () => {
+      // DEFAULT_TIER_CONFIG: 60 -> 120 -> 240 daily queries and rpm.
+      const byId = Object.fromEntries(ACCOUNT_PLANS.map((p) => [p.id, p]));
+      expect(byId.pro_max.points[0]).toContain("2x");
+      expect(byId.pro_ultra.points[0]).toContain("4x");
+    });
+
+    it("points a Business account at Max, and a Max account at Ultra", () => {
+      expect(recommendedCapacityCard("pro")).toBe("pro_max");
+      expect(recommendedCapacityCard("business")).toBe("pro_max");
+      expect(recommendedCapacityCard("business_max")).toBe("pro_ultra");
+      expect(recommendedCapacityCard("pro_max")).toBe("pro_ultra");
+    });
+
+    it("recommends nothing above Ultra or off the business ladder", () => {
       for (const plan of [
-        "pro",
-        "business",
+        "pro_ultra",
+        "business_ultra",
         "standard",
         "lifetime",
         "team",
@@ -58,14 +89,8 @@ describe("account plan options", () => {
         null,
         undefined,
       ]) {
-        expect(businessCapacityTier(plan)).toBeNull();
+        expect(recommendedCapacityCard(plan)).toBeNull();
       }
-    });
-
-    it("prices agree with the upgrade path in lib/app-entitlement", () => {
-      // Drift here would quote one price on the card and another at checkout.
-      expect(businessCapacityTier("pro_max")?.monthly).toBe(100);
-      expect(businessCapacityTier("pro_ultra")?.monthly).toBe(200);
     });
   });
 
@@ -80,23 +105,25 @@ describe("account plan options", () => {
       expect(accountPlanForEntitlement("lifetime", true)).toBe("standard");
     });
 
-    it("keeps every Business capacity level on Business", () => {
-      for (const plan of [
-        "pro",
-        "business",
-        "pro_max",
-        "business_max",
+    it("marks the capacity level the account actually pays for", () => {
+      // A Business Max account used to read "$50 / seat / month" under a
+      // "your plan" badge while actually paying $100.
+      expect(accountPlanForEntitlement("pro_max", true)).toBe("pro_max");
+      expect(accountPlanForEntitlement("business_max", true)).toBe("pro_max");
+      expect(accountPlanForEntitlement("pro_ultra", true)).toBe("pro_ultra");
+      expect(accountPlanForEntitlement("business_ultra", true)).toBe(
         "pro_ultra",
-        "business_ultra",
-        "team",
-        "enterprise",
-      ]) {
+      );
+    });
+
+    it("keeps base Business, Team and Enterprise on the Business card", () => {
+      for (const plan of ["pro", "business", "team", "enterprise"]) {
         expect(accountPlanForEntitlement(plan, true)).toBe("pro");
       }
     });
 
     it("is case insensitive", () => {
-      expect(accountPlanForEntitlement("PRO_ULTRA", true)).toBe("pro");
+      expect(accountPlanForEntitlement("PRO_ULTRA", true)).toBe("pro_ultra");
     });
 
     it("falls back to paid access when the plan name is missing", () => {

--- a/apps/screenpipe-app-tauri/components/settings/account-plan-options.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/account-plan-options.tsx
@@ -4,9 +4,12 @@
 
 "use client";
 
-import { Check } from "lucide-react";
+import { Check, ExternalLinkIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { planDisplayName } from "@/lib/app-entitlement";
+import {
+  getBusinessCapacityUpgrade,
+  type BusinessCapacityUpgrade,
+} from "@/lib/app-entitlement";
 import type { SelectablePlan } from "@/lib/upgrade-flow";
 
 /**
@@ -17,9 +20,28 @@ import type { SelectablePlan } from "@/lib/upgrade-flow";
  * `plan: "pro"`, so a user who wanted Basic had no way to choose it — and a
  * subscriber had no way to see what else existed. Free is listed because it is
  * what the account falls back to, not as something to buy.
+ *
+ * Business Max and Ultra are cards of their own. They shipped in #5681 behind
+ * `NEXT_PUBLIC_BUSINESS_POWER_PLANS_ENABLED`, which was never set in any build,
+ * so the only Max/Ultra surface in the app never rendered once.
  */
 
-export type AccountPlanId = "free" | "standard" | "pro";
+export type AccountPlanId =
+  | "free"
+  | "standard"
+  | "pro"
+  | "pro_max"
+  | "pro_ultra";
+
+/** Where a card's action goes.
+ *
+ *  Basic and Business run the in-app Stripe checkout. The capacity levels
+ *  change an existing subscription rather than start one, which needs the web
+ *  billing page for proration, so they deep-link with the target preset —
+ *  the same URL contract the (dark) capacity upsell used. */
+export type PlanPurchase =
+  | { kind: "checkout"; plan: SelectablePlan }
+  | { kind: "billing"; targetPlan: BusinessCapacityUpgrade["targetPlan"] };
 
 type PlanRow = {
   id: AccountPlanId;
@@ -27,10 +49,21 @@ type PlanRow = {
   monthly: number;
   cadence: string;
   points: string[];
+  /** Button copy. Spelled out because "choose business ultra" does not fit a
+   *  card this narrow. */
+  cta: string;
+  /** null for Free: it is the fallback, not something to buy. */
+  purchase: PlanPurchase | null;
 };
 
 // Mirrors lib/pricing-tiers.ts on the website. Kept as plain data here because
 // the desktop app has no import path to the marketing pricing module.
+//
+// Max and Ultra buy capacity, not credits or models: the gateway collapses
+// every business tier to the same 400 credits and the same frontier catalog
+// (getHostedAiPlan), and raises only daily queries and requests per minute
+// (60 → 120 → 240 in usage-tracker's DEFAULT_TIER_CONFIG). Say that, so nobody
+// upgrades expecting a bigger allowance.
 export const ACCOUNT_PLANS: PlanRow[] = [
   {
     id: "free",
@@ -38,6 +71,8 @@ export const ACCOUNT_PLANS: PlanRow[] = [
     monthly: 0,
     cadence: "/ month",
     points: ["10 AI credits / month · Auto only", "limited history"],
+    cta: "included",
+    purchase: null,
   },
   {
     id: "standard",
@@ -45,6 +80,8 @@ export const ACCOUNT_PLANS: PlanRow[] = [
     monthly: 25,
     cadence: "/ month",
     points: ["150 AI credits / month", "unlimited history & scheduled tasks"],
+    cta: "choose basic",
+    purchase: { kind: "checkout", plan: "standard" },
   },
   {
     id: "pro",
@@ -55,32 +92,52 @@ export const ACCOUNT_PLANS: PlanRow[] = [
       "400 AI credits / month",
       "frontier Claude + GPT · cloud sync",
     ],
+    cta: "choose business",
+    purchase: { kind: "checkout", plan: "pro" },
+  },
+  {
+    id: "pro_max",
+    name: "business max",
+    monthly: 100,
+    cadence: "/ seat / month",
+    points: [
+      "2x daily queries & request rate",
+      "same 400 credits & frontier models",
+    ],
+    cta: "choose max",
+    purchase: { kind: "billing", targetPlan: "pro_max" },
+  },
+  {
+    id: "pro_ultra",
+    name: "business ultra",
+    monthly: 200,
+    cadence: "/ seat / month",
+    points: [
+      "4x daily queries & request rate",
+      "same 400 credits & frontier models",
+    ],
+    cta: "choose ultra",
+    purchase: { kind: "billing", targetPlan: "pro_ultra" },
   },
 ];
 
-// Business is one family with capacity levels stacked above the $50 seat, so a
-// Max or Ultra subscriber belongs on the business card. They must not be shown
-// Business's price as their own, though: before this, a Business Max account
-// read "$50 / seat / month" under a "your plan" badge while actually paying
-// $100. Prices mirror `BusinessCapacityUpgrade` in lib/app-entitlement.ts.
-const BUSINESS_CAPACITY_MONTHLY: Record<string, number> = {
-  pro_max: 100,
-  business_max: 100,
-  pro_ultra: 200,
-  business_ultra: 200,
+/** Card ids keyed by the billing target they upgrade to, so the "next step"
+ *  badge follows the one ladder in lib/app-entitlement. */
+const CARD_FOR_TARGET: Record<
+  BusinessCapacityUpgrade["targetPlan"],
+  AccountPlanId
+> = {
+  pro_max: "pro_max",
+  pro_ultra: "pro_ultra",
 };
 
-/**
- * The capacity level an entitlement actually sits at, when it is above the
- * base Business seat. Returns null for every plan the business card already
- * describes correctly.
- */
-export function businessCapacityTier(
+/** The capacity card to mark as the immediate next step, so a Business account
+ *  is pointed at Max rather than at Max and Ultra shouting equally. */
+export function recommendedCapacityCard(
   plan: string | null | undefined,
-): { name: string; monthly: number } | null {
-  const monthly = BUSINESS_CAPACITY_MONTHLY[(plan || "").trim().toLowerCase()];
-  if (monthly === undefined) return null;
-  return { name: planDisplayName(plan).toLowerCase(), monthly };
+): AccountPlanId | null {
+  const upgrade = getBusinessCapacityUpgrade(plan);
+  return upgrade ? CARD_FOR_TARGET[upgrade.targetPlan] : null;
 }
 
 /** Which card to mark "current" for an entitlement plan (users.plan). */
@@ -95,12 +152,19 @@ export function accountPlanForEntitlement(
     // AI tier, so it is not Business.
     case "lifetime":
       return "standard";
-    case "pro":
-    case "business":
+    // Each capacity level owns a card now, so the badge lands on the tier the
+    // account actually pays for. Before this a Business Max account read
+    // "$50 / seat / month" under a "your plan" badge while paying $100.
     case "pro_max":
     case "business_max":
+      return "pro_max";
     case "pro_ultra":
     case "business_ultra":
+      return "pro_ultra";
+    case "pro":
+    case "business":
+    // Team and Enterprise are billed elsewhere; Business is the closest
+    // self-serve card and stays the one marked current.
     case "team":
     case "enterprise":
       return "pro";
@@ -115,11 +179,10 @@ export function AccountPlanOptions({
   fallbackTo,
   busy = false,
   disabledReason,
-  onChoose,
+  onSelect,
 }: {
   current: AccountPlanId;
-  /** Raw entitlement (users.plan), so a Business capacity level above the base
-   *  seat can state its own name and price instead of Business's. */
+  /** Raw entitlement (users.plan), used to point at the next capacity step. */
   entitlementPlan?: string | null;
   /** Plan the account drops to when a trial or grant ends. */
   fallbackTo?: AccountPlanId;
@@ -127,30 +190,25 @@ export function AccountPlanOptions({
   /** Set when this account must not buy from the app (e.g. a seat billed by a
    *  workspace). Prices stay readable, the purchase action does not. */
   disabledReason?: string;
-  onChoose: (plan: SelectablePlan) => void;
+  onSelect: (purchase: PlanPurchase) => void;
 }) {
+  const recommended = recommendedCapacityCard(entitlementPlan);
+
   return (
-    <div className="grid gap-3 sm:grid-cols-3" data-testid="account-plan-options">
+    <div
+      className="grid gap-3 sm:grid-cols-3 xl:grid-cols-5"
+      data-testid="account-plan-options"
+    >
       {ACCOUNT_PLANS.map((plan) => {
         const isCurrent = plan.id === current;
         const isFallback = !isCurrent && plan.id === fallbackTo;
-        const paidId: SelectablePlan | null =
-          plan.id === "free" ? null : plan.id;
-        const selectable = paidId !== null && !isCurrent && !disabledReason;
-
-        // Only the card the account is actually on restates itself; the other
-        // cards stay the plain self-serve offer.
-        const capacity =
-          plan.id === "pro" && isCurrent
-            ? businessCapacityTier(entitlementPlan)
-            : null;
-        const displayName = capacity?.name ?? plan.name;
-        const displayMonthly = capacity?.monthly ?? plan.monthly;
-        // The base seat's credit line is wrong for a higher capacity level, and
-        // the exact allowance is not modelled here — say only what is true.
-        const points = capacity
-          ? ["higher monthly AI credit allowance", ...plan.points.slice(1)]
-          : plan.points;
+        const isRecommended =
+          !isCurrent && !isFallback && plan.id === recommended;
+        const purchase = plan.purchase;
+        const selectable = purchase !== null && !isCurrent && !disabledReason;
+        // Capacity changes are proration on an existing subscription, so they
+        // finish in the browser. Say so rather than appearing to buy in place.
+        const leavesApp = purchase?.kind === "billing";
 
         return (
           <div
@@ -163,7 +221,7 @@ export function AccountPlanOptions({
           >
             <div className="flex items-start justify-between gap-2">
               <span className="text-sm font-semibold lowercase">
-                {displayName}
+                {plan.name}
               </span>
               {isCurrent ? (
                 <span className="shrink-0 rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-medium text-primary">
@@ -173,18 +231,25 @@ export function AccountPlanOptions({
                 <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[10px] text-muted-foreground">
                   next
                 </span>
+              ) : isRecommended ? (
+                <span
+                  className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[10px] text-muted-foreground"
+                  data-testid="account-plan-next-step"
+                >
+                  next step
+                </span>
               ) : null}
             </div>
 
             <div className="mt-1 flex items-baseline gap-1">
-              <span className="text-xl font-bold">${displayMonthly}</span>
+              <span className="text-xl font-bold">${plan.monthly}</span>
               <span className="text-[10px] text-muted-foreground">
                 {plan.cadence}
               </span>
             </div>
 
             <ul className="mt-2 flex-1 space-y-1">
-              {points.map((point) => (
+              {plan.points.map((point) => (
                 <li
                   key={point}
                   className="flex items-start gap-1.5 text-xs text-muted-foreground"
@@ -195,16 +260,25 @@ export function AccountPlanOptions({
               ))}
             </ul>
 
-            {selectable && paidId ? (
+            {selectable && purchase ? (
               <Button
                 size="sm"
-                variant={plan.id === "pro" ? "default" : "outline"}
+                // Emphasise the step forward. Keying this to Business alone
+                // made a downgrade the loudest button on a Max/Ultra account.
+                variant={
+                  isRecommended || (!recommended && plan.id === "pro")
+                    ? "default"
+                    : "outline"
+                }
                 className="mt-3 h-7 w-full text-xs"
                 disabled={busy}
-                onClick={() => onChoose(paidId)}
+                onClick={() => onSelect(purchase)}
                 data-testid={`account-plan-choose-${plan.id}`}
               >
-                {busy ? "checking…" : `choose ${plan.name}`}
+                {busy ? "checking…" : plan.cta}
+                {leavesApp && !busy ? (
+                  <ExternalLinkIcon className="ml-1.5 h-3 w-3" />
+                ) : null}
               </Button>
             ) : (
               <p className="mt-3 rounded-md bg-muted px-2 py-1.5 text-center text-[10px] text-muted-foreground">
@@ -212,7 +286,7 @@ export function AccountPlanOptions({
                   ? "your plan"
                   : isFallback
                     ? "after it ends"
-                    : (disabledReason ?? "included")}
+                    : (disabledReason ?? plan.cta)}
               </p>
             )}
           </div>

--- a/apps/screenpipe-app-tauri/components/settings/account-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/account-section.tsx
@@ -30,7 +30,6 @@ import { toast } from "@/components/ui/use-toast";
 import { commands } from "@/lib/utils/tauri";
 import { openExternalUrl } from "@/lib/open-external-url";
 import {
-  getBusinessCapacityUpgrade,
   planDisplayName,
   isSignedInCloudSubscriber,
   type AppUser,
@@ -64,6 +63,7 @@ import {
 import {
   AccountPlanOptions,
   accountPlanForEntitlement,
+  type PlanPurchase,
 } from "./account-plan-options";
 
 const ACCOUNT_URL = screenpipeWebUrl("/account", "https://screenpipe.com");
@@ -155,21 +155,30 @@ export function AccountSection() {
   const hasExistingSubscription =
     hasExistingStripeSubscriptionPlan(subscriptionPlan) &&
     !hasExpiringProfilePlan;
-  const capacityUpgrade =
-    process.env.NEXT_PUBLIC_BUSINESS_POWER_PLANS_ENABLED === "true"
-      ? getBusinessCapacityUpgrade(subscriptionPlan)
-      : null;
-
-  const openCapacityUpgrade = async () => {
-    if (!capacityUpgrade) return;
+  /** Capacity levels change an existing subscription, so they are proration on
+   *  the web billing page rather than a new in-app checkout. */
+  const openCapacityBilling = async (
+    targetPlan: Extract<PlanPurchase, { kind: "billing" }>["targetPlan"],
+  ) => {
     const billingUrl = new URL(BILLING_URL);
-    billingUrl.searchParams.set("target_plan", capacityUpgrade.targetPlan);
+    billingUrl.searchParams.set("target_plan", targetPlan);
     billingUrl.searchParams.set("interval", "month");
     posthog.capture("desktop_business_capacity_upgrade_opened", {
       current_plan: subscriptionPlan,
-      target_plan: capacityUpgrade.targetPlan,
+      target_plan: targetPlan,
     });
     await openExternalUrl(billingUrl.toString());
+  };
+
+  const selectPlan = (purchase: PlanPurchase) => {
+    if (purchase.kind === "billing") {
+      void openCapacityBilling(purchase.targetPlan);
+      return;
+    }
+    void handleCheckout({
+      ...defaultUpgradeSelection("account-plan-options"),
+      plan: purchase.plan,
+    });
   };
 
   useEffect(() => {
@@ -552,39 +561,9 @@ export function AccountSection() {
               entitlementPlan={subscriptionPlan}
               fallbackTo={hasExpiringProfilePlan ? "free" : undefined}
               busy={checkoutBusy}
-              onChoose={(plan) =>
-                handleCheckout({
-                  ...defaultUpgradeSelection("account-plan-options"),
-                  plan,
-                })
-              }
+              onSelect={selectPlan}
             />
           </div>
-
-          {capacityUpgrade && (
-            <div
-              className="mt-4 flex items-center justify-between gap-4 rounded-lg border border-border/60 bg-muted/20 px-3.5 py-3"
-              data-testid="account-capacity-upgrade"
-            >
-              <div className="min-w-0">
-                <p className="text-sm font-medium">need more AI capacity?</p>
-                <p className="text-xs text-muted-foreground">
-                  {capacityUpgrade.name} adds higher query and request-rate
-                  limits for ${capacityUpgrade.monthlyPrice}/month.
-                </p>
-              </div>
-              <Button
-                variant="outline"
-                size="sm"
-                className="shrink-0"
-                data-testid="account-capacity-upgrade-button"
-                onClick={openCapacityUpgrade}
-              >
-                view {capacityUpgrade.name.replace("Business ", "")}
-                <ExternalLinkIcon className="ml-1.5 h-3.5 w-3.5" />
-              </Button>
-            </div>
-          )}
 
           {/* Pipe sync */}
           <div className="mt-4 pt-4 border-t border-border/50">
@@ -874,12 +853,7 @@ export function AccountSection() {
                   entitlementPlan={subscriptionPlan}
                   fallbackTo={hasExpiringProfilePlan ? "free" : undefined}
                   busy={checkoutBusy}
-                  onChoose={(plan) =>
-                    handleCheckout({
-                      ...defaultUpgradeSelection("account-plan-options"),
-                      plan,
-                    })
-                  }
+                  onSelect={selectPlan}
                 />
               </div>
             </Card>
@@ -901,12 +875,7 @@ export function AccountSection() {
                 <AccountPlanOptions
                   current="free"
                   busy={checkoutBusy}
-                  onChoose={(plan) =>
-                    handleCheckout({
-                      ...defaultUpgradeSelection("account-plan-options"),
-                      plan,
-                    })
-                  }
+                  onSelect={selectPlan}
                 />
               </div>
             </Card>


### PR DESCRIPTION
## Problem

Settings → Account offers three plans: free, basic, business. Business Max and Ultra are never shown, on any account, in any build.

## Where found

Reported from the running app: a Business subscriber's Account pane shows only three cards.

## Evidence

Max and Ultra landed in #5681 (`648db969e`) behind a flag:

```ts
// components/settings/account-section.tsx
const capacityUpgrade =
  process.env.NEXT_PUBLIC_BUSINESS_POWER_PLANS_ENABLED === "true"
    ? getBusinessCapacityUpgrade(subscriptionPlan)
    : null;
```

`NEXT_PUBLIC_BUSINESS_POWER_PLANS_ENABLED` occurs in exactly three places in the repo: that read, and two tests that `vi.stubEnv` it. No `.env`, no `env` block in `next.config.mjs`, no CI export. It is `undefined` in every build, so `capacityUpgrade` is always `null` and the block guarded by it has never rendered for a user.

Separately, `ACCOUNT_PLANS` only ever had three rows, so even with the flag on, Max/Ultra were a text strip below the grid rather than plans.

## Root cause

Two: a rollout flag that was never ungated, and a picker whose plan list stops at Business.

## Fix

Make them plans. Five cards, each priced, each able to hold "current", with the next rung marked "next step" from the existing `getBusinessCapacityUpgrade` ladder.

- Basic and Business keep the in-app Stripe checkout. Max and Ultra change an existing subscription rather than start one, so they deep-link to web billing with `target_plan` preset — the same URL and PostHog event the dark strip used, now reachable. The external-link glyph says the action finishes in the browser.
- **Truthful capacity copy.** `getHostedAiPlan` collapses every business tier to the same 400 credits and the same frontier catalog; only `dailyQueries`/`rpm` move (60 → 120 → 240 in `DEFAULT_TIER_CONFIG`). The old Max card said "higher monthly AI credit allowance", which the gateway does not grant. Cards now read "2x daily queries & request rate" and "same 400 credits & frontier models".
- **Stop emphasising a downgrade.** The primary button keyed off Business, so on a Max account "choose business" was the loudest thing on screen. It now follows the recommended next step.
- Deletes the flag, the strip it gated, and `businessCapacityTier`, whose only job was relabelling the Business card for tiers that now have their own.

## Before / after

Business subscriber — the reported state:

**before**

![before](https://raw.githubusercontent.com/screenpipe/screenpipe/assets-plan-picker-max-ultra/shot-before.png)

**after**

![after](https://raw.githubusercontent.com/screenpipe/screenpipe/assets-plan-picker-max-ultra/shot-after-business.png)

Business Max subscriber. Before, the Max card *was* the Business card wearing Max's name and price, so the ladder had no rungs and the credit line was wrong:

**before**

![before max](https://raw.githubusercontent.com/screenpipe/screenpipe/assets-plan-picker-max-ultra/shot-before-max.png)

**after**

![after max](https://raw.githubusercontent.com/screenpipe/screenpipe/assets-plan-picker-max-ultra/shot-after-max.png)

Free account:

![after free](https://raw.githubusercontent.com/screenpipe/screenpipe/assets-plan-picker-max-ultra/shot-after-free.png)

## Validation

- `vitest components/settings lib/app-entitlement.test.ts` — 320 passed / 34 files
- `account-plan-options.test.ts` — 13 passed, incl. new coverage that the cards never claim credits the gateway does not grant
- The two tests that stubbed the dead flag now drive the cards and assert the same billing URL + PostHog payload, so the contract is verified through a surface that renders
- `tsc --noEmit` clean; `biome check` clean on changed files; `knip` adds no unused export
- `bun run e2e:coverage:check` up to date (no new spec)
- Screenshots are real renders of these components at 1280px, "before" rendered from the pre-change file at `HEAD`

## Not covered

No packaged-app E2E: the picker is exercised through jsdom + component tests, not a Tauri run. Checkout itself is unchanged — Max/Ultra hand off to web billing and I did not put a card through Stripe.