### PR TITLE
fix(vision): split trigger-wait so #3939 freezes name the real stage

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -32,15 +32,15 @@ results and `cargo llvm-cov` data on top when judging release confidence.
 
 - Mapped suites: 32
 - Mapped Rust files: 321
-- Active test blocks: 3084
+- Active test blocks: 3088
 - Ignored/manual test blocks: 137
-- Weighted coverage points: 2540.2
+- Weighted coverage points: 2543.6
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 2953 | 132 | 2480.2 | 21 | 11 | 100% |
-| macos | 29 | 3006 | 112 | 2490.6 | 22 | 11 | 100% |
-| linux | 25 | 2629 | 105 | 2187.0 | 20 | 11 | 100% |
+| windows | 29 | 2957 | 132 | 2483.6 | 21 | 11 | 100% |
+| macos | 29 | 3010 | 112 | 2494.0 | 22 | 11 | 100% |
+| linux | 25 | 2633 | 105 | 2190.4 | 20 | 11 | 100% |
 
 ## Refresh
 

--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -32,15 +32,15 @@ results and `cargo llvm-cov` data on top when judging release confidence.
 
 - Mapped suites: 32
 - Mapped Rust files: 321
-- Active test blocks: 3088
+- Active test blocks: 3089
 - Ignored/manual test blocks: 137
-- Weighted coverage points: 2543.6
+- Weighted coverage points: 2544.6
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 2957 | 132 | 2483.6 | 21 | 11 | 100% |
-| macos | 29 | 3010 | 112 | 2494.0 | 22 | 11 | 100% |
-| linux | 25 | 2633 | 105 | 2190.4 | 20 | 11 | 100% |
+| windows | 29 | 2958 | 132 | 2484.6 | 21 | 11 | 100% |
+| macos | 29 | 3011 | 112 | 2495.0 | 22 | 11 | 100% |
+| linux | 25 | 2634 | 105 | 2191.4 | 20 | 11 | 100% |
 
 ## Refresh
 

--- a/apps/screenpipe-app-tauri/e2e/specs/capture-stall-stage-marker.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/capture-stall-stage-marker.spec.ts
@@ -43,7 +43,8 @@
 
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { E2E_SEED_FLAGS, getAppPid } from "../helpers/app-launcher.js";
 import {
@@ -57,29 +58,51 @@ import { t, waitForAppReady } from "../helpers/test-utils.js";
 const dataDir = resolve(homedir(), ".screenpipe", ".e2e");
 const SILENT_MARKER = resolve(dataDir, "e2e-capture-loop-silent-fired");
 
+const METRICS_RS = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../../crates/screenpipe-screen/src/metrics.rs",
+);
+
 /**
- * Every stage the loop can report. A frozen loop must name one of these.
+ * Every stage the loop can report, read from the enum that emits them.
  *
- * Mirrors `CaptureLoopStage::as_str` in crates/screenpipe-screen/src/metrics.rs.
- * A stage added there but missed here fails this spec only when a poll happens
- * to land in that stage's window, so a short-lived stage shows up as a flake
- * rather than an honest failure. Keep the two lists in step.
+ * Derived rather than hand-mirrored. A copied list goes stale the moment a
+ * stage is added, and since a short-lived stage is rarely the one sampled, the
+ * stale copy fails as an intermittent flake instead of an honest error — which
+ * is how it gets written off as infrastructure. Reading the single source of
+ * truth means a new stage is either picked up automatically, or extraction
+ * fails loudly right here.
  */
