### PR TITLE
fix(live-view): report unconfigured blocks honestly

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -32,15 +32,15 @@ results and `cargo llvm-cov` data on top when judging release confidence.
 
 - Mapped suites: 32
 - Mapped Rust files: 321
-- Active test blocks: 3082
+- Active test blocks: 3084
 - Ignored/manual test blocks: 137
-- Weighted coverage points: 2538.8
+- Weighted coverage points: 2540.2
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 2951 | 132 | 2478.8 | 21 | 11 | 100% |
-| macos | 29 | 3004 | 112 | 2489.2 | 22 | 11 | 100% |
-| linux | 25 | 2627 | 105 | 2185.6 | 20 | 11 | 100% |
+| windows | 29 | 2953 | 132 | 2480.2 | 21 | 11 | 100% |
+| macos | 29 | 3006 | 112 | 2490.6 | 22 | 11 | 100% |
+| linux | 25 | 2629 | 105 | 2187.0 | 20 | 11 | 100% |
 
 ## Refresh
 

--- a/apps/screenpipe-app-tauri/components/settings/__tests__/brain-overview.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/brain-overview.test.tsx
@@ -791,6 +791,62 @@ describe("BrainOverview", () => {
     expect(screen.queryByText("loading data")).toBeNull();
   });
 
