### PR TITLE
fix(notifications): stop the repeat gate from eating every alert it just cleared

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -32,15 +32,15 @@ results and `cargo llvm-cov` data on top when judging release confidence.
 
 - Mapped suites: 32
 - Mapped Rust files: 321
-- Active test blocks: 3082
+- Active test blocks: 3084
 - Ignored/manual test blocks: 137
-- Weighted coverage points: 2538.8
+- Weighted coverage points: 2540.2
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 2951 | 132 | 2478.8 | 21 | 11 | 100% |
-| macos | 29 | 3004 | 112 | 2489.2 | 22 | 11 | 100% |
-| linux | 25 | 2627 | 105 | 2185.6 | 20 | 11 | 100% |
+| windows | 29 | 2953 | 132 | 2480.2 | 21 | 11 | 100% |
+| macos | 29 | 3006 | 112 | 2490.6 | 22 | 11 | 100% |
+| linux | 25 | 2629 | 105 | 2187.0 | 20 | 11 | 100% |
 
 ## Refresh
 

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -3385,12 +3385,63 @@ pub(crate) fn notification_belongs_to_overlay(notification_type: Option<&str>) -
     matches!(notification_type, Some("meeting"))
 }
 
+/// What actually happened to an alert we tried to surface.
+///
+/// `show_notification_panel` returned `Ok(())` whether it drew the panel or
+/// dropped the alert at a gate, so `/notify` logged "panel shown" for
+/// notifications the user never saw. Callers that report an outcome need to be
+/// able to tell those apart.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NotificationDelivery {
+    /// Drawn by the shortcut overlay pill, which owns its own alert types.
+    ShownOnOverlay,
+    /// Drawn by the standalone panel (native SwiftUI, or the webview fallback).
+    ShownOnPanel,
+    /// Dropped: master-off, snooze, or quiet hours.
+    SuppressedReduced,
+    /// Dropped: identical alert already surfaced inside its cooldown.
+    SuppressedRepeat,
+}
+
+impl NotificationDelivery {
+    pub(crate) fn was_shown(self) -> bool {
+        matches!(self, Self::ShownOnOverlay | Self::ShownOnPanel)
+    }
+
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::ShownOnOverlay => "shown_on_overlay",
+            Self::ShownOnPanel => "shown_on_panel",
+            Self::SuppressedReduced => "suppressed_reduced_state",
+            Self::SuppressedRepeat => "suppressed_repeat",
+        }
+    }
+}
+
 #[tauri::command]
 #[specta::specta]
 pub async fn show_notification_panel(
     app_handle: tauri::AppHandle,
     payload: String,
 ) -> Result<(), String> {
+    deliver_notification_panel(app_handle, payload, true)
+        .await
+        .map(|_| ())
+}
+
+/// Render an alert, returning what actually happened to it.
+///
+/// `apply_repeat_gate` exists because the repeat gate is check-and-record, so
+/// running it twice for one alert makes the second call collide with the
+/// record the first call just wrote. `/notify` already gates before it
+/// persists, so it passes `false` and stays the single recorder for that path;
+/// the direct callers (capture-stall, audio device/health) come straight here
+/// and pass `true`.
+pub(crate) async fn deliver_notification_panel(
+    app_handle: tauri::AppHandle,
+    payload: String,
+    apply_repeat_gate: bool,
+) -> Result<NotificationDelivery, String> {
     use tauri::{Emitter, WebviewWindowBuilder};
 
     let label = "notification-panel";
@@ -3413,7 +3464,7 @@ pub async fn show_notification_panel(
             "show_notification_panel: suppressed (master/snooze/quiet, type={:?})",
             notification_type
         );
-        return Ok(());
+        return Ok(NotificationDelivery::SuppressedReduced);
     }
 
     // Repeat gate — see `gate::repeat_suppressed_now`. Critical alerts are
