### PR TITLE
feat: expose frame event source and keep metadata coherent

### DIFF
--- a/crates/screenpipe-db/src/db/accessibility.rs
+++ b/crates/screenpipe-db/src/db/accessibility.rs
@@ -91,7 +91,8 @@ impl DatabaseManager {
                 COALESCE(vc.file_path, '') as file_path,
                 COALESCE(f.offset_index, 0) as offset_index,
                 f.name as frame_name,
-                f.browser_url
+                f.browser_url,
+                f.capture_trigger
             FROM candidates c
             JOIN frames f ON f.id = c.id
             LEFT JOIN video_chunks vc ON f.video_chunk_id = vc.id
@@ -217,7 +218,8 @@ impl DatabaseManager {
                 COALESCE(vc.file_path, '') as file_path,
                 COALESCE(f.offset_index, 0) as offset_index,
                 f.name as frame_name,
-                f.browser_url
+                f.browser_url,
+                f.capture_trigger
             FROM candidates c
             JOIN frames f ON f.id = c.id
             LEFT JOIN video_chunks vc ON f.video_chunk_id = vc.id

--- a/crates/screenpipe-db/src/db/search.rs
+++ b/crates/screenpipe-db/src/db/search.rs
@@ -652,7 +652,8 @@ impl DatabaseManager {
                 GROUP_CONCAT(tags.name, ',') as tags,
                 frames.browser_url,
                 frames.focused,
-                frames.text_source
+                frames.text_source,
+                frames.capture_trigger
             FROM candidates
             JOIN frames ON frames.id = candidates.id
             LEFT JOIN video_chunks ON frames.video_chunk_id = video_chunks.id
@@ -702,6 +703,7 @@ impl DatabaseManager {
                 browser_url: raw.browser_url,
                 focused: raw.focused,
                 text_source: raw.text_source,
+                capture_trigger: raw.capture_trigger,
             })
             .collect()
     }
@@ -859,7 +861,8 @@ impl DatabaseManager {
             GROUP_CONCAT(tags.name, ',') as tags,
             frames.browser_url,
             frames.focused,
-            frames.text_source
+            frames.text_source,
+            frames.capture_trigger
         FROM candidates
         JOIN frames ON frames.id = candidates.id
         LEFT JOIN video_chunks ON frames.video_chunk_id = video_chunks.id

--- a/crates/screenpipe-db/src/types.rs
+++ b/crates/screenpipe-db/src/types.rs
@@ -169,6 +169,8 @@ pub struct OCRResultRaw {
     /// or `"ocr"` (fallback for terminals, canvas-rendered apps, weak a11y).
     /// `None` for legacy rows captured before text_source was tracked.
     pub text_source: Option<String>,
+    /// Why the underlying frame was captured. `None` for legacy rows.
+    pub capture_trigger: Option<String>,
 }
 
 #[derive(OaSchema, Debug, Serialize, Deserialize)]
@@ -191,6 +193,8 @@ pub struct OCRResult {
     /// `"ocr"` (fallback). `None` for legacy rows. Despite the field name
     /// `ocr_text`, the content is accessibility-derived for most captures.
     pub text_source: Option<String>,
+    /// Why the underlying frame was captured. `None` for legacy rows.
+    pub capture_trigger: Option<String>,
 }
 
 /// Content type for search queries.
@@ -521,6 +525,8 @@ pub struct UiContent {
     pub offset_index: i64,
     pub frame_name: Option<String>,
     pub browser_url: Option<String>,
+    /// Why the underlying frame was captured. `None` for legacy rows.
+    pub capture_trigger: Option<String>,
 }
 
 #[derive(OaSchema, Debug, Clone)]

--- a/crates/screenpipe-db/tests/on_screen_filter_test.rs
+++ b/crates/screenpipe-db/tests/on_screen_filter_test.rs
@@ -258,7 +258,7 @@ mod tests {
             None, // browser_url
             None, // document_path
             true,
-            Some("event"),
+            Some("visual_change"),
             Some("alpha-marker first\nalpha-marker second"),
             Some("accessibility"),
             Some(&tree),
@@ -280,5 +280,6 @@ mod tests {
             1,
             "GROUP BY f.id must collapse multiple matching elements to one frame row"
         );
+        assert_eq!(rows[0].capture_trigger.as_deref(), Some("visual_change"));
     }
 }

--- a/crates/screenpipe-db/tests/search_ocr_snapshot_test.rs
+++ b/crates/screenpipe-db/tests/search_ocr_snapshot_test.rs
@@ -40,7 +40,7 @@ mod tests {
                 Some("GitHub"),
                 None,
                 true,
-                None,
+                Some("typing_pause"),
                 None,
                 None,
                 None,
@@ -99,6 +99,38 @@ mod tests {
                     ocr.ocr_text
                 );
                 assert_eq!(ocr.app_name, "chrome.exe");
+                assert_eq!(ocr.capture_trigger.as_deref(), Some("typing_pause"));
+            }
+            other => panic!("Expected OCR result, got: {:?}", other),
+        }
+
+        // Empty-query browsing uses a separate optimized SQL projection.
+        let browse_results = db
+            .search(
+                "",
+                ContentType::OCR,
+                100,
+                0,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        match &browse_results[0] {
+            SearchResult::OCR(ocr) => {
+                assert_eq!(ocr.capture_trigger.as_deref(), Some("typing_pause"));
             }
             other => panic!("Expected OCR result, got: {:?}", other),
         }

--- a/crates/screenpipe-engine/src/event_driven_capture.rs
+++ b/crates/screenpipe-engine/src/event_driven_capture.rs
@@ -2283,7 +2283,7 @@ fn resolve_capture_metadata_with_policy(
     Option<String>,
     Option<String>,
 ) {
-    let (mut app_name, mut window_name, browser_url, document_path) = match tree_snapshot {
+    let (mut app_name, mut window_name, mut browser_url, mut document_path) = match tree_snapshot {
         Some(snap) => (
             Some(snap.app_name.clone()),
             Some(snap.window_name.clone()),
@@ -2320,9 +2320,15 @@ fn resolve_capture_metadata_with_policy(
         } if !trigger_app_name.is_empty() => {
             if app_name.as_deref() != Some(trigger_app_name.as_str()) {
                 debug!(
-                    "focused app mismatch on app_switch: trigger='{}', tree={:?}; using trigger value",
+                    "focused app mismatch on app_switch: trigger='{}', tree={:?}; using trigger value and dropping stale window context",
                     trigger_app_name, app_name
                 );
+                // App-switch events typically do not carry the new window
+                // title. Keeping the previous tree's title, URL, or document
+                // path would create a metadata pair that never existed.
+                window_name = None;
+                browser_url = None;
+                document_path = None;
             }
             app_name = Some(trigger_app_name.clone());
         }
@@ -3916,6 +3922,45 @@ mod tests {
             Some("Google Chrome"),
             None,
         ));
+    }
+
+    #[test]
+    fn resolve_capture_metadata_drops_stale_window_context_on_app_switch() {
+        let snapshot = screenpipe_a11y::tree::TreeSnapshot {
+            app_name: "TextEdit".into(),
+            app_id: Some("com.apple.TextEdit".into()),
+            executable: None,
+            app_version: None,
+            window_name: "M1_B.txt".into(),
+            text_content: "visible text".into(),
+            nodes: Vec::new(),
+            semantic_nodes: Vec::new(),
+            browser_url: Some("https://stale.example".into()),
+            document_path: Some("/tmp/M1_B.txt".into()),
+            timestamp: Utc::now(),
+            node_count: 0,
+            walk_duration: Duration::from_millis(1),
+            content_hash: 0,
+            simhash: 0,
+            truncated: false,
+            truncation_reason: screenpipe_a11y::tree::TruncationReason::None,
+            max_depth_reached: 0,
+            window_bounds: None,
+        };
+
+        let (app_name, window_name, browser_url, document_path) = resolve_capture_metadata(
+            Some(&snapshot),
+            &CaptureTrigger::AppSwitch {
+                app_name: "Finder".into(),
+                target: None,
+            },
+            None,
+        );
+
+        assert_eq!(app_name.as_deref(), Some("Finder"));
+        assert_eq!(window_name, None);
+        assert_eq!(browser_url, None);
+        assert_eq!(document_path, None);
     }
 
     #[test]

--- a/crates/screenpipe-engine/src/routes/content.rs
+++ b/crates/screenpipe-engine/src/routes/content.rs
@@ -140,6 +140,9 @@ pub struct OCRContent {
     /// historically called OCR but most captures are accessibility-derived
     /// — read this field to know which path produced the text.
     pub text_source: Option<String>,
+    /// Why this frame was captured, such as `click`, `typing_pause`, `idle`,
+    /// or `visual_change`. `None` for legacy rows.
+    pub event_source: Option<String>,
 }
 
 #[derive(OaSchema, Serialize, Deserialize, Debug, Clone)]
@@ -184,6 +187,8 @@ pub struct UiContent {
     pub offset_index: i64,
     pub frame_name: Option<String>,
     pub browser_url: Option<String>,
+    /// Why this frame was captured. `None` for legacy rows.
+    pub event_source: Option<String>,
 }
 
 /// User input event content (clicks, keystrokes, clipboard, etc.)

--- a/crates/screenpipe-engine/src/routes/search.rs
+++ b/crates/screenpipe-engine/src/routes/search.rs
@@ -623,6 +623,7 @@ pub fn search_result_to_content_item(
             focused: ocr.focused,
             device_name: ocr.device_name.clone(),
             text_source: ocr.text_source.clone(),
+            event_source: ocr.capture_trigger.clone(),
         }),
         SearchResult::Audio(audio) => {
             let transcription = truncate(audio.transcription.clone());
@@ -660,6 +661,7 @@ pub fn search_result_to_content_item(
             offset_index: ui.offset_index,
             frame_name: ui.frame_name.clone(),
             browser_url: ui.browser_url.clone(),
+            event_source: ui.capture_trigger.clone(),
         }),
         SearchResult::Input(input) => ContentItem::Input(InputContent {
             id: input.id,
@@ -1693,6 +1695,7 @@ mod tests {
             focused: None,
             device_name: "test-device".to_string(),
             text_source: Some("ocr".to_string()),
+            event_source: None,
         }
     }
 
@@ -1708,6 +1711,7 @@ mod tests {
             offset_index: 0,
             frame_name: None,
             browser_url: None,
+            event_source: None,
         }
     }
 
@@ -1822,6 +1826,7 @@ mod tests {
                 focused: Some(true),
                 device_name: "test-device".to_string(),
                 text_source: Some("ocr".to_string()),
+                capture_trigger: Some("typing_pause".to_string()),
             })
         };
 