-const KNOWN_STAGES = [
-  "heartbeat",
-  "focus-gate",
-  "warm-wait",
-  "cold-wait",
-  "pause-gate",
-  "release-stream",
-  "invalidate-streams",
-  "exclusion-probe",
-  "visual-probe",
-  "trigger-wait",
-  "trigger-drain",
-  "capture",
-  "hot-cache-push",
-];
+function knownStagesFromRust(): string[] {
+  const source = readFileSync(METRICS_RS, "utf8");
+  const asStr = source.match(
+    /pub fn as_str\(self\) -> &'static str \{([\s\S]*?)\n {4}\}/,
+  );
+  if (!asStr) {
+    throw new Error(
+      `could not find CaptureLoopStage::as_str in ${METRICS_RS}. ` +
+        `Fix the extraction rather than hardcoding the stage list.`,
+    );
+  }
+
+  const stages = [...asStr[1].matchAll(/=>\s*"([a-z-]+)"/g)].map((m) => m[1]);
+
+  // Guard the extraction itself. A regex that silently matched nothing, or
+  // matched the wrong block, would leave every membership assertion below
+  // vacuously true — the spec would pass while checking nothing.
+  for (const anchor of ["unknown", "heartbeat", "capture", "trigger-wait"]) {
+    if (!stages.includes(anchor)) {
+      throw new Error(
+        `stage extraction looks wrong: expected "${anchor}" among ` +
+          `[${stages.join(", ")}]`,
+      );
+    }
+  }
+  return stages;
+}
+
+/** A frozen loop must name one of these. */
+const KNOWN_STAGES = knownStagesFromRust();
 
 type HealthBody = {
   frame_status?: string;

--- a/apps/screenpipe-app-tauri/e2e/specs/capture-stall-stage-marker.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/capture-stall-stage-marker.spec.ts
@@ -57,7 +57,14 @@ import { t, waitForAppReady } from "../helpers/test-utils.js";
 const dataDir = resolve(homedir(), ".screenpipe", ".e2e");
 const SILENT_MARKER = resolve(dataDir, "e2e-capture-loop-silent-fired");
 
-/** Every stage the loop can report. A frozen loop must name one of these. */
+/**
+ * Every stage the loop can report. A frozen loop must name one of these.
+ *
+ * Mirrors `CaptureLoopStage::as_str` in crates/screenpipe-screen/src/metrics.rs.
+ * A stage added there but missed here fails this spec only when a poll happens
+ * to land in that stage's window, so a short-lived stage shows up as a flake
+ * rather than an honest failure. Keep the two lists in step.
+ */
 const KNOWN_STAGES = [
   "heartbeat",
   "focus-gate",
@@ -69,6 +76,7 @@ const KNOWN_STAGES = [
   "exclusion-probe",
   "visual-probe",
   "trigger-wait",
+  "trigger-drain",
   "capture",
   "hot-cache-push",
 ];

--- a/crates/screenpipe-engine/src/event_driven_capture.rs
+++ b/crates/screenpipe-engine/src/event_driven_capture.rs
@@ -1598,6 +1598,21 @@ pub(crate) async fn event_driven_capture_loop(
                 }
             }
 
+            // The bounded wait above returned, so anything past this point is
+            // synchronous gate work, not the timer. Re-marking here keeps the
+            // watchdog's "frozen in <stage>" message honest: `trigger-wait`
+            // now accuses only the 250ms-bounded await (a freeze there means
+            // the task was never resumed), while `trigger-drain` accuses the
+            // synchronous gates below (a freeze there means a lock is held by
+            // another thread). Previously both shared one marker, so a
+            // multi-minute #3939 freeze reported `trigger-wait` even though a
+            // 250ms timeout cannot account for it.
+            record_loop_stage(
+                &vision_metrics,
+                &monitor_liveness,
+                screenpipe_screen::CaptureLoopStage::TriggerDrain,
+            );
+
             // Drain any remaining triggers that piled up while we were
             // waiting on the first one.
             if !closed_now {

--- a/crates/screenpipe-screen/src/metrics.rs
+++ b/crates/screenpipe-screen/src/metrics.rs
@@ -931,47 +931,102 @@ mod tests {
         assert_eq!(s.frames_dropped, 3);
     }
 
+    /// The wire form (discriminant + name) every stage is expected to have.
+    ///
+    /// Deliberately no wildcard arm: adding a variant to [`CaptureLoopStage`]
+    /// stops compiling *here*, which forces whoever adds it to extend
+    /// `from_u8` and `ALL_STAGES` in the same edit. `from_u8` has a `_`
+    /// fallback, so without this guard a missing arm compiles fine and the
+    /// watchdog silently reports "unknown" for the new stage — the exact
+    /// failure the stage marker exists to prevent.
+    fn expected_wire_form(stage: CaptureLoopStage) -> (u8, &'static str) {
+        match stage {
+            CaptureLoopStage::Unknown => (0, "unknown"),
+            CaptureLoopStage::Heartbeat => (1, "heartbeat"),
+            CaptureLoopStage::FocusGate => (2, "focus-gate"),
+            CaptureLoopStage::WarmWait => (3, "warm-wait"),
+            CaptureLoopStage::ColdWait => (4, "cold-wait"),
+            CaptureLoopStage::PauseGate => (5, "pause-gate"),
+            CaptureLoopStage::ReleaseStream => (6, "release-stream"),
+            CaptureLoopStage::InvalidateStreams => (7, "invalidate-streams"),
+            CaptureLoopStage::ExclusionProbe => (8, "exclusion-probe"),
+            CaptureLoopStage::VisualProbe => (9, "visual-probe"),
+            CaptureLoopStage::TriggerWait => (10, "trigger-wait"),
+            CaptureLoopStage::Capture => (11, "capture"),
+            CaptureLoopStage::HotCachePush => (12, "hot-cache-push"),
+            CaptureLoopStage::TriggerDrain => (13, "trigger-drain"),
+        }
+    }
+
+    const ALL_STAGES: &[CaptureLoopStage] = &[
+        CaptureLoopStage::Unknown,
+        CaptureLoopStage::Heartbeat,
+        CaptureLoopStage::FocusGate,
+        CaptureLoopStage::WarmWait,
+        CaptureLoopStage::ColdWait,
+        CaptureLoopStage::PauseGate,
+        CaptureLoopStage::ReleaseStream,
+        CaptureLoopStage::InvalidateStreams,
+        CaptureLoopStage::ExclusionProbe,
+        CaptureLoopStage::VisualProbe,
+        CaptureLoopStage::TriggerWait,
+        CaptureLoopStage::Capture,
+        CaptureLoopStage::HotCachePush,
+        CaptureLoopStage::TriggerDrain,
+    ];
+
     /// Every stage must survive the `AtomicU8` round-trip the watchdog reads
-    /// back. A variant added without its `from_u8` arm still compiles (the
-    /// match has a `_` fallback) and would silently degrade the watchdog's
-    /// stall message to "unknown" — the opposite of why the stage exists.
+    /// back, and must keep the discriminant it was released with.
     #[test]
     fn every_loop_stage_round_trips_through_its_discriminant() {
-        const ALL: &[CaptureLoopStage] = &[
-            CaptureLoopStage::Unknown,
-            CaptureLoopStage::Heartbeat,
-            CaptureLoopStage::FocusGate,
-            CaptureLoopStage::WarmWait,
-            CaptureLoopStage::ColdWait,
-            CaptureLoopStage::PauseGate,
-            CaptureLoopStage::ReleaseStream,
-            CaptureLoopStage::InvalidateStreams,
-            CaptureLoopStage::ExclusionProbe,
-            CaptureLoopStage::VisualProbe,
-            CaptureLoopStage::TriggerWait,
-            CaptureLoopStage::Capture,
-            CaptureLoopStage::HotCachePush,
-            CaptureLoopStage::TriggerDrain,
-        ];
-
-        for stage in ALL {
+        for stage in ALL_STAGES {
+            let (discriminant, name) = expected_wire_form(*stage);
             assert_eq!(
-                CaptureLoopStage::from_u8(*stage as u8),
-                *stage,
-                "{} does not round-trip through discriminant {}",
-                stage.as_str(),
-                *stage as u8
+                *stage as u8, discriminant,
+                "{name} changed discriminant; stored values in flight would be misread"
             );
-            // `Unknown` is the one stage allowed to be called "unknown"; any
-            // other variant landing there means a missing `as_str` arm.
-            if !matches!(stage, CaptureLoopStage::Unknown) {
-                assert_ne!(
-                    stage.as_str(),
-                    "unknown",
-                    "discriminant {} has no distinct name",
-                    *stage as u8
-                );
-            }
+            assert_eq!(
+                CaptureLoopStage::from_u8(discriminant),
+                *stage,
+                "{name} does not round-trip through discriminant {discriminant}"
+            );
+            assert_eq!(stage.as_str(), name, "{name} reports the wrong name");
+        }
+    }
+
+    /// Catches the other half of the drift: a variant added to the enum and to
+    /// `from_u8`, but never added to `ALL_STAGES`, so the loop above silently
+    /// stops covering it.
+    #[test]
+    fn all_stages_covers_every_decodable_discriminant() {
+        let highest = ALL_STAGES
+            .iter()
+            .map(|stage| *stage as u8)
+            .max()
+            .expect("ALL_STAGES is never empty");
+
+        for discriminant in 0..=highest {
+            let claimants = ALL_STAGES
+                .iter()
+                .filter(|stage| **stage as u8 == discriminant)
+                .count();
+            assert_eq!(
+                claimants, 1,
+                "discriminant {discriminant} is claimed by {claimants} stages, expected exactly 1"
+            );
+        }
+
+        // Anything past the known range must stay Unknown. If it decodes to a
+        // real stage, a variant was added to the enum and `from_u8` but left
+        // out of `ALL_STAGES`.
+        for discriminant in (u16::from(highest) + 1)..=u16::from(u8::MAX) {
+            let decoded = CaptureLoopStage::from_u8(discriminant as u8);
+            assert_eq!(
+                decoded,
+                CaptureLoopStage::Unknown,
+                "discriminant {discriminant} decodes to {} but is missing from ALL_STAGES",
+                decoded.as_str()
+            );
         }
     }
 

--- a/crates/screenpipe-screen/src/metrics.rs
+++ b/crates/screenpipe-screen/src/metrics.rs
@@ -87,12 +87,24 @@ pub enum CaptureLoopStage {
     ExclusionProbe = 8,
     /// Bounded visual-change probe screenshot.
     VisualProbe = 9,
-    /// Waiting for a capture trigger.
+    /// Parked on the bounded (250ms) wait for the first capture trigger.
     TriggerWait = 10,
     /// Running the capture itself (screenshot + a11y walk + persist).
     Capture = 11,
     /// Pushing the captured frame into the hot cache.
     HotCachePush = 12,
+    /// Trigger wait returned; draining coalesced triggers and running the
+    /// synchronous gates (reduce, checkpoint promotion, visual-check decision)
+    /// before the exclusion probe.
+    ///
+    /// Split out of [`CaptureLoopStage::TriggerWait`] because that marker
+    /// covered both the bounded await *and* every synchronous gate after it.
+    /// A 250ms-bounded await cannot itself explain the multi-minute
+    /// gone-silent freezes, so "frozen in trigger-wait" was ambiguous exactly
+    /// where the #3939 triage needed precision: `trigger-wait` now means the
+    /// task was never resumed from a bounded timer, while `trigger-drain`
+    /// means a synchronous gate blocked (a lock held by another thread).
+    TriggerDrain = 13,
 }
 
 impl CaptureLoopStage {
@@ -113,6 +125,7 @@ impl CaptureLoopStage {
             CaptureLoopStage::TriggerWait => "trigger-wait",
             CaptureLoopStage::Capture => "capture",
             CaptureLoopStage::HotCachePush => "hot-cache-push",
+            CaptureLoopStage::TriggerDrain => "trigger-drain",
         }
     }
 
@@ -133,6 +146,7 @@ impl CaptureLoopStage {
             10 => CaptureLoopStage::TriggerWait,
             11 => CaptureLoopStage::Capture,
             12 => CaptureLoopStage::HotCachePush,
+            13 => CaptureLoopStage::TriggerDrain,
             _ => CaptureLoopStage::Unknown,
         }
     }
@@ -915,5 +929,70 @@ mod tests {
         assert_eq!(s.frames_dropped_timeout, 2);
         assert_eq!(s.frames_dropped_error, 1);
         assert_eq!(s.frames_dropped, 3);
+    }
+
+    /// Every stage must survive the `AtomicU8` round-trip the watchdog reads
+    /// back. A variant added without its `from_u8` arm still compiles (the
+    /// match has a `_` fallback) and would silently degrade the watchdog's
+    /// stall message to "unknown" — the opposite of why the stage exists.
+    #[test]
+    fn every_loop_stage_round_trips_through_its_discriminant() {
+        const ALL: &[CaptureLoopStage] = &[
+            CaptureLoopStage::Unknown,
+            CaptureLoopStage::Heartbeat,
+            CaptureLoopStage::FocusGate,
+            CaptureLoopStage::WarmWait,
+            CaptureLoopStage::ColdWait,
+            CaptureLoopStage::PauseGate,
+            CaptureLoopStage::ReleaseStream,
+            CaptureLoopStage::InvalidateStreams,
+            CaptureLoopStage::ExclusionProbe,
+            CaptureLoopStage::VisualProbe,
+            CaptureLoopStage::TriggerWait,
+            CaptureLoopStage::Capture,
+            CaptureLoopStage::HotCachePush,
+            CaptureLoopStage::TriggerDrain,
+        ];
+
+        for stage in ALL {
+            assert_eq!(
+                CaptureLoopStage::from_u8(*stage as u8),
+                *stage,
+                "{} does not round-trip through discriminant {}",
+                stage.as_str(),
+                *stage as u8
+            );
+            // `Unknown` is the one stage allowed to be called "unknown"; any
+            // other variant landing there means a missing `as_str` arm.
+            if !matches!(stage, CaptureLoopStage::Unknown) {
+                assert_ne!(
+                    stage.as_str(),
+                    "unknown",
+                    "discriminant {} has no distinct name",
+                    *stage as u8
+                );
+            }
+        }
+    }
+
+    /// The trigger wait and the synchronous gates after it must be
+    /// distinguishable, otherwise a #3939 freeze cannot be attributed to
+    /// either the timer or a blocking lock.
+    #[test]
+    fn trigger_wait_and_trigger_drain_are_distinct_stages() {
+        assert_ne!(
+            CaptureLoopStage::TriggerWait as u8,
+            CaptureLoopStage::TriggerDrain as u8
+        );
+        assert_eq!(CaptureLoopStage::TriggerWait.as_str(), "trigger-wait");
+        assert_eq!(CaptureLoopStage::TriggerDrain.as_str(), "trigger-drain");
+
+        // The watchdog reads the stage out of the live metrics, so prove the
+        // transition is observable there and not just on the enum.
+        let m = PipelineMetrics::new();
+        m.record_loop_stage(CaptureLoopStage::TriggerWait);
+        assert_eq!(m.loop_stage().0, CaptureLoopStage::TriggerWait);
+        m.record_loop_stage(CaptureLoopStage::TriggerDrain);
+        assert_eq!(m.loop_stage().0, CaptureLoopStage::TriggerDrain);
     }
 }

--- a/docs/coverage/CORE.md
+++ b/docs/coverage/CORE.md
@@ -9,10 +9,10 @@ confidence, and criticality.
 - Tracked crates: screenpipe-engine, screenpipe-db, screenpipe-sqlite-coordinator, screenpipe-audio, screenpipe-screen, screenpipe-a11y
 - Mapped suites: 32
 - Mapped Rust files: 321
-- Active test blocks: 3084
+- Active test blocks: 3088
 - Ignored/manual test blocks: 137
-- Declared test blocks: 3221
-- Weighted coverage points: 2540.2
+- Declared test blocks: 3225
+- Weighted coverage points: 2543.6
 
 Confidence weights: strong=1.0, partial=0.7, conditional=0.4, smoke=0.3.
 Criticality weights: high=1.0, medium=0.7, low=0.4.
@@ -23,19 +23,19 @@ are explicitly enabled in a runtime lane.
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 2953 | 132 | 2480.2 | 21 | 11 | 100% |
-| macos | 29 | 3006 | 112 | 2490.6 | 22 | 11 | 100% |
-| linux | 25 | 2629 | 105 | 2187.0 | 20 | 11 | 100% |
+| windows | 29 | 2957 | 132 | 2483.6 | 21 | 11 | 100% |
+| macos | 29 | 3010 | 112 | 2494.0 | 22 | 11 | 100% |
+| linux | 25 | 2633 | 105 | 2190.4 | 20 | 11 | 100% |
 
 ## Crate Summary
 
 | Crate | Suites | Integration files | Source unit files | Active tests | Ignored tests | Weighted points | Flows |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| screenpipe-engine | 10 | 18 | 102 | 1455 | 42 | 1117.4 | 10 |
+| screenpipe-engine | 10 | 18 | 102 | 1457 | 42 | 1118.8 | 10 |
 | screenpipe-db | 5 | 52 | 14 | 447 | 16 | 424.2 | 9 |
 | screenpipe-sqlite-coordinator | 1 | 0 | 2 | 16 | 0 | 16.0 | 2 |
 | screenpipe-audio | 6 | 25 | 51 | 591 | 43 | 517.4 | 5 |
-| screenpipe-screen | 6 | 9 | 18 | 241 | 9 | 216.9 | 4 |
+| screenpipe-screen | 6 | 9 | 18 | 243 | 9 | 218.9 | 4 |
 | screenpipe-a11y | 4 | 2 | 28 | 334 | 27 | 248.3 | 3 |
 
 ## Line Coverage
@@ -68,21 +68,21 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | database | 6 suites / 366 active / 12 ignored / 343.2 pts | 6 suites / 366 active / 12 ignored / 343.2 pts | 6 suites / 366 active / 12 ignored / 343.2 pts |
 | db-search | 2 suites / 111 active / 9 ignored / 111.0 pts | 2 suites / 111 active / 9 ignored / 111.0 pts | 2 suites / 111 active / 9 ignored / 111.0 pts |
 | engine-lifecycle | 6 suites / 208 active / 1 ignored / 183.6 pts | 6 suites / 208 active / 1 ignored / 183.6 pts | 5 suites / 202 active / 1 ignored / 181.9 pts |
-| local-api | 2 suites / 326 active / 9 ignored / 230.0 pts | 2 suites / 326 active / 9 ignored / 230.0 pts | 2 suites / 326 active / 9 ignored / 230.0 pts |
-| meeting | 6 suites / 1418 active / 19 ignored / 1160.9 pts | 6 suites / 1418 active / 19 ignored / 1160.9 pts | 4 suites / 1130 active / 15 ignored / 895.4 pts |
+| local-api | 2 suites / 327 active / 9 ignored / 230.7 pts | 2 suites / 327 active / 9 ignored / 230.7 pts | 2 suites / 327 active / 9 ignored / 230.7 pts |
+| meeting | 6 suites / 1419 active / 19 ignored / 1161.6 pts | 6 suites / 1419 active / 19 ignored / 1161.6 pts | 4 suites / 1131 active / 15 ignored / 896.1 pts |
 | ocr | 4 suites / 124 active / 7 ignored / 118.3 pts | 4 suites / 128 active / 7 ignored / 123.8 pts | 3 suites / 119 active / 6 ignored / 114.8 pts |
 | os-integration | 1 suites / 6 active / 0 ignored / 1.7 pts | 1 suites / 6 active / 0 ignored / 1.7 pts | - |
-| performance | 13 suites / 1375 active / 67 ignored / 1212.6 pts | 14 suites / 1473 active / 70 ignored / 1251.8 pts | 13 suites / 1375 active / 67 ignored / 1212.6 pts |
+| performance | 13 suites / 1378 active / 67 ignored / 1215.3 pts | 14 suites / 1476 active / 70 ignored / 1254.5 pts | 13 suites / 1378 active / 67 ignored / 1215.3 pts |
 | pipes | 1 suites / 462 active / 3 ignored / 323.4 pts | 1 suites / 462 active / 3 ignored / 323.4 pts | 1 suites / 462 active / 3 ignored / 323.4 pts |
-| privacy | 5 suites / 871 active / 36 ignored / 707.5 pts | 5 suites / 920 active / 16 ignored / 712.4 pts | 5 suites / 846 active / 14 ignored / 685.0 pts |
+| privacy | 5 suites / 873 active / 36 ignored / 709.5 pts | 5 suites / 922 active / 16 ignored / 714.4 pts | 5 suites / 848 active / 14 ignored / 687.0 pts |
 | real-app | - | 1 suites / 98 active / 3 ignored / 39.2 pts | - |
 | speaker | 2 suites / 348 active / 8 ignored / 348.0 pts | 2 suites / 348 active / 8 ignored / 348.0 pts | 2 suites / 348 active / 8 ignored / 348.0 pts |
-| storage | 3 suites / 475 active / 29 ignored / 385.0 pts | 3 suites / 475 active / 29 ignored / 385.0 pts | 3 suites / 475 active / 29 ignored / 385.0 pts |
+| storage | 3 suites / 476 active / 29 ignored / 385.7 pts | 3 suites / 476 active / 29 ignored / 385.7 pts | 3 suites / 476 active / 29 ignored / 385.7 pts |
 | sync | 1 suites / 462 active / 3 ignored / 323.4 pts | 1 suites / 462 active / 3 ignored / 323.4 pts | 1 suites / 462 active / 3 ignored / 323.4 pts |
-| timeline | 4 suites / 934 active / 33 ignored / 759.4 pts | 4 suites / 934 active / 33 ignored / 759.4 pts | 4 suites / 934 active / 33 ignored / 759.4 pts |
-| transcription | 5 suites / 699 active / 40 ignored / 551.9 pts | 5 suites / 699 active / 40 ignored / 551.9 pts | 5 suites / 699 active / 40 ignored / 551.9 pts |
+| timeline | 4 suites / 938 active / 33 ignored / 762.8 pts | 4 suites / 938 active / 33 ignored / 762.8 pts | 4 suites / 938 active / 33 ignored / 762.8 pts |
+| transcription | 5 suites / 700 active / 40 ignored / 552.6 pts | 5 suites / 700 active / 40 ignored / 552.6 pts | 5 suites / 700 active / 40 ignored / 552.6 pts |
 | ui-events | 4 suites / 701 active / 28 ignored / 533.9 pts | 3 suites / 652 active / 5 ignored / 499.6 pts | 3 suites / 652 active / 5 ignored / 499.6 pts |
-| vision-capture | 5 suites / 494 active / 32 ignored / 391.3 pts | 5 suites / 498 active / 32 ignored / 396.8 pts | 4 suites / 489 active / 31 ignored / 387.8 pts |
+| vision-capture | 5 suites / 497 active / 32 ignored / 394.0 pts | 5 suites / 501 active / 32 ignored / 399.5 pts | 4 suites / 492 active / 31 ignored / 390.5 pts |
 
 ## Critical Flow Matrix
 
@@ -133,8 +133,8 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | db-runtime-reliability | screenpipe-db | windows, macos, linux | database, performance | performance-liveness | high | partial | mixed | 13 | 30 | 6 | SQLite hard-fault classification, failpoint VFS injection, fresh-identity recovery verification with integrity/FK/write canaries, query cancellation, close-severs-connections regressions, multi-pool WAL parity, runtime version pinning, and WAL chaos plus memory-pressure probes, plus read-only quarantine self-heal verification for transient IOERR faults. |
 | db-search-indexing | screenpipe-db | windows, macos, linux | db-search, ocr, accessibility, performance | local-api-search, capture-ocr-pipeline, accessibility-ui-events, performance-liveness | high | strong | mixed | 13 | 105 | 4 | FTS, tokenizer, OCR snapshot search, query planning, ordering, accessibility search, and contention coverage. |
 | db-timeline-frames | screenpipe-db | windows, macos, linux | database, timeline, storage, performance | timeline-streaming, performance-liveness | high | strong | mixed | 18 | 175 | 3 | Frame/audio joins, timeline query shape, suggestions frames, write queue, DB primitives (src/db.rs split into src/db/ modules), feedback record upserts, media eviction anti-join regressions, SAF output registry, semantic storage, and timeline performance. |
-| engine-api-routes | screenpipe-engine | windows, macos, linux | local-api, timeline, meeting, transcription | local-api-search, timeline-streaming, meeting-live-notes, audio-record-transcribe | high | partial | mixed | 31 | 320 | 4 | Route/unit coverage for search, health, streaming, meetings, time/timezone, and transcription. Legacy endpoint/websocket tests require local data and remain ignored. |
-| engine-capture-timeline | screenpipe-engine | windows, macos, linux | vision-capture, timeline, storage, performance | capture-ocr-pipeline, timeline-streaming, performance-liveness | high | partial | mixed | 23 | 262 | 26 | Covers capture trigger logic, frame/audio linking, hot cache, timeline refresh regressions, fragmented MP4 extraction, and HD-mode control. Several real-data tests are intentionally ignored by default. |
+| engine-api-routes | screenpipe-engine | windows, macos, linux | local-api, timeline, meeting, transcription | local-api-search, timeline-streaming, meeting-live-notes, audio-record-transcribe | high | partial | mixed | 31 | 321 | 4 | Route/unit coverage for search, health, streaming, meetings, time/timezone, and transcription. Legacy endpoint/websocket tests require local data and remain ignored. |
+| engine-capture-timeline | screenpipe-engine | windows, macos, linux | vision-capture, timeline, storage, performance | capture-ocr-pipeline, timeline-streaming, performance-liveness | high | partial | mixed | 23 | 263 | 26 | Covers capture trigger logic, frame/audio linking, hot cache, timeline refresh regressions, fragmented MP4 extraction, and HD-mode control. Several real-data tests are intentionally ignored by default. |
 | engine-config-lifecycle | screenpipe-engine | windows, macos, linux | configuration, engine-lifecycle, performance | settings-to-engine-config, engine-health-lifecycle, performance-liveness | high | strong | mixed | 11 | 111 | 1 | Fast logic coverage for the config bridge, tray health debounce, sleep/power policies, and queue backpressure. |
 | engine-db-recovery-cli | screenpipe-engine | windows, macos, linux | database, engine-lifecycle | engine-health-lifecycle, performance-liveness | high | strong | unit | 1 | 8 | 0 | Exact DB/WAL/SHM working-copy preservation, rollback on archive failure, and restart repair for crashes during the multi-file generation swap. |
 | engine-focus-os | screenpipe-engine | windows, macos | engine-lifecycle, os-integration | engine-health-lifecycle, performance-liveness | medium | conditional | unit | 3 | 6 | 0 | Platform focus-tracker parsing/helpers. These files are cfg-gated and only execute on their target OS. |
@@ -144,7 +144,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | engine-retention-storage | screenpipe-engine | windows, macos, linux | storage, engine-lifecycle, performance | engine-health-lifecycle, performance-liveness | medium | strong | mixed | 5 | 38 | 0 | Local retention deletion (including lean-mode heavy-text stripping), cloud archive watermarking, atomic state-file replacement, and the low-disk capture monitor. |
 | engine-telemetry-observability | screenpipe-engine | windows, macos, linux | engine-lifecycle, performance | engine-health-lifecycle, performance-liveness | medium | strong | unit | 6 | 29 | 0 | PostHog capture gating, telemetry context shaping, piggyback telemetry forwarding, crash-log helpers, resource monitoring, and the recording-coverage reliability metric. |
 | screen-capture-ocr-contract | screenpipe-screen | windows, macos, linux | vision-capture, ocr | capture-ocr-pipeline | high | partial | unit | 3 | 14 | 0 | Cross-platform cached-OCR unit coverage for RawCaptureResult to CaptureResult metadata, browser URL, focus state, window-to-screen OCR coordinate transformation, Tesseract output parsing, and contour-based text-region detection for the meeting OCR gate. |
-| screen-capture-windowing | screenpipe-screen | windows, macos, linux | vision-capture, timeline, performance, privacy | capture-ocr-pipeline, timeline-streaming, privacy-and-redaction, performance-liveness | high | strong | mixed | 14 | 177 | 0 | Window filtering, empty-window regressions, retry policy, URL timing, monitor cache, OCR cache, snapshots, and image comparison. |
+| screen-capture-windowing | screenpipe-screen | windows, macos, linux | vision-capture, timeline, performance, privacy | capture-ocr-pipeline, timeline-streaming, privacy-and-redaction, performance-liveness | high | strong | mixed | 14 | 179 | 0 | Window filtering, empty-window regressions, retry policy, URL timing, monitor cache, OCR cache, snapshots, and image comparison. |
 | screen-custom-ocr | screenpipe-screen | windows, macos, linux | ocr | capture-ocr-pipeline | medium | conditional | manual | 1 | 0 | 2 | Custom OCR tests are ignored by default and only contribute when explicitly run. |
 | screen-macos-ocr | screenpipe-screen | macos | ocr, vision-capture | capture-ocr-pipeline | high | strong | mixed | 2 | 9 | 1 | Apple Vision OCR source/unit coverage and fixture OCR assertions. |
 | screen-monitor-platform | screenpipe-screen | windows, macos, linux | vision-capture | capture-ocr-pipeline | medium | partial | unit | 5 | 36 | 5 | Per-OS monitor enumeration (Windows, macOS, Wayland/portal on Linux) and the persistent Windows.Graphics.Capture session. Each file is cfg-gated and only executes on its target OS. |
@@ -353,7 +353,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | engine-telemetry-observability | screenpipe-engine | src/crash_log.rs | source | 4 | 0 | 4 |
 | engine-retention-storage | screenpipe-engine | src/disk_pressure.rs | source | 11 | 0 | 11 |
 | engine-meeting-privacy-sync | screenpipe-engine | src/drm_detector.rs | source | 19 | 2 | 21 |
-| engine-capture-timeline | screenpipe-engine | src/event_driven_capture.rs | source | 82 | 0 | 82 |
+| engine-capture-timeline | screenpipe-engine | src/event_driven_capture.rs | source | 83 | 0 | 83 |
 | engine-meeting-privacy-sync | screenpipe-engine | src/external_memory_sync.rs | source | 10 | 0 | 10 |
 | engine-capture-timeline | screenpipe-engine | src/focus_aware_controller.rs | source | 14 | 0 | 14 |
 | engine-focus-os | screenpipe-engine | src/focus_tracker/darwin.rs | source | 3 | 0 | 3 |
@@ -406,7 +406,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | engine-api-routes | screenpipe-engine | src/routes/request_origin.rs | source | 1 | 0 | 1 |
 | engine-api-routes | screenpipe-engine | src/routes/response_format.rs | source | 6 | 0 | 6 |
 | engine-api-routes | screenpipe-engine | src/routes/retranscribe.rs | source | 3 | 0 | 3 |
-| engine-api-routes | screenpipe-engine | src/routes/search.rs | source | 24 | 0 | 24 |
+| engine-api-routes | screenpipe-engine | src/routes/search.rs | source | 25 | 0 | 25 |
 | engine-api-routes | screenpipe-engine | src/routes/semantic.rs | source | 2 | 0 | 2 |
 | engine-api-routes | screenpipe-engine | src/routes/speakers.rs | source | 4 | 0 | 4 |
 | engine-api-routes | screenpipe-engine | src/routes/streaming.rs | source | 15 | 0 | 15 |
@@ -452,7 +452,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | screen-capture-windowing | screenpipe-screen | src/capture_screenshot_by_window.rs | source | 63 | 0 | 63 |
 | screen-capture-ocr-contract | screenpipe-screen | src/core.rs | source | 1 | 0 | 1 |
 | screen-capture-windowing | screenpipe-screen | src/frame_comparison.rs | source | 16 | 0 | 16 |
-| screen-capture-windowing | screenpipe-screen | src/metrics.rs | source | 10 | 0 | 10 |
+| screen-capture-windowing | screenpipe-screen | src/metrics.rs | source | 12 | 0 | 12 |
 | screen-windows-ocr | screenpipe-screen | src/microsoft.rs | source | 4 | 0 | 4 |
 | screen-capture-windowing | screenpipe-screen | src/monitor.rs | source | 5 | 0 | 5 |
 | screen-monitor-platform | screenpipe-screen | src/monitor/linux_portal.rs | source | 5 | 0 | 5 |

--- a/docs/coverage/CORE.md
+++ b/docs/coverage/CORE.md
@@ -9,10 +9,10 @@ confidence, and criticality.
 - Tracked crates: screenpipe-engine, screenpipe-db, screenpipe-sqlite-coordinator, screenpipe-audio, screenpipe-screen, screenpipe-a11y
 - Mapped suites: 32
 - Mapped Rust files: 321
-- Active test blocks: 3088
+- Active test blocks: 3089
 - Ignored/manual test blocks: 137
-- Declared test blocks: 3225
-- Weighted coverage points: 2543.6
+- Declared test blocks: 3226
+- Weighted coverage points: 2544.6
 
 Confidence weights: strong=1.0, partial=0.7, conditional=0.4, smoke=0.3.
 Criticality weights: high=1.0, medium=0.7, low=0.4.
@@ -23,9 +23,9 @@ are explicitly enabled in a runtime lane.
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 2957 | 132 | 2483.6 | 21 | 11 | 100% |
-| macos | 29 | 3010 | 112 | 2494.0 | 22 | 11 | 100% |
-| linux | 25 | 2633 | 105 | 2190.4 | 20 | 11 | 100% |
+| windows | 29 | 2958 | 132 | 2484.6 | 21 | 11 | 100% |
+| macos | 29 | 3011 | 112 | 2495.0 | 22 | 11 | 100% |
+| linux | 25 | 2634 | 105 | 2191.4 | 20 | 11 | 100% |
 
 ## Crate Summary
 
@@ -35,7 +35,7 @@ are explicitly enabled in a runtime lane.
 | screenpipe-db | 5 | 52 | 14 | 447 | 16 | 424.2 | 9 |
 | screenpipe-sqlite-coordinator | 1 | 0 | 2 | 16 | 0 | 16.0 | 2 |
 | screenpipe-audio | 6 | 25 | 51 | 591 | 43 | 517.4 | 5 |
-| screenpipe-screen | 6 | 9 | 18 | 243 | 9 | 218.9 | 4 |
+| screenpipe-screen | 6 | 9 | 18 | 244 | 9 | 219.9 | 4 |
 | screenpipe-a11y | 4 | 2 | 28 | 334 | 27 | 248.3 | 3 |
 
 ## Line Coverage
@@ -72,17 +72,17 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | meeting | 6 suites / 1419 active / 19 ignored / 1161.6 pts | 6 suites / 1419 active / 19 ignored / 1161.6 pts | 4 suites / 1131 active / 15 ignored / 896.1 pts |
 | ocr | 4 suites / 124 active / 7 ignored / 118.3 pts | 4 suites / 128 active / 7 ignored / 123.8 pts | 3 suites / 119 active / 6 ignored / 114.8 pts |
 | os-integration | 1 suites / 6 active / 0 ignored / 1.7 pts | 1 suites / 6 active / 0 ignored / 1.7 pts | - |
-| performance | 13 suites / 1378 active / 67 ignored / 1215.3 pts | 14 suites / 1476 active / 70 ignored / 1254.5 pts | 13 suites / 1378 active / 67 ignored / 1215.3 pts |
+| performance | 13 suites / 1379 active / 67 ignored / 1216.3 pts | 14 suites / 1477 active / 70 ignored / 1255.5 pts | 13 suites / 1379 active / 67 ignored / 1216.3 pts |
 | pipes | 1 suites / 462 active / 3 ignored / 323.4 pts | 1 suites / 462 active / 3 ignored / 323.4 pts | 1 suites / 462 active / 3 ignored / 323.4 pts |
-| privacy | 5 suites / 873 active / 36 ignored / 709.5 pts | 5 suites / 922 active / 16 ignored / 714.4 pts | 5 suites / 848 active / 14 ignored / 687.0 pts |
+| privacy | 5 suites / 874 active / 36 ignored / 710.5 pts | 5 suites / 923 active / 16 ignored / 715.4 pts | 5 suites / 849 active / 14 ignored / 688.0 pts |
 | real-app | - | 1 suites / 98 active / 3 ignored / 39.2 pts | - |
 | speaker | 2 suites / 348 active / 8 ignored / 348.0 pts | 2 suites / 348 active / 8 ignored / 348.0 pts | 2 suites / 348 active / 8 ignored / 348.0 pts |
 | storage | 3 suites / 476 active / 29 ignored / 385.7 pts | 3 suites / 476 active / 29 ignored / 385.7 pts | 3 suites / 476 active / 29 ignored / 385.7 pts |
 | sync | 1 suites / 462 active / 3 ignored / 323.4 pts | 1 suites / 462 active / 3 ignored / 323.4 pts | 1 suites / 462 active / 3 ignored / 323.4 pts |
-| timeline | 4 suites / 938 active / 33 ignored / 762.8 pts | 4 suites / 938 active / 33 ignored / 762.8 pts | 4 suites / 938 active / 33 ignored / 762.8 pts |
+| timeline | 4 suites / 939 active / 33 ignored / 763.8 pts | 4 suites / 939 active / 33 ignored / 763.8 pts | 4 suites / 939 active / 33 ignored / 763.8 pts |
 | transcription | 5 suites / 700 active / 40 ignored / 552.6 pts | 5 suites / 700 active / 40 ignored / 552.6 pts | 5 suites / 700 active / 40 ignored / 552.6 pts |
 | ui-events | 4 suites / 701 active / 28 ignored / 533.9 pts | 3 suites / 652 active / 5 ignored / 499.6 pts | 3 suites / 652 active / 5 ignored / 499.6 pts |
-| vision-capture | 5 suites / 497 active / 32 ignored / 394.0 pts | 5 suites / 501 active / 32 ignored / 399.5 pts | 4 suites / 492 active / 31 ignored / 390.5 pts |
+| vision-capture | 5 suites / 498 active / 32 ignored / 395.0 pts | 5 suites / 502 active / 32 ignored / 400.5 pts | 4 suites / 493 active / 31 ignored / 391.5 pts |
 
 ## Critical Flow Matrix
 
@@ -144,7 +144,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | engine-retention-storage | screenpipe-engine | windows, macos, linux | storage, engine-lifecycle, performance | engine-health-lifecycle, performance-liveness | medium | strong | mixed | 5 | 38 | 0 | Local retention deletion (including lean-mode heavy-text stripping), cloud archive watermarking, atomic state-file replacement, and the low-disk capture monitor. |
 | engine-telemetry-observability | screenpipe-engine | windows, macos, linux | engine-lifecycle, performance | engine-health-lifecycle, performance-liveness | medium | strong | unit | 6 | 29 | 0 | PostHog capture gating, telemetry context shaping, piggyback telemetry forwarding, crash-log helpers, resource monitoring, and the recording-coverage reliability metric. |
 | screen-capture-ocr-contract | screenpipe-screen | windows, macos, linux | vision-capture, ocr | capture-ocr-pipeline | high | partial | unit | 3 | 14 | 0 | Cross-platform cached-OCR unit coverage for RawCaptureResult to CaptureResult metadata, browser URL, focus state, window-to-screen OCR coordinate transformation, Tesseract output parsing, and contour-based text-region detection for the meeting OCR gate. |
-| screen-capture-windowing | screenpipe-screen | windows, macos, linux | vision-capture, timeline, performance, privacy | capture-ocr-pipeline, timeline-streaming, privacy-and-redaction, performance-liveness | high | strong | mixed | 14 | 179 | 0 | Window filtering, empty-window regressions, retry policy, URL timing, monitor cache, OCR cache, snapshots, and image comparison. |
+| screen-capture-windowing | screenpipe-screen | windows, macos, linux | vision-capture, timeline, performance, privacy | capture-ocr-pipeline, timeline-streaming, privacy-and-redaction, performance-liveness | high | strong | mixed | 14 | 180 | 0 | Window filtering, empty-window regressions, retry policy, URL timing, monitor cache, OCR cache, snapshots, and image comparison. |
 | screen-custom-ocr | screenpipe-screen | windows, macos, linux | ocr | capture-ocr-pipeline | medium | conditional | manual | 1 | 0 | 2 | Custom OCR tests are ignored by default and only contribute when explicitly run. |
 | screen-macos-ocr | screenpipe-screen | macos | ocr, vision-capture | capture-ocr-pipeline | high | strong | mixed | 2 | 9 | 1 | Apple Vision OCR source/unit coverage and fixture OCR assertions. |
 | screen-monitor-platform | screenpipe-screen | windows, macos, linux | vision-capture | capture-ocr-pipeline | medium | partial | unit | 5 | 36 | 5 | Per-OS monitor enumeration (Windows, macOS, Wayland/portal on Linux) and the persistent Windows.Graphics.Capture session. Each file is cfg-gated and only executes on its target OS. |
@@ -452,7 +452,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | screen-capture-windowing | screenpipe-screen | src/capture_screenshot_by_window.rs | source | 63 | 0 | 63 |
 | screen-capture-ocr-contract | screenpipe-screen | src/core.rs | source | 1 | 0 | 1 |
 | screen-capture-windowing | screenpipe-screen | src/frame_comparison.rs | source | 16 | 0 | 16 |
-| screen-capture-windowing | screenpipe-screen | src/metrics.rs | source | 12 | 0 | 12 |
+| screen-capture-windowing | screenpipe-screen | src/metrics.rs | source | 13 | 0 | 13 |
 | screen-windows-ocr | screenpipe-screen | src/microsoft.rs | source | 4 | 0 | 4 |
 | screen-capture-windowing | screenpipe-screen | src/monitor.rs | source | 5 | 0 | 5 |
 | screen-monitor-platform | screenpipe-screen | src/monitor/linux_portal.rs | source | 5 | 0 | 5 |


### PR DESCRIPTION
## Problem

The gone-silent watchdog reports **"frozen in `<stage>`"** so a stall names a locatable point in the capture loop. For the #3939 gone-silent freeze it names the wrong place.

Observed on macOS over ~2 hours, six separate freezes, every one identical:

```
vision capture stalled on monitor N (gone-silent stall): status=Running,
frozen in trigger-wait for 104s, loop heartbeat 104s ago, last attempt 105s ago,
no terminal capture outcome for 105s — restarting VisionManager (#3939)
```

Durations were 87s, 104s, 110s, 243s. But the await that `TriggerWait` marks is:

```rust
match tokio::time::timeout(poll_interval, trigger_rx.recv()).await   // poll_interval = 250ms
```

**A 250ms-bounded timeout cannot account for a 243s freeze.** The marker was lying about where the loop stopped.

## Where found

`TriggerWait` is recorded *before* the bounded await and never re-recorded after it. The next marker is `ExclusionProbe`, ~140 lines later. So one stage covered two very different failure modes:

```
  record_loop_stage(TriggerWait)
      |
      |  timeout(250ms, trigger_rx.recv()).await      <-- bounded, cannot hang
      |  drain try_recv() loop                        \
      |  retain / reduce_drained_triggers()            |  synchronous gates,
      |  pending checkpoint promotion                  |  can block on a lock
      |  should_run_visual_check(...)                 /
      |
  record_loop_stage(ExclusionProbe)
```

Everything in that span reports `trigger-wait`.

## Root cause

Missing stage transition, not a logic bug. The marker's own doc comment states its purpose is to turn *"loop heartbeat 248s ago"* into *"frozen in `<stage>` for 248s"* — and for this stall it resolved to a span whose only await is bounded at 250ms, which is the one explanation ruled out by the evidence.

## Fix

Record `TriggerDrain` as soon as the bounded wait returns, so the two causes separate:

| stage | meaning |
|---|---|
| `trigger-wait` | task was never resumed from a bounded timer (scheduler/timer level) |
| `trigger-drain` | a synchronous gate blocked (lock held by another thread) |

**Before / after** for the same freeze:

```
before   frozen in trigger-wait for 243s     -> ambiguous across ~140 lines,
                                                and impossible for a 250ms await

after    frozen in trigger-wait  for 243s    -> task never resumed; look at the
                                                runtime, timer driver, task liveness
         frozen in trigger-drain for 243s    -> a sync gate is blocking; look at the
                                                locks behind poll_activity /
                                                keyboard_idle_ms / drm / schedule
```

Instrumentation only. No behaviour change: one extra atomic store per iteration on a path that already performs two.

## Validation

- `cargo test -p screenpipe-screen --lib metrics::` — 12 passed, including two new tests
  - `every_loop_stage_round_trips_through_its_discriminant` guards the `AtomicU8` round-trip the watchdog reads back. A variant added without its `from_u8` arm still compiles (the match has a `_` fallback) and would silently degrade the watchdog message to `unknown`. This test fails without the `from_u8` arm in this PR.
  - `trigger_wait_and_trigger_drain_are_distinct_stages` asserts the transition through live `PipelineMetrics`, not just the enum.
- `cargo test -p screenpipe-engine --lib vision_manager::monitor_watcher` — 26 passed
- `cargo check -p screenpipe-engine` clean; `rustfmt --check` clean on both files; no new clippy warnings in the touched files

### Not covered

No runtime assertion that the real loop reaches the new marker. No existing harness drives the capture loop and asserts stages, and I deliberately did not start a second capture instance on the affected machine: another SCK consumer during an active wedge would confound the measurement. **Runtime confirmation is the next #3939 freeze on a build containing this** — it should now report `trigger-wait` or `trigger-drain`, and either answer narrows the root cause.

## Context

While gathering this I also verified the surrounding detection is working correctly, in case it saves someone repeating it:

- `/health` is honest. Across full freeze cycles it reported `healthy`/200 below the 60s threshold, then `degraded`/503 with `frame_status: stale`, then recovered. It does not mask the stall.
- The watchdog detects and restarts every time; recovery succeeded on all six freezes.
- A process stack sample taken mid-freeze showed **no** capture-loop frames on any thread and ~50 tokio workers parked idle, so the runtime is not starved and no thread is spinning. The task is parked at an await that is not resuming — which is exactly what the new marker will disambiguate.