@@ -3424,17 +3475,19 @@ pub async fn show_notification_panel(
         crate::notifications::gate::title_from_payload(&payload).unwrap_or_default();
     let notification_body =
         crate::notifications::gate::body_from_payload(&payload).unwrap_or_default();
-    if crate::notifications::gate::repeat_suppressed_now(
-        notification_type.as_deref(),
-        notification_pipe.as_deref(),
-        &notification_title,
-        &notification_body,
-    ) {
+    if apply_repeat_gate
+        && crate::notifications::gate::repeat_suppressed_now(
+            notification_type.as_deref(),
+            notification_pipe.as_deref(),
+            &notification_title,
+            &notification_body,
+        )
+    {
         info!(
             "show_notification_panel: suppressed (repeat within cooldown, type={:?})",
             notification_type
         );
-        return Ok(());
+        return Ok(NotificationDelivery::SuppressedRepeat);
     }
 
     // The pill speaks up for its own alerts wherever it is native. Windows has
@@ -3448,7 +3501,7 @@ pub async fn show_notification_panel(
         {
             info!("meeting notification rendered from the shortcut overlay");
             let _ = app_handle.emit("native-notification-shown", &payload);
-            return Ok(());
+            return Ok(NotificationDelivery::ShownOnOverlay);
         }
     }
 
@@ -3467,7 +3520,7 @@ pub async fn show_notification_panel(
         {
             info!("meeting notification rendered from the shortcut overlay");
             let _ = app_handle.emit("native-notification-shown", &payload);
-            return Ok(());
+            return Ok(NotificationDelivery::ShownOnOverlay);
         }
 
         if native_notification::is_available() {
@@ -3476,7 +3529,7 @@ pub async fn show_notification_panel(
                 // Emit event so the main window can save notification history + PostHog analytics
                 // (the webview panel page does this in JS, but we bypass it with native)
                 let _ = app_handle.emit("native-notification-shown", &payload);
-                return Ok(());
+                return Ok(NotificationDelivery::ShownOnPanel);
             }
             warn!("Native notification panel failed, falling back to webview");
         }
@@ -3588,7 +3641,7 @@ pub async fn show_notification_panel(
             });
         }
 
-        return Ok(());
+        return Ok(NotificationDelivery::ShownOnPanel);
     }
 
     info!("Creating new notification-panel window");
@@ -3705,7 +3758,7 @@ pub async fn show_notification_panel(
         });
     }
 
-    Ok(())
+    Ok(NotificationDelivery::ShownOnPanel)
 }
 
 #[tauri::command]

--- a/apps/screenpipe-app-tauri/src-tauri/src/notifications/gate.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/notifications/gate.rs
@@ -869,6 +869,37 @@ mod tests {
         assert!(!repeat_suppressed_now(Some("pipe"), Some("p"), "   ", ""));
     }
 
