### PR TITLE
fix(ai-presets): send stream:false on the connection test probe

### DIFF
--- a/apps/screenpipe-app-tauri/lib/utils/ai-preset-connection.test.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/ai-preset-connection.test.ts
@@ -38,6 +38,82 @@ describe("testAiPresetConnection", () => {
     });
   });
 
+  // Regression for #6196: omniroute and similar OpenAI-compatible gateways
+  // answer with SSE unless the request opts out explicitly, and the SSE body
+  // then fails response.json() with a bogus "connection failed".
+  it("gets JSON from a gateway that streams unless stream:false is sent", async () => {
+    const gateway = vi.fn(async (_input: string, init?: RequestInit) => {
+      const body = JSON.parse(init!.body as string);
+      if (body.stream !== false) {
+        return new Response(
+          'data: {"choices":[{"delta":{"content":"hi"}}]}\n\ndata: [DONE]\n\n',
+          { status: 200, headers: { "Content-Type": "text/event-stream" } },
+        );
+      }
+      return new Response(
+        JSON.stringify({ choices: [{ message: { content: "hi" } }] }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+
+    await expect(
+      testAiPresetConnection(
+        {
+          provider: "custom",
+          url: "http://127.0.0.1:20128/v1",
+          model: "gpt-4o-mini",
+        },
+        { fetch: gateway },
+      ),
+    ).resolves.toMatchObject({ reply: "hi" });
+
+    expect(JSON.parse(gateway.mock.calls[0][1]!.body as string).stream).toBe(false);
+  });
+
+  it("keeps stream:false on the max_completion_tokens retry", async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: { message: "Unsupported parameter: use max_completion_tokens" },
+          }),
+          { status: 400 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ choices: [{ message: { content: "hi" } }] }),
+          { status: 200 },
+        ),
+      );
+
+    await expect(
+      testAiPresetConnection(
+        { provider: "custom", url: "https://gw.example.com/v1", model: "gpt-5" },
+        { fetch: request },
+      ),
+    ).resolves.toMatchObject({ reply: "hi" });
+
+    for (const call of request.mock.calls) {
+      expect(JSON.parse(call[1]!.body as string).stream).toBe(false);
+    }
+  });
+
+  it("asks Anthropic for a non-streaming reply too", async () => {
+    const request = vi.fn(async () =>
+      new Response(JSON.stringify({ content: [{ text: "hi" }] }), { status: 200 }));
+
+    await expect(
+      testAiPresetConnection(
+        { provider: "anthropic", model: "claude-sonnet-5", apiKey: "k" },
+        { fetch: request },
+      ),
+    ).resolves.toMatchObject({ reply: "hi" });
+
+    expect(JSON.parse(request.mock.calls[0][1]!.body as string).stream).toBe(false);
+  });
+
   it("surfaces Google's array-shaped error message", async () => {
     const request = vi.fn(async () =>
       new Response(

--- a/apps/screenpipe-app-tauri/lib/utils/ai-preset-connection.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/ai-preset-connection.ts
@@ -76,11 +76,15 @@ export async function testAiPresetConnection(
   const isAnthropic = preset.provider === "anthropic";
   const startedAt = performance.now();
 
+  // `stream: false` is explicit on both shapes: the reply is read with
+  // response.json(), and some compatible gateways stream by default when the
+  // field is omitted.
   let body = isAnthropic
     ? {
         model: preset.model || "",
         messages: [{ role: "user", content: "say hi" }],
         max_tokens: 50,
+        stream: false,
       }
     : buildChatTestBody(preset.model || "", "say hi", 50, "max_tokens");
 

--- a/apps/screenpipe-app-tauri/lib/utils/chat-test-body.test.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/chat-test-body.test.ts
@@ -15,6 +15,7 @@ describe("buildChatTestBody", () => {
     expect(body).toEqual({
       model: "gpt-4",
       messages: [{ role: "user", content: "say hi" }],
+      stream: false,
       max_tokens: 50,
     });
     expect(body.max_completion_tokens).toBeUndefined();
@@ -25,6 +26,7 @@ describe("buildChatTestBody", () => {
     expect(body).toEqual({
       model: "gpt-5",
       messages: [{ role: "user", content: "say hi" }],
+      stream: false,
       max_completion_tokens: 50,
     });
     expect(body.max_tokens).toBeUndefined();
@@ -35,6 +37,21 @@ describe("buildChatTestBody", () => {
     const b = buildChatTestBody("m", "hi", 10, "max_completion_tokens");
     expect(a.max_tokens !== undefined && a.max_completion_tokens !== undefined).toBe(false);
     expect(b.max_tokens !== undefined && b.max_completion_tokens !== undefined).toBe(false);
+  });
+
+  // Gateways such as omniroute stream by default when `stream` is absent,
+  // which breaks the response.json() the connection test performs.
+  it("always requests a non-streaming reply", () => {
+    for (const field of ["max_tokens", "max_completion_tokens"] as const) {
+      const body = buildChatTestBody("m", "hi", 10, field);
+      expect(body.stream).toBe(false);
+      expect(JSON.parse(JSON.stringify(body)).stream).toBe(false);
+    }
+  });
+
+  it("serializes stream:false rather than dropping it", () => {
+    const wire = JSON.stringify(buildChatTestBody("m", "hi", 10));
+    expect(wire).toContain('"stream":false');
   });
 });
 

--- a/apps/screenpipe-app-tauri/lib/utils/chat-test-body.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/chat-test-body.ts
@@ -14,6 +14,11 @@
  * - We can't detect the endpoint capability statically, so we try
  *   `max_tokens` first (broadest compatibility), and fall back to
  *   `max_completion_tokens` if the endpoint rejects it.
+ * - `stream` is always sent explicitly as `false`. The OpenAI spec says an
+ *   absent `stream` means non-streaming, but several compatible gateways
+ *   (omniroute and friends) default to SSE instead. The caller reads the
+ *   reply with `response.json()`, so an SSE body fails to parse and the
+ *   connection test reports a bogus failure.
  */
 
 export type ChatTokensField = "max_tokens" | "max_completion_tokens";
@@ -21,6 +26,7 @@ export type ChatTokensField = "max_tokens" | "max_completion_tokens";
 export interface ChatTestBody {
   model: string;
   messages: Array<{ role: string; content: string }>;
+  stream: false;
   max_tokens?: number;
   max_completion_tokens?: number;
 }
@@ -37,6 +43,7 @@ export function buildChatTestBody(
   const body: ChatTestBody = {
     model,
     messages: [{ role: "user", content: prompt }],
+    stream: false,
   };
   if (tokensField === "max_tokens") {
     body.max_tokens = maxTokens;


### PR DESCRIPTION
Fixes #6196

## Problem

Adding a custom AI preset that points at a locally-running OpenAI-compatible gateway (omniroute at `http://127.0.0.1:20128/v1` in the report) fails at **Test Connection**, and the preset cannot be saved.

`buildChatTestBody()` never set `stream`. Per the OpenAI spec an absent `stream` means non-streaming, but several compatible gateways default to **SSE** when the field is missing. `testAiPresetConnection()` reads the reply with `response.json()`, so the gateway's `data: {...}` stream fails to parse and surfaces as a generic "connection failed" — the user is locked out of their own gateway by a probe detail, with nothing in the UI pointing at the cause.

## Where it was found

Reported by @cbellosoto with a reproduction against omniroute (v2.6.10, Arch/Wayland), including root cause and the exact missing field.

## Reproduction and pre-fix failure

Run an OpenAI-compatible gateway that streams by default, then Settings → Models & keys → Create Preset → Custom → gateway URL → pick a model → Test Connection.

Encoded as a test that fakes exactly that gateway (SSE unless `stream:false` is sent). Against `main` it fails:

```
FAIL  lib/utils/ai-preset-connection.test.ts > gets JSON from a gateway that streams unless stream:false is sent
FAIL  lib/utils/ai-preset-connection.test.ts > keeps stream:false on the max_completion_tokens retry
FAIL  lib/utils/ai-preset-connection.test.ts > asks Anthropic for a non-streaming reply too
Tests  3 failed | 3 passed (6)
```

## Root cause

`ChatTestBody` had no `stream` field, so the probe delegated the streaming decision to the server. Servers disagree.

## Fix

Send `stream: false` explicitly, on every probe the connection test can emit:

- `buildChatTestBody()` — typed as `stream: false`, so it cannot be dropped or flipped by a caller
- the `max_completion_tokens` retry, which rebuilds the body
- the Anthropic body, built inline in `ai-preset-connection.ts` (same `response.json()` read, same exposure behind a proxy)

Nothing else changes: no token-field logic, no endpoint/header logic, no UI.

## Validation

- `lib/utils/chat-test-body.test.ts` — 20 passed (2 new: wire-format assertion that `"stream":false` is serialized, and both token-field variants)
- `lib/utils/ai-preset-connection.test.ts` — 6 passed (3 new, listed above)
- Reverted the two source hunks and re-ran: the 3 new integration tests fail, confirming they pin the reported behavior rather than the implementation
- `bun run typecheck` clean

Not verified here: a live omniroute instance. The gateway is simulated at the `fetch` boundary, matching the SSE-vs-JSON behavior described in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)