### PR TITLE
fix: preserve authoritative chat references

### DIFF
--- a/apps/screenpipe-app-tauri/lib/chat/__tests__/conversation-history.test.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/__tests__/conversation-history.test.ts
@@ -38,4 +38,72 @@ describe("chat conversation history helpers", () => {
     expect(withConversationHistory("next", messages)).toContain("<conversation_history>");
     expect(withConversationHistory("next", messages)).toContain("[tool: search]");
   });
+
+  it("keeps an established source of truth visible when old turns are capped", () => {
+    const source = "~/.screenpipe-dev/pi-chat/tools/activity_registry.json";
+    const messages: Message[] = [
+      {
+        id: "1",
+        role: "user",
+        content: `Use ${source} as the source of truth for my activities.`,
+        timestamp: 1,
+      },
+      ...Array.from({ length: 5 }, (_, i) => ({
+        id: `filler-${i}`,
+        role: "assistant" as const,
+        content: `later unrelated turn ${i}`,
+        timestamp: i + 2,
+      })),
+    ];
+
+    const prompt = withConversationHistory("add workout", messages, 2);
+
+    expect(prompt).toContain("<known_authoritative_references>");
+    expect(prompt).toContain(`source: ${source}`);
+    expect(prompt).toContain("read back the established target");
+  });
+
+  it("carries approved local tools across history caps", () => {
+    const index = "~/.screenpipe/pi-chat/tools/memory_index.md";
+    const tool = "~/.screenpipe/pi-chat/tools/apple_calendar_add_event.py";
+    const messages: Message[] = [
+      {
+        id: "1",
+        role: "assistant",
+        content: `Calendar workflow uses ${index} and approved local tool ${tool}.`,
+        timestamp: 1,
+      },
+      ...Array.from({ length: 5 }, (_, i) => ({
+        id: `filler-${i}`,
+        role: "user" as const,
+        content: `later unrelated turn ${i}`,
+        timestamp: i + 2,
+      })),
+    ];
+
+    const prompt = withConversationHistory("schedule it", messages, 2);
+
+    expect(prompt).toContain(`source: ${index}`);
+    expect(prompt).toContain(`approved local tool: ${tool}`);
+  });
+
+  it("keeps an existing artifact path across history caps", () => {
+    const artifact = "/Users/rudrabhaskar/Downloads/screenpipe-summary.html";
+    const messages: Message[] = [
+      {
+        id: "1",
+        role: "assistant",
+        content: `The existing artifact for this task is ${artifact}.`,
+        timestamp: 1,
+      },
+      ...Array.from({ length: 5 }, (_, i) => ({
+        id: `filler-${i}`,
+        role: "user" as const,
+        content: `later unrelated turn ${i}`,
+        timestamp: i + 2,
+      })),
+    ];
+
+    expect(withConversationHistory("update the same artifact", messages, 2)).toContain(`artifact: ${artifact}`);
+  });
 });

--- a/apps/screenpipe-app-tauri/lib/chat/conversation-history.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/conversation-history.ts
@@ -4,6 +4,26 @@
 
 import type { Message } from "@/lib/chat/types";
 
+const AUTHORITATIVE_REF_LIMIT = 8;
+const LOCAL_REF_PATTERN =
+  /(?:~|\/[^\s"'`<>]+)\/\.screenpipe(?:-dev)?\/pi-chat\/tools\/[^\s"'`<>),]+|\/Users\/[^\n"'`<>]+?\.html/g;
+
+function referenceKind(ref: string): "approved local tool" | "artifact" | "source" {
+  if (/\.(?:py|sh|js|ts)$/.test(ref)) return "approved local tool";
+  return /\.html$/.test(ref) ? "artifact" : "source";
+}
+
+function formatAuthoritativeReferenceLines(messages: Message[], limit = AUTHORITATIVE_REF_LIMIT): string {
+  const refs = new Map<string, string>();
+
+  for (const match of formatConversationHistoryLines(messages, messages.length).matchAll(LOCAL_REF_PATTERN)) {
+    const ref = match[0].replace(/[.,;:)\]]+$/, "");
+    refs.set(ref, `- ${referenceKind(ref)}: ${ref}`);
+  }
+
+  return Array.from(refs.values()).slice(-limit).join("\n");
+}
+
 export function formatConversationHistoryLines(messages: Message[], limit = 40): string {
   return messages
     .slice(-limit)
@@ -33,6 +53,10 @@ export function formatConversationHistoryLines(messages: Message[], limit = 40):
 
 export function withConversationHistory(userMessage: string, messages: Message[], limit = 40): string {
   if (messages.length === 0) return userMessage;
+  const referenceLines = formatAuthoritativeReferenceLines(messages);
   const historyLines = formatConversationHistoryLines(messages, limit);
-  return `<conversation_history>\n${historyLines}\n</conversation_history>\n\n${userMessage}`;
+  const references = referenceLines
+    ? `<known_authoritative_references>\n${referenceLines}\nBefore using a different source or claiming completion, read back the established target. If it conflicts with the latest request, ask one focused question.\n</known_authoritative_references>\n\n`
+    : "";
+  return `${references}<conversation_history>\n${historyLines}\n</conversation_history>\n\n${userMessage}`;
 }


### PR DESCRIPTION
Closes #6206

This keeps known local references available when a chat gets long enough for the normal conversation history window to drop older turns.

What changed:
- keeps a small bounded list of previously seen local sources/tools before the capped history block
- covers `.screenpipe/pi-chat/tools` references like the activity registry and calendar helper
- keeps existing local HTML artifact paths visible so the next turn does not silently switch targets
- adds regression coverage for source of truth, approved local tool, and existing artifact cases

Testing:
- `bun run vitest run --config vitest.config.ts lib/chat/__tests__/conversation-history.test.ts`
- `bun run typecheck`

Recording:
<video src="https://github.com/user-attachments/assets/29230d78-c3d3-4cfa-b5de-d0366804c661" controls></video>
