### PR TITLE
fix(connections): remove admin-only M365 scope (#6229)

### DIFF
--- a/crates/screenpipe-connect/src/connections/microsoft365.rs
+++ b/crates/screenpipe-connect/src/connections/microsoft365.rs
@@ -19,10 +19,9 @@ use serde_json::{Map, Value};
 //   Mail.Read, Mail.ReadWrite, Mail.Send,
 //   Calendars.Read, Calendars.ReadWrite,
 //   Files.Read, Files.ReadWrite,
-//   Chat.ReadWrite, Team.ReadBasic.All,
-//   ChannelMessage.Read.All  (requires tenant admin consent at
-//     https://login.microsoftonline.com/<tenant>/adminconsent — other scopes
-//     work with standard user consent).
+//   Chat.ReadWrite, Team.ReadBasic.All.
+// All requested scopes work with standard user consent. Admin-consent-only
+// scopes belong in a separate, explicit consent flow rather than the default.
 static OAUTH: OAuthConfig = OAuthConfig {
     auth_url: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
     client_id: "be765a6d-62fd-4abe-9703-3ffcfee711b9",
@@ -34,7 +33,7 @@ static OAUTH: OAuthConfig = OAuthConfig {
              Calendars.Read Calendars.ReadWrite \
              Files.Read Files.ReadWrite \
              Chat.ReadWrite \
-             Team.ReadBasic.All ChannelMessage.Read.All",
+             Team.ReadBasic.All",
         ),
         // select_account so a second connect shows Microsoft's account picker
         // instead of silently consenting under the already-signed-in account —
@@ -132,5 +131,50 @@ impl Integration for Microsoft365 {
 
         let name = resp["displayName"].as_str().unwrap_or("unknown");
         Ok(format!("connected as {}", name))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_scopes() -> Vec<&'static str> {
+        Microsoft365
+            .oauth_config()
+            .expect("microsoft365 uses OAuth")
+            .extra_auth_params
+            .iter()
+            .find(|(key, _)| *key == "scope")
+            .map(|(_, value)| value.split_whitespace().collect())
+            .expect("scope param present")
+    }
+
+    #[test]
+    fn default_scope_excludes_admin_consent_only_channel_messages() {
+        assert!(!default_scopes().contains(&"ChannelMessage.Read.All"));
+    }
+
+    #[test]
+    fn default_scope_retains_microsoft365_access() {
+        let scopes = default_scopes();
+        for required in [
+            "offline_access",
+            "openid",
+            "profile",
+            "Mail.Read",
+            "Mail.ReadWrite",
+            "Mail.Send",
+            "Calendars.Read",
+            "Calendars.ReadWrite",
+            "Files.Read",
+            "Files.ReadWrite",
+            "Chat.ReadWrite",
+            "Team.ReadBasic.All",
+        ] {
+            assert!(
+                scopes.contains(&required),
+                "missing required scope: {required}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes screenpipe/screenpipe#6229.

The default Microsoft 365 OAuth request included `ChannelMessage.Read.All`, a delegated permission that requires tenant administrator consent. Because it was bundled with the normal Mail, Calendar, Files, Chat, and Team scopes, users in tenants that restrict admin-only consent could not complete the Microsoft 365 connection.

This change:

* removes `ChannelMessage.Read.All` from the default Microsoft 365 OAuth scope;
* retains the existing user-consentable Microsoft 365 scopes;
* adds focused regression tests covering both conditions.

The Teams connector and shared OAuth, callback, deep-link, timeout, and frontend behavior are unchanged.

## Before / After

### Before

The default Microsoft 365 OAuth scope contained `ChannelMessage.Read.All`, causing affected tenants to show the Microsoft 365 “Need admin approval” or `access_denied` flow.

A manually captured screenshot of the affected flow will be attached separately, with personal information blurred before upload.

<img src="https://github.com/user-attachments/assets/c47f95fe-ffc1-44d3-a15e-86c7963d52e8 " alt="Before" width="1325" data-linear-height="1187" />

<img src="https://github.com/user-attachments/assets/4729e000-9bc3-4ead-92c6-f44e9842547c " alt="Screenshot 2026-08-14 102400" width="1315" data-linear-height="809" />

### After — automated verification

Live UI verification was not performed because the local development OAuth redirect is unreliable. No successful live OAuth screenshot is included or claimed.

The fix is verified through focused automated regression coverage:

* Before the fix, the default Microsoft 365 scope contained `ChannelMessage.Read.All`.
* After the fix, the regression test verifies that `ChannelMessage.Read.All` is absent.
* The test also verifies that the intended Mail, Calendar, Files, Chat, and Team scopes remain present.
* All relevant Rust tests and checks passed.

This automated verification proves the default scope configuration changed as intended; it is distinct from live end-to-end OAuth verification.

## Verification

* `cargo test -p screenpipe-connect microsoft365`
* `cargo test -p screenpipe-connect`
* `cargo check -p screenpipe-connect`
* `cargo build -p screenpipe-connect`
* `cargo clippy -p screenpipe-connect --all-targets -- -W clippy::all`
* `cargo fmt --all -- --check`
* `git diff --check`

Live Microsoft OAuth verification could not be completed because the local development OAuth redirect is not working reliably.