@@ -1830,12 +1835,35 @@ mod tests {
             None,
         );
         let lightweight_projection = search_result_to_content_item(&make_result(""), None);
+        let full_json = serde_json::to_value(full_projection).unwrap();
+        let lightweight_json = serde_json::to_value(lightweight_projection).unwrap();
 
         assert_eq!(
-            serde_json::to_value(full_projection).unwrap(),
-            serde_json::to_value(lightweight_projection).unwrap(),
+            full_json, lightweight_json,
             "the HTTP search shape must not expose OCR bounding-box JSON"
         );
+        assert_eq!(full_json["content"]["event_source"], "typing_pause");
+    }
+
+    #[test]
+    fn accessibility_event_source_is_observable_in_search_response() {
+        let result = SearchResult::UI(screenpipe_db::UiContent {
+            id: 42,
+            text: "visible text".to_string(),
+            timestamp: Utc::now(),
+            app_name: "test".to_string(),
+            window_name: "test window".to_string(),
+            initial_traversal_at: None,
+            file_path: "frame.jpg".to_string(),
+            offset_index: 0,
+            frame_name: Some("display-1".to_string()),
+            browser_url: None,
+            capture_trigger: Some("visual_change".to_string()),
+        });
+
+        let json = serde_json::to_value(search_result_to_content_item(&result, None)).unwrap();
+
+        assert_eq!(json["content"]["event_source"], "visual_change");
     }
 
     #[test]


