### PR TITLE
fix(capture): recover app attribution when an app-switch trigger has no name

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -32,15 +32,15 @@ results and `cargo llvm-cov` data on top when judging release confidence.
 
 - Mapped suites: 32
 - Mapped Rust files: 321
-- Active test blocks: 3087
+- Active test blocks: 3096
 - Ignored/manual test blocks: 137
-- Weighted coverage points: 2542.3
+- Weighted coverage points: 2548.6
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 2956 | 132 | 2482.3 | 21 | 11 | 100% |
-| macos | 29 | 3009 | 112 | 2492.7 | 22 | 11 | 100% |
-| linux | 25 | 2632 | 105 | 2189.1 | 20 | 11 | 100% |
+| windows | 29 | 2965 | 132 | 2488.6 | 21 | 11 | 100% |
+| macos | 29 | 3018 | 112 | 2499.0 | 22 | 11 | 100% |
+| linux | 25 | 2641 | 105 | 2195.4 | 20 | 11 | 100% |
 
 ## Refresh
 

--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -32,15 +32,15 @@ results and `cargo llvm-cov` data on top when judging release confidence.
 
 - Mapped suites: 32
 - Mapped Rust files: 321
-- Active test blocks: 3082
+- Active test blocks: 3087
 - Ignored/manual test blocks: 137
-- Weighted coverage points: 2538.8
+- Weighted coverage points: 2542.3
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 2951 | 132 | 2478.8 | 21 | 11 | 100% |
-| macos | 29 | 3004 | 112 | 2489.2 | 22 | 11 | 100% |
-| linux | 25 | 2627 | 105 | 2185.6 | 20 | 11 | 100% |
+| windows | 29 | 2956 | 132 | 2482.3 | 21 | 11 | 100% |
+| macos | 29 | 3009 | 112 | 2492.7 | 22 | 11 | 100% |
+| linux | 25 | 2632 | 105 | 2189.1 | 20 | 11 | 100% |
 
 ## Refresh
 