+  it("reports an honest partial refresh when a block is not configured", async () => {
+    const refreshedAt = new Date().toISOString();
+    const mixedView: ViewDefinition = {
+      ...populatedView,
+      slots: [
+        {
+          ...populatedView.slots[0],
+          value: {
+            ...populatedView.slots[0].value!,
+            artifactVersion: 3,
+            updatedAt: refreshedAt,
+          },
+        },
+        {
+          ...populatedView.slots[0],
+          id: "meeting-commitments",
+          title: "Meeting commitments",
+          order: 1,
+          binding: null,
+          value: null,
+        },
+      ],
+    };
+    mocks.listBrainViews.mockResolvedValue({
+      status: "ok",
+      data: [mixedView],
+    });
+    render(<BrainOverview />);
+
+    expect(
+      await screen.findByTestId("overview-unconfigured-blocks"),
+    ).toHaveTextContent("1 Block is not connected to a scheduled task");
+    expect(
+      screen.getByTestId("overview-card-source-status-meeting-commitments"),
+    ).toHaveTextContent("not configured");
+
+    fireEvent.click(screen.getByTestId("overview-refresh-data"));
+
+    expect(
+      await screen.findByTestId("live-view-data-status"),
+    ).toHaveTextContent("1 of 2 sections updated · 1 not configured");
+    await waitFor(() =>
+      expect(mocks.capture).toHaveBeenCalledWith(
+        "live_view_refresh_completed",
+        expect.objectContaining({
+          status: "partial",
+          requested_block_count: 2,
+          connected_block_count: 1,
+          unconfigured_block_count: 1,
+          refreshed_block_count: 1,
+          all_requested_blocks_refreshed: false,
+        }),
+      ),
+    );
+  });
+
   it("captures a failed refresh outcome without sending Pipe names", async () => {
     mocks.listBrainViews.mockResolvedValue({
       status: "ok",
@@ -1193,6 +1249,9 @@ describe("BrainOverview", () => {
 
     await screen.findByTestId("brain-overview-scroll");
     expect(screen.queryByTestId("overview-freshness")).toBeNull();
+    expect(
+      screen.getByTestId("overview-unconfigured-blocks"),
+    ).toHaveTextContent("1 Block is not connected to a scheduled task");
   });
 
   it("keeps vertical scrolling on the dashboard while dense tables can scroll sideways", async () => {

--- a/apps/screenpipe-app-tauri/components/settings/__tests__/live-view-card.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/live-view-card.test.tsx
@@ -194,4 +194,19 @@ describe("LiveViewCard range and freshness", () => {
       screen.getByTestId("overview-card-updated-process-steps"),
     ).toHaveTextContent(/^updated .* · artifact #42 · v1$/);
   });
+
+  it("marks an unconfigured block as unable to refresh", () => {
+    render(<LiveViewCard slot={{ ...listSlot, binding: null, value: null }} />);
+
+    expect(screen.getByText("No scheduled task connected")).toBeTruthy();
+    expect(
+      screen.getByTestId("overview-card-source-status-process-steps"),
+    ).toHaveTextContent("not configured");
+    expect(
+      screen.getByTestId("overview-card-source-status-process-steps"),
+    ).toHaveAttribute(
+      "title",
+      "This block is not connected to a scheduled task, so refresh cannot update it.",
+    );
+  });
 });

--- a/apps/screenpipe-app-tauri/components/settings/brain-overview.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/brain-overview.tsx
@@ -162,6 +162,8 @@ type DataRefreshState = {
   startedAt: number;
   startFailureCount: number;
   filled: number;
+  refreshableTotal: number;
+  unconfiguredCount: number;
   total: number;
   message?: string;
 };
@@ -290,13 +292,25 @@ function serializedSlots(slots: ViewSlot[]): BrainViewSlotInput[] {
 
 function DataRefreshBanner({ state }: { state: DataRefreshState }) {
   const active = state.status === "starting" || state.status === "running";
+  const configurationNote =
+    state.unconfiguredCount > 0
+      ? `${state.unconfiguredCount} section${
+          state.unconfiguredCount === 1 ? "" : "s"
+        } not configured`
+      : null;
+  const withConfigurationNote = (message: string) =>
+    configurationNote ? `${message} · ${configurationNote}` : message;
   const message =
     state.status === "starting"
-      ? `starting ${state.pipeNames.join(", ")}`
+      ? withConfigurationNote(`starting ${state.pipeNames.join(", ")}`)
       : state.status === "running"
         ? state.filled > 0
-          ? `${state.filled} of ${state.total} sections updated`
-          : `${state.pipeNames.join(", ")} ${state.pipeNames.length === 1 ? "is" : "are"} building your live data`
+          ? withConfigurationNote(
+              `${state.filled} of ${state.refreshableTotal} connected sections updated`,
+            )
+          : withConfigurationNote(
+              `${state.pipeNames.join(", ")} ${state.pipeNames.length === 1 ? "is" : "are"} building your live data`,
+            )
         : state.status === "complete"
           ? `${state.total} sections updated from source data`
           : state.message || "some sections could not be updated";
@@ -316,7 +330,7 @@ function DataRefreshBanner({ state }: { state: DataRefreshState }) {
       <span>{message}</span>
       {active && (
         <span className="ml-auto tabular-nums text-muted-foreground">
-          {state.filled}/{state.total}
+          {state.filled}/{state.refreshableTotal}
         </span>
       )}
     </div>
@@ -1052,9 +1066,9 @@ export function BrainOverview({
       requestedSlots?: ViewSlot[],
       trigger: LiveViewRefreshTrigger = "manual",
     ) => {
-      const boundSlots = (requestedSlots ?? targetView.slots).filter(
-        (slot) => slot.binding,
-      );
+      const targetSlots = requestedSlots ?? targetView.slots;
+      const boundSlots = targetSlots.filter((slot) => slot.binding);
+      const unconfiguredCount = targetSlots.length - boundSlots.length;
       const pipeNames = Array.from(
         new Set(
           boundSlots
@@ -1065,7 +1079,9 @@ export function BrainOverview({
       const analyticsProperties = {
         ...liveViewAnalyticsProperties(targetView, views.length),
         trigger,
-        requested_block_count: boundSlots.length,
+        requested_block_count: targetSlots.length,
+        connected_block_count: boundSlots.length,
+        unconfigured_block_count: unconfiguredCount,
         requested_pipe_count: pipeNames.length,
         is_onboarding: Boolean(getOnboardingLiveViewActivation(targetView.id)),
       };
@@ -1092,7 +1108,9 @@ export function BrainOverview({
         startedAt,
         startFailureCount: 0,
         filled: 0,
-        total: boundSlots.length,
+        refreshableTotal: boundSlots.length,
+        unconfiguredCount,
+        total: targetSlots.length,
       });
 
       // Give every source feeding this dashboard a cadence before running it.
@@ -1369,7 +1387,15 @@ export function BrainOverview({
           if (!current || current.startedAt !== dataRefresh.startedAt) {
             return current;
           }
-          if (filled >= current.total) {
+          if (filled >= current.refreshableTotal) {
+            if (current.unconfiguredCount > 0) {
+              return {
+                ...current,
+                status: "partial",
+                filled,
+                message: `${filled} of ${current.total} sections updated · ${current.unconfiguredCount} not configured`,
+              };
+            }
             return { ...current, status: "complete", filled };
           }
           if (timedOut) {
@@ -1379,7 +1405,13 @@ export function BrainOverview({
               filled,
               message:
                 filled > 0
-                  ? `${filled} of ${current.total} sections updated. The scheduled tasks are still working on the rest.`
+                  ? `${filled} of ${current.refreshableTotal} connected sections updated. The scheduled tasks are still working on the rest.${
+                      current.unconfiguredCount > 0
+                        ? ` ${current.unconfiguredCount} section${
+                            current.unconfiguredCount === 1 ? " is" : "s are"
+                          } not configured.`
+                        : ""
+                    }`
                   : "The scheduled tasks are still working. This view will update when they publish data.",
             };
           }
@@ -1415,6 +1447,8 @@ export function BrainOverview({
       time_range: dataRefresh.timeRange,
       duration_ms: Math.max(0, Date.now() - dataRefresh.startedAt),
       requested_block_count: dataRefresh.total,
+      connected_block_count: dataRefresh.refreshableTotal,
+      unconfigured_block_count: dataRefresh.unconfiguredCount,
       requested_pipe_count: dataRefresh.pipeNames.length,
       refreshed_block_count: dataRefresh.filled,
       pipe_start_failure_count: dataRefresh.startFailureCount,
@@ -2893,6 +2927,7 @@ export function BrainOverview({
 
   if (!view) return null;
   const boundSlotCount = slots.filter((slot) => slot.binding).length;
+  const unconfiguredBlockCount = slots.length - boundSlotCount;
   const periodRanges = allowedLiveViewTimeRanges(view.periodPolicy);
   const freshness = summarizeLiveViewFreshness(slots);
   const latestUpdate = freshness.label;
@@ -3044,6 +3079,16 @@ export function BrainOverview({
                 </span>
               </>
             )}
+          </p>
+        )}
+        {unconfiguredBlockCount > 0 && !onboardingColdStart && (
+          <p
+            data-testid="overview-unconfigured-blocks"
+            className="mb-3 shrink-0 text-[11px] text-muted-foreground"
+          >
+            {unconfiguredBlockCount} Block
+            {unconfiguredBlockCount === 1 ? " is" : "s are"} not connected to a
+            scheduled task
           </p>
         )}
         {canvasError && (

--- a/apps/screenpipe-app-tauri/components/settings/live-view-card.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/live-view-card.tsx
@@ -49,6 +49,7 @@ const SOURCE_STATUS_LABELS: Record<LiveViewSourceStatus, string | null> = {
   auto: null,
   manual: "manual only",
   paused: "paused",
+  unconfigured: "not configured",
   unknown: null,
 };
 
@@ -58,6 +59,8 @@ const SOURCE_STATUS_TITLES: Record<LiveViewSourceStatus, string | null> = {
     "This task has no schedule, so this block only changes when you press refresh.",
   paused:
     "This task is turned off, so this block only changes when you press refresh.",
+  unconfigured:
+    "This block is not connected to a scheduled task, so refresh cannot update it.",
   unknown: null,
 };
 
@@ -421,6 +424,7 @@ export function LiveViewCard({
   >(null);
   const hasActions = Boolean(onFeedback || onRegenerate || onAiEdit);
   const busy = refreshing || aiEditing || feedbackSaving !== null;
+  const effectiveSourceStatus = slot.binding ? sourceStatus : "unconfigured";
 
   const submitAiEdit = async (event: React.FormEvent) => {
     event.preventDefault();
@@ -658,13 +662,13 @@ export function LiveViewCard({
             ? `Scheduled task: ${slot.binding.pipeName}`
             : "No scheduled task connected"}
         </span>
-        {slot.binding && SOURCE_STATUS_LABELS[sourceStatus] && (
+        {SOURCE_STATUS_LABELS[effectiveSourceStatus] && (
           <span
             data-testid={`overview-card-source-status-${slot.id}`}
             className="shrink-0 border border-border px-1 py-px uppercase tracking-wide"
-            title={SOURCE_STATUS_TITLES[sourceStatus] ?? undefined}
+            title={SOURCE_STATUS_TITLES[effectiveSourceStatus] ?? undefined}
           >
-            {SOURCE_STATUS_LABELS[sourceStatus]}
+            {SOURCE_STATUS_LABELS[effectiveSourceStatus]}
           </span>
         )}
         {slot.value && (

--- a/apps/screenpipe-app-tauri/lib/live-views/__tests__/source-status.test.ts
+++ b/apps/screenpipe-app-tauri/lib/live-views/__tests__/source-status.test.ts
@@ -45,8 +45,11 @@ describe("liveViewSourceStatus", () => {
 
   it("stays unknown rather than guessing when the task list is unavailable", () => {
     expect(liveViewSourceStatus("activity-enrichment", [])).toBe("unknown");
-    expect(liveViewSourceStatus(null, SNAPSHOTS)).toBe("unknown");
-    expect(liveViewSourceStatus(undefined, SNAPSHOTS)).toBe("unknown");
+  });
+
+  it("separates an unconfigured block from an unavailable task list", () => {
+    expect(liveViewSourceStatus(null, SNAPSHOTS)).toBe("unconfigured");
+    expect(liveViewSourceStatus(undefined, SNAPSHOTS)).toBe("unconfigured");
   });
 });
 

--- a/apps/screenpipe-app-tauri/lib/live-views/source-status.ts
+++ b/apps/screenpipe-app-tauri/lib/live-views/source-status.ts
@@ -11,7 +11,7 @@
  * the refresh button is pressed says so, instead of silently showing a value
  * frozen at whenever it was last clicked.
  */
-export type LiveViewSourceStatus = "auto" | "manual" | "paused" | "unknown";
+export type LiveViewSourceStatus = "auto" | "manual" | "paused" | "unconfigured" | "unknown";
 
 export type PipeScheduleSnapshot = {
   name: string;
@@ -47,7 +47,7 @@ export function liveViewSourceStatus(
   pipeName: string | null | undefined,
   snapshots: readonly PipeScheduleSnapshot[],
 ): LiveViewSourceStatus {
-  if (!pipeName) return "unknown";
+  if (!pipeName) return "unconfigured";
   const snapshot = snapshots.find((candidate) => candidate.name === pipeName);
   if (!snapshot) return "unknown";
   if (!snapshot.enabled) return "paused";

--- a/docs/coverage/CORE.md
+++ b/docs/coverage/CORE.md
@@ -9,10 +9,10 @@ confidence, and criticality.
 - Tracked crates: screenpipe-engine, screenpipe-db, screenpipe-sqlite-coordinator, screenpipe-audio, screenpipe-screen, screenpipe-a11y
 - Mapped suites: 32
 - Mapped Rust files: 321
-- Active test blocks: 3082
+- Active test blocks: 3084
 - Ignored/manual test blocks: 137
-- Declared test blocks: 3219
-- Weighted coverage points: 2538.8
+- Declared test blocks: 3221
+- Weighted coverage points: 2540.2
 
 Confidence weights: strong=1.0, partial=0.7, conditional=0.4, smoke=0.3.
 Criticality weights: high=1.0, medium=0.7, low=0.4.
@@ -23,15 +23,15 @@ are explicitly enabled in a runtime lane.
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 2951 | 132 | 2478.8 | 21 | 11 | 100% |
-| macos | 29 | 3004 | 112 | 2489.2 | 22 | 11 | 100% |
-| linux | 25 | 2627 | 105 | 2185.6 | 20 | 11 | 100% |
+| windows | 29 | 2953 | 132 | 2480.2 | 21 | 11 | 100% |
+| macos | 29 | 3006 | 112 | 2490.6 | 22 | 11 | 100% |
+| linux | 25 | 2629 | 105 | 2187.0 | 20 | 11 | 100% |
 
 ## Crate Summary
 
 | Crate | Suites | Integration files | Source unit files | Active tests | Ignored tests | Weighted points | Flows |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| screenpipe-engine | 10 | 18 | 102 | 1453 | 42 | 1116.0 | 10 |
+| screenpipe-engine | 10 | 18 | 102 | 1455 | 42 | 1117.4 | 10 |
 | screenpipe-db | 5 | 52 | 14 | 447 | 16 | 424.2 | 9 |
 | screenpipe-sqlite-coordinator | 1 | 0 | 2 | 16 | 0 | 16.0 | 2 |
 | screenpipe-audio | 6 | 25 | 51 | 591 | 43 | 517.4 | 5 |
@@ -72,17 +72,17 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | meeting | 6 suites / 1418 active / 19 ignored / 1160.9 pts | 6 suites / 1418 active / 19 ignored / 1160.9 pts | 4 suites / 1130 active / 15 ignored / 895.4 pts |
 | ocr | 4 suites / 124 active / 7 ignored / 118.3 pts | 4 suites / 128 active / 7 ignored / 123.8 pts | 3 suites / 119 active / 6 ignored / 114.8 pts |
 | os-integration | 1 suites / 6 active / 0 ignored / 1.7 pts | 1 suites / 6 active / 0 ignored / 1.7 pts | - |
-| performance | 13 suites / 1373 active / 67 ignored / 1211.2 pts | 14 suites / 1471 active / 70 ignored / 1250.4 pts | 13 suites / 1373 active / 67 ignored / 1211.2 pts |
+| performance | 13 suites / 1375 active / 67 ignored / 1212.6 pts | 14 suites / 1473 active / 70 ignored / 1251.8 pts | 13 suites / 1375 active / 67 ignored / 1212.6 pts |
 | pipes | 1 suites / 462 active / 3 ignored / 323.4 pts | 1 suites / 462 active / 3 ignored / 323.4 pts | 1 suites / 462 active / 3 ignored / 323.4 pts |
 | privacy | 5 suites / 871 active / 36 ignored / 707.5 pts | 5 suites / 920 active / 16 ignored / 712.4 pts | 5 suites / 846 active / 14 ignored / 685.0 pts |
 | real-app | - | 1 suites / 98 active / 3 ignored / 39.2 pts | - |
 | speaker | 2 suites / 348 active / 8 ignored / 348.0 pts | 2 suites / 348 active / 8 ignored / 348.0 pts | 2 suites / 348 active / 8 ignored / 348.0 pts |
-| storage | 3 suites / 473 active / 29 ignored / 383.6 pts | 3 suites / 473 active / 29 ignored / 383.6 pts | 3 suites / 473 active / 29 ignored / 383.6 pts |
+| storage | 3 suites / 475 active / 29 ignored / 385.0 pts | 3 suites / 475 active / 29 ignored / 385.0 pts | 3 suites / 475 active / 29 ignored / 385.0 pts |
 | sync | 1 suites / 462 active / 3 ignored / 323.4 pts | 1 suites / 462 active / 3 ignored / 323.4 pts | 1 suites / 462 active / 3 ignored / 323.4 pts |
-| timeline | 4 suites / 932 active / 33 ignored / 758.0 pts | 4 suites / 932 active / 33 ignored / 758.0 pts | 4 suites / 932 active / 33 ignored / 758.0 pts |
+| timeline | 4 suites / 934 active / 33 ignored / 759.4 pts | 4 suites / 934 active / 33 ignored / 759.4 pts | 4 suites / 934 active / 33 ignored / 759.4 pts |
 | transcription | 5 suites / 699 active / 40 ignored / 551.9 pts | 5 suites / 699 active / 40 ignored / 551.9 pts | 5 suites / 699 active / 40 ignored / 551.9 pts |
 | ui-events | 4 suites / 701 active / 28 ignored / 533.9 pts | 3 suites / 652 active / 5 ignored / 499.6 pts | 3 suites / 652 active / 5 ignored / 499.6 pts |
-| vision-capture | 5 suites / 492 active / 32 ignored / 389.9 pts | 5 suites / 496 active / 32 ignored / 395.4 pts | 4 suites / 487 active / 31 ignored / 386.4 pts |
+| vision-capture | 5 suites / 494 active / 32 ignored / 391.3 pts | 5 suites / 498 active / 32 ignored / 396.8 pts | 4 suites / 489 active / 31 ignored / 387.8 pts |
 
 ## Critical Flow Matrix
 
@@ -134,7 +134,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | db-search-indexing | screenpipe-db | windows, macos, linux | db-search, ocr, accessibility, performance | local-api-search, capture-ocr-pipeline, accessibility-ui-events, performance-liveness | high | strong | mixed | 13 | 105 | 4 | FTS, tokenizer, OCR snapshot search, query planning, ordering, accessibility search, and contention coverage. |
 | db-timeline-frames | screenpipe-db | windows, macos, linux | database, timeline, storage, performance | timeline-streaming, performance-liveness | high | strong | mixed | 18 | 175 | 3 | Frame/audio joins, timeline query shape, suggestions frames, write queue, DB primitives (src/db.rs split into src/db/ modules), feedback record upserts, media eviction anti-join regressions, SAF output registry, semantic storage, and timeline performance. |
 | engine-api-routes | screenpipe-engine | windows, macos, linux | local-api, timeline, meeting, transcription | local-api-search, timeline-streaming, meeting-live-notes, audio-record-transcribe | high | partial | mixed | 31 | 320 | 4 | Route/unit coverage for search, health, streaming, meetings, time/timezone, and transcription. Legacy endpoint/websocket tests require local data and remain ignored. |
-| engine-capture-timeline | screenpipe-engine | windows, macos, linux | vision-capture, timeline, storage, performance | capture-ocr-pipeline, timeline-streaming, performance-liveness | high | partial | mixed | 23 | 260 | 26 | Covers capture trigger logic, frame/audio linking, hot cache, timeline refresh regressions, fragmented MP4 extraction, and HD-mode control. Several real-data tests are intentionally ignored by default. |
+| engine-capture-timeline | screenpipe-engine | windows, macos, linux | vision-capture, timeline, storage, performance | capture-ocr-pipeline, timeline-streaming, performance-liveness | high | partial | mixed | 23 | 262 | 26 | Covers capture trigger logic, frame/audio linking, hot cache, timeline refresh regressions, fragmented MP4 extraction, and HD-mode control. Several real-data tests are intentionally ignored by default. |
 | engine-config-lifecycle | screenpipe-engine | windows, macos, linux | configuration, engine-lifecycle, performance | settings-to-engine-config, engine-health-lifecycle, performance-liveness | high | strong | mixed | 11 | 111 | 1 | Fast logic coverage for the config bridge, tray health debounce, sleep/power policies, and queue backpressure. |
 | engine-db-recovery-cli | screenpipe-engine | windows, macos, linux | database, engine-lifecycle | engine-health-lifecycle, performance-liveness | high | strong | unit | 1 | 8 | 0 | Exact DB/WAL/SHM working-copy preservation, rollback on archive failure, and restart repair for crashes during the multi-file generation swap. |
 | engine-focus-os | screenpipe-engine | windows, macos | engine-lifecycle, os-integration | engine-health-lifecycle, performance-liveness | medium | conditional | unit | 3 | 6 | 0 | Platform focus-tracker parsing/helpers. These files are cfg-gated and only execute on their target OS. |
@@ -353,7 +353,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | engine-telemetry-observability | screenpipe-engine | src/crash_log.rs | source | 4 | 0 | 4 |
 | engine-retention-storage | screenpipe-engine | src/disk_pressure.rs | source | 11 | 0 | 11 |
 | engine-meeting-privacy-sync | screenpipe-engine | src/drm_detector.rs | source | 19 | 2 | 21 |
-| engine-capture-timeline | screenpipe-engine | src/event_driven_capture.rs | source | 80 | 0 | 80 |
+| engine-capture-timeline | screenpipe-engine | src/event_driven_capture.rs | source | 82 | 0 | 82 |
 | engine-meeting-privacy-sync | screenpipe-engine | src/external_memory_sync.rs | source | 10 | 0 | 10 |
 | engine-capture-timeline | screenpipe-engine | src/focus_aware_controller.rs | source | 14 | 0 | 14 |
 | engine-focus-os | screenpipe-engine | src/focus_tracker/darwin.rs | source | 3 | 0 | 3 |


### PR DESCRIPTION
## summary

- mark Blocks without a scheduled task as `not configured`
- count every requested Block in refresh completion instead of silently excluding unconfigured Blocks
- finish mixed refreshes as partial, for example `5 of 6 sections updated · 1 not configured`
- add connected and unconfigured Block counts to privacy-safe refresh analytics
- mechanically refresh the already-stale core coverage dashboards required by CI

## before / after

```text
before
[ 5 sections updated from source data ]
Meeting commitments: blank, silently omitted from completion

after
[ 5 of 6 sections updated · 1 not configured ]
Meeting commitments: [ NOT CONFIGURED ]
```

## verification

- `bun x vitest run --config vitest.config.ts lib/live-views/__tests__/source-status.test.ts components/settings/__tests__/live-view-card.test.tsx components/settings/__tests__/brain-overview.test.tsx` (68 passed)
- `bun run typecheck`
- `bun run coverage:all:check`
- focused ESLint: no errors; two pre-existing `react-hooks/exhaustive-deps` warnings remain in `brain-overview.tsx`
