### PR TITLE
chore(gateway): re-vendor the enterprise conformance suite

### DIFF
--- a/crates/screenpipe-gateway/e2e/conformance/VENDORED_FROM
+++ b/crates/screenpipe-gateway/e2e/conformance/VENDORED_FROM
@@ -1,7 +1,7 @@
 repo:   screenpipe/website (PRIVATE)
-branch: main
-commit: c3fc73b43c496d86fad54ecff65a4e350d179a7c
-date:   2026-08-11T16:43:39Z
+branch: HEAD
+commit: cb61270247bd1db937343f32d0d5ed1de79add53
+date:   2026-08-13T20:55:57Z
 files:  openapi/enterprise-v1.yaml       -> enterprise-v1.yaml
         conformance/spec.ts              -> spec.ts
         conformance/cases.ts             -> cases.ts

--- a/crates/screenpipe-gateway/e2e/conformance/cases.ts
+++ b/crates/screenpipe-gateway/e2e/conformance/cases.ts
@@ -54,33 +54,42 @@ const FILES_W = { since: SEEDED_WINDOW.since };
 export const cases: Case[] = [
   // ── /devices ─────────────────────────────────────────────────────────────
   {
-    id: "devices: both seeded devices, newest first",
+    id: "devices: legacy shape and last-seen order remain unchanged",
     path: "/api/enterprise/v1/devices",
     expectStatus: 200,
     expect: (b) => {
       if (b.count !== EXPECTED.devices) throw new Error(`count=${b.count}`);
-      if (b.devices.length !== b.count) throw new Error("count disagrees with devices.length");
+      if (b.devices.length !== b.count)
+        throw new Error("count disagrees with devices.length");
+      if ("next_cursor" in b)
+        throw new Error("legacy response grew next_cursor");
       const ids = b.devices.map((d: any) => d.device_id).sort();
-      if (JSON.stringify(ids) !== JSON.stringify([...EXPECTED.deviceIds].sort())) {
+      if (
+        JSON.stringify(ids) !== JSON.stringify([...EXPECTED.deviceIds].sort())
+      ) {
         throw new Error(`device_ids=${JSON.stringify(ids)}`);
       }
-      // Ordering is part of the contract: last_seen DESC on both, so bob (hour
-      // 10) precedes alice (hour 09) even though the two implementations derive
-      // last_seen from different sources (DEV-LIVENESS).
       if (b.devices[0].device_id !== "dev-bob") {
-        throw new Error(`expected dev-bob first, got ${b.devices[0].device_id}`);
+        throw new Error(
+          `expected dev-bob first, got ${b.devices[0].device_id}`,
+        );
       }
       // Labels come from the wire format on the gateway and from the
       // enterprise_devices row hosted; the fixtures make them agree.
-      const byId = Object.fromEntries(b.devices.map((d: any) => [d.device_id, d]));
-      if (byId["dev-alice"].label !== "alice-mbp") throw new Error("alice label");
-      if (byId["dev-bob"].label !== "bob-thinkpad") throw new Error("bob label");
+      const byId = Object.fromEntries(
+        b.devices.map((d: any) => [d.device_id, d]),
+      );
+      if (byId["dev-alice"].label !== "alice-mbp")
+        throw new Error("alice label");
+      if (byId["dev-bob"].label !== "bob-thinkpad")
+        throw new Error("bob label");
     },
     expectHosted: {
       why: "DEV-PLATFORM",
       assert: (b) => {
         const alice = b.devices.find((d: any) => d.device_id === "dev-alice");
-        if (alice.platform !== "macos") throw new Error(`platform=${alice.platform}`);
+        if (alice.platform !== "macos")
+          throw new Error(`platform=${alice.platform}`);
       },
     },
     expectGateway: {
@@ -88,10 +97,49 @@ export const cases: Case[] = [
       assert: (b) => {
         for (const d of b.devices) {
           if (d.platform !== null || d.app_version !== null) {
-            throw new Error(`gateway must report null platform/app_version, got ${JSON.stringify(d)}`);
+            throw new Error(
+              `gateway must report null platform/app_version, got ${JSON.stringify(d)}`,
+            );
           }
         }
       },
+    },
+  },
+  {
+    id: "devices: member email is hosted identity and nullable on the gateway",
+    path: "/api/enterprise/v1/devices",
+    expectStatus: 200,
+    expectHosted: {
+      why: "DEV-MEMBER-EMAIL",
+      assert: (b) => {
+        const alice = b.devices.find((d: any) => d.device_id === "dev-alice");
+        if (alice.member_email !== "alice@conformance.test") {
+          throw new Error(`member_email=${alice.member_email}`);
+        }
+      },
+    },
+    expectGateway: {
+      why: "DEV-MEMBER-EMAIL",
+      assert: (b) => {
+        for (const d of b.devices) {
+          if (d.member_email !== null) {
+            throw new Error(
+              `gateway must report null member_email, got ${JSON.stringify(d)}`,
+            );
+          }
+        }
+      },
+    },
+  },
+  {
+    id: "devices: limit=1 returns a continuation cursor",
+    path: "/api/enterprise/v1/devices",
+    query: { pagination: "keyset", limit: "1" },
+    expectStatus: 200,
+    expect: (b) => {
+      if (b.count !== 1) throw new Error(`limit ignored: ${b.count}`);
+      if (b.next_cursor === null)
+        throw new Error("second device was silently truncated");
     },
   },
 
@@ -103,10 +151,16 @@ export const cases: Case[] = [
     expectStatus: 200,
     expect: (b) => {
       if (b.query !== "roadmap") throw new Error(`query echoed as ${b.query}`);
-      if (b.result_count !== b.results.length) throw new Error("result_count disagrees");
-      if (b.result_count === 0) throw new Error("no results — the window or the corpus is wrong");
-      if (b.window_hours !== 24) throw new Error(`window_hours=${b.window_hours}`);
-      if (b.device_id !== null || b.app_name !== null) throw new Error("unfiltered echo");
+      if (b.result_count !== b.results.length)
+        throw new Error("result_count disagrees");
+      if ("next_cursor" in b)
+        throw new Error("legacy response grew next_cursor");
+      if (b.result_count === 0)
+        throw new Error("no results — the window or the corpus is wrong");
+      if (b.window_hours !== 24)
+        throw new Error(`window_hours=${b.window_hours}`);
+      if (b.device_id !== null || b.app_name !== null)
+        throw new Error("unfiltered echo");
       const devices = new Set<string>(b.results.map((r: any) => r.device_id));
       for (const id of EXPECTED.deviceIds) {
         if (!devices.has(id)) {
@@ -116,7 +170,9 @@ export const cases: Case[] = [
       const kinds = new Set<string>(b.results.map((r: any) => r.kind));
       for (const k of ["frame", "parsed", "audio", "memory"]) {
         if (!kinds.has(k)) {
-          throw new Error(`missing kind ${k} in ${Array.from(kinds).join(", ")}`);
+          throw new Error(
+            `missing kind ${k} in ${Array.from(kinds).join(", ")}`,
+          );
         }
       }
       // Every result must be INSIDE the requested window on both targets. The
@@ -127,31 +183,48 @@ export const cases: Case[] = [
           throw new Error(`result outside the window: ${r.t}`);
         }
       }
+      const ts = b.results.map((r: any) => r.t);
+      if (JSON.stringify(ts) !== JSON.stringify([...ts].sort().reverse())) {
+        throw new Error(
+          `search results must be newest-first: ${JSON.stringify(ts)}`,
+        );
+      }
     },
     expectHosted: {
       why: "SEARCH-ALGORITHM",
       assert: (b) => {
-        if (b.bytes_scanned <= 0) throw new Error("hosted must report a real byte count");
-        if (b.objects_scanned <= 0) throw new Error("hosted must report scanned objects");
+        if (b.bytes_scanned <= 0)
+          throw new Error("hosted must report a real byte count");
+        if (b.objects_scanned <= 0)
+          throw new Error("hosted must report scanned objects");
       },
     },
     expectGateway: {
       why: "SEARCH-ALGORITHM",
       assert: (b) => {
-        if (b.bytes_scanned !== 0 || b.objects_scanned !== 0 || b.truncated !== false) {
+        if (
+          b.bytes_scanned !== 0 ||
+          b.objects_scanned !== 0 ||
+          b.truncated !== false
+        ) {
           throw new Error(
             "the gateway has no byte-budget scan to describe, so these must be " +
-              `honestly 0/0/false — got ${b.bytes_scanned}/${b.objects_scanned}/${b.truncated}`
+              `honestly 0/0/false — got ${b.bytes_scanned}/${b.objects_scanned}/${b.truncated}`,
           );
         }
-        // The gateway sorts results newest-first and the hosted API does not
-        // (SEARCH-ORDER). Pinned here so the gateway's guarantee, which is the
-        // stronger of the two, cannot silently regress.
-        const ts = b.results.map((r: any) => r.t);
-        if (JSON.stringify(ts) !== JSON.stringify([...ts].sort().reverse())) {
-          throw new Error(`the gateway must sort newest-first: ${JSON.stringify(ts)}`);
-        }
       },
+    },
+  },
+  {
+    id: "search: limit=1 returns a continuation cursor",
+    path: "/api/enterprise/v1/search",
+    query: { q: "roadmap", ...W, pagination: "keyset", limit: "1" },
+    expectStatus: 200,
+    expect: (b) => {
+      if (b.result_count !== 1)
+        throw new Error(`limit ignored: ${b.result_count}`);
+      if (b.next_cursor === null)
+        throw new Error("matching records were silently truncated");
     },
   },
   {
@@ -161,9 +234,11 @@ export const cases: Case[] = [
     expectStatus: 200,
     expect: (b) => {
       if (b.device_id !== "dev-alice") throw new Error(`echo=${b.device_id}`);
-      if (b.result_count === 0) throw new Error("device filter returned nothing");
+      if (b.result_count === 0)
+        throw new Error("device filter returned nothing");
       for (const r of b.results) {
-        if (r.device_id !== "dev-alice") throw new Error(`leaked ${r.device_id}`);
+        if (r.device_id !== "dev-alice")
+          throw new Error(`leaked ${r.device_id}`);
       }
     },
   },
@@ -173,7 +248,8 @@ export const cases: Case[] = [
     query: { q: "roadmap", since: "2020-01-01", until: "2020-01-02" },
     expectStatus: 200,
     expect: (b) => {
-      if (b.result_count !== 0 || b.results.length !== 0) throw new Error("expected empty");
+      if (b.result_count !== 0 || b.results.length !== 0)
+        throw new Error("expected empty");
     },
   },
   {
@@ -184,10 +260,11 @@ export const cases: Case[] = [
     expect: (b) => {
       if (b.window_hours !== 24) {
         throw new Error(
-          `a bare date must be UTC midnight on both, giving a 24h window; got ${b.window_hours}`
+          `a bare date must be UTC midnight on both, giving a 24h window; got ${b.window_hours}`,
         );
       }
-      if (b.result_count === 0) throw new Error("the July-22 window must contain the corpus");
+      if (b.result_count === 0)
+        throw new Error("the July-22 window must contain the corpus");
     },
   },
   {
@@ -217,13 +294,20 @@ export const cases: Case[] = [
     expectStatus: 200,
     expect: (b) => {
       if (b.kind !== "all") throw new Error(`kind echoed as ${b.kind}`);
-      if (b.record_count !== b.records.length) throw new Error("record_count disagrees");
+      if (b.record_count !== b.records.length)
+        throw new Error("record_count disagrees");
       if (b.record_count !== EXPECTED.recordsAllKinds) {
-        throw new Error(`expected ${EXPECTED.recordsAllKinds} records, got ${b.record_count}`);
+        throw new Error(
+          `expected ${EXPECTED.recordsAllKinds} records, got ${b.record_count}`,
+        );
       }
+      if ("next_cursor" in b)
+        throw new Error("legacy response grew next_cursor");
       const ts = b.records.map((r: any) => r.t);
       if (JSON.stringify(ts) !== JSON.stringify([...ts].sort())) {
-        throw new Error(`records must be ascending by t: ${JSON.stringify(ts)}`);
+        throw new Error(
+          `records must be ascending by t: ${JSON.stringify(ts)}`,
+        );
       }
     },
   },
@@ -233,7 +317,8 @@ export const cases: Case[] = [
     query: { kind: "memory", ...W },
     expectStatus: 200,
     expect: (b) => {
-      if (b.record_count !== EXPECTED.memories) throw new Error(`count=${b.record_count}`);
+      if (b.record_count !== EXPECTED.memories)
+        throw new Error(`count=${b.record_count}`);
       for (const r of b.records) {
         if (r.kind !== "memory") throw new Error(`leaked kind ${r.kind}`);
         if (!r.content?.includes("gateway ships this quarter")) {
@@ -241,7 +326,9 @@ export const cases: Case[] = [
         }
         if (r.memory_id !== 1) throw new Error(`memory_id=${r.memory_id}`);
         if (r.importance !== 0.8) throw new Error(`importance=${r.importance}`);
-        if (JSON.stringify(r.tags) !== JSON.stringify(["decision", "roadmap"])) {
+        if (
+          JSON.stringify(r.tags) !== JSON.stringify(["decision", "roadmap"])
+        ) {
           throw new Error(`tags=${JSON.stringify(r.tags)}`);
         }
       }
@@ -254,7 +341,8 @@ export const cases: Case[] = [
     expectStatus: 200,
     expect: (b) => {
       if (b.kind !== "parsed") throw new Error(`kind=${b.kind}`);
-      if (b.record_count !== EXPECTED.parsed) throw new Error(`count=${b.record_count}`);
+      if (b.record_count !== EXPECTED.parsed)
+        throw new Error(`count=${b.record_count}`);
       for (const r of b.records) {
         if (r.kind !== "parsed") throw new Error(`leaked kind ${r.kind}`);
         if (r.app !== "Slack" || !r.text?.includes("structured update")) {
@@ -269,8 +357,10 @@ export const cases: Case[] = [
     query: { kind: "nonsense", ...W },
     expectStatus: 200,
     expect: (b) => {
-      if (b.kind !== "nonsense") throw new Error("the kind must still be echoed");
-      if (b.record_count !== 0) throw new Error(`expected empty, got ${b.record_count}`);
+      if (b.kind !== "nonsense")
+        throw new Error("the kind must still be echoed");
+      if (b.record_count !== 0)
+        throw new Error(`expected empty, got ${b.record_count}`);
     },
   },
   {
@@ -282,16 +372,20 @@ export const cases: Case[] = [
     // It is a case anyway because it pins the SHAPE of the empty answer, which
     // is what a consumer of the documented divergence relies on.
     expect: (b) => {
-      if (b.record_count !== 0) throw new Error(`expected empty, got ${b.record_count}`);
+      if (b.record_count !== 0)
+        throw new Error(`expected empty, got ${b.record_count}`);
     },
   },
   {
     id: "records: limit is respected",
     path: "/api/enterprise/v1/records",
-    query: { ...W, limit: "3" },
+    query: { ...W, pagination: "keyset", limit: "3" },
     expectStatus: 200,
     expect: (b) => {
-      if (b.record_count !== 3) throw new Error(`limit ignored: ${b.record_count}`);
+      if (b.record_count !== 3)
+        throw new Error(`limit ignored: ${b.record_count}`);
+      if (b.next_cursor === null)
+        throw new Error("remaining records were silently truncated");
     },
   },
 
@@ -302,8 +396,10 @@ export const cases: Case[] = [
     query: FILES_W,
     expectStatus: 200,
     expect: (b) => {
-      if (b.count !== b.files.length) throw new Error("count disagrees with files.length");
-      if (b.count !== EXPECTED.batchObjects) throw new Error(`count=${b.count}`);
+      if (b.count !== b.files.length)
+        throw new Error("count disagrees with files.length");
+      if (b.count !== EXPECTED.batchObjects)
+        throw new Error(`count=${b.count}`);
       for (const f of b.files) {
         if (!f.key.startsWith(`enterprise-telemetry/${LICENSE_ID}/`)) {
           throw new Error(`key escapes the org prefix: ${f.key}`);
@@ -321,7 +417,8 @@ export const cases: Case[] = [
     expectStatus: 200,
     expect: (b) => {
       if (b.count !== 1) throw new Error(`page_size ignored: ${b.count}`);
-      if (b.next_cursor === null) throw new Error("more objects exist, so next_cursor must be set");
+      if (b.next_cursor === null)
+        throw new Error("more objects exist, so next_cursor must be set");
     },
   },
   {
@@ -331,7 +428,8 @@ export const cases: Case[] = [
     expectStatus: 200,
     expect: (b) => {
       // This is THE case: 1 item hosted, 100 on the gateway, before the fix.
-      if (b.count !== 1) throw new Error(`expected the clamp to 1, got ${b.count}`);
+      if (b.count !== 1)
+        throw new Error(`expected the clamp to 1, got ${b.count}`);
     },
   },
   {
@@ -350,7 +448,8 @@ export const cases: Case[] = [
     expectStatus: 200,
     expect: (b) => {
       if (b.device_id !== "dev-alice") throw new Error(`echo=${b.device_id}`);
-      if (b.count !== 1) throw new Error(`expected 1 alice object, got ${b.count}`);
+      if (b.count !== 1)
+        throw new Error(`expected 1 alice object, got ${b.count}`);
       if (b.files[0].device_id !== "dev-alice") throw new Error("wrong device");
     },
   },
@@ -397,10 +496,16 @@ export const cases: Case[] = [
       if (b.device !== "org") throw new Error(`device=${b.device}`);
       if (b.count !== b.rollups.length) throw new Error("count disagrees");
       if (b.count !== EXPECTED.rollups) throw new Error(`count=${b.count}`);
+      if ("next_cursor" in b)
+        throw new Error("legacy response grew next_cursor");
       const r = b.rollups[0];
       if (r.day !== "2026-07-22") throw new Error(`day=${r.day}`);
-      if (r.data.records !== 12) throw new Error(`data passed through wrong: ${JSON.stringify(r.data)}`);
-      if (JSON.stringify(r.data.devices) !== JSON.stringify(["dev-alice", "dev-bob"])) {
+      if (r.data.records !== 12)
+        throw new Error(`data passed through wrong: ${JSON.stringify(r.data)}`);
+      if (
+        JSON.stringify(r.data.devices) !==
+        JSON.stringify(["dev-alice", "dev-bob"])
+      ) {
         throw new Error(`data.devices=${JSON.stringify(r.data.devices)}`);
       }
     },
@@ -412,7 +517,8 @@ export const cases: Case[] = [
     expectStatus: 200,
     expect: (b) => {
       if (b.count !== 0) throw new Error(`expected empty, got ${b.count}`);
-      if (b.from !== "2020-01-01" || b.to !== "2020-01-02") throw new Error("bounds not echoed");
+      if (b.from !== "2020-01-01" || b.to !== "2020-01-02")
+        throw new Error("bounds not echoed");
     },
   },
   {
@@ -426,7 +532,8 @@ export const cases: Case[] = [
       // because the intuitive expectation ("dev___etc") is wrong, and because a
       // surviving ".." only fails to be traversal since the value is a storage
       // key prefix rather than a filesystem path.
-      if (b.device !== "dev_.._etc") throw new Error(`sanitized to ${b.device}`);
+      if (b.device !== "dev_.._etc")
+        throw new Error(`sanitized to ${b.device}`);
     },
   },
   {
@@ -448,7 +555,8 @@ export const cases: Case[] = [
     expectStatus: 200,
     expect: (b) => {
       if (b.kind !== "sop") throw new Error(`kind=${b.kind}`);
-      if (b.count !== b.entries.length) throw new Error("count disagrees with entries");
+      if (b.count !== b.entries.length)
+        throw new Error("count disagrees with entries");
       if (b.count !== 1) throw new Error(`count=${b.count}`);
     },
   },
@@ -459,7 +567,8 @@ export const cases: Case[] = [
     targets: ["hosted"],
     expectStatus: 400,
     expect: (b) => {
-      if (!b.error?.includes("invalid kind")) throw new Error(`error=${b.error}`);
+      if (!b.error?.includes("invalid kind"))
+        throw new Error(`error=${b.error}`);
       // Every v1 400 carries a machine code. This one did not until the spec
       // declared BadRequest for it and the suite refused to validate the body —
       // which is the whole point of writing the contract down first.

--- a/crates/screenpipe-gateway/e2e/conformance/enterprise-v1.yaml
+++ b/crates/screenpipe-gateway/e2e/conformance/enterprise-v1.yaml
@@ -80,10 +80,29 @@ x-divergences:
       Neither field is in the wire format, so the gateway has no source for
       them. Typed `[string, "null"]` on both rather than omitted, so a consumer
       writes one branch instead of two.
+  DEV-MEMBER-EMAIL:
+    id: DEV-MEMBER-EMAIL
+    operations: ["GET /devices"]
+    fields: ["devices[].member_email"]
+    hosted: >-
+      enterprise_devices.member_email from the latest device heartbeat: the
+      verified account email when member-authenticated, otherwise null.
+    gateway: always null
+    rationale: >-
+      The customer-run gateway reads telemetry batches from object storage and
+      has no account-identity channel. Keeping the field required and nullable
+      gives consumers one stable response shape without inventing identity.
   SEARCH-ALGORITHM:
     id: SEARCH-ALGORITHM
     operations: ["GET /search"]
-    fields: ["results", "records_scanned", "bytes_scanned", "objects_scanned", "truncated"]
+    fields:
+      [
+        "results",
+        "records_scanned",
+        "bytes_scanned",
+        "objects_scanned",
+        "truncated",
+      ]
     hosted: >-
       case-insensitive SUBSTRING match over a 256KB byte budget. `q=oadma`
       matches "roadmap". The three counters describe that scan and `truncated`
@@ -97,26 +116,6 @@ x-divergences:
       Ingest-once is the gateway's reason to exist; throwing away the index to
       emulate a substring scan over blobs would make it slower AND worse. The
       counters are honestly zero rather than fabricated.
-  SEARCH-ORDER:
-    id: SEARCH-ORDER
-    operations: ["GET /search"]
-    fields: ["results"]
-    hosted: >-
-      results come back in SCAN order: objects newest-first, but lines in file
-      order within each object. So a single object's frame/parsed/audio/ui/memory rows
-      appear in the order the device wrote them, not by timestamp.
-    gateway: >-
-      results are sorted by `t` DESCENDING before truncation.
-    rationale: >-
-      NOT ruled on — found by this suite, not by the SCR-288 audit, and recorded
-      rather than silently converged because changing hosted result ordering is a
-      consumer-visible behavior change that needs an owner. The gateway's
-      guarantee is the stronger one and is pinned by the suite so it cannot
-      regress; the shared assertion is the weaker property both hold (every
-      result is inside the requested window). `/records` is NOT affected — both
-      sort ascending by `t` there.
-      TODO(owner): decide whether hosted /search should sort. If yes this entry
-      goes away and the assertion moves into the shared `expect`.
   SNAPSHOT-KIND:
     id: SNAPSHOT-KIND
     operations: ["GET /records"]
@@ -139,8 +138,8 @@ x-divergences:
       a page can come back count:0 with a non-null next_cursor. The cursor is
       the storage backend's continuation token.
     gateway: >-
-      time-filters the whole listing then applies skip/take, so `count` is exact
-      and `next_cursor` is a decimal offset.
+      time-filters the whole listing then applies a stable object-key keyset, so
+      `count` is exact and inserts before the cursor do not shift later pages.
     rationale: >-
       Cursors are OPAQUE by contract and are not interchangeable across targets.
       A client must treat next_cursor as a token from the same target and must
@@ -193,13 +192,21 @@ paths:
       operationId: listDevices
       summary: List the devices enrolled under the bearer's organization
       x-scope: read:devices
-      x-divergence: [DEV-LIVENESS, DEV-PLATFORM, TIMESTAMP-SERIALIZATION]
+      x-divergence:
+        [DEV-LIVENESS, DEV-PLATFORM, DEV-MEMBER-EMAIL, TIMESTAMP-SERIALIZATION]
+      parameters:
+        - $ref: "#/components/parameters/Pagination"
+        - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Cursor"
       responses:
         "200":
-          description: The organization's devices, most recently seen first
+          description: >-
+            Devices in legacy last-seen order by default, or stable device-id
+            order when pagination=keyset.
           content:
             application/json:
               schema: { $ref: "#/components/schemas/DeviceList" }
+        "400": { $ref: "#/components/responses/BadRequest" }
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
         "500": { $ref: "#/components/responses/ServerError" }
@@ -209,7 +216,7 @@ paths:
       operationId: searchRecords
       summary: Search telemetry records
       x-scope: read:search
-      x-divergence: [SEARCH-ALGORITHM, SEARCH-ORDER]
+      x-divergence: [SEARCH-ALGORITHM]
       parameters:
         - $ref: "#/components/parameters/Q"
         - $ref: "#/components/parameters/DeviceId"
@@ -217,7 +224,9 @@ paths:
         - $ref: "#/components/parameters/Since"
         - $ref: "#/components/parameters/Until"
         - $ref: "#/components/parameters/SinceHoursAgo"
+        - $ref: "#/components/parameters/Pagination"
         - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Cursor"
       responses:
         "200":
           description: Matching records, newest first
@@ -251,7 +260,9 @@ paths:
         - $ref: "#/components/parameters/Since"
         - $ref: "#/components/parameters/Until"
         - $ref: "#/components/parameters/SinceHoursAgo"
+        - $ref: "#/components/parameters/Pagination"
         - $ref: "#/components/parameters/Limit"
+        - $ref: "#/components/parameters/Cursor"
       responses:
         "200":
           description: Records in the window, oldest first
@@ -389,6 +400,8 @@ paths:
           in: query
           required: false
           schema: { type: integer, default: 35, minimum: 1, maximum: 100 }
+        - $ref: "#/components/parameters/Pagination"
+        - $ref: "#/components/parameters/Cursor"
       responses:
         "200":
           description: Rollups in range, newest day first
@@ -583,6 +596,24 @@ components:
       in: query
       required: false
       schema: { type: integer, default: 50, minimum: 1, maximum: 200 }
+    Pagination:
+      name: pagination
+      in: query
+      required: false
+      schema: { type: string, enum: [keyset] }
+      description: >-
+        Set to `keyset` to opt into pagination and receive `next_cursor`.
+        Omit it for the legacy response shape and ordering.
+    Cursor:
+      name: cursor
+      in: query
+      required: false
+      schema: { type: string }
+      description: >-
+        OPAQUE continuation token from a previous response's `next_cursor`.
+        Pass it back unchanged with the same filters; clients must not construct it.
+        Search, records, devices, and rollups require `pagination=keyset` and
+        use keyset state tied to a frozen scan boundary.
 
   responses:
     BadRequest:
@@ -706,7 +737,12 @@ components:
         app: { type: [string, "null"] }
         window: { type: [string, "null"] }
         url: { type: [string, "null"] }
-        text: { type: [string, "null"], description: Frame OCR / accessibility text, or parsed-app projection text }
+        text:
+          {
+            type: [string, "null"],
+            description: Frame OCR / accessibility text,
+            or parsed-app projection text,
+          }
         transcription: { type: [string, "null"] }
         speaker: { type: [string, "null"] }
         content: { type: [string, "null"], description: 'kind:"memory" only' }
@@ -721,12 +757,36 @@ components:
     Device:
       type: object
       additionalProperties: false
-      required: [device_id, label, platform, app_version, last_seen, enrolled_at]
+      required:
+        [
+          device_id,
+          label,
+          member_email,
+          platform,
+          app_version,
+          last_seen,
+          enrolled_at,
+        ]
       properties:
         device_id: { type: string }
-        label: { type: string, description: Hostname when known, else the device id }
-        platform: { type: [string, "null"], description: Always null on the gateway (DEV-PLATFORM) }
-        app_version: { type: [string, "null"], description: Always null on the gateway (DEV-PLATFORM) }
+        label:
+          { type: string, description: Hostname when known, else the device id }
+        member_email:
+          type: [string, "null"]
+          format: email
+          description: >-
+            Verified account email carried by the latest member-authenticated
+            heartbeat; always null on the gateway (DEV-MEMBER-EMAIL).
+        platform:
+          {
+            type: [string, "null"],
+            description: Always null on the gateway (DEV-PLATFORM),
+          }
+        app_version:
+          {
+            type: [string, "null"],
+            description: Always null on the gateway (DEV-PLATFORM),
+          }
         last_seen:
           type: [string, "null"]
           format: date-time
@@ -745,6 +805,9 @@ components:
         devices:
           type: array
           items: { $ref: "#/components/schemas/Device" }
+        next_cursor:
+          type: [string, "null"]
+          description: Present only with pagination=keyset; null on the final page.
 
     SearchResult:
       type: object
@@ -769,13 +832,34 @@ components:
           minimum: 0
           description: Effective response window; use the `since_hours_ago` query parameter to request a relative window.
         records_scanned: { type: integer, minimum: 0 }
-        bytes_scanned: { type: integer, minimum: 0, description: Always 0 on the gateway (SEARCH-ALGORITHM) }
-        objects_scanned: { type: integer, minimum: 0, description: Always 0 on the gateway (SEARCH-ALGORITHM) }
-        truncated: { type: boolean, description: Always false on the gateway (SEARCH-ALGORITHM) }
+        bytes_scanned:
+          {
+            type: integer,
+            minimum: 0,
+            description: Always 0 on the gateway (SEARCH-ALGORITHM),
+          }
+        objects_scanned:
+          {
+            type: integer,
+            minimum: 0,
+            description: Always 0 on the gateway (SEARCH-ALGORITHM),
+          }
+        truncated:
+          {
+            type: boolean,
+            description: Always false on the gateway (SEARCH-ALGORITHM),
+          }
         result_count: { type: integer, minimum: 0 }
         results:
           type: array
           items: { $ref: "#/components/schemas/RecordSummary" }
+        next_cursor:
+          type: [string, "null"]
+          description: >-
+            Present only with pagination=keyset. Mutation-safe token for more matches
+            in the frozen scan window. A null
+            cursor with truncated:true means the byte budget, not pagination, ended
+            the scan; narrow the query or time window.
 
     RecordList:
       type: object
@@ -791,7 +875,12 @@ components:
         - records
       properties:
         device_id: { type: [string, "null"] }
-        kind: { type: string, description: Echoed back lower-cased, including an unrecognized one }
+        kind:
+          {
+            type: string,
+            description: Echoed back lower-cased,
+            including an unrecognized one,
+          }
         window_hours:
           type: number
           minimum: 0
@@ -803,6 +892,13 @@ components:
         records:
           type: array
           items: { $ref: "#/components/schemas/RecordSummary" }
+        next_cursor:
+          type: [string, "null"]
+          description: >-
+            Present only with pagination=keyset. Mutation-safe token for more records
+            in the frozen scan window. A null
+            cursor with truncated:true means the byte budget, not pagination, ended
+            the scan; narrow the time window.
 
     FileEntry:
       type: object
@@ -810,12 +906,21 @@ components:
       required: [key, size, last_modified, device_id]
       properties:
         key: { type: string }
-        size: { type: [integer, "null"], minimum: 0, description: Nullable on the gateway (FILES-NULLABILITY) }
+        size:
+          {
+            type: [integer, "null"],
+            minimum: 0,
+            description: Nullable on the gateway (FILES-NULLABILITY),
+          }
         last_modified:
           type: [string, "null"]
           format: date-time
           description: Nullable on the gateway (FILES-NULLABILITY)
-        device_id: { type: string, description: '"unknown" when the key has no device segment' }
+        device_id:
+          {
+            type: string,
+            description: '"unknown" when the key has no device segment',
+          }
 
     FileList:
       type: object
@@ -864,6 +969,9 @@ components:
         rollups:
           type: array
           items: { $ref: "#/components/schemas/Rollup" }
+        next_cursor:
+          type: [string, "null"]
+          description: Present only with pagination=keyset; null on the final page.
 
     ManifestEntry:
       type: object
@@ -883,7 +991,8 @@ components:
         - key
       properties:
         artifact_id: { type: string }
-        kind: { type: string, enum: [sop, skill, memory, chart, trajectory, intel] }
+        kind:
+          { type: string, enum: [sop, skill, memory, chart, trajectory, intel] }
         type: { type: string }
         title: { type: string }
         status: { type: string }
@@ -925,7 +1034,12 @@ components:
       additionalProperties: false
       required: [name, prompt_body]
       properties:
-        name: { type: string, pattern: "^[a-zA-Z0-9][a-zA-Z0-9_-]*$", maxLength: 100 }
+        name:
+          {
+            type: string,
+            pattern: "^[a-zA-Z0-9][a-zA-Z0-9_-]*$",
+            maxLength: 100,
+          }
         prompt_body: { type: string, maxLength: 262144 }
         display_name: { type: string }
         schedule: { type: string, default: every 30m }

--- a/crates/screenpipe-gateway/e2e/conformance/fixtures/devices.json
+++ b/crates/screenpipe-gateway/e2e/conformance/fixtures/devices.json
@@ -9,8 +9,10 @@
     "gateway (divergence DEV-PLATFORM): neither field is in the wire format, so",
     "there is nothing for a gateway to read them from. `last_seen_at` is",
     "heartbeat liveness here and MAX(record timestamp) there (DEV-LIVENESS).",
-    "Both are recorded divergences, so the suite asserts their TYPE and not",
-    "their value.",
+    "`member_email` is the hosted heartbeat identity and is ALWAYS null on the",
+    "gateway (DEV-MEMBER-EMAIL), which has no account-identity channel.",
+    "The contract keeps every field present and nullable; target-specific cases",
+    "pin the values available on each side.",
     "",
     "`last_seen_at` sits inside the seeded July-22 window so a hosted /devices",
     "response is ordered the same way a gateway one is (bob newer than alice)."
@@ -19,6 +21,7 @@
     {
       "device_id": "dev-bob",
       "hostname": "bob-thinkpad",
+      "member_email": "bob@conformance.test",
       "platform": "windows",
       "app_version": "2.5.136",
       "last_seen_at": "2026-07-22T10:08:00+00:00",
@@ -27,6 +30,7 @@
     {
       "device_id": "dev-alice",
       "hostname": "alice-mbp",
+      "member_email": "alice@conformance.test",
       "platform": "macos",
       "app_version": "2.5.136",
       "last_seen_at": "2026-07-22T09:08:00+00:00",

--- a/crates/screenpipe-gateway/e2e/conformance/fixtures/index.ts
+++ b/crates/screenpipe-gateway/e2e/conformance/fixtures/index.ts
@@ -47,6 +47,7 @@ export const NON_SK_ENT_TOKEN: string = tokensFile.non_sk_ent_token;
 export const DEVICE_ROWS: Array<{
   device_id: string;
   hostname: string;
+  member_email: string | null;
   platform: string;
   app_version: string;
   last_seen_at: string;

--- a/crates/screenpipe-gateway/e2e/conformance/run.test.ts
+++ b/crates/screenpipe-gateway/e2e/conformance/run.test.ts
@@ -21,22 +21,31 @@
 
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@/lib/supabase", async () => (await import("./targets/hosted-inproc")).supabaseMock());
-vi.mock("@/lib/enterprise/storage", async () =>
-  (await import("./targets/hosted-inproc")).storageMock()
+vi.mock("@/lib/supabase", async () =>
+  (await import("./targets/hosted-inproc")).supabaseMock(),
 );
-vi.mock("@/lib/enterprise/audit", async () => (await import("./targets/hosted-inproc")).auditMock());
+vi.mock("@/lib/enterprise/storage", async () =>
+  (await import("./targets/hosted-inproc")).storageMock(),
+);
+vi.mock("@/lib/enterprise/audit", async () =>
+  (await import("./targets/hosted-inproc")).auditMock(),
+);
 vi.mock("@/lib/enterprise/artifacts/store", async () =>
-  (await import("./targets/hosted-inproc")).artifactsStoreMock()
+  (await import("./targets/hosted-inproc")).artifactsStoreMock(),
 );
 vi.mock("@/lib/enterprise/auth", async () =>
-  (await import("./targets/hosted-inproc")).enterpriseAuthMock()
+  (await import("./targets/hosted-inproc")).enterpriseAuthMock(),
 );
 vi.mock("@clerk/backend", () => ({ verifyToken: vi.fn() }));
 vi.mock("@clerk/nextjs/server", () => ({ clerkClient: vi.fn() }));
 
 import { cases, type Case } from "./cases";
-import { ALL_SCOPES_TOKEN, EXPECTED, LICENSE_ID, SEEDED_WINDOW } from "./fixtures";
+import {
+  ALL_SCOPES_TOKEN,
+  EXPECTED,
+  LICENSE_ID,
+  SEEDED_WINDOW,
+} from "./fixtures";
 import {
   contentTypeFor,
   operationFor,
@@ -58,7 +67,9 @@ beforeAll(() => {
   process.env.SUPABASE_SERVICE_KEY ||= "conformance-service-key";
 });
 
-async function send(req: Parameters<typeof import("./targets/http").request>[0]) {
+async function send(
+  req: Parameters<typeof import("./targets/http").request>[0],
+) {
   if (activeTarget() === "http") {
     return (await import("./targets/http")).request(req);
   }
@@ -72,7 +83,8 @@ async function send(req: Parameters<typeof import("./targets/http").request>[0])
  * catch-all routes are templated in the spec and concrete in a case.
  */
 function specPathFor(path: string): string {
-  if (path.startsWith("/api/enterprise/v1/files/")) return "/api/enterprise/v1/files/{key}";
+  if (path.startsWith("/api/enterprise/v1/files/"))
+    return "/api/enterprise/v1/files/{key}";
   if (path.startsWith("/api/enterprise/v1/frames/")) {
     return "/api/enterprise/v1/frames/{device_id}/{frame_id}";
   }
@@ -101,20 +113,25 @@ async function check(c: Case) {
   const raw = await res.clone().text();
   expect(
     res.status,
-    `${method} ${c.path} -> ${res.status}, body: ${raw.slice(0, 400)}`
+    `${method} ${c.path} -> ${res.status}, body: ${raw.slice(0, 400)}`,
   ).toBe(c.expectStatus);
 
   // 2. Content type, exactly as the spec declares it for this status.
   const declared = contentTypeFor(method, specPath, c.expectStatus);
   const actual = (res.headers.get("content-type") ?? "").split(";")[0].trim();
-  expect(actual, `${method} ${c.path} ${c.expectStatus} content-type`).toBe(declared);
+  expect(actual, `${method} ${c.path} ${c.expectStatus} content-type`).toBe(
+    declared,
+  );
 
   // 3. Required response headers.
   for (const [name, schema] of Object.entries<any>(
-    requiredHeaders(method, specPath, c.expectStatus)
+    requiredHeaders(method, specPath, c.expectStatus),
   )) {
     const value = res.headers.get(name);
-    expect(value, `${method} ${c.path}: required header '${name}' is missing`).not.toBeNull();
+    expect(
+      value,
+      `${method} ${c.path}: required header '${name}' is missing`,
+    ).not.toBeNull();
     if (schema.schema?.const !== undefined) {
       expect(value, `header '${name}'`).toBe(schema.schema.const);
     }
@@ -129,7 +146,7 @@ async function check(c: Case) {
     expect(
       ok,
       `${method} ${c.path} ${c.expectStatus} does not match the spec:\n${validate.errorText()}\n` +
-        `body: ${JSON.stringify(body).slice(0, 600)}`
+        `body: ${JSON.stringify(body).slice(0, 600)}`,
     ).toBe(true);
   }
 
@@ -140,7 +157,9 @@ async function check(c: Case) {
   return { res, body, raw };
 }
 
-const applicable = cases.filter((c) => (c.targets ?? ["hosted", "gateway"]).includes(impl));
+const applicable = cases.filter((c) =>
+  (c.targets ?? ["hosted", "gateway"]).includes(impl),
+);
 
 describe(`conformance [${activeTarget()} / impl=${impl}]`, () => {
   it("has cases to run (an empty run must never look like a pass)", () => {
@@ -152,6 +171,106 @@ describe(`conformance [${activeTarget()} / impl=${impl}]`, () => {
       await check(c);
     });
   }
+});
+
+describe(`keyset pagination [${impl}]`, () => {
+  it.each([
+    [
+      "devices",
+      "/api/enterprise/v1/devices",
+      { pagination: "keyset", limit: "1" },
+      "devices",
+    ],
+    [
+      "search",
+      "/api/enterprise/v1/search",
+      {
+        q: "roadmap",
+        since: SEEDED_WINDOW.since,
+        until: SEEDED_WINDOW.until,
+        pagination: "keyset",
+        limit: "1",
+      },
+      "results",
+    ],
+    [
+      "records",
+      "/api/enterprise/v1/records",
+      {
+        since: SEEDED_WINDOW.since,
+        until: SEEDED_WINDOW.until,
+        pagination: "keyset",
+        limit: "3",
+      },
+      "records",
+    ],
+    [
+      "files",
+      "/api/enterprise/v1/files",
+      { since: SEEDED_WINDOW.since, page_size: "1" },
+      "files",
+    ],
+  ])(
+    "%s follows the returned opaque cursor without repeating a row",
+    async (name, path, query, field) => {
+      const first = await send({ path, query, headers: authHeader() });
+      expect(first.status, await first.clone().text()).toBe(200);
+      const firstBody = await first.json();
+      expect(firstBody.next_cursor).toEqual(expect.any(String));
+      if (name !== "files" || impl === "gateway") {
+        expect(firstBody.next_cursor).not.toMatch(/^\d+$/);
+      }
+
+      const second = await send({
+        path,
+        query: { ...query, cursor: firstBody.next_cursor },
+        headers: authHeader(),
+      });
+      expect(second.status, await second.clone().text()).toBe(200);
+      const secondBody = await second.json();
+      const identity = (row: any) =>
+        row.kind === undefined
+          ? (row.key ?? row.device_id)
+          : [
+              row.device_id,
+              row.kind,
+              row.t,
+              row.frame_id,
+              row.memory_id,
+              row.text,
+              row.transcription,
+            ].join("|");
+      expect(firstBody[field].map(identity)).not.toContain(
+        secondBody[field][0] && identity(secondBody[field][0]),
+      );
+    },
+  );
+
+  it("binds a cursor to its original filters", async () => {
+    const first = await send({
+      path: "/api/enterprise/v1/search",
+      query: {
+        q: "roadmap",
+        ...SEEDED_WINDOW,
+        pagination: "keyset",
+        limit: "1",
+      },
+      headers: authHeader(),
+    });
+    const body = await first.json();
+    const reused = await send({
+      path: "/api/enterprise/v1/search",
+      query: {
+        q: "different",
+        ...SEEDED_WINDOW,
+        pagination: "keyset",
+        limit: "1",
+        cursor: body.next_cursor,
+      },
+      headers: authHeader(),
+    });
+    expect(reused.status).toBe(400);
+  });
 });
 
 /**
@@ -171,9 +290,14 @@ describe(`binary routes [${impl}]`, () => {
     expect(files.length).toBe(EXPECTED.batchObjects);
     const key: string = files[0].key;
 
-    const res = await send({ path: `/api/enterprise/v1/files/${key}`, headers: authHeader() });
+    const res = await send({
+      path: `/api/enterprise/v1/files/${key}`,
+      headers: authHeader(),
+    });
     expect(res.status, await res.clone().text()).toBe(200);
-    expect((res.headers.get("content-type") ?? "").split(";")[0]).toBe("application/x-ndjson");
+    expect((res.headers.get("content-type") ?? "").split(";")[0]).toBe(
+      "application/x-ndjson",
+    );
     // The spec marks this header required — it is how a consumer knows WHICH
     // object it got when it followed a cursor.
     expect(res.headers.get("x-screenpipe-source")).toBe(key);
@@ -183,7 +307,9 @@ describe(`binary routes [${impl}]`, () => {
     const lines = text.trim().split("\n");
     expect(lines.length).toBe(7); // the six in-window records + one stale record
     const kinds = lines.map((l) => JSON.parse(l).kind);
-    expect(new Set(kinds)).toEqual(new Set(["frame", "parsed", "audio", "ui", "memory"]));
+    expect(new Set(kinds)).toEqual(
+      new Set(["frame", "parsed", "audio", "ui", "memory"]),
+    );
     for (const line of lines) {
       const rec = JSON.parse(line);
       expect(EXPECTED.deviceIds).toContain(rec.device_id);
@@ -202,12 +328,14 @@ describe(`binary routes [${impl}]`, () => {
         headers: authHeader(),
       });
       expect(res.status, await res.clone().text()).toBe(200);
-      expect((res.headers.get("content-type") ?? "").split(";")[0]).toBe("image/jpeg");
+      expect((res.headers.get("content-type") ?? "").split(";")[0]).toBe(
+        "image/jpeg",
+      );
       expect(res.headers.get("cache-control")).toBe("private, max-age=3600");
       const bytes = new Uint8Array(await res.arrayBuffer());
       // A real JPEG SOI marker, so a JSON error body cannot pass as an image.
       expect([bytes[0], bytes[1]]).toEqual([0xff, 0xd8]);
-    }
+    },
   );
 });
 
@@ -218,43 +346,62 @@ describe(`binary routes [${impl}]`, () => {
  * This is the SCR-288 divergence-11 fix, asserted at the surface rather than the
  * unit: every content scope refuses, and the two hand-rolled routes refuse too.
  */
-describe.runIf(activeTarget() === "hosted-inproc")("write-only archive (hosted only)", () => {
-  beforeEach(async () => {
-    const { posture } = await import("./targets/hosted-inproc");
-    posture.writeOnlyArchive = true;
-  });
+describe.runIf(activeTarget() === "hosted-inproc")(
+  "write-only archive (hosted only)",
+  () => {
+    beforeEach(async () => {
+      const { posture } = await import("./targets/hosted-inproc");
+      posture.writeOnlyArchive = true;
+    });
 
-  const contentRoutes: Array<[string, string, Record<string, string> | undefined]> = [
-    ["GET", "/api/enterprise/v1/search", { q: "roadmap" }],
-    ["GET", "/api/enterprise/v1/records", undefined],
-    ["GET", "/api/enterprise/v1/files", undefined],
-    ["GET", "/api/enterprise/v1/rollups", undefined],
-    ["GET", "/api/enterprise/v1/workflows/generated", undefined],
-    [
-      "GET",
-      `/api/enterprise/v1/files/enterprise-telemetry/${LICENSE_ID}/dev-alice/direct/batch-alice.jsonl`,
-      undefined,
-    ],
-    ["GET", "/api/enterprise/v1/frames/dev-alice/1", undefined],
-  ];
+    const contentRoutes: Array<
+      [string, string, Record<string, string> | undefined]
+    > = [
+      ["GET", "/api/enterprise/v1/search", { q: "roadmap" }],
+      ["GET", "/api/enterprise/v1/records", undefined],
+      ["GET", "/api/enterprise/v1/files", undefined],
+      ["GET", "/api/enterprise/v1/rollups", undefined],
+      ["GET", "/api/enterprise/v1/workflows/generated", undefined],
+      [
+        "GET",
+        `/api/enterprise/v1/files/enterprise-telemetry/${LICENSE_ID}/dev-alice/direct/batch-alice.jsonl`,
+        undefined,
+      ],
+      ["GET", "/api/enterprise/v1/frames/dev-alice/1", undefined],
+    ];
 
-  it.each(contentRoutes)("%s %s refuses with a typed 409", async (method, path, query) => {
-    const { request } = await import("./targets/hosted-inproc");
-    const res = await request({ method, path, query, headers: authHeader() });
-    const raw = await res.clone().text();
-    expect(res.status, `${path} -> ${res.status}: ${raw.slice(0, 300)}`).toBe(409);
-    const validate = validatorFor(method, specPathFor(path), 409)!;
-    const body = JSON.parse(raw);
-    expect(validate(body), validate.errorText()).toBe(true);
-    expect(body.code).toBe("write_only_archive");
-    expect(body.surface).toBe("hosted_api");
-    // The whole point of the denial is to route the caller somewhere useful.
-    expect(body.gateway_url).toBeTruthy();
-  });
+    it.each(contentRoutes)(
+      "%s %s refuses with a typed 409",
+      async (method, path, query) => {
+        const { request } = await import("./targets/hosted-inproc");
+        const res = await request({
+          method,
+          path,
+          query,
+          headers: authHeader(),
+        });
+        const raw = await res.clone().text();
+        expect(
+          res.status,
+          `${path} -> ${res.status}: ${raw.slice(0, 300)}`,
+        ).toBe(409);
+        const validate = validatorFor(method, specPathFor(path), 409)!;
+        const body = JSON.parse(raw);
+        expect(validate(body), validate.errorText()).toBe(true);
+        expect(body.code).toBe("write_only_archive");
+        expect(body.surface).toBe("hosted_api");
+        // The whole point of the denial is to route the caller somewhere useful.
+        expect(body.gateway_url).toBeTruthy();
+      },
+    );
 
-  it("does NOT refuse /devices — fleet metadata is control-plane, not content", async () => {
-    const { request } = await import("./targets/hosted-inproc");
-    const res = await request({ path: "/api/enterprise/v1/devices", headers: authHeader() });
-    expect(res.status).toBe(200);
-  });
-});
+    it("does NOT refuse /devices — fleet metadata is control-plane, not content", async () => {
+      const { request } = await import("./targets/hosted-inproc");
+      const res = await request({
+        path: "/api/enterprise/v1/devices",
+        headers: authHeader(),
+      });
+      expect(res.status).toBe(200);
+    });
+  },
+);

--- a/crates/screenpipe-gateway/e2e/conformance/strictness.test.ts
+++ b/crates/screenpipe-gateway/e2e/conformance/strictness.test.ts
@@ -61,6 +61,7 @@ const goodDeviceList = () => ({
     {
       device_id: "dev-alice",
       label: "alice-mbp",
+      member_email: "alice@conformance.test",
       platform: "macos",
       app_version: "2.5.136",
       last_seen: "2026-07-22T09:08:00+00:00",
@@ -69,6 +70,7 @@ const goodDeviceList = () => ({
     {
       device_id: "dev-bob",
       label: "bob-thinkpad",
+      member_email: null,
       platform: null,
       app_version: null,
       last_seen: "2026-07-22T10:08:00Z",
@@ -125,6 +127,16 @@ describe("the good bodies validate (or every rejection below proves nothing)", (
     const v = componentValidator(name as string);
     expect(v(body), v.errorText()).toBe(true);
   });
+
+  it.each([
+    ["DeviceList", goodDeviceList()],
+    ["SearchResult", goodSearchResult()],
+    ["RollupList", goodRollupList()],
+  ])("%s also accepts the opt-in pagination field", (name, body: any) => {
+    body.next_cursor = null;
+    const v = componentValidator(name);
+    expect(v(body), v.errorText()).toBe(true);
+  });
 });
 
 describe("renaming a required field is REJECTED", () => {
@@ -167,7 +179,7 @@ describe("renaming a required field is REJECTED", () => {
       body.files[0][`x_${field}`] = body.files[0][field];
       delete body.files[0][field];
       expect(componentValidator("FileList")(body)).toBe(false);
-    }
+    },
   );
 });
 
@@ -263,7 +275,9 @@ describe("nulling a non-nullable field is REJECTED", () => {
 
 describe("the nullable fields ARE allowed to be null (accepted divergences)", () => {
   it("every RecordSummary field except kind", () => {
-    const nullable = Object.keys(goodRecordSummary()).filter((k) => k !== "kind");
+    const nullable = Object.keys(goodRecordSummary()).filter(
+      (k) => k !== "kind",
+    );
     for (const field of nullable) {
       const body: any = goodRecordSummary();
       body[field] = null;
@@ -279,6 +293,12 @@ describe("the nullable fields ARE allowed to be null (accepted divergences)", ()
     expect(componentValidator("DeviceList")(body)).toBe(true);
   });
 
+  it("Device.member_email — null when no verified identity source exists (DEV-MEMBER-EMAIL)", () => {
+    const body: any = goodDeviceList();
+    body.devices[0].member_email = null;
+    expect(componentValidator("DeviceList")(body)).toBe(true);
+  });
+
   it("FileEntry.size / last_modified — nullable on the gateway (FILES-NULLABILITY)", () => {
     const body: any = goodFileList();
     body.files[0].size = null;
@@ -288,10 +308,22 @@ describe("the nullable fields ARE allowed to be null (accepted divergences)", ()
 });
 
 describe("removing a required field is REJECTED", () => {
+  it("Device.member_email", () => {
+    const body: any = goodDeviceList();
+    delete body.devices[0].member_email;
+    expect(componentValidator("DeviceList")(body)).toBe(false);
+  });
+
   it.each([
     ["DeviceList", ["count", "devices"]],
-    ["SearchResult", ["query", "result_count", "results", "truncated", "window_hours"]],
-    ["FileList", ["device_id", "count", "files", "next_cursor", "window_hours"]],
+    [
+      "SearchResult",
+      ["query", "result_count", "results", "truncated", "window_hours"],
+    ],
+    [
+      "FileList",
+      ["device_id", "count", "files", "next_cursor", "window_hours"],
+    ],
     ["RollupList", ["ok", "device", "from", "to", "count", "rollups"]],
   ])("%s", (name, fields) => {
     for (const field of fields as string[]) {
@@ -304,7 +336,7 @@ describe("removing a required field is REJECTED", () => {
       delete body[field];
       expect(
         componentValidator(name as string)(body),
-        `${name} validated without required '${field}'`
+        `${name} validated without required '${field}'`,
       ).toBe(false);
     }
   });
@@ -313,7 +345,9 @@ describe("removing a required field is REJECTED", () => {
 describe("error bodies are strict too", () => {
   it("{error} accepts only that", () => {
     expect(componentValidator("Error")({ error: "not found" })).toBe(true);
-    expect(componentValidator("Error")({ error: "x", stack: "..." })).toBe(false);
+    expect(componentValidator("Error")({ error: "x", stack: "..." })).toBe(
+      false,
+    );
     expect(componentValidator("Error")({})).toBe(false);
   });
 
@@ -333,17 +367,23 @@ describe("error bodies are strict too", () => {
 
   it("the write-only denial code and surface are pinned", () => {
     const v = componentValidator("WriteOnlyDenial");
-    expect(v({ error: "x", code: "write_only_archive", surface: "hosted_api" })).toBe(true);
+    expect(
+      v({ error: "x", code: "write_only_archive", surface: "hosted_api" }),
+    ).toBe(true);
     expect(
       v({
         error: "x",
         code: "write_only_archive",
         surface: "hosted_api",
         gateway_url: "https://gw",
-      })
+      }),
     ).toBe(true);
-    expect(v({ error: "x", code: "write_only", surface: "hosted_api" })).toBe(false);
-    expect(v({ error: "x", code: "write_only_archive", surface: "made_up" })).toBe(false);
+    expect(v({ error: "x", code: "write_only", surface: "hosted_api" })).toBe(
+      false,
+    );
+    expect(
+      v({ error: "x", code: "write_only_archive", surface: "made_up" }),
+    ).toBe(false);
   });
 });
 
@@ -351,17 +391,25 @@ describe("the spec itself stays strict — a relaxation fails HERE", () => {
   it("every JSON response object schema sets additionalProperties: false", () => {
     // The one deliberate exception is documented in the spec: a rollup's `data`
     // and an artifact body are passthroughs whose shape the route does not own.
-    const allowed = new Set(["Rollup.data", "GeneratedWorkflows.artifacts.items"]);
+    const allowed = new Set([
+      "Rollup.data",
+      "GeneratedWorkflows.artifacts.items",
+    ]);
     const offenders: string[] = [];
     walk(rawSpec().components.schemas, "");
     function walk(node: any, path: string) {
       if (!node || typeof node !== "object") return;
-      if (Array.isArray(node)) return node.forEach((n, i) => walk(n, `${path}[${i}]`));
+      if (Array.isArray(node))
+        return node.forEach((n, i) => walk(n, `${path}[${i}]`));
       const isObjectSchema =
         node.type === "object" ||
         (Array.isArray(node.type) && node.type.includes("object")) ||
         !!node.properties;
-      if (isObjectSchema && node.additionalProperties !== false && !allowed.has(path)) {
+      if (
+        isObjectSchema &&
+        node.additionalProperties !== false &&
+        !allowed.has(path)
+      ) {
         offenders.push(path || "<root>");
       }
       for (const [k, v] of Object.entries(node)) {
@@ -374,7 +422,10 @@ describe("the spec itself stays strict — a relaxation fails HERE", () => {
         }
       }
     }
-    expect(offenders, `these object schemas would validate a renamed field`).toEqual([]);
+    expect(
+      offenders,
+      `these object schemas would validate a renamed field`,
+    ).toEqual([]);
   });
 
   it("every RESPONSE object schema has an exhaustive required list", () => {
@@ -402,10 +453,17 @@ describe("the spec itself stays strict — a relaxation fails HERE", () => {
     }
     expect(
       requestSchemas.size,
-      "no request schemas found — the derivation broke and this test is now vacuous"
+      "no request schemas found — the derivation broke and this test is now vacuous",
     ).toBeGreaterThan(0);
 
-    const optionalByDesign = new Set(["WriteOnlyDenial.gateway_url"]);
+    const optionalByDesign = new Set([
+      "WriteOnlyDenial.gateway_url",
+      // Pagination is opt-in so legacy responses retain their exact shape.
+      "DeviceList.next_cursor",
+      "SearchResult.next_cursor",
+      "RecordList.next_cursor",
+      "RollupList.next_cursor",
+    ]);
     const gaps: string[] = [];
     for (const [name, schema] of Object.entries<any>(doc.components.schemas)) {
       if (!schema.properties) continue;
@@ -418,7 +476,10 @@ describe("the spec itself stays strict — a relaxation fails HERE", () => {
         }
       }
     }
-    expect(gaps, "these properties could vanish without the schema noticing").toEqual([]);
+    expect(
+      gaps,
+      "these properties could vanish without the schema noticing",
+    ).toEqual([]);
   });
 
   it("every operation declares an x-scope, or is an explicitly public route", () => {
@@ -426,7 +487,7 @@ describe("the spec itself stays strict — a relaxation fails HERE", () => {
       expect(
         op.scope !== null || op.isPublic,
         `${op.method} ${op.path} has neither x-scope nor x-public: true — the ` +
-          `auth matrix cannot classify it, so it would be silently unasserted`
+          `auth matrix cannot classify it, so it would be silently unasserted`,
       ).toBe(true);
     }
   });
@@ -437,7 +498,7 @@ describe("the spec itself stays strict — a relaxation fails HERE", () => {
       for (const id of op.divergences) {
         expect(
           Object.keys(ledger),
-          `${op.method} ${op.path} claims divergence '${id}'`
+          `${op.method} ${op.path} claims divergence '${id}'`,
         ).toContain(id);
       }
     }
@@ -447,19 +508,22 @@ describe("the spec itself stays strict — a relaxation fails HERE", () => {
     for (const [id, entry] of Object.entries<any>(divergenceLedger())) {
       expect(entry.rationale, `${id} has no rationale`).toBeTruthy();
       expect(entry.hosted, `${id} does not say what hosted does`).toBeTruthy();
-      expect(entry.gateway, `${id} does not say what the gateway does`).toBeTruthy();
+      expect(
+        entry.gateway,
+        `${id} does not say what the gateway does`,
+      ).toBeTruthy();
     }
   });
 
   it("validatorFor THROWS for a status the spec does not describe", () => {
-    expect(() => validatorFor("GET", "/api/enterprise/v1/devices", 418)).toThrow(
-      /does not define a 418 response/
-    );
+    expect(() =>
+      validatorFor("GET", "/api/enterprise/v1/devices", 418),
+    ).toThrow(/does not define a 418 response/);
   });
 
   it("validatorFor THROWS for an operation the spec does not describe", () => {
-    expect(() => validatorFor("GET", "/api/enterprise/v1/experimental", 200)).toThrow(
-      /does not describe/
-    );
+    expect(() =>
+      validatorFor("GET", "/api/enterprise/v1/experimental", 200),
+    ).toThrow(/does not describe/);
   });
 });


### PR DESCRIPTION
## Problem

The vendored conformance suite under `crates/screenpipe-gateway/e2e/conformance/` has been behind the website's copy since 2026-08-11.

The website is the source of truth and owns the guard (`vendored spec is current`), because screenpipe CI cannot check out the private repo. That guard has failed on **every website commit for two days**, so it is the one red check people have learned to scroll past. As the job's own comment notes, nothing on this side can see the drift, so a screenpipe PR can land against a stale copy and go green.

## What changed

Produced by the suite's own script, not by hand:

```bash
cd crates/screenpipe-gateway/e2e/conformance && ./revendor.sh <website>
```

The substance is a `DEV-MEMBER-EMAIL` divergence entry for `devices[].member_email`: the hosted API populates it from the latest device heartbeat, the customer-run gateway has no account-identity channel and always reports `null`. The field stays required and nullable so consumers get one stable response shape. The rest is the matching cases, fixtures and strictness updates, plus refreshed `VENDORED_FROM` provenance.

The generated JSONL batches and the rollup are byte-identical on both sides, so neither copy was hand-edited.

## Validation

Not validated locally. The suite runs under the compose e2e (MinIO + gateway + MCP) and the machine this was prepared on has no Docker, so `gateway-e2e` on this PR is the thing that proves it. Opening it as a PR for that reason rather than pushing to main.

The expectation is that this is behaviour-neutral for the gateway: the new entry documents `null` as correct gateway output rather than tightening anything.