--- a/crates/screenpipe-db/tests/accessibility_late_materialization_test.rs
+++ b/crates/screenpipe-db/tests/accessibility_late_materialization_test.rs
@@ -87,7 +87,8 @@ async fn common_term_page_matches_legacy_query() {
             COALESCE(vc.file_path, '') AS file_path,
             COALESCE(f.offset_index, 0) AS offset_index,
             f.name AS frame_name,
-            f.browser_url
+            f.browser_url,
+            f.capture_trigger
         FROM frames f
         LEFT JOIN video_chunks vc ON f.video_chunk_id = vc.id
         JOIN frames_fts ON f.id = frames_fts.rowid

--- a/crates/screenpipe-engine/src/event_driven_capture.rs
+++ b/crates/screenpipe-engine/src/event_driven_capture.rs
@@ -1814,10 +1814,7 @@ pub(crate) async fn event_driven_capture_loop(
                 // Pre-capture DRM gate: check BEFORE any SCK call.
                 // Uses AX APIs only — prevents even a single leaked frame.
                 {
-                    let trigger_app = match &trigger {
-                        CaptureTrigger::AppSwitch { app_name, .. } => Some(app_name.as_str()),
-                        _ => None,
-                    };
+                    let trigger_app = drm_trigger_app_name(&trigger);
                     if crate::drm_detector::pre_capture_drm_check(pause_on_drm_content, trigger_app)
                     {
                         debug!(
@@ -2273,6 +2270,59 @@ pub(crate) fn should_query_lightweight_focus(trigger: &CaptureTrigger) -> bool {
         CaptureTrigger::AppSwitch { app_name, .. } => app_name.trim().is_empty(),
         _ => true,
     }
+}
+
+/// The app name handed to the pre-capture DRM gate, which runs before any
+/// screenshot call and exists to stop even one protected frame being grabbed.
+///
+/// `pre_capture_drm_check` treats `Some(name)` as authoritative: it takes a
+/// fast path that checks `is_drm_app` / `is_browser` and then returns "no DRM"
+/// without querying anything. Handing it the same `unwrap_or_default()` blank
+/// behind #6164 therefore matched neither test and reported no DRM, skipping
+/// the AX lookup that would have caught it — the gate silently did nothing.
+/// A nameless trigger has to look like the absence of a name so the check
+/// falls through and asks the platform.
+pub(crate) fn drm_trigger_app_name(trigger: &CaptureTrigger) -> Option<&str> {
+    match trigger {
+        CaptureTrigger::AppSwitch { app_name, .. } => {
+            Some(app_name.trim()).filter(|name| !name.is_empty())
+        }
+        _ => None,
+    }
+}
+
+/// The app name the pre-walk gates key on: the terminal OCR throttle, the
+/// per-app walk budget, and the app-only ignored-window safety net.
+///
+/// This has to make the same judgement as [`should_query_lightweight_focus`].
+/// Taking the trigger's name unconditionally meant an unnamed app switch keyed
+/// every gate on `""`: the walk budget pooled the cost of *every* unnamed
+/// switch — whatever app was really focused — into one bucket, so a single
+/// expensive Electron walk could promote `""` to a throttled tier and make the
+/// next capture of a light app get skipped outright. On Windows that bucket is
+/// hot, because transient shell windows produce unnamed switches on every
+/// click.
+///
+/// The lookup [`should_query_lightweight_focus`] just re-enabled has the real
+/// answer, so prefer the trigger's name only when it actually is one and fall
+/// back to the platform otherwise. Normalizing keeps the budget key equal to
+/// the name `record_walk` later reports from the tree walk.
+// Private to match `LightweightFocusedMetadata`'s own visibility — a
+// `pub(crate)` signature naming a private type trips `private_interfaces`.
+fn capture_gate_app_name(
+    trigger: &CaptureTrigger,
+    lightweight_metadata: Option<&LightweightFocusedMetadata>,
+) -> Option<String> {
+    match trigger {
+        CaptureTrigger::AppSwitch { app_name, .. } => {
+            normalize_metadata_value(Some(app_name.as_str()))
+        }
+        _ => None,
+    }
+    .or_else(|| {
+        lightweight_metadata
+            .and_then(|metadata| normalize_metadata_value(metadata.app_name.as_deref()))
+    })
 }
 
 fn resolve_capture_metadata(
@@ -2839,12 +2889,7 @@ async fn do_capture(
             None
         };
     let trigger_app = if monitor_hosts_focus {
-        match trigger {
-            CaptureTrigger::AppSwitch { app_name, .. } => Some(app_name.clone()),
-            _ => lightweight_focused_metadata
-                .as_ref()
-                .and_then(|metadata| metadata.app_name.clone()),
-        }
+        capture_gate_app_name(trigger, lightweight_focused_metadata.as_ref())
     } else {
         None
     };
@@ -3795,6 +3840,153 @@ mod tests {
 
         assert_eq!(app_name.as_deref(), Some("Explorer"));
         assert_eq!(window_name.as_deref(), Some("Downloads"));
+    }
+
+    /// A named app switch keys the pre-walk gates on its own name, and does
+    /// not need the lookup to have run.
+    #[test]
+    fn capture_gates_key_on_a_named_app_switch() {
+        assert_eq!(
+            capture_gate_app_name(
+                &CaptureTrigger::AppSwitch {
+                    app_name: "  Arc  ".into(),
+                    target: None,
+                },
+                None,
+            )
+            .as_deref(),
+            // Trimmed, so the walk budget's key matches the name `record_walk`
+            // reports back from the tree walk.
+            Some("Arc"),
+        );
+    }
+
+    /// The counterpart to `should_query_lightweight_focus`: an unnamed app
+    /// switch must key the walk budget and the ignored-window safety net on
+    /// the app the lookup found, never on `""`.
+    #[test]
+    fn capture_gates_key_on_the_lookup_when_the_app_switch_is_unnamed() {
+        let metadata = LightweightFocusedMetadata {
+            app_name: Some("Explorer".into()),
+            window_name: None,
+        };
+        for blank in ["", " ", "\t", "\n  "] {
+            let trigger = CaptureTrigger::AppSwitch {
+                app_name: blank.into(),
+                target: None,
+            };
+            assert_eq!(
+                capture_gate_app_name(&trigger, Some(&metadata)).as_deref(),
+                Some("Explorer"),
+                "AppSwitch {blank:?} must not key the walk budget on the empty \
+                 string — that pools every unnamed switch into one cost bucket",
+            );
+        }
+    }
+
+    /// Whenever a gate has no app name to key on, the lookup must have been
+    /// the missing source rather than a name we threw away.
+    #[test]
+    fn capture_gates_only_lack_an_app_when_the_lookup_also_came_back_empty() {
+        for name in ["Arc", "", "   "] {
+            let trigger = CaptureTrigger::AppSwitch {
+                app_name: name.into(),
+                target: None,
+            };
+            assert_eq!(
+                capture_gate_app_name(&trigger, None).is_none(),
+                should_query_lightweight_focus(&trigger),
+                "AppSwitch {name:?}: a gate key is missing only when the trigger \
+                 carried no name and the platform lookup returned nothing",
+            );
+        }
+    }
+
+    /// A named app switch still takes the DRM check's fast path.
+    #[test]
+    fn the_drm_gate_uses_a_named_app_switch_directly() {
+        assert_eq!(
+            drm_trigger_app_name(&CaptureTrigger::AppSwitch {
+                app_name: "  Netflix  ".into(),
+                target: None,
+            }),
+            Some("Netflix"),
+        );
+    }
+
+    /// A nameless app switch must not look like a name to the DRM gate.
+    /// `Some("")` matches neither `is_drm_app` nor `is_browser`, so the fast
+    /// path returns "no DRM" without querying — the pre-screenshot gate is
+    /// then a no-op and a protected frame can be captured.
+    #[test]
+    fn the_drm_gate_falls_through_when_the_app_switch_is_unnamed() {
+        for blank in ["", " ", "\t", "\n  "] {
+            assert_eq!(
+                drm_trigger_app_name(&CaptureTrigger::AppSwitch {
+                    app_name: blank.into(),
+                    target: None,
+                }),
+                None,
+                "AppSwitch {blank:?} must fall through to the platform query \
+                 rather than silently reporting no DRM",
+            );
+        }
+    }
+
+    /// Every other trigger already fell through; that must not regress.
+    #[test]
+    fn the_drm_gate_falls_through_for_every_other_trigger() {
+        for trigger in [
+            CaptureTrigger::WindowFocus {
+                window_name: "Netflix".into(),
+                target: None,
+            },
+            CaptureTrigger::Click { x: 1, y: 2 },
+            CaptureTrigger::TypingPause,
+            CaptureTrigger::ScrollStop,
+            CaptureTrigger::KeyPress,
+            CaptureTrigger::Clipboard,
+            CaptureTrigger::VisualChange,
+            CaptureTrigger::Idle,
+            CaptureTrigger::Manual,
+        ] {
+            assert_eq!(
+                drm_trigger_app_name(&trigger),
+                None,
+                "{} must keep querying the focused app for DRM",
+                trigger.as_str(),
+            );
+        }
+    }
+
+    /// Every other trigger keeps keying the gates on the lookup, unchanged.
+    #[test]
+    fn capture_gates_still_key_other_triggers_on_the_lookup() {
+        let metadata = LightweightFocusedMetadata {
+            app_name: Some("wezterm".into()),
+            window_name: None,
+        };
+        for trigger in [
+            CaptureTrigger::WindowFocus {
+                window_name: "Inbox".into(),
+                target: None,
+            },
+            CaptureTrigger::Click { x: 1, y: 2 },
+            CaptureTrigger::TypingPause,
+            CaptureTrigger::ScrollStop,
+            CaptureTrigger::KeyPress,
+            CaptureTrigger::Clipboard,
+            CaptureTrigger::VisualChange,
+            CaptureTrigger::Idle,
+            CaptureTrigger::Manual,
+        ] {
+            assert_eq!(
+                capture_gate_app_name(&trigger, Some(&metadata)).as_deref(),
+                Some("wezterm"),
+                "{} must keep keying the gates on the lookup",
+                trigger.as_str(),
+            );
+        }
     }
 
     #[test]

--- a/crates/screenpipe-engine/src/event_driven_capture.rs
+++ b/crates/screenpipe-engine/src/event_driven_capture.rs
@@ -2254,6 +2254,27 @@ fn normalize_metadata_value(value: Option<&str>) -> Option<String> {
         .map(str::to_string)
 }
 
+/// Whether this capture still needs the platform's lightweight focused-app
+/// query, or whether the trigger already carries the answer.
+///
+/// An app-switch trigger normally names the app it switched to, which is why
+/// the extra blocking lookup was skipped for it. But
+/// `capture_trigger_kind_with_ignored` builds the trigger with
+/// `unwrap_or_default()`, so a UI event that arrived without an app name
+/// yields `AppSwitch { app_name: "" }`. `resolve_capture_metadata` then
+/// correctly refuses to write that empty string — and with the lookup skipped
+/// too, the frame lands with no attribution at all: OCR text, no app, no
+/// window (#6164). `/activity-summary` drops those rows outright, so the time
+/// does not merely go unattributed, it disappears.
+///
+/// Only an app switch that actually names an app is authoritative.
+pub(crate) fn should_query_lightweight_focus(trigger: &CaptureTrigger) -> bool {
+    match trigger {
+        CaptureTrigger::AppSwitch { app_name, .. } => app_name.trim().is_empty(),
+        _ => true,
+    }
+}
+
 fn resolve_capture_metadata(
     tree_snapshot: Option<&screenpipe_a11y::tree::TreeSnapshot>,
     trigger: &CaptureTrigger,
@@ -2313,30 +2334,40 @@ fn resolve_capture_metadata_with_policy(
         }
     }
 
+    // Trigger names go through the same normalization as every other source:
+    // a whitespace-only name is as useless as a blank one, and
+    // `/activity-summary` only filters on `!= ''`, so "   " would otherwise
+    // land in the database as a phantom app. It must also agree with
+    // `should_query_lightweight_focus` — a name discarded here has to have
+    // been replaced by the platform lookup, or the frame ends up unattributed.
     match trigger {
         CaptureTrigger::AppSwitch {
             app_name: trigger_app_name,
             ..
-        } if !trigger_app_name.is_empty() => {
-            if app_name.as_deref() != Some(trigger_app_name.as_str()) {
-                debug!(
-                    "focused app mismatch on app_switch: trigger='{}', tree={:?}; using trigger value",
-                    trigger_app_name, app_name
-                );
+        } => {
+            if let Some(name) = normalize_metadata_value(Some(trigger_app_name.as_str())) {
+                if app_name.as_deref() != Some(name.as_str()) {
+                    debug!(
+                        "focused app mismatch on app_switch: trigger='{}', tree={:?}; using trigger value",
+                        trigger_app_name, app_name
+                    );
+                }
+                app_name = Some(name);
             }
-            app_name = Some(trigger_app_name.clone());
         }
         CaptureTrigger::WindowFocus {
             window_name: trigger_window_name,
             ..
-        } if !trigger_window_name.is_empty() => {
-            if window_name.as_deref() != Some(trigger_window_name.as_str()) {
-                debug!(
-                    "focused window mismatch on window_focus: trigger='{}', tree={:?}; using trigger value",
-                    trigger_window_name, window_name
-                );
+        } => {
+            if let Some(name) = normalize_metadata_value(Some(trigger_window_name.as_str())) {
+                if window_name.as_deref() != Some(name.as_str()) {
+                    debug!(
+                        "focused window mismatch on window_focus: trigger='{}', tree={:?}; using trigger value",
+                        trigger_window_name, window_name
+                    );
+                }
+                window_name = Some(name);
             }
-            window_name = Some(trigger_window_name.clone());
         }
         _ => {}
     }
@@ -2762,10 +2793,9 @@ async fn do_capture(
     // the name directly; for all other triggers (visual change, idle, manual)
     // we do a lightweight platform query. This ensures the walk budget applies
     // to ALL captures, not just app switches.
-    let lightweight_focused_metadata = if monitor_hosts_focus {
-        match trigger {
-            CaptureTrigger::AppSwitch { .. } => None,
-            _ => match tokio::time::timeout(
+    let lightweight_focused_metadata =
+        if monitor_hosts_focus && should_query_lightweight_focus(trigger) {
+            match tokio::time::timeout(
                 Duration::from_secs(1),
                 tokio::task::spawn_blocking(get_focused_metadata_lightweight),
             )
@@ -2780,11 +2810,10 @@ async fn do_capture(
                     debug!("focused metadata lookup timed out");
                     None
                 }
-            },
-        }
-    } else {
-        None
-    };
+            }
+        } else {
+            None
+        };
     let trigger_app = if monitor_hosts_focus {
         match trigger {
             CaptureTrigger::AppSwitch { app_name, .. } => Some(app_name.clone()),
@@ -3636,6 +3665,109 @@ mod tests {
         assert_eq!(CaptureTrigger::VisualChange.as_str(), "visual_change");
         assert_eq!(CaptureTrigger::Idle.as_str(), "idle");
         assert_eq!(CaptureTrigger::Manual.as_str(), "manual");
+    }
+
+    /// #6164: an app-switch trigger is only authoritative when it names an
+    /// app. `capture_trigger_kind_with_ignored` fills the name with
+    /// `unwrap_or_default()`, so a UI event without one produces
+    /// `AppSwitch { app_name: "" }` — and skipping the lightweight lookup for
+    /// it left the frame with no attribution at all.
+    #[test]
+    fn a_named_app_switch_skips_the_lightweight_focus_query() {
+        assert!(!should_query_lightweight_focus(
+            &CaptureTrigger::AppSwitch {
+                app_name: "Arc".into(),
+                target: None,
+            }
+        ));
+    }
+
+    #[test]
+    fn an_unnamed_app_switch_still_asks_the_platform_who_is_focused() {
+        for blank in ["", " ", "\t", "\n  "] {
+            assert!(
+                should_query_lightweight_focus(&CaptureTrigger::AppSwitch {
+                    app_name: blank.into(),
+                    target: Some((10, 20)),
+                }),
+                "AppSwitch with {blank:?} carries no usable name — it must not \
+                 suppress the only remaining metadata source",
+            );
+        }
+    }
+
+    /// Every other trigger already queried; that must not regress.
+    #[test]
+    fn every_other_trigger_queries_the_lightweight_focus() {
+        for trigger in [
+            CaptureTrigger::WindowFocus {
+                window_name: "Inbox".into(),
+                target: None,
+            },
+            CaptureTrigger::WindowFocus {
+                window_name: String::new(),
+                target: None,
+            },
+            CaptureTrigger::Click { x: 1, y: 2 },
+            CaptureTrigger::TypingPause,
+            CaptureTrigger::ScrollStop,
+            CaptureTrigger::KeyPress,
+            CaptureTrigger::Clipboard,
+            CaptureTrigger::VisualChange,
+            CaptureTrigger::Idle,
+            CaptureTrigger::Manual,
+        ] {
+            assert!(
+                should_query_lightweight_focus(&trigger),
+                "{} must keep querying focused metadata",
+                trigger.as_str(),
+            );
+        }
+    }
+
+    /// The two halves have to agree: whenever the resolver would discard the
+    /// trigger's app name, the capture must have asked the platform instead.
+    /// Otherwise the frame is written with a NULL app_name and
+    /// `/activity-summary` drops it.
+    #[test]
+    fn a_trigger_name_is_either_used_or_replaced_by_a_lookup() {
+        for name in ["Arc", "", "   "] {
+            let trigger = CaptureTrigger::AppSwitch {
+                app_name: name.into(),
+                target: None,
+            };
+            // What the resolver produces with no tree and no lightweight data.
+            let (resolved, _, _, _) = resolve_capture_metadata(None, &trigger, None);
+            let trigger_name_was_used = resolved.is_some();
+            assert_eq!(
+                trigger_name_was_used,
+                !should_query_lightweight_focus(&trigger),
+                "AppSwitch {name:?}: trigger name used = {trigger_name_was_used}, \
+                 but lookup skipped = {}",
+                !should_query_lightweight_focus(&trigger),
+            );
+        }
+    }
+
+    /// End to end through the resolver: a blank app-switch plus the lookup
+    /// this change re-enables produces an attributed frame.
+    #[test]
+    fn an_unnamed_app_switch_recovers_attribution_from_the_lookup() {
+        let trigger = CaptureTrigger::AppSwitch {
+            app_name: String::new(),
+            target: None,
+        };
+        assert!(should_query_lightweight_focus(&trigger));
+
+        let metadata = LightweightFocusedMetadata {
+            app_name: Some("Explorer".into()),
+            window_name: Some("Downloads".into()),
+        };
+        let (app_name, window_name, _, _) =
+            resolve_capture_metadata(None, &trigger, Some(&metadata));
+
+        assert_eq!(app_name.as_deref(), Some("Explorer"));
+        assert_eq!(window_name.as_deref(), Some("Downloads"));
     }
 
     #[test]

--- a/docs/coverage/CORE.md
+++ b/docs/coverage/CORE.md
@@ -9,10 +9,10 @@ confidence, and criticality.
 - Tracked crates: screenpipe-engine, screenpipe-db, screenpipe-sqlite-coordinator, screenpipe-audio, screenpipe-screen, screenpipe-a11y
 - Mapped suites: 32
 - Mapped Rust files: 321
-- Active test blocks: 3087
+- Active test blocks: 3096
 - Ignored/manual test blocks: 137
-- Declared test blocks: 3224
-- Weighted coverage points: 2542.3
+- Declared test blocks: 3233
+- Weighted coverage points: 2548.6
 
 Confidence weights: strong=1.0, partial=0.7, conditional=0.4, smoke=0.3.
 Criticality weights: high=1.0, medium=0.7, low=0.4.
@@ -23,15 +23,15 @@ are explicitly enabled in a runtime lane.
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 2956 | 132 | 2482.3 | 21 | 11 | 100% |
-| macos | 29 | 3009 | 112 | 2492.7 | 22 | 11 | 100% |
-| linux | 25 | 2632 | 105 | 2189.1 | 20 | 11 | 100% |
+| windows | 29 | 2965 | 132 | 2488.6 | 21 | 11 | 100% |
+| macos | 29 | 3018 | 112 | 2499.0 | 22 | 11 | 100% |
+| linux | 25 | 2641 | 105 | 2195.4 | 20 | 11 | 100% |
 
 ## Crate Summary
 
 | Crate | Suites | Integration files | Source unit files | Active tests | Ignored tests | Weighted points | Flows |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| screenpipe-engine | 10 | 18 | 102 | 1458 | 42 | 1119.5 | 10 |
+| screenpipe-engine | 10 | 18 | 102 | 1467 | 42 | 1125.8 | 10 |
 | screenpipe-db | 5 | 52 | 14 | 447 | 16 | 424.2 | 9 |
 | screenpipe-sqlite-coordinator | 1 | 0 | 2 | 16 | 0 | 16.0 | 2 |
 | screenpipe-audio | 6 | 25 | 51 | 591 | 43 | 517.4 | 5 |
@@ -72,17 +72,17 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | meeting | 6 suites / 1418 active / 19 ignored / 1160.9 pts | 6 suites / 1418 active / 19 ignored / 1160.9 pts | 4 suites / 1130 active / 15 ignored / 895.4 pts |
 | ocr | 4 suites / 124 active / 7 ignored / 118.3 pts | 4 suites / 128 active / 7 ignored / 123.8 pts | 3 suites / 119 active / 6 ignored / 114.8 pts |
 | os-integration | 1 suites / 6 active / 0 ignored / 1.7 pts | 1 suites / 6 active / 0 ignored / 1.7 pts | - |
-| performance | 13 suites / 1378 active / 67 ignored / 1214.7 pts | 14 suites / 1476 active / 70 ignored / 1253.9 pts | 13 suites / 1378 active / 67 ignored / 1214.7 pts |
+| performance | 13 suites / 1387 active / 67 ignored / 1221.0 pts | 14 suites / 1485 active / 70 ignored / 1260.2 pts | 13 suites / 1387 active / 67 ignored / 1221.0 pts |
 | pipes | 1 suites / 462 active / 3 ignored / 323.4 pts | 1 suites / 462 active / 3 ignored / 323.4 pts | 1 suites / 462 active / 3 ignored / 323.4 pts |
 | privacy | 5 suites / 871 active / 36 ignored / 707.5 pts | 5 suites / 920 active / 16 ignored / 712.4 pts | 5 suites / 846 active / 14 ignored / 685.0 pts |
 | real-app | - | 1 suites / 98 active / 3 ignored / 39.2 pts | - |
 | speaker | 2 suites / 348 active / 8 ignored / 348.0 pts | 2 suites / 348 active / 8 ignored / 348.0 pts | 2 suites / 348 active / 8 ignored / 348.0 pts |
-| storage | 3 suites / 478 active / 29 ignored / 387.1 pts | 3 suites / 478 active / 29 ignored / 387.1 pts | 3 suites / 478 active / 29 ignored / 387.1 pts |
+| storage | 3 suites / 487 active / 29 ignored / 393.4 pts | 3 suites / 487 active / 29 ignored / 393.4 pts | 3 suites / 487 active / 29 ignored / 393.4 pts |
 | sync | 1 suites / 462 active / 3 ignored / 323.4 pts | 1 suites / 462 active / 3 ignored / 323.4 pts | 1 suites / 462 active / 3 ignored / 323.4 pts |
-| timeline | 4 suites / 937 active / 33 ignored / 761.5 pts | 4 suites / 937 active / 33 ignored / 761.5 pts | 4 suites / 937 active / 33 ignored / 761.5 pts |
+| timeline | 4 suites / 946 active / 33 ignored / 767.8 pts | 4 suites / 946 active / 33 ignored / 767.8 pts | 4 suites / 946 active / 33 ignored / 767.8 pts |
 | transcription | 5 suites / 699 active / 40 ignored / 551.9 pts | 5 suites / 699 active / 40 ignored / 551.9 pts | 5 suites / 699 active / 40 ignored / 551.9 pts |
 | ui-events | 4 suites / 701 active / 28 ignored / 533.9 pts | 3 suites / 652 active / 5 ignored / 499.6 pts | 3 suites / 652 active / 5 ignored / 499.6 pts |
-| vision-capture | 5 suites / 497 active / 32 ignored / 393.4 pts | 5 suites / 501 active / 32 ignored / 398.9 pts | 4 suites / 492 active / 31 ignored / 389.9 pts |
+| vision-capture | 5 suites / 506 active / 32 ignored / 399.7 pts | 5 suites / 510 active / 32 ignored / 405.2 pts | 4 suites / 501 active / 31 ignored / 396.2 pts |
 
 ## Critical Flow Matrix
 
@@ -134,7 +134,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | db-search-indexing | screenpipe-db | windows, macos, linux | db-search, ocr, accessibility, performance | local-api-search, capture-ocr-pipeline, accessibility-ui-events, performance-liveness | high | strong | mixed | 13 | 105 | 4 | FTS, tokenizer, OCR snapshot search, query planning, ordering, accessibility search, and contention coverage. |
 | db-timeline-frames | screenpipe-db | windows, macos, linux | database, timeline, storage, performance | timeline-streaming, performance-liveness | high | strong | mixed | 18 | 175 | 3 | Frame/audio joins, timeline query shape, suggestions frames, write queue, DB primitives (src/db.rs split into src/db/ modules), feedback record upserts, media eviction anti-join regressions, SAF output registry, semantic storage, and timeline performance. |
 | engine-api-routes | screenpipe-engine | windows, macos, linux | local-api, timeline, meeting, transcription | local-api-search, timeline-streaming, meeting-live-notes, audio-record-transcribe | high | partial | mixed | 31 | 320 | 4 | Route/unit coverage for search, health, streaming, meetings, time/timezone, and transcription. Legacy endpoint/websocket tests require local data and remain ignored. |
-| engine-capture-timeline | screenpipe-engine | windows, macos, linux | vision-capture, timeline, storage, performance | capture-ocr-pipeline, timeline-streaming, performance-liveness | high | partial | mixed | 23 | 265 | 26 | Covers capture trigger logic, frame/audio linking, hot cache, timeline refresh regressions, fragmented MP4 extraction, and HD-mode control. Several real-data tests are intentionally ignored by default. |
+| engine-capture-timeline | screenpipe-engine | windows, macos, linux | vision-capture, timeline, storage, performance | capture-ocr-pipeline, timeline-streaming, performance-liveness | high | partial | mixed | 23 | 274 | 26 | Covers capture trigger logic, frame/audio linking, hot cache, timeline refresh regressions, fragmented MP4 extraction, and HD-mode control. Several real-data tests are intentionally ignored by default. |
 | engine-config-lifecycle | screenpipe-engine | windows, macos, linux | configuration, engine-lifecycle, performance | settings-to-engine-config, engine-health-lifecycle, performance-liveness | high | strong | mixed | 11 | 111 | 1 | Fast logic coverage for the config bridge, tray health debounce, sleep/power policies, and queue backpressure. |
 | engine-db-recovery-cli | screenpipe-engine | windows, macos, linux | database, engine-lifecycle | engine-health-lifecycle, performance-liveness | high | strong | unit | 1 | 8 | 0 | Exact DB/WAL/SHM working-copy preservation, rollback on archive failure, and restart repair for crashes during the multi-file generation swap. |
 | engine-focus-os | screenpipe-engine | windows, macos | engine-lifecycle, os-integration | engine-health-lifecycle, performance-liveness | medium | conditional | unit | 3 | 6 | 0 | Platform focus-tracker parsing/helpers. These files are cfg-gated and only execute on their target OS. |
@@ -353,7 +353,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | engine-telemetry-observability | screenpipe-engine | src/crash_log.rs | source | 4 | 0 | 4 |
 | engine-retention-storage | screenpipe-engine | src/disk_pressure.rs | source | 11 | 0 | 11 |
 | engine-meeting-privacy-sync | screenpipe-engine | src/drm_detector.rs | source | 19 | 2 | 21 |
-| engine-capture-timeline | screenpipe-engine | src/event_driven_capture.rs | source | 85 | 0 | 85 |
+| engine-capture-timeline | screenpipe-engine | src/event_driven_capture.rs | source | 94 | 0 | 94 |
 | engine-meeting-privacy-sync | screenpipe-engine | src/external_memory_sync.rs | source | 10 | 0 | 10 |
 | engine-capture-timeline | screenpipe-engine | src/focus_aware_controller.rs | source | 14 | 0 | 14 |
 | engine-focus-os | screenpipe-engine | src/focus_tracker/darwin.rs | source | 3 | 0 | 3 |

--- a/docs/coverage/CORE.md
+++ b/docs/coverage/CORE.md
@@ -9,10 +9,10 @@ confidence, and criticality.
 - Tracked crates: screenpipe-engine, screenpipe-db, screenpipe-sqlite-coordinator, screenpipe-audio, screenpipe-screen, screenpipe-a11y
 - Mapped suites: 32
 - Mapped Rust files: 321
-- Active test blocks: 3082
+- Active test blocks: 3087
 - Ignored/manual test blocks: 137
-- Declared test blocks: 3219
-- Weighted coverage points: 2538.8
+- Declared test blocks: 3224
+- Weighted coverage points: 2542.3
 
 Confidence weights: strong=1.0, partial=0.7, conditional=0.4, smoke=0.3.
 Criticality weights: high=1.0, medium=0.7, low=0.4.
@@ -23,15 +23,15 @@ are explicitly enabled in a runtime lane.
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 2951 | 132 | 2478.8 | 21 | 11 | 100% |
-| macos | 29 | 3004 | 112 | 2489.2 | 22 | 11 | 100% |
-| linux | 25 | 2627 | 105 | 2185.6 | 20 | 11 | 100% |
+| windows | 29 | 2956 | 132 | 2482.3 | 21 | 11 | 100% |
+| macos | 29 | 3009 | 112 | 2492.7 | 22 | 11 | 100% |
+| linux | 25 | 2632 | 105 | 2189.1 | 20 | 11 | 100% |
 
 ## Crate Summary
 
 | Crate | Suites | Integration files | Source unit files | Active tests | Ignored tests | Weighted points | Flows |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| screenpipe-engine | 10 | 18 | 102 | 1453 | 42 | 1116.0 | 10 |
+| screenpipe-engine | 10 | 18 | 102 | 1458 | 42 | 1119.5 | 10 |
 | screenpipe-db | 5 | 52 | 14 | 447 | 16 | 424.2 | 9 |
 | screenpipe-sqlite-coordinator | 1 | 0 | 2 | 16 | 0 | 16.0 | 2 |
 | screenpipe-audio | 6 | 25 | 51 | 591 | 43 | 517.4 | 5 |
@@ -72,17 +72,17 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | meeting | 6 suites / 1418 active / 19 ignored / 1160.9 pts | 6 suites / 1418 active / 19 ignored / 1160.9 pts | 4 suites / 1130 active / 15 ignored / 895.4 pts |
 | ocr | 4 suites / 124 active / 7 ignored / 118.3 pts | 4 suites / 128 active / 7 ignored / 123.8 pts | 3 suites / 119 active / 6 ignored / 114.8 pts |
 | os-integration | 1 suites / 6 active / 0 ignored / 1.7 pts | 1 suites / 6 active / 0 ignored / 1.7 pts | - |
-| performance | 13 suites / 1373 active / 67 ignored / 1211.2 pts | 14 suites / 1471 active / 70 ignored / 1250.4 pts | 13 suites / 1373 active / 67 ignored / 1211.2 pts |
+| performance | 13 suites / 1378 active / 67 ignored / 1214.7 pts | 14 suites / 1476 active / 70 ignored / 1253.9 pts | 13 suites / 1378 active / 67 ignored / 1214.7 pts |
 | pipes | 1 suites / 462 active / 3 ignored / 323.4 pts | 1 suites / 462 active / 3 ignored / 323.4 pts | 1 suites / 462 active / 3 ignored / 323.4 pts |
 | privacy | 5 suites / 871 active / 36 ignored / 707.5 pts | 5 suites / 920 active / 16 ignored / 712.4 pts | 5 suites / 846 active / 14 ignored / 685.0 pts |
 | real-app | - | 1 suites / 98 active / 3 ignored / 39.2 pts | - |
 | speaker | 2 suites / 348 active / 8 ignored / 348.0 pts | 2 suites / 348 active / 8 ignored / 348.0 pts | 2 suites / 348 active / 8 ignored / 348.0 pts |
-| storage | 3 suites / 473 active / 29 ignored / 383.6 pts | 3 suites / 473 active / 29 ignored / 383.6 pts | 3 suites / 473 active / 29 ignored / 383.6 pts |
+| storage | 3 suites / 478 active / 29 ignored / 387.1 pts | 3 suites / 478 active / 29 ignored / 387.1 pts | 3 suites / 478 active / 29 ignored / 387.1 pts |
 | sync | 1 suites / 462 active / 3 ignored / 323.4 pts | 1 suites / 462 active / 3 ignored / 323.4 pts | 1 suites / 462 active / 3 ignored / 323.4 pts |
-| timeline | 4 suites / 932 active / 33 ignored / 758.0 pts | 4 suites / 932 active / 33 ignored / 758.0 pts | 4 suites / 932 active / 33 ignored / 758.0 pts |
+| timeline | 4 suites / 937 active / 33 ignored / 761.5 pts | 4 suites / 937 active / 33 ignored / 761.5 pts | 4 suites / 937 active / 33 ignored / 761.5 pts |
 | transcription | 5 suites / 699 active / 40 ignored / 551.9 pts | 5 suites / 699 active / 40 ignored / 551.9 pts | 5 suites / 699 active / 40 ignored / 551.9 pts |
 | ui-events | 4 suites / 701 active / 28 ignored / 533.9 pts | 3 suites / 652 active / 5 ignored / 499.6 pts | 3 suites / 652 active / 5 ignored / 499.6 pts |
-| vision-capture | 5 suites / 492 active / 32 ignored / 389.9 pts | 5 suites / 496 active / 32 ignored / 395.4 pts | 4 suites / 487 active / 31 ignored / 386.4 pts |
+| vision-capture | 5 suites / 497 active / 32 ignored / 393.4 pts | 5 suites / 501 active / 32 ignored / 398.9 pts | 4 suites / 492 active / 31 ignored / 389.9 pts |
 
 ## Critical Flow Matrix
 
@@ -134,7 +134,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | db-search-indexing | screenpipe-db | windows, macos, linux | db-search, ocr, accessibility, performance | local-api-search, capture-ocr-pipeline, accessibility-ui-events, performance-liveness | high | strong | mixed | 13 | 105 | 4 | FTS, tokenizer, OCR snapshot search, query planning, ordering, accessibility search, and contention coverage. |
 | db-timeline-frames | screenpipe-db | windows, macos, linux | database, timeline, storage, performance | timeline-streaming, performance-liveness | high | strong | mixed | 18 | 175 | 3 | Frame/audio joins, timeline query shape, suggestions frames, write queue, DB primitives (src/db.rs split into src/db/ modules), feedback record upserts, media eviction anti-join regressions, SAF output registry, semantic storage, and timeline performance. |
 | engine-api-routes | screenpipe-engine | windows, macos, linux | local-api, timeline, meeting, transcription | local-api-search, timeline-streaming, meeting-live-notes, audio-record-transcribe | high | partial | mixed | 31 | 320 | 4 | Route/unit coverage for search, health, streaming, meetings, time/timezone, and transcription. Legacy endpoint/websocket tests require local data and remain ignored. |
-| engine-capture-timeline | screenpipe-engine | windows, macos, linux | vision-capture, timeline, storage, performance | capture-ocr-pipeline, timeline-streaming, performance-liveness | high | partial | mixed | 23 | 260 | 26 | Covers capture trigger logic, frame/audio linking, hot cache, timeline refresh regressions, fragmented MP4 extraction, and HD-mode control. Several real-data tests are intentionally ignored by default. |
+| engine-capture-timeline | screenpipe-engine | windows, macos, linux | vision-capture, timeline, storage, performance | capture-ocr-pipeline, timeline-streaming, performance-liveness | high | partial | mixed | 23 | 265 | 26 | Covers capture trigger logic, frame/audio linking, hot cache, timeline refresh regressions, fragmented MP4 extraction, and HD-mode control. Several real-data tests are intentionally ignored by default. |
 | engine-config-lifecycle | screenpipe-engine | windows, macos, linux | configuration, engine-lifecycle, performance | settings-to-engine-config, engine-health-lifecycle, performance-liveness | high | strong | mixed | 11 | 111 | 1 | Fast logic coverage for the config bridge, tray health debounce, sleep/power policies, and queue backpressure. |
 | engine-db-recovery-cli | screenpipe-engine | windows, macos, linux | database, engine-lifecycle | engine-health-lifecycle, performance-liveness | high | strong | unit | 1 | 8 | 0 | Exact DB/WAL/SHM working-copy preservation, rollback on archive failure, and restart repair for crashes during the multi-file generation swap. |
 | engine-focus-os | screenpipe-engine | windows, macos | engine-lifecycle, os-integration | engine-health-lifecycle, performance-liveness | medium | conditional | unit | 3 | 6 | 0 | Platform focus-tracker parsing/helpers. These files are cfg-gated and only execute on their target OS. |
@@ -353,7 +353,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | engine-telemetry-observability | screenpipe-engine | src/crash_log.rs | source | 4 | 0 | 4 |
 | engine-retention-storage | screenpipe-engine | src/disk_pressure.rs | source | 11 | 0 | 11 |
 | engine-meeting-privacy-sync | screenpipe-engine | src/drm_detector.rs | source | 19 | 2 | 21 |
-| engine-capture-timeline | screenpipe-engine | src/event_driven_capture.rs | source | 80 | 0 | 80 |
+| engine-capture-timeline | screenpipe-engine | src/event_driven_capture.rs | source | 85 | 0 | 85 |
 | engine-meeting-privacy-sync | screenpipe-engine | src/external_memory_sync.rs | source | 10 | 0 | 10 |
 | engine-capture-timeline | screenpipe-engine | src/focus_aware_controller.rs | source | 14 | 0 | 14 |
 | engine-focus-os | screenpipe-engine | src/focus_tracker/darwin.rs | source | 3 | 0 | 3 |


### PR DESCRIPTION
Refs #6164

## Problem

Frames land with OCR text but **no `app_name` and no `window_name`**. The reporter measured 219 blank-metadata frames against 13 attributed ones in a 10-minute window, with `/activity-summary` showing only the 13.

This is worse than "unattributed": `/activity-summary` filters `app_name IS NOT NULL AND app_name != ''` in five places, including the query behind `total_active_minutes`. Blank-metadata frames do not show up as unknown time — **the time disappears**, and `data_status` can report `empty_but_recording` on a database full of frames.

## Root cause

`capture_trigger_kind_with_ignored` (`ui_recorder.rs:1207`) builds the trigger with `unwrap_or_default()`:

```rust
Some(CaptureTrigger::AppSwitch {
    app_name: db_event.app_name.clone().unwrap_or_default(),  // → "" when the UI event had none
    target,
})
```

`resolve_capture_metadata` correctly refuses to write that empty string. But `do_capture` skipped the lightweight focused-app lookup for **every** app switch:

```rust
match trigger {
    CaptureTrigger::AppSwitch { .. } => None,   // trigger "already knows" the app
    _ => /* ask the platform */
}
```

The assumption holds only when the name is populated. When the UI event had no app name *and* the accessibility tree walk returns nothing, both sources are gone and the frame is written with `app_name = NULL` — even though `get_focused_metadata_lightweight()` (`GetForegroundWindow` on Windows) was sitting right there.

Windows hits this hardest: transient shell windows (`MSCTFIME UI`, `Shell_TrayWnd`) steal focus for 10-50ms on every mouse click and make the tree walk return `Skipped`/`NotFound`, and UIA needs COM where macOS AX does not.

**The issue's frame-linker hypothesis is not the cause.** `frame_linker` only ever runs `UPDATE ui_events SET frame_id = ...`; it never writes frame metadata, so its `stale entries expired without pairing` warning is a separate signal. A frame with blank `app_name` was blank at insert time.

## Fix

Skip the lookup only for an app switch that actually names an app:

```rust
pub(crate) fn should_query_lightweight_focus(trigger: &CaptureTrigger) -> bool {
    match trigger {
        CaptureTrigger::AppSwitch { app_name, .. } => app_name.trim().is_empty(),
        _ => true,
    }
}
```

Extracted as a predicate rather than left inline, so the decision is testable — `do_capture` is a 500-line async fn.

Second, smaller fix found by the tests: the resolver's guard was `!trigger_app_name.is_empty()`, so a **whitespace-only** trigger name was accepted verbatim. Since `/activity-summary` filters on `!= ''` and not on trimmed emptiness, `"   "` would have appeared as a real application. Trigger names now go through `normalize_metadata_value` like every other source.

## Scope

This closes one concrete, deterministic source of blank metadata. The other paths mapped while investigating are **not** addressed here and #6164 should stay open for them:

- `monitor_hosts_focus == false` hard-nulls app/window in `paired_capture.rs:245-254`; the focus tracker is fail-closed, so a wedged or unresolvable tracker blanks every frame. This is current tested-in behavior (`paired_capture.rs:1833`) and changing it is a separate decision.
- `insert_hd_index_frame` writes app/window-less frames by design.
- `/activity-summary` silently discarding blank rows rather than reporting unattributed time is a product decision, and an existing test (`null_and_empty_app_excluded`) pins today's behavior.

## Validation

- `screenpipe-engine` `event_driven_capture` — 85 passed, 5 new:
  - a named app switch still skips the lookup (no added latency on the common path)
  - an unnamed one queries, across `""`, `" "`, `"\t"`, `"\n  "`
  - every other trigger kind still queries (10 variants, no regression)
  - a consistency test asserting the two halves agree: whenever the resolver discards the trigger name, the lookup must have run
  - end-to-end through the resolver: blank trigger + lookup produces an attributed frame
- The consistency test **failed on first run** and found the whitespace-only hole described above — kept, and the resolver fixed
- Restored the original `AppSwitch { .. } => false` and re-ran: 3 of the 5 new tests fail, confirming they pin the reported behavior
- `cargo fmt --check` clean, and verified this adds no formatting drift (0 hunks on `origin/main`, 0 here)
- Coverage dashboards regenerated for the new tests

Not verified here: a Windows machine reproducing the original 219:13 ratio. The fix is covered at the decision boundary; measuring the blank-frame rate needs the reporter's environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up found while testing (added to this PR)

Two more gates read the same `unwrap_or_default()` blank. Both are the original
bug in a place the first commit did not visit.

### The walk budget pooled every unnamed switch into one bucket

`do_capture` took the trigger's app name unconditionally for its pre-walk
gates, so an unnamed app switch keyed the terminal-OCR throttle, the per-app
walk budget, and the app-only ignored-window safety net on `""`. `should_walk("")`
accumulated `last_walk` timestamps from every unnamed switch regardless of which
app was really focused, while `record_walk` recorded per real app — so a capture
could be throttled on an unrelated app's timing, and a throttled decision skips
the capture outright (`event_driven_capture.rs`, walk-budget branch). That is the
same "the time disappears" symptom this PR set out to fix.

`capture_gate_app_name` now makes the same judgement as
`should_query_lightweight_focus` and keys the gates on the app the lookup found.
Normalizing also collapses `"  Arc  "` and `"Arc"`, which `AppWalkBudget`'s raw
`HashMap` treated as separate buckets.

### The pre-capture DRM gate silently did nothing for an unnamed switch

`pre_capture_drm_check` treats `Some(name)` as authoritative: it checks
`is_drm_app` / `is_browser`, then returns "no DRM" without querying anything.
`Some("")` matched neither, so it returned `false` at `drm_detector.rs:371` and
never reached the `get_focused_app_info()` fallback — disabling the one gate that
runs *before* the screenshot, whose whole job is to stop even a single protected
frame. `drm_trigger_app_name` makes a nameless trigger look like the absence of a
name so the check falls through to the platform. macOS-only (the gate is
`cfg(target_os = "macos")`) and only when DRM pause is enabled.

## Privacy direction

Worth stating explicitly, since "fill in more metadata" sounds risky: every gate
here is a *match ⇒ skip* filter, so populating a previously-blank name can only
add matches. Traced end to end, this PR moves the unnamed-app-switch case from
**stored** to **skipped** — the app-only safety net and the
`resolved_window_matches_privacy_filters` gate were both dead against `""`
(`matches_any(patterns, "", "")` is `false` for every pattern shape). No path was
found where filling a name causes a previously-skipped capture to be stored.

## Merge

Merged with `main`, which had since landed #6226 (incognito metadata fallback)
and #6230 (frame event source / metadata coherence). #6230 touched the same
`AppSwitch` arm; resolved by keeping both intents — normalization from this
branch, plus #6230's dropping of stale window/URL/document context on a genuine
app mismatch. Since the comparison is now against the *normalized* name,
`"  Arc  "` vs tree `"Arc"` no longer counts as a mismatch, so identical apps
stop discarding their own window context.

## Validation of the additions

- `screenpipe-engine` `event_driven_capture`: **95 passed, 0 failed** (8 new tests here)
- `cargo clippy -p screenpipe-engine`: the only warning in the touched file is
  pre-existing (`should_run_visual_check`, 8 args); none from this change
- `cargo fmt -p screenpipe-engine --check`: clean
- Coverage dashboards regenerated; `coverage:all:check` passes
- The 3 failures in the full `--lib` run (`atomic_file`, two `cli::db`
  recovery tests) reproduce **identically on a clean `origin/main`** with
  `Access is denied (os error 5)` — a local Windows temp-dir issue, not a
  regression. Verified by stashing, checking out `origin/main`, and re-running.
- Windows E2E is red on this PR, but the same suite is red on `main` and the
  failures are settings-UI selectors unrelated to this Rust change.