+    /// The gate checks *and* records, so asking it twice about one alert makes
+    /// the second question collide with the answer the first one wrote.
+    ///
+    /// `/notify` gated before persisting and then handed the alert to
+    /// `show_notification_panel`, which gated again — so every high-priority
+    /// notification that came through the route was dropped microseconds after
+    /// being cleared, and the route still logged it as shown. Only the direct
+    /// callers, which pass through once, kept working.
+    ///
+    /// The fix is one recorder per alert, not a longer cooldown: this asserts
+    /// the double-ask really does suppress, so the single-ask contract in
+    /// `deliver_notification_panel(.., apply_repeat_gate: false)` stays load-bearing.
+    #[test]
+    fn asking_the_same_gate_twice_suppresses_a_first_time_alert() {
+        let mut ledger = empty_ledger();
+        let key = repeat_key(Some("meeting"), None, "meeting detected", "with alice");
+        let cooldown = repeat_cooldown_ms(Some("meeting"));
+
+        // The route clears it and records the delivery.
+        assert!(
+            !check_and_record(&mut ledger, key.clone(), 1_000, cooldown),
+            "a first-time alert must pass the gate"
+        );
+        // The delivery path asks about the very same alert a moment later.
+        assert!(
+            check_and_record(&mut ledger, key, 1_001, cooldown),
+            "asking twice suppresses the alert the caller just cleared — \
+             exactly one caller may run the gate per alert"
+        );
+    }
+
     #[test]
     fn title_is_read_from_payload() {
         assert_eq!(

--- a/apps/screenpipe-app-tauri/src-tauri/src/notifications/routes.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/notifications/routes.rs
@@ -336,16 +336,32 @@ pub async fn send_notification(
         tokio::spawn(async move {
             match tokio::time::timeout(
                 std::time::Duration::from_secs(5),
-                crate::commands::show_notification_panel(app, panel_json),
+                // `false`: the repeat gate already ran above, and it records as
+                // well as checks — running it again here would collide with the
+                // record this same alert just wrote and drop every notification.
+                crate::commands::deliver_notification_panel(app, panel_json, false),
             )
             .await
             {
-                Ok(Ok(())) => {
-                    info!(
-                        id = %delivery_id,
-                        notification_type = %delivery_type,
-                        "High-priority notification panel shown"
-                    );
+                Ok(Ok(delivery)) => {
+                    // Report what happened, not that we asked. The delivery path
+                    // still drops alerts at the reduced-state gate, so a blanket
+                    // "shown" here hid real suppressions in the logs.
+                    if delivery.was_shown() {
+                        info!(
+                            id = %delivery_id,
+                            notification_type = %delivery_type,
+                            outcome = %delivery.as_str(),
+                            "High-priority notification shown"
+                        );
+                    } else {
+                        info!(
+                            id = %delivery_id,
+                            notification_type = %delivery_type,
+                            outcome = %delivery.as_str(),
+                            "High-priority notification suppressed before display"
+                        );
+                    }
                 }
                 Ok(Err(e)) => {
                     error!(

--- a/docs/coverage/CORE.md
+++ b/docs/coverage/CORE.md
@@ -9,10 +9,10 @@ confidence, and criticality.
 - Tracked crates: screenpipe-engine, screenpipe-db, screenpipe-sqlite-coordinator, screenpipe-audio, screenpipe-screen, screenpipe-a11y
 - Mapped suites: 32
 - Mapped Rust files: 321
-- Active test blocks: 3082
+- Active test blocks: 3084
 - Ignored/manual test blocks: 137
-- Declared test blocks: 3219
-- Weighted coverage points: 2538.8
+- Declared test blocks: 3221
+- Weighted coverage points: 2540.2
 
 Confidence weights: strong=1.0, partial=0.7, conditional=0.4, smoke=0.3.
 Criticality weights: high=1.0, medium=0.7, low=0.4.
@@ -23,15 +23,15 @@ are explicitly enabled in a runtime lane.
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 2951 | 132 | 2478.8 | 21 | 11 | 100% |
-| macos | 29 | 3004 | 112 | 2489.2 | 22 | 11 | 100% |
-| linux | 25 | 2627 | 105 | 2185.6 | 20 | 11 | 100% |
+| windows | 29 | 2953 | 132 | 2480.2 | 21 | 11 | 100% |
+| macos | 29 | 3006 | 112 | 2490.6 | 22 | 11 | 100% |
+| linux | 25 | 2629 | 105 | 2187.0 | 20 | 11 | 100% |
 
 ## Crate Summary
 
 | Crate | Suites | Integration files | Source unit files | Active tests | Ignored tests | Weighted points | Flows |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| screenpipe-engine | 10 | 18 | 102 | 1453 | 42 | 1116.0 | 10 |
+| screenpipe-engine | 10 | 18 | 102 | 1455 | 42 | 1117.4 | 10 |
 | screenpipe-db | 5 | 52 | 14 | 447 | 16 | 424.2 | 9 |
 | screenpipe-sqlite-coordinator | 1 | 0 | 2 | 16 | 0 | 16.0 | 2 |
 | screenpipe-audio | 6 | 25 | 51 | 591 | 43 | 517.4 | 5 |
@@ -72,17 +72,17 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | meeting | 6 suites / 1418 active / 19 ignored / 1160.9 pts | 6 suites / 1418 active / 19 ignored / 1160.9 pts | 4 suites / 1130 active / 15 ignored / 895.4 pts |
 | ocr | 4 suites / 124 active / 7 ignored / 118.3 pts | 4 suites / 128 active / 7 ignored / 123.8 pts | 3 suites / 119 active / 6 ignored / 114.8 pts |
 | os-integration | 1 suites / 6 active / 0 ignored / 1.7 pts | 1 suites / 6 active / 0 ignored / 1.7 pts | - |
-| performance | 13 suites / 1373 active / 67 ignored / 1211.2 pts | 14 suites / 1471 active / 70 ignored / 1250.4 pts | 13 suites / 1373 active / 67 ignored / 1211.2 pts |
+| performance | 13 suites / 1375 active / 67 ignored / 1212.6 pts | 14 suites / 1473 active / 70 ignored / 1251.8 pts | 13 suites / 1375 active / 67 ignored / 1212.6 pts |
 | pipes | 1 suites / 462 active / 3 ignored / 323.4 pts | 1 suites / 462 active / 3 ignored / 323.4 pts | 1 suites / 462 active / 3 ignored / 323.4 pts |
 | privacy | 5 suites / 871 active / 36 ignored / 707.5 pts | 5 suites / 920 active / 16 ignored / 712.4 pts | 5 suites / 846 active / 14 ignored / 685.0 pts |
 | real-app | - | 1 suites / 98 active / 3 ignored / 39.2 pts | - |
 | speaker | 2 suites / 348 active / 8 ignored / 348.0 pts | 2 suites / 348 active / 8 ignored / 348.0 pts | 2 suites / 348 active / 8 ignored / 348.0 pts |
-| storage | 3 suites / 473 active / 29 ignored / 383.6 pts | 3 suites / 473 active / 29 ignored / 383.6 pts | 3 suites / 473 active / 29 ignored / 383.6 pts |
+| storage | 3 suites / 475 active / 29 ignored / 385.0 pts | 3 suites / 475 active / 29 ignored / 385.0 pts | 3 suites / 475 active / 29 ignored / 385.0 pts |
 | sync | 1 suites / 462 active / 3 ignored / 323.4 pts | 1 suites / 462 active / 3 ignored / 323.4 pts | 1 suites / 462 active / 3 ignored / 323.4 pts |
-| timeline | 4 suites / 932 active / 33 ignored / 758.0 pts | 4 suites / 932 active / 33 ignored / 758.0 pts | 4 suites / 932 active / 33 ignored / 758.0 pts |
+| timeline | 4 suites / 934 active / 33 ignored / 759.4 pts | 4 suites / 934 active / 33 ignored / 759.4 pts | 4 suites / 934 active / 33 ignored / 759.4 pts |
 | transcription | 5 suites / 699 active / 40 ignored / 551.9 pts | 5 suites / 699 active / 40 ignored / 551.9 pts | 5 suites / 699 active / 40 ignored / 551.9 pts |
 | ui-events | 4 suites / 701 active / 28 ignored / 533.9 pts | 3 suites / 652 active / 5 ignored / 499.6 pts | 3 suites / 652 active / 5 ignored / 499.6 pts |
-| vision-capture | 5 suites / 492 active / 32 ignored / 389.9 pts | 5 suites / 496 active / 32 ignored / 395.4 pts | 4 suites / 487 active / 31 ignored / 386.4 pts |
+| vision-capture | 5 suites / 494 active / 32 ignored / 391.3 pts | 5 suites / 498 active / 32 ignored / 396.8 pts | 4 suites / 489 active / 31 ignored / 387.8 pts |
 
 ## Critical Flow Matrix
 
@@ -134,7 +134,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | db-search-indexing | screenpipe-db | windows, macos, linux | db-search, ocr, accessibility, performance | local-api-search, capture-ocr-pipeline, accessibility-ui-events, performance-liveness | high | strong | mixed | 13 | 105 | 4 | FTS, tokenizer, OCR snapshot search, query planning, ordering, accessibility search, and contention coverage. |
 | db-timeline-frames | screenpipe-db | windows, macos, linux | database, timeline, storage, performance | timeline-streaming, performance-liveness | high | strong | mixed | 18 | 175 | 3 | Frame/audio joins, timeline query shape, suggestions frames, write queue, DB primitives (src/db.rs split into src/db/ modules), feedback record upserts, media eviction anti-join regressions, SAF output registry, semantic storage, and timeline performance. |
 | engine-api-routes | screenpipe-engine | windows, macos, linux | local-api, timeline, meeting, transcription | local-api-search, timeline-streaming, meeting-live-notes, audio-record-transcribe | high | partial | mixed | 31 | 320 | 4 | Route/unit coverage for search, health, streaming, meetings, time/timezone, and transcription. Legacy endpoint/websocket tests require local data and remain ignored. |
-| engine-capture-timeline | screenpipe-engine | windows, macos, linux | vision-capture, timeline, storage, performance | capture-ocr-pipeline, timeline-streaming, performance-liveness | high | partial | mixed | 23 | 260 | 26 | Covers capture trigger logic, frame/audio linking, hot cache, timeline refresh regressions, fragmented MP4 extraction, and HD-mode control. Several real-data tests are intentionally ignored by default. |
+| engine-capture-timeline | screenpipe-engine | windows, macos, linux | vision-capture, timeline, storage, performance | capture-ocr-pipeline, timeline-streaming, performance-liveness | high | partial | mixed | 23 | 262 | 26 | Covers capture trigger logic, frame/audio linking, hot cache, timeline refresh regressions, fragmented MP4 extraction, and HD-mode control. Several real-data tests are intentionally ignored by default. |
 | engine-config-lifecycle | screenpipe-engine | windows, macos, linux | configuration, engine-lifecycle, performance | settings-to-engine-config, engine-health-lifecycle, performance-liveness | high | strong | mixed | 11 | 111 | 1 | Fast logic coverage for the config bridge, tray health debounce, sleep/power policies, and queue backpressure. |
 | engine-db-recovery-cli | screenpipe-engine | windows, macos, linux | database, engine-lifecycle | engine-health-lifecycle, performance-liveness | high | strong | unit | 1 | 8 | 0 | Exact DB/WAL/SHM working-copy preservation, rollback on archive failure, and restart repair for crashes during the multi-file generation swap. |
 | engine-focus-os | screenpipe-engine | windows, macos | engine-lifecycle, os-integration | engine-health-lifecycle, performance-liveness | medium | conditional | unit | 3 | 6 | 0 | Platform focus-tracker parsing/helpers. These files are cfg-gated and only execute on their target OS. |
@@ -353,7 +353,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | engine-telemetry-observability | screenpipe-engine | src/crash_log.rs | source | 4 | 0 | 4 |
 | engine-retention-storage | screenpipe-engine | src/disk_pressure.rs | source | 11 | 0 | 11 |
 | engine-meeting-privacy-sync | screenpipe-engine | src/drm_detector.rs | source | 19 | 2 | 21 |
-| engine-capture-timeline | screenpipe-engine | src/event_driven_capture.rs | source | 80 | 0 | 80 |
+| engine-capture-timeline | screenpipe-engine | src/event_driven_capture.rs | source | 82 | 0 | 82 |
 | engine-meeting-privacy-sync | screenpipe-engine | src/external_memory_sync.rs | source | 10 | 0 | 10 |
 | engine-capture-timeline | screenpipe-engine | src/focus_aware_controller.rs | source | 14 | 0 | 14 |
 | engine-focus-os | screenpipe-engine | src/focus_tracker/darwin.rs | source | 3 | 0 | 3 |


### PR DESCRIPTION
## Problem

No notification has reached the panel since #6199 landed this morning. Not pipe results, not meeting alerts, nothing that arrives over `/notify`.

The repeat gate from #6199 is check-and-record, and it runs **twice** for every `/notify` alert:

1. `notifications/routes.rs:201` — gates before persisting, and **records** the alert
2. `commands.rs:3460` inside `show_notification_panel` — gates again, finds the record step 1 just wrote, drops the alert as a repeat

The two calls are ~0.3 ms apart, so the second one always hits the cooldown. Only the direct callers (capture-stall, audio device/health) still surface, because they enter at `show_notification_panel` and pass the gate once.

## Where it was found

Louis noticed the top-right panel had gone quiet. Live logs from installed 2.6.20:

| day | panel attempts | suppressed |
|---|---|---|
| Aug 10 | 12 | 0 |
| Aug 11 | 10 | 0 |
| Aug 12 | 14 | 0 |
| **Aug 13** (#6199 lands) | **6** | **rising** |

## Reproduction

Against installed 2.6.20, a title and body **never sent before** — so nothing legitimate to dedupe against:

```
POST /notify {"title":"repro alpha","body":"first ever alert, unique body 4417","priority":"high"}
-> 200 {"success":true,"message":"Notification sent successfully"}
```

Before this change:

```
routes:   Received notification request: ... title: "repro alpha"
commands: show_notification_panel called
commands: show_notification_panel: suppressed (repeat within cooldown, type=Some("pipe"))
routes:   High-priority notification panel shown        <- nothing was shown
```

Nothing rendered. The route reported it as delivered.

## Root cause

`repeat_suppressed_now` checks *and* records. Two callers per alert means the second question collides with the first answer. New regression test asserting exactly that:

```rust
assert!(!check_and_record(&mut ledger, key.clone(), 1_000, cooldown));  // route clears it
assert!( check_and_record(&mut ledger, key,         1_001, cooldown));  // delivery drops it
```

## Fix

Scoped to *who runs the gate*, not to what the gate decides.

- `deliver_notification_panel(app, payload, apply_repeat_gate)` is the real delivery path. `/notify` passes `false` and stays the single recorder for that path; the direct callers keep `show_notification_panel`, which passes `true`.
- Delivery returns `NotificationDelivery` (`ShownOnOverlay` / `ShownOnPanel` / `SuppressedReduced` / `SuppressedRepeat`) instead of a bare `Ok(())`, so `/notify` logs what happened rather than that it asked. That bare `Ok(())` is why this failed silently — a suppression and a delivery were indistinguishable in the logs.

Deliberately unchanged: priority gating, reduced states, cooldown windows, which types the overlay pill owns. The `show_notification_panel` Tauri command keeps its signature, so no binding changes.

## Validation

- `cargo test --bin screenpipe-app notifications` — 92 passed, includes the new regression test
- `cargo test --bin screenpipe-app commands` — 40 passed
- `cargo clippy --bin screenpipe-app` — no new warnings in the changed ranges (103 pre-existing, unchanged)
- `rustfmt --check` clean on the changed hunks; the diffs rustfmt reports in `native_actions.rs` and `routes.rs` tests are pre-existing on `main` (verified against `origin/main`)
- Live repro above captured against installed 2.6.20

**Not yet done:** a packaged build confirming the panel visibly returns. The evidence here is the proven cause, the live repro of that exact path, and the unit test on the mechanism. Happy to run a packaged canary before merge if you want it.

## Follow-ups, not in this PR

- Every pipe following the built-in prompt template (`screenpipe-core/src/pipes/mod.rs:6815`) posts without a `priority` field, so it defaults to `normal` and lands in the inbox with no toast. That is the priority-inbox design working as intended, but the template never got the memo — worth deciding separately.
- `/notify` returns the identical `"Notification sent successfully"` on the toast path and the silent-inbox path, so callers cannot tell them apart.