### PR DESCRIPTION
## description

Expose each frame's stored `frames.capture_trigger` value as `event_source` in OCR and accessibility search responses (including `content_type=all`). Legacy rows return `null`.

Also keep app-switch metadata coherent: when the trigger reports a different app than the accessibility snapshot, retain the trigger's app and discard the stale window title, browser URL, and document path instead of emitting an impossible mixed pair.

This intentionally does not synthesize `idle`, `visual_change`, or `manual` rows in the input feed. Capture triggers and stored frames are not reliably 1:1 because triggers can coalesce, deduplicate, drop, or fan out across monitors.

Source report: https://gist.github.com/dhruvdabhi101/a498fb678ae01fdedf546d1faaff73d7

## AI assistance and human ownership

- AI tool(s) used (`none` if not used): OpenAI Codex
- autonomy level (`none`, `autocomplete`, `chat`, or `agent`): agent
- what I personally verified: Not yet. Codex ran regression tests, route serialization tests, the existing non-focused-monitor isolation test, formatting, and a final diff against current `main`.

- [ ] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [ ] The problem statement, rationale, and replies to maintainers are my own.

## evidence type

- [ ] UI or behavior change — before/after recording
- [x] Backend change — regression tests and relevant logs/results
- [ ] Performance change — reproducible before/after benchmarks
- [ ] Docs, CI, or pure refactor — relevant checks and an explanation; no video required

## before

Not applicable. This changes backend response metadata and capture attribution; regression tests reproduce both missing `event_source` projections and the stale app/window pairing.

## after

OCR and accessibility frame results expose `event_source`. App-switch mismatches no longer combine the new app with the prior app's window context.

## how to test

1. `cargo test -p screenpipe-db --test search_ocr_snapshot_test --test on_screen_filter_test -- --nocapture` — 9 passed.
2. `cargo test -p screenpipe-engine --lib resolve_capture_metadata -- --nocapture` — 7 passed.
3. `cargo test -p screenpipe-engine --lib routes::search::tests -- --nocapture` — 25 passed.
4. `cargo test -p screenpipe-capture non_focused_monitor_gets_gated_ocr_on_its_own_pixels --lib -- --nocapture` — 1 passed.
5. `cargo fmt --all -- --check` and `git diff --check origin/main...HEAD` — passed.

## desktop app checklist (if applicable)

Not applicable. No Tauri command handlers or frontend-exported Rust bindings changed.
