### PR TITLE
fix(config): accept legacy scalar monitorIds

### DIFF
--- a/crates/screenpipe-config/src/recording.rs
+++ b/crates/screenpipe-config/src/recording.rs
@@ -6,6 +6,26 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Older desktop builds persisted a single selected monitor as a string, while
+/// current builds persist an array. Accept both shapes so an upgrade preserves
+/// the user's selection instead of rejecting the entire settings store.
+fn deserialize_monitor_ids<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StringOrVec {
+        Vec(Vec<String>),
+        String(String),
+    }
+
+    Ok(match StringOrVec::deserialize(deserializer)? {
+        StringOrVec::Vec(ids) => ids,
+        StringOrVec::String(id) => vec![id],
+    })
+}
+
 /// Custom vocabulary entry for transcription biasing and word replacement.
 #[derive(Clone, Debug, Default, Serialize, PartialEq)]
 #[cfg_attr(feature = "specta", derive(specta::Type))]
@@ -292,7 +312,7 @@ pub struct RecordingSettings {
     pub disable_timeline: bool,
 
     /// Specific monitor IDs to capture.
-    #[serde(rename = "monitorIds")]
+    #[serde(rename = "monitorIds", deserialize_with = "deserialize_monitor_ids")]
     pub monitor_ids: Vec<String>,
 
     /// Capture from all connected monitors.
@@ -1017,6 +1037,27 @@ mod tests {
         let json = r#"{"unknownFutureField": true, "port": 4040}"#;
         let settings: RecordingSettings = serde_json::from_str(json).unwrap();
         assert_eq!(settings.port, 4040);
+    }
+
+    #[test]
+    fn legacy_scalar_monitor_id_deserializes_as_single_selection() {
+        let mut json = serde_json::to_value(RecordingSettings::default()).unwrap();
+        json["monitorIds"] = serde_json::json!(r"\\.\DISPLAY1_3840x2160_0,0");
+
+        let settings: RecordingSettings = serde_json::from_value(json).unwrap();
+
+        assert_eq!(
+            settings.monitor_ids,
+            vec![r"\\.\DISPLAY1_3840x2160_0,0".to_string()]
+        );
+    }
+
+    #[test]
+    fn malformed_monitor_id_shape_still_fails_deserialization() {
+        let mut json = serde_json::to_value(RecordingSettings::default()).unwrap();
+        json["monitorIds"] = serde_json::json!({"id": "DISPLAY1"});
+
+        assert!(serde_json::from_value::<RecordingSettings>(json).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Root cause

`RecordingSettings.monitor_ids` accepts only `Vec<String>`, but an older desktop settings shape persisted a single selected Windows monitor as a scalar string. On upgrade, `SettingsStore::get` rejects the entire settings object with `invalid type: string ..., expected a sequence`, falls back to defaults for the process, and intentionally does not overwrite the original store. That makes the failure recur at startup and temporarily discards all stored choices in memory.

This patch accepts either the current array or the legacy scalar and maps the scalar to a one-element list. Malformed object shapes still fail instead of being silently coerced.

## Privacy-safe Sentry impact

- Issue: `SCREENPIPE-APP-JZ`
- UTC window: `2026-08-13T03:00:54.565Z/2026-08-14T03:00:54.565Z`
- Exact Explore aggregate: 0 identified users, 1 event
- Severity: handled error; no confirmed security, privacy, or data-loss impact
- Release/platform: `screenpipe-app@2.6.20`, Windows 10

## Exact revisions

- Baseline: `8826dbda83f6233d7eae5d4beacd028f51d296fb`
- Patch/tested head: `86d3d784079bdb95db35a7efc6f705aca345cc48`

## Test matrix

- Regression test on baseline: failed with exit 101 and the exact `expected a sequence` error
- Regression test on patch: passed
- Existing array and empty/default settings: passed in `screenpipe-config` suite
- Malformed object input: explicitly remains rejected
- `cargo test -p screenpipe-config --all-features`: 38 passed
- `cargo fmt --all -- --check`: passed
- `cargo clippy -p screenpipe-config --all-targets --all-features -- -D warnings`: passed
- macOS desktop `cargo check --manifest-path apps/screenpipe-app-tauri/src-tauri/Cargo.toml --bin screenpipe-app`: passed after documented sidecar prebuild
- Clean deterministic scenario: 3/3 passed
- Exact-head required CI: 10/10 green, including Windows Rust test/build and integration jobs
- Advisory Windows E2E: failed in unrelated settings/highlight/navigation UI specs; the touched Rust config parser was not implicated
- Windows physical startup: unproven locally
- Soak/stress: not applicable to a bounded settings-deserialization branch

## Before/after evidence

- Before: `/Users/louisbeaumont/Documents/Codex/2026-08-05/cre/outputs/hourly-sentry-fixes/SCREENPIPE-APP-JZ/86d3d784079bdb95db35a7efc6f705aca345cc48/before.mp4`
- After: `/Users/louisbeaumont/Documents/Codex/2026-08-05/cre/outputs/hourly-sentry-fixes/SCREENPIPE-APP-JZ/86d3d784079bdb95db35a7efc6f705aca345cc48/after.mp4`
- Manifest/checksums/logs: `/Users/louisbeaumont/Documents/Codex/2026-08-05/cre/outputs/hourly-sentry-fixes/SCREENPIPE-APP-JZ/86d3d784079bdb95db35a7efc6f705aca345cc48/`

The clips use the same synthetic input, command, assertion, seed, and 1280x720 viewport. They contain no customer data, tokens, notifications, or unrelated windows and are not committed or uploaded.

## Risk and rollback

Risk is limited to deserialization of `monitorIds`: arrays are unchanged, scalar strings become one-element arrays, and other shapes still fail. Cross-platform serde behavior is portable, but the observed Windows startup path still needs CI/platform validation.

Rollback: revert `86d3d784079bdb95db35a7efc6f705aca345cc48`.

## Evidence state

- [x] Source-level root cause reproduced
- [x] Baseline failure and patch pass preserved
- [x] Focused, package, format, lint, desktop-check, edge, and three-run evidence preserved
- [x] Before/after videos inspected and checksummed
- [x] Final diff contains one source file only
- [x] Exact-head required CI green
- [ ] Windows physical/platform evidence
- [ ] Merged
- [ ] Deployed/released
- [ ] Installed canary verified
- [ ] Affected-user recovery verified
