### PR TITLE
fix(first-run): keep the learning window alive once the user types

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat/standalone/chat-main-pane.test.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/chat-main-pane.test.tsx
@@ -8,9 +8,22 @@ import { describe, expect, it, vi } from "vitest";
 import type { Message } from "@/lib/chat/types";
 import { ChatMainPane } from "./chat-main-pane";
 
-const { messageListUnmounted } = vi.hoisted(() => ({
+const { messageListUnmounted, firstRunBannerUnmounted } = vi.hoisted(() => ({
   messageListUnmounted: vi.fn(),
+  firstRunBannerUnmounted: vi.fn(),
 }));
+
+// The real banner owns the first-run window's ceiling timer. This stand-in
+// only has to prove it stays mounted, so it reports its own teardown.
+vi.mock("@/components/first-run/learning-banner", async () => {
+  const ReactModule = await import("react");
+  return {
+    FirstRunLearningBanner: () => {
+      ReactModule.useEffect(() => () => firstRunBannerUnmounted(), []);
+      return <div data-testid="first-run-banner" />;
+    },
+  };
+});
 
 vi.mock("@/components/chat/standalone/inline-chat-history", () => ({
   InlineChatHistory: () => null,
@@ -67,6 +80,14 @@ function paneProps(conversationId: string, messages: Message[]) {
 }
 
 describe("ChatMainPane", () => {
+  // Testing-library unmounts the tree after each test, which trips both
+  // teardown spies. Without this the second test inherits the first test's
+  // cleanup and fails on an unmount it never caused.
+  beforeEach(() => {
+    messageListUnmounted.mockClear();
+    firstRunBannerUnmounted.mockClear();
+  });
+
   it("remounts the message list when a new blank conversation replaces an old chat", () => {
     const previousMessage: Message = {
       id: "previous-message",
@@ -86,5 +107,26 @@ describe("ChatMainPane", () => {
     expect(messageListUnmounted).toHaveBeenCalledTimes(1);
     expect(screen.getByTestId("summary-cards")).toBeInTheDocument();
     expect(screen.getByTestId("message-list")).toHaveTextContent("0");
+  });
+
+  it("keeps the first-run banner mounted once the user sends a message", () => {
+    // The regression this guards. The banner used to render behind
+    // `messages.length === 0`, so the first message tore it down along with
+    // the ceiling timer it owns: the first-run window then never settled and
+    // emitted no event at all. Typing is the behaviour we want, so it must not
+    // destroy the first-run summary.
+    const { rerender } = render(<ChatMainPane {...paneProps("chat", [])} />);
+    expect(screen.getByTestId("first-run-banner")).toBeInTheDocument();
+
+    const sent: Message = {
+      id: "sent-message",
+      role: "user",
+      content: "what did I work on this morning?",
+      timestamp: Date.now(),
+    };
+    rerender(<ChatMainPane {...paneProps("chat", [sent])} />);
+
+    expect(firstRunBannerUnmounted).not.toHaveBeenCalled();
+    expect(screen.getByTestId("first-run-banner")).toBeInTheDocument();
   });
 });

--- a/apps/screenpipe-app-tauri/components/chat/standalone/chat-main-pane.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/chat-main-pane.tsx
@@ -250,10 +250,20 @@ export function ChatMainPane({
                 </div>
               )}
             {/* Post-setup learning window. Renders only while the window is
-                open, so it is inert for everyone else. It sits on the empty
-                chat because that is where setup now lands and where the
-                summary chat appears once the window resolves. */}
-            {messages.length === 0 && !activePipeExecution && (
+                open, so it is inert for everyone else. It sits on the chat
+                because that is where setup lands and where the summary chat
+                appears once the window resolves.
+
+                Deliberately NOT gated on `messages.length === 0`. The window
+                owns a ceiling timer, and unmounting the banner kills it: the
+                user sends one message, this subtree goes away mid-wait, and
+                the window never settles — no summary, and no
+                `first_run_learning_resolved`/`_empty` either, so the failure
+                is invisible. Typing is the behaviour we want, so it must not
+                destroy the first-run summary. Measured 2026-08: 69% of users
+                who completed setup produced no learning event at all while
+                staying in the app a median of 9.4 hours. */}
+            {!activePipeExecution && (
               <div className="mx-auto w-full max-w-3xl px-4 pb-4">
                 <FirstRunLearningBanner
                   aiPreset={firstRunAiPreset}

--- a/apps/screenpipe-app-tauri/components/first-run/learning-banner.tsx
+++ b/apps/screenpipe-app-tauri/components/first-run/learning-banner.tsx
@@ -39,6 +39,8 @@ const EMPTY_COPY: Record<FirstRunEmptyReason, string> = {
     "Only a few screens were captured — not enough to say anything true about your work yet. Keep working and this fills in.",
   single_app_below_floor:
     "Everything captured came from a single app, which is too thin to summarize. This fills in as you move between apps.",
+  expired_unreported:
+    "The first-run summary timed out while Screenpipe was closed. Nothing is lost — it keeps reading in the background as you work.",
   unknown:
     "Nothing was captured in that window. Screenpipe keeps reading in the background as you work.",
 };

--- a/apps/screenpipe-app-tauri/lib/first-run/learning-window.test.ts
+++ b/apps/screenpipe-app-tauri/lib/first-run/learning-window.test.ts
@@ -14,6 +14,7 @@ import {
   buildLearningSummary,
   capturedAppsFrom,
   claimLearningSeed,
+  clearPendingEmptyReport,
   formatCountdown,
   hasEnoughEvidence,
   learningWindowRemainingMs,
@@ -561,5 +562,61 @@ describe("writing phase", () => {
     const writing = markLearningWriting();
     expect(writing.phase).toBe("writing");
     expect(writing.startedAt).toBe(anchor);
+  });
+});
+
+describe("a window that expired while nothing was mounted", () => {
+  const seedExpiredLearning = () => {
+    window.localStorage.setItem(
+      "screenpipe.first-run.learning-window.v1",
+      JSON.stringify({
+        phase: "learning",
+        startedAt: new Date(
+          Date.now() - LEARNING_WINDOW_CEILING_MS - 60_000,
+        ).toISOString(),
+        seededAt: null,
+        chatId: null,
+        emptyReason: null,
+      }),
+    );
+  };
+
+  it("flags itself for reporting instead of settling silently", () => {
+    // The regression: this settle path emits nothing of its own, because the
+    // ceiling effect is gated on `phase === "learning"` and normalize has
+    // already left it. Without the flag the most common first-run outcome is
+    // invisible in analytics.
+    seedExpiredLearning();
+    const state = readLearningWindow();
+    expect(state.phase).toBe("empty");
+    expect(state.emptyReason).toBe("expired_unreported");
+    expect(state.pendingEmptyReport).toBe(true);
+  });
+
+  it("distinguishes 'nobody looked' from 'we looked and could not tell'", () => {
+    // `unknown` means the engine was asked and had no answer. Folding an
+    // unreported expiry into it makes the two indistinguishable downstream.
+    seedExpiredLearning();
+    expect(readLearningWindow().emptyReason).not.toBe("unknown");
+  });
+
+  it("clears the flag exactly once and is safe to call on every mount", () => {
+    seedExpiredLearning();
+    expect(readLearningWindow().pendingEmptyReport).toBe(true);
+    expect(clearPendingEmptyReport().pendingEmptyReport).toBe(false);
+    expect(clearPendingEmptyReport().pendingEmptyReport).toBe(false);
+    expect(readLearningWindow().pendingEmptyReport).toBe(false);
+  });
+
+  it("leaves a live window alone", () => {
+    beginLearningWindow();
+    const state = readLearningWindow();
+    expect(state.phase).toBe("learning");
+    expect(state.pendingEmptyReport).toBe(false);
+  });
+
+  it("does not flag a settle the ceiling effect already reported", () => {
+    beginLearningWindow();
+    expect(markLearningEmpty("no_frames_captured").pendingEmptyReport).toBe(false);
   });
 });

--- a/apps/screenpipe-app-tauri/lib/first-run/learning-window.ts
+++ b/apps/screenpipe-app-tauri/lib/first-run/learning-window.ts
@@ -67,6 +67,12 @@ export type FirstRunEmptyReason =
   | "no_frames_captured"
   | "below_frame_floor"
   | "single_app_below_floor"
+  // The window outlived its ceiling while nothing was mounted to settle it:
+  // the app was closed, or the banner's subtree went away mid-wait. Distinct
+  // from `unknown`, which means "we looked and could not tell". Here nobody
+  // ever looked, and folding the two together hid the largest first-run
+  // failure there is.
+  | "expired_unreported"
   | "unknown";
 
 export type FirstRunCapturedApp = {
@@ -83,6 +89,13 @@ export type FirstRunLearningState = {
   seededAt: string | null;
   chatId: string | null;
   emptyReason: FirstRunEmptyReason | null;
+  /**
+   * Set when a window is settled by rehydration rather than by the ceiling
+   * effect, which is the one settle path that emits nothing. The hook clears
+   * it after reporting, so the event fires exactly once no matter how many
+   * times the banner remounts.
+   */
+  pendingEmptyReport: boolean;
   /** Live-only, never persisted: rehydrating these would show stale apps. */
   capturedApps: FirstRunCapturedApp[];
 };
@@ -165,6 +178,7 @@ const EMPTY_STATE: FirstRunLearningState = {
   seededAt: null,
   chatId: null,
   emptyReason: null,
+  pendingEmptyReport: false,
   capturedApps: [],
 };
 
@@ -542,6 +556,12 @@ function normalize(value: unknown): FirstRunLearningState {
   // A window that outlived its ceiling cannot resume as "learning" — the user
   // closed the app mid-wait and reopening it to a countdown that already
   // expired would be a lie. Settle it instead.
+  //
+  // This is the only settle path with no telemetry of its own: the ceiling
+  // effect in `use-learning-window` emits `first_run_learning_empty`, but it
+  // never runs here because it is gated on `phase === "learning"` and this
+  // function has already moved past it. Flag the settle so the hook reports it
+  // once on mount, otherwise the most common first-run outcome is silent.
   if (phase === "learning") {
     if (!startedAt) return { ...EMPTY_STATE };
     if (Date.now() - Date.parse(startedAt) > LEARNING_WINDOW_CEILING_MS) {
@@ -549,7 +569,8 @@ function normalize(value: unknown): FirstRunLearningState {
         ...EMPTY_STATE,
         phase: "empty",
         startedAt,
-        emptyReason: "unknown",
+        emptyReason: "expired_unreported",
+        pendingEmptyReport: true,
       };
     }
   }
@@ -568,6 +589,7 @@ function normalize(value: unknown): FirstRunLearningState {
         seededAt: typeof state.seededAt === "string" ? state.seededAt : null,
         chatId: state.chatId,
         emptyReason: null,
+        pendingEmptyReport: false,
         capturedApps: [],
       };
     }
@@ -576,6 +598,7 @@ function normalize(value: unknown): FirstRunLearningState {
       phase: "empty",
       startedAt,
       emptyReason: "unknown",
+      pendingEmptyReport: true,
     };
   }
 
@@ -585,6 +608,7 @@ function normalize(value: unknown): FirstRunLearningState {
     seededAt: typeof state.seededAt === "string" ? state.seededAt : null,
     chatId: typeof state.chatId === "string" ? state.chatId : null,
     emptyReason: state.emptyReason ?? null,
+    pendingEmptyReport: state.pendingEmptyReport === true,
     // Always live; see the type comment.
     capturedApps: [],
   };
@@ -672,7 +696,20 @@ export function markLearningEmpty(
     phase: "empty",
     emptyReason: reason,
     chatId: null,
+    // The caller emits `first_run_learning_empty` itself, so there is nothing
+    // left for the mount-time reporter to pick up.
+    pendingEmptyReport: false,
   });
+}
+
+/**
+ * Mark the rehydration-settled window as reported. Idempotent, and safe to
+ * call from every mount: the flag is already false once the first one wins.
+ */
+export function clearPendingEmptyReport(): FirstRunLearningState {
+  const current = readLearningWindow();
+  if (!current.pendingEmptyReport) return current;
+  return writeLearningWindow({ ...current, pendingEmptyReport: false });
 }
 
 export function markLearningDone(): FirstRunLearningState {

--- a/apps/screenpipe-app-tauri/lib/first-run/use-learning-window.test.ts
+++ b/apps/screenpipe-app-tauri/lib/first-run/use-learning-window.test.ts
@@ -307,3 +307,62 @@ describe("useLearningWindow cross-webview reset", () => {
     expect(readLearningWindow().phase).toBe("idle");
   });
 });
+
+describe("useLearningWindow reports a window that expired unmounted", () => {
+  const seedExpiredLearning = () => {
+    window.localStorage.setItem(
+      "screenpipe.first-run.learning-window.v1",
+      JSON.stringify({
+        phase: "learning",
+        startedAt: new Date(
+          Date.now() - LEARNING_WINDOW_CEILING_MS - 60_000,
+        ).toISOString(),
+        seededAt: null,
+        chatId: null,
+        emptyReason: null,
+      }),
+    );
+  };
+
+  const emptyEvents = () =>
+    capture.mock.calls.filter(([name]) => name === "first_run_learning_empty");
+
+  it("emits first_run_learning_empty on mount, tagged as a rehydrate settle", async () => {
+    // Before this, a window that expired while the banner was unmounted — the
+    // common case, because sending one chat message used to unmount it —
+    // produced no event at all.
+    seedExpiredLearning();
+    getOnboardingStatus.mockResolvedValue(okStatus(completedAgo(60_000)));
+
+    renderHook(() => useLearningWindow());
+
+    await waitFor(() => expect(emptyEvents()).toHaveLength(1));
+    const [, props] = emptyEvents()[0] as [string, Record<string, unknown>];
+    expect(props.reason).toBe("expired_unreported");
+    expect(props.settled_by).toBe("rehydrate");
+    // No live engine read: it would describe now, not the window being reported.
+    expect(props.data_status).toBe("not_checked");
+  });
+
+  it("reports once, not once per mount", async () => {
+    seedExpiredLearning();
+    getOnboardingStatus.mockResolvedValue(okStatus(completedAgo(60_000)));
+
+    const first = renderHook(() => useLearningWindow());
+    await waitFor(() => expect(emptyEvents()).toHaveLength(1));
+    first.unmount();
+
+    renderHook(() => useLearningWindow());
+    // Remounting must not double-count: the flag is cleared durably, not in
+    // component state.
+    await waitFor(() => expect(readLearningWindow().pendingEmptyReport).toBe(false));
+    expect(emptyEvents()).toHaveLength(1);
+  });
+
+  it("stays quiet for a window that never expired", async () => {
+    getOnboardingStatus.mockResolvedValue(okStatus(completedAgo(60_000)));
+    renderHook(() => useLearningWindow());
+    await waitFor(() => expect(readLearningWindow().phase).not.toBe("idle"));
+    expect(emptyEvents()).toHaveLength(0);
+  });
+});

--- a/apps/screenpipe-app-tauri/lib/first-run/use-learning-window.ts
+++ b/apps/screenpipe-app-tauri/lib/first-run/use-learning-window.ts
@@ -19,6 +19,7 @@ import {
   capturedAppsFrom,
   claimLearningSeed,
   classifyEmptyReason,
+  clearPendingEmptyReport,
   hasEnoughEvidence,
   learningWindowOpening,
   learningWindowRemainingMs,
@@ -331,6 +332,28 @@ export function useLearningWindow(
     const timer = setTimeout(() => void settle(), remaining);
     return () => clearTimeout(timer);
   }, [isLearning, startedAt]);
+
+  // Report a window that rehydration settled. That path is the one settle with
+  // no telemetry: the ceiling effect above is gated on `learning`, and
+  // `normalize` has already left that phase by the time anything mounts. Until
+  // this existed, a window that expired while nothing was mounted produced no
+  // event at all, so the outcome was indistinguishable from "user never
+  // finished setup" in PostHog.
+  const pendingEmptyReport = state.pendingEmptyReport;
+  useEffect(() => {
+    if (!pendingEmptyReport) return;
+    posthog.capture("first_run_learning_empty", {
+      reason: state.emptyReason ?? "expired_unreported",
+      // No live engine call here: the window is long settled and a status read
+      // now would describe the present, not the window it is reporting on.
+      data_status: "not_checked",
+      frame_count: 0,
+      // Separates this from the ceiling-effect emit above, which happens with
+      // the banner mounted and a fresh activity read behind it.
+      settled_by: "rehydrate",
+    });
+    setState(clearPendingEmptyReport());
+  }, [pendingEmptyReport, state.emptyReason]);
 
   const dismiss = useCallback(
     (options: { opened?: boolean } = {}) => {


### PR DESCRIPTION
## Problem

The first-run summary is the strongest activation moment we have, and **sending one chat message destroyed it.**

`FirstRunLearningBanner` renders in exactly one place, `chat-main-pane.tsx`, and it rendered behind `messages.length === 0`. Setup lands on the empty chat, the window opens, the user types, `messages.length` goes to 1, the banner unmounts, and the ceiling `setTimeout` it owns dies with it. The window never settles: no summary, and no `first_run_learning_resolved` / `_empty` either, so the failure was invisible in PostHog.

## Where found

PostHog project 330448, completers between 2026-08-07 and 2026-08-11, Docker CI excluded.

| post-setup state | n | D1 |
|---|---|---|
| no learning event at all | 139 | 20.9% |
| learning empty | 25 | 28.0% |
| summary ready, never opened | 20 | 30.0% |
| **summary opened** | **17** | **76.5%** |

69% of people who finished setup produced no learning event at all.

## Reproduction and pre-fix failure

The obvious theory was that they quit before the ceiling. They did not. Dwell after `engine_completed` for the no-event bucket:

| <60s | 60-120s | 120-300s | >300s | median |
|---|---|---|---|---|
| 3 | 2 | 6 | **131** | **9.4 hours** |

They stay for a workday. The window dies because the component does.

Deterministic repro is the new pane test: render with zero messages, rerender with one, assert the banner did not unmount. With the old guard restored it fails on `expected "spy" to not be called at all, but actually been called 1 times`. With the guard removed it passes.

## Root cause

1. `messages.length === 0` in the banner's render condition, which is also the condition the user leaves the instant the feature is useful.
2. `normalize()` in `learning-window.ts` rewrites an expired `learning` window to `empty` on rehydrate, but the ceiling effect that emits `first_run_learning_empty` is gated on `phase === "learning"` and so never runs. That settle path emitted nothing at all.

## Fix

- Drop the `messages.length === 0` guard. The banner already returns null while the window is inert, so the guard bought no inertness and cost the timer.
- Add `pendingEmptyReport`. When rehydration settles a window, the hook emits `first_run_learning_empty` once with `settled_by: "rehydrate"` and the new `expired_unreported` reason, then clears the flag durably so a remount cannot double count.

`expired_unreported` is deliberately distinct from `unknown`. `unknown` means the engine was asked and had no answer; this means nobody ever looked. Folding them together is what hid the largest first-run failure we have.

Scope note: this does **not** change the ceiling. With the window surviving unmount, the existing 2 minute ceiling settles it correctly in the background.

## Validation

- 129 tests pass across `lib/first-run`, `components/first-run` and the chat pane suite. 8 new: 5 on the normalize/report contract, 3 on emit-exactly-once across remounts.
- Red/green proven on the pane test, both directions, output above.
- `tsc --noEmit` clean on the changed area, ESLint clean on all 7 files.
- Full frontend run is 3328 passed / 62 failed. Those 62 are the known jsdom `localStorage` baseline. Verified on a pristine `origin/main` worktree: the same three files fail 44/44 there, identically. Not introduced here.

## What this does not do

It does not make more people open the summary once it resolves, which is the 30.0% vs 76.5% gap and the larger remaining lever. That is a separate change.
