### PR TITLE
docs: add ort fix for ubuntu 22.04

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,6 +194,30 @@ next to the released app without taking over its identity or updater settings.
    cargo build --release
    ```
 
+   on ubuntu 22.04 (`glibc 2.35`), `cargo build` may fail while compiling `ort-sys` with errors such as `__isoc23_strtol` or `could not link to the ONNX Runtime build`. this happens when `ort-sys` attempts to use static prebuilts compiled for newer `glibc` versions.
+
+   download Microsoft's ONNX Runtime binary and use dynamic linking instead:
+
+   ```bash
+   wget https://github.com/microsoft/onnxruntime/releases/download/v1.19.2/onnxruntime-linux-x64-1.19.2.tgz
+   tar -xvf onnxruntime-linux-x64-1.19.2.tgz
+
+   export ORT_LIB_LOCATION="$(pwd)/onnxruntime-linux-x64-1.19.2/lib"
+   export ORT_PREFER_DYNAMIC_LINK=1
+   export LD_LIBRARY_PATH="$ORT_LIB_LOCATION:$LD_LIBRARY_PATH"
+
+   cargo build --release
+   ```
+
+   to persist the runtime library path across terminal sessions:
+
+   ```bash
+   echo 'export LD_LIBRARY_PATH="$HOME/screenpipe/onnxruntime-linux-x64-1.19.2/lib:$LD_LIBRARY_PATH"' >> ~/.bashrc
+   source ~/.bashrc
+   ```
+
+   adjust the path if ONNX Runtime was extracted somewhere else.
+
 5. **run the application**:
    ```bash
    ./target/release/screenpipe


### PR DESCRIPTION
## description

Added instructions for resolving `ort-sys` / ONNX Runtime build issues on Ubuntu 22.04 (`glibc 2.35`).

The documentation explains how to use Microsoft's ONNX Runtime binary with dynamic linking when the default static prebuilt fails with errors such as `__isoc23_strtol` or `could not link to the ONNX Runtime build`. It also includes an example for persisting the runtime library path in `~/.bashrc`.

related issue: #

## AI assistance and human ownership

read the [AI-assisted contribution policy](https://github.com/screenpipe/screenpipe/blob/main/CONTRIBUTING.md#ai-assisted-contributions).

- AI tool(s) used (`none` if not used): ChatGPT
- autonomy level (`none`, `autocomplete`, `chat`, or `agent`): chat
- what I personally verified: reproduced the Ubuntu 22.04 build issue and verified that dynamically linking Microsoft's ONNX Runtime binary resolves it.

- [x] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [x] The problem statement, rationale, and replies to maintainers are my own.

## evidence type

check every category that applies and provide its required evidence below.

- [ ] UI or behavior change — before/after recording
- [ ] Backend change — regression tests and relevant logs/results
- [ ] Performance change — reproducible before/after benchmarks
- [x] Docs, CI, or pure refactor — relevant checks and an explanation; no video required

## before

not applicable. this is a documentation-only change describing a build issue encountered on Ubuntu 22.04.

## after

not applicable. the updated Linux build instructions document the working ONNX Runtime dynamic-linking setup and how to persist the runtime library path across terminal sessions.

## how to test

1. On Ubuntu 22.04, attempt `cargo build --release` and reproduce the `ort-sys` linking failure.
2. Download ONNX Runtime v1.19.2 and set `ORT_LIB_LOCATION`, `ORT_PREFER_DYNAMIC_LINK=1`, and `LD_LIBRARY_PATH` as documented.
3. Run `cargo build --release` again and verify that the ONNX Runtime linking issue is resolved.

## desktop app checklist (if applicable)

not applicable. this PR only changes documentation and does not modify Tauri commands or frontend-exported Rust types.
