### PR TITLE
fix(meetings): stop the note view reporting that nothing is happening

### DIFF
--- a/apps/screenpipe-app-tauri/components/meeting-notes/meeting-share-menu.test.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/meeting-share-menu.test.tsx
@@ -44,14 +44,32 @@ describe("meeting share control", () => {
       <MeetingShareMenu canShareSummary={false} onShare={onShare} />,
     );
 
-    // The label names the scope, so the primary click never silently changes
-    // meaning between states.
+    // The accessible name still names the scope, so the primary click never
+    // silently changes meaning between states. The control is icon-only at
+    // rest: fewer than 1 in 10 people who open a meeting use any share action,
+    // so a visible word here competed with the tabs beside it.
     const primary = screen.getByRole("button", {
       name: "copy meeting + transcript",
     });
-    expect(primary).toHaveTextContent("copy");
+    expect(primary).toHaveTextContent("");
     fireEvent.click(primary);
     expect(onShare).toHaveBeenCalledWith("meeting");
+  });
+
+  // The word comes back only to confirm the copy, which is the one moment it
+  // carries information the icon does not.
+  it("names the action only while confirming it", () => {
+    render(
+      <MeetingShareMenu
+        canShareSummary={false}
+        copiedAction="meeting"
+        onShare={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "copy meeting + transcript" }),
+    ).toHaveTextContent("copied");
   });
 
   it("offers the remaining destinations behind the caret", async () => {

--- a/apps/screenpipe-app-tauri/components/meeting-notes/meeting-share-menu.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/meeting-share-menu.tsx
@@ -13,6 +13,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
+import { MEETING_RULE_ACTION_CLASS } from "./meeting-workspace";
 
 /**
  * One share control for the whole meeting.
@@ -43,9 +44,8 @@ export type MeetingShareAction =
 
 // Matches the tab buttons on the same rule: same height, same rhythm, same
 // separator. The control has to read as part of the rule, not as a chip
-// floating on it.
-const RULE_ACTION_CLASS =
-  "flex h-11 shrink-0 items-center gap-2 border-l border-border font-mono text-[11px] uppercase tracking-[0.12em] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:z-10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-foreground disabled:text-muted-foreground/50 disabled:hover:bg-transparent";
+// floating on it. Now shared with the meeting actions that moved onto this rule.
+const RULE_ACTION_CLASS = MEETING_RULE_ACTION_CLASS;
 
 const ACTION_LABEL: Record<MeetingShareAction, string> = {
   summary: "copy summary",
@@ -78,8 +78,6 @@ export function MeetingShareMenu({
   onShare: (action: MeetingShareAction) => void;
 }) {
   const primary: MeetingShareAction = canShareSummary ? "summary" : "meeting";
-  // Short enough to sit on the rule next to three tabs at narrow widths.
-  const primaryLabel = canShareSummary ? "share" : "copy";
   const secondary: MeetingShareAction[] = canShareSummary
     ? ["email", "transcript", "meeting"]
     : ["transcript"];
@@ -107,9 +105,11 @@ export function MeetingShareMenu({
         ) : (
           <PrimaryIcon className="h-3.5 w-3.5" />
         )}
-        <span className="hidden sm:inline">
-          {confirmed ? "copied" : primaryLabel}
-        </span>
+        {/* Icon only at rest. Fewer than 1 in 10 people who open a meeting use
+            any share action, so a text label here competed with the tabs for
+            attention it had not earned. The word comes back to confirm the
+            copy, which is the moment it actually carries information. */}
+        {confirmed && <span className="hidden sm:inline">copied</span>}
       </button>
 
       <DropdownMenu>

--- a/apps/screenpipe-app-tauri/components/meeting-notes/meeting-workspace.test.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/meeting-workspace.test.tsx
@@ -108,8 +108,42 @@ describe("meeting workspace tabs", () => {
     expect(screen.getByRole("tab", { name: "summary" })).toHaveFocus();
   });
 
-  // Whichever branch renders, the tabs sit on exactly one bottom rule.
-  it("keeps a single bottom rule with and without a trailing action", () => {
+  // A dot on a tab is a request for attention. Work in flight and failures
+  // qualify; a summary that finished normally does not, and it used to stay
+  // lit on every summarized meeting forever.
+  it("only marks the summary tab while work is in flight or has failed", () => {
+    const { rerender } = render(
+      <MeetingWorkspaceTabs
+        value="notes"
+        onValueChange={vi.fn()}
+        summaryState="working"
+      />,
+    );
+    expect(screen.getByLabelText("summary working")).toBeVisible();
+
+    rerender(
+      <MeetingWorkspaceTabs
+        value="notes"
+        onValueChange={vi.fn()}
+        summaryState="attention"
+      />,
+    );
+    expect(screen.getByLabelText("summary attention")).toBeVisible();
+
+    rerender(
+      <MeetingWorkspaceTabs
+        value="notes"
+        onValueChange={vi.fn()}
+        summaryState={null}
+      />,
+    );
+    expect(screen.queryByLabelText(/^summary /)).toBeNull();
+  });
+
+  // Standalone, the tabs draw their own rule. With a trailing action they are
+  // the last row of the meeting header, which already draws a full-bleed rule,
+  // so drawing one here too produced a visibly doubled line.
+  it("draws its own bottom rule only when it is not in the meeting header", () => {
     const { container: plain } = render(
       <MeetingWorkspaceTabs value="notes" onValueChange={vi.fn()} />,
     );
@@ -122,7 +156,7 @@ describe("meeting workspace tabs", () => {
         trailing={<button type="button">copy</button>}
       />,
     );
-    expect(withTrailing.querySelectorAll(".border-b")).toHaveLength(1);
+    expect(withTrailing.querySelectorAll(".border-b")).toHaveLength(0);
   });
 });
 

--- a/apps/screenpipe-app-tauri/components/meeting-notes/meeting-workspace.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/meeting-workspace.tsx
@@ -44,7 +44,9 @@ export function MeetingWorkspaceTabs({
 }: {
   value: MeetingWorkspaceTab;
   onValueChange: (value: MeetingWorkspaceTab) => void;
-  summaryState?: "working" | "ready" | "attention" | null;
+  // Only states that want something from the reader get a dot. "finished
+  // normally" is not one of them.
+  summaryState?: "working" | "attention" | null;
   // Rendered on the same rule as the tabs but outside the tablist, so a
   // note-wide action stays reachable from every tab without becoming a
   // fourth pseudo-tab for arrow-key navigation.
@@ -111,8 +113,8 @@ export function MeetingWorkspaceTabs({
                 aria-label={`summary ${state}`}
                 className={cn(
                   "h-1.5 w-1.5 shrink-0",
-                  state === "working" && "animate-pulse bg-current",
-                  state === "ready" && "bg-current",
+                  state === "working" &&
+                    "animate-pulse bg-current motion-reduce:animate-none",
                   state === "attention" && "bg-amber-500",
                 )}
               />
@@ -125,8 +127,11 @@ export function MeetingWorkspaceTabs({
 
   if (!trailing) return tablist;
 
+  // No border here: this row is the last thing in the meeting header, which
+  // already draws a full-bleed rule underneath it. Both together read as a
+  // doubled line, one inset and one not.
   return (
-    <div className="flex min-w-0 items-stretch border-b border-border">
+    <div className="flex min-w-0 items-stretch">
       {tablist}
       <div className="ml-auto flex shrink-0 items-stretch">{trailing}</div>
     </div>

--- a/apps/screenpipe-app-tauri/components/meeting-notes/meeting-workspace.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/meeting-workspace.tsx
@@ -27,6 +27,12 @@ export const MEETING_READING_COLUMN_CLASS = "w-full";
 export const MEETING_QUIET_CONTROL_CLASS =
   "rounded-none border-0 bg-transparent text-muted-foreground transition-colors hover:bg-transparent hover:text-foreground focus-visible:text-foreground";
 
+// Actions that sit on the tab rule share the tabs' own geometry so the row
+// reads as one band instead of a strip of floating boxes. Shared with the note
+// view now that the meeting actions live here rather than in a footer.
+export const MEETING_RULE_ACTION_CLASS =
+  "flex h-11 shrink-0 items-center gap-2 border-l border-border font-mono text-[11px] uppercase tracking-[0.12em] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:z-10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-foreground disabled:text-muted-foreground/50 disabled:hover:bg-transparent";
+
 const MEETING_TABS: ReadonlyArray<{
   value: MeetingWorkspaceTab;
   label: string;

--- a/apps/screenpipe-app-tauri/components/meeting-notes/note-view.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/note-view.tsx
@@ -161,6 +161,8 @@ import { meetingRetranscribeSuccessCopy } from "./transcript-recovery-copy";
 import { startMeetingSummaryRun } from "./meeting-summary-run";
 
 const AUTOSAVE_DEBOUNCE_MS = 800;
+// How long a successful save stays on screen before the footer goes quiet.
+const SAVE_RECEIPT_DWELL_MS = 4000;
 
 interface NoteViewProps {
   meeting: MeetingRecord;
@@ -1267,6 +1269,19 @@ export function NoteView({
     meeting.meeting_start,
     meeting.meeting_end,
   );
+  // A save receipt is news for a moment and noise after that. There was no
+  // path back to "idle", so the first autosave pinned "saved · 07:46" to the
+  // footer for the rest of the session. Errors are excluded: those persist
+  // until the retry effect resolves them.
+  useEffect(() => {
+    if (saveState.kind !== "saved") return;
+    const timer = window.setTimeout(
+      () => setSaveState({ kind: "idle" }),
+      SAVE_RECEIPT_DWELL_MS,
+    );
+    return () => window.clearTimeout(timer);
+  }, [saveState]);
+
   const hasSaveStatus = saveState.kind !== "idle";
   const joinSuggestion = useMemo(() => {
     if (!isLive) return null;
@@ -1442,6 +1457,15 @@ export function NoteView({
     summaryLifecycle.kind === "failed"
       ? meetingSummaryFailure(summaryLifecycle.execution).upgrade
       : null;
+  // Whether the footer has anything to report. A finished meeting that is not
+  // recording, summarizing or failing has no news, and the badge plus detail
+  // line collapse to a single quiet caption.
+  // summaryWorking already covers finalizing, queued and running.
+  const footerHasNews =
+    isLive ||
+    summaryWorking ||
+    hasSaveStatus ||
+    summaryLifecycle.kind === "failed";
   const transcriptActionLabel = transcriptOpen
     ? "hide transcript"
     : "show transcript";
@@ -1474,13 +1498,15 @@ export function NoteView({
   // a truncated one in someone's inbox.
   const canShareSummary =
     Boolean(extractMeetingSummary(note)) && !summaryWorking;
+  // A dot on a tab means "this needs you". A summary that finished normally
+  // does not, and leaving the dot lit forever on every summarized meeting is
+  // what teaches people to stop reading dots. Only in-flight work and failures
+  // earn one.
   const summaryTabState = summaryWorking
     ? "working"
-    : summaryLifecycle.kind === "completed"
-      ? "ready"
-      : summaryLifecycle.kind === "failed"
-        ? "attention"
-        : null;
+    : summaryLifecycle.kind === "failed"
+      ? "attention"
+      : null;
   const summarySurfaceState = summaryWorking
     ? "working"
     : summaryLifecycle.kind === "completed"
@@ -1530,34 +1556,40 @@ export function NoteView({
             />
           </div>
 
-          <div className="mt-3 flex min-w-0 items-center gap-2 overflow-x-auto pb-3 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-            <Pill icon={<Calendar className="h-3.5 w-3.5" />}>
-              {meetingDateLabel}
-            </Pill>
-            <Pill icon={<Clock className="h-3.5 w-3.5" />}>
-              <span className="text-foreground/80">{meetingStartClock}</span>
-              {isLive || !meetingEndClock ? (
-                <span className="inline-flex items-center gap-1 border border-foreground/15 bg-foreground/[0.03] px-1.5 py-0.5 text-[10px] font-medium leading-none text-foreground">
-                  <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-foreground" />
-                  ongoing
-                </span>
-              ) : (
-                <>
-                  <span className="text-muted-foreground/35">-</span>
-                  <span className="text-foreground/80">{meetingEndClock}</span>
-                  <span className="text-muted-foreground/35">·</span>
-                  <span>{meetingDurationLabel}</span>
-                </>
-              )}
-            </Pill>
-            <AttendeesPill
-              value={attendees}
-              count={attendeeCount}
-              onChange={setAttendees}
-            />
-            {meeting.meeting_app && meeting.meeting_app !== "manual" && (
-              <Pill>{meeting.meeting_app.toLowerCase()}</Pill>
+          {/* Date, time and source are labels, not controls. As bordered pills
+              they read as four more things to act on; as one muted line they
+              read as what they are. Attendees keeps its box because it is the
+              only part of this row that opens something. */}
+          <div className="mt-1.5 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 pb-3 text-xs text-muted-foreground">
+            <span>{meetingDateLabel}</span>
+            <span aria-hidden>·</span>
+            <span>{meetingStartClock}</span>
+            {isLive || !meetingEndClock ? (
+              <span className="inline-flex items-center gap-1 font-medium text-foreground">
+                <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-foreground motion-reduce:animate-none" />
+                ongoing
+              </span>
+            ) : (
+              <>
+                <span aria-hidden>-</span>
+                <span>{meetingEndClock}</span>
+                <span aria-hidden>·</span>
+                <span>{meetingDurationLabel}</span>
+              </>
             )}
+            {meeting.meeting_app && meeting.meeting_app !== "manual" && (
+              <>
+                <span aria-hidden>·</span>
+                <span>{meeting.meeting_app.toLowerCase()}</span>
+              </>
+            )}
+            <span className="ml-1">
+              <AttendeesPill
+                value={attendees}
+                count={attendeeCount}
+                onChange={setAttendees}
+              />
+            </span>
           </div>
 
           <MeetingWorkspaceTabs
@@ -1715,8 +1747,17 @@ export function NoteView({
               onResumeInput={() => void handleResumeInputCapture()}
             />
           )}
-          <div className="flex min-h-14 min-w-0 flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div
+            className={cn(
+              "flex min-w-0 flex-col gap-3 sm:flex-row sm:items-center sm:justify-between",
+              footerHasNews ? "min-h-14" : "min-h-9",
+            )}
+          >
             <div className="flex min-w-0 items-center gap-3">
+              {/* At rest the badge was a permanent checkmark next to a line
+                  that already said "meeting saved". Only a state that is
+                  actually happening gets a 32px box. */}
+              {footerHasNews && (
               <span
                 className={cn(
                   "flex h-8 w-8 shrink-0 items-center justify-center border border-border",
@@ -1753,10 +1794,21 @@ export function NoteView({
                   <Check className="h-4 w-4" />
                 )}
               </span>
+              )}
               <div className="min-w-0">
-                <div className="flex items-center gap-2 text-sm font-medium">
+                <div
+                  className={cn(
+                    "flex items-center gap-2",
+                    footerHasNews
+                      ? "text-sm font-medium"
+                      : "text-[11px] text-muted-foreground",
+                  )}
+                >
                   <span>{summaryStatus.title}</span>
                 </div>
+                {/* The detail line explains what is happening. When nothing is
+                    happening it explained that nothing was happening. */}
+                {footerHasNews && (
                 <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-muted-foreground">
                   <span>
                     <MeetingDuration
@@ -1792,38 +1844,30 @@ export function NoteView({
                     </>
                   )}
                 </div>
+                )}
               </div>
             </div>
 
+            {/* The transcript toggle that used to sit here was a third way to
+                do what the TRANSCRIPT tab does: `transcriptOpen` is literally
+                `activeTab === "transcript"`. The tab is the one that survives. */}
             <TooltipProvider delayDuration={200}>
               <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
-                <MeetingControlTooltip label={transcriptActionLabel}>
-                  <Button
-                    variant={transcriptOpen ? "default" : "outline"}
-                    size="sm"
-                    onClick={() => setTranscriptOpen((v) => !v)}
-                    className="h-9 w-9 rounded-none p-0"
-                    aria-label={transcriptActionLabel}
-                  >
-                    <FileText className="h-3.5 w-3.5" />
-                  </Button>
-                </MeetingControlTooltip>
                 {!isLive && (
                   <MeetingControlTooltip label={summaryActionLabel}>
+                    {/* The summary tab owns the prominent generate/retry
+                        button next to the output it produces. This one is the
+                        shortcut from the other tabs, so it takes the same
+                        recessive treatment as the rest of the cluster. */}
                     <Button
-                      variant={
-                        summaryLifecycle.kind === "idle" ||
-                        summaryLifecycle.kind === "failed"
-                          ? "default"
-                          : "outline"
-                      }
+                      variant="ghost"
                       size="sm"
                       onClick={handleSummaryAction}
                       disabled={
                         summaryWorking || retranscribing || !canSummarizeMeeting
                       }
                       aria-label={summaryActionLabel}
-                      className="h-9 w-9 rounded-none p-0"
+                      className={cn(MEETING_QUIET_CONTROL_CLASS, "h-9 w-9 p-0")}
                     >
                       {summaryWorking ? (
                         <Loader2 className="h-3.5 w-3.5 animate-spin" />

--- a/apps/screenpipe-app-tauri/components/meeting-notes/note-view.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/note-view.tsx
@@ -152,6 +152,7 @@ import {
   extractMeetingSummary,
   MEETING_QUIET_CONTROL_CLASS,
   MEETING_READING_COLUMN_CLASS,
+  MEETING_RULE_ACTION_CLASS,
   MEETING_SHELL_CLASS,
   MeetingSummarySurface,
   MeetingWorkspaceTabs,
@@ -1466,6 +1467,12 @@ export function NoteView({
     summaryWorking ||
     hasSaveStatus ||
     summaryLifecycle.kind === "failed";
+  // The footer exists to report something. A finished meeting that is not
+  // recording, summarizing, failing or saving has nothing to report, and its
+  // resting caption ("meeting saved") was pure reassurance, so the whole bar
+  // goes away rather than shrinking. The inactivity prompt is the one banner
+  // that can appear while not live, so it has to keep the bar alive.
+  const footerVisible = footerHasNews || (!isLive && Boolean(inactivityPrompt));
   const transcriptActionLabel = transcriptOpen
     ? "hide transcript"
     : "show transcript";
@@ -1514,6 +1521,160 @@ export function NoteView({
       : summaryLifecycle.kind === "failed"
         ? "attention"
         : "idle";
+
+  // Meeting actions sit on the tab rule beside share. They used to require a
+  // footer that stayed on screen for every finished meeting just to hold them.
+  const meetingActions = (
+    <TooltipProvider delayDuration={200}>
+                {!isLive && (
+                  <MeetingControlTooltip label={summaryActionLabel}>
+                    {/* The summary tab owns the prominent generate/retry
+                        button next to the output it produces. This one is the
+                        shortcut from the other tabs, so it takes the same
+                        recessive treatment as the rest of the cluster. */}
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={handleSummaryAction}
+                      disabled={
+                        summaryWorking || retranscribing || !canSummarizeMeeting
+                      }
+                      aria-label={summaryActionLabel}
+                      className={cn(
+                        MEETING_RULE_ACTION_CLASS,
+                        // shadcn Button draws a full border; the rule only wants
+                        // the left separator the tabs and share button use.
+                        "border-y-0 border-r-0 px-3",
+                      )}
+                    >
+                      {summaryWorking ? (
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      ) : summaryLifecycle.kind === "completed" ? (
+                        <RefreshCw className="h-3.5 w-3.5" />
+                      ) : summaryLifecycle.kind === "failed" ? (
+                        <RefreshCw className="h-3.5 w-3.5" />
+                      ) : (
+                        <Sparkles className="h-3.5 w-3.5" />
+                      )}
+                    </Button>
+                  </MeetingControlTooltip>
+                )}
+                {/* Everything past summarize is occasional or destructive, so
+                    it lives one level down instead of adding more identical
+                    squares next to the primary action. */}
+                {!isLive && (
+                  <AlertDialog
+                    open={confirmingAction !== null}
+                    onOpenChange={(open) => {
+                      if (!open) setConfirmingAction(null);
+                    }}
+                  >
+                    <DropdownMenu>
+                      <MeetingControlTooltip label="more meeting actions">
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            aria-label="more meeting actions"
+                            className={cn(
+                        MEETING_RULE_ACTION_CLASS,
+                        // shadcn Button draws a full border; the rule only wants
+                        // the left separator the tabs and share button use.
+                        "border-y-0 border-r-0 px-3",
+                      )}
+                          >
+                            <MoreHorizontal className="h-3.5 w-3.5" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                      </MeetingControlTooltip>
+                      <DropdownMenuContent align="end" className="w-56">
+                        <DropdownMenuItem
+                          disabled={resuming}
+                          onSelect={() => void onResume()}
+                        >
+                          {resuming ? (
+                            <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                          ) : (
+                            <Play className="mr-2 h-3.5 w-3.5" />
+                          )}
+                          {resuming ? "resuming meeting" : "resume meeting"}
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          disabled={retranscribing || summaryWorking}
+                          onSelect={() => setConfirmingAction("retranscribe")}
+                        >
+                          {retranscribing ? (
+                            <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                          ) : (
+                            <AudioLines className="mr-2 h-3.5 w-3.5" />
+                          )}
+                          retranscribe saved audio
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          disabled={exporting}
+                          onSelect={() => void handleExport()}
+                        >
+                          {exporting ? (
+                            <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                          ) : (
+                            <Download className="mr-2 h-3.5 w-3.5" />
+                          )}
+                          export to mp4
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          onSelect={() => setConfirmingAction("delete")}
+                        >
+                          <Trash2 className="mr-2 h-3.5 w-3.5" />
+                          delete meeting
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                    {confirmingAction === "retranscribe" ? (
+                      <AlertDialogContent>
+                        <AlertDialogHeader>
+                          <AlertDialogTitle>
+                            retranscribe meeting
+                          </AlertDialogTitle>
+                          <AlertDialogDescription>
+                            rebuild the transcript from saved audio. this
+                            replaces the current transcript and refreshes the
+                            summary when automatic summary is on.
+                          </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                          <AlertDialogCancel>cancel</AlertDialogCancel>
+                          <AlertDialogAction
+                            onClick={() => void handleRetranscribe()}
+                          >
+                            retranscribe
+                          </AlertDialogAction>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    ) : confirmingAction === "delete" ? (
+                      <AlertDialogContent>
+                        <AlertDialogHeader>
+                          <AlertDialogTitle>delete meeting</AlertDialogTitle>
+                          <AlertDialogDescription>
+                            your notes and transcript will be permanently
+                            deleted.
+                          </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                          <AlertDialogCancel>cancel</AlertDialogCancel>
+                          <AlertDialogAction
+                            variant="destructive"
+                            onClick={() => void handleDelete()}
+                          >
+                            delete
+                          </AlertDialogAction>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    ) : null}
+                  </AlertDialog>
+                )}
+    </TooltipProvider>
+  );
 
   return (
     <div ref={rootRef} className="relative flex h-full flex-col bg-background">
@@ -1609,17 +1770,21 @@ export function NoteView({
             // a third inside the summary tab used to compete with it, and the
             // reachable one was always the transcript dump.
             trailing={
-              <MeetingShareMenu
-                canShareSummary={canShareSummary}
-                busy={copying}
-                copiedAction={copiedAction}
-                onShare={(action) => {
-                  if (action === "summary") void handleCopySummary();
-                  else if (action === "email") void handleEmailSummary();
-                  else if (action === "transcript") void handleCopyTranscript();
-                  else void handleCopy();
-                }}
-              />
+              <>
+                <MeetingShareMenu
+                  canShareSummary={canShareSummary}
+                  busy={copying}
+                  copiedAction={copiedAction}
+                  onShare={(action) => {
+                    if (action === "summary") void handleCopySummary();
+                    else if (action === "email") void handleEmailSummary();
+                    else if (action === "transcript")
+                      void handleCopyTranscript();
+                    else void handleCopy();
+                  }}
+                />
+                {meetingActions}
+              </>
             }
           />
         </div>
@@ -1718,6 +1883,7 @@ export function NoteView({
         )}
       </main>
 
+      {footerVisible && (
       <footer className="z-30 min-w-0 shrink-0 border-t border-border bg-background">
         <div className={cn(MEETING_SHELL_CLASS, "py-3")}>
           {!isLive && inactivityPrompt && (
@@ -1848,152 +2014,9 @@ export function NoteView({
               </div>
             </div>
 
-            {/* The transcript toggle that used to sit here was a third way to
-                do what the TRANSCRIPT tab does: `transcriptOpen` is literally
-                `activeTab === "transcript"`. The tab is the one that survives. */}
-            <TooltipProvider delayDuration={200}>
-              <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
-                {!isLive && (
-                  <MeetingControlTooltip label={summaryActionLabel}>
-                    {/* The summary tab owns the prominent generate/retry
-                        button next to the output it produces. This one is the
-                        shortcut from the other tabs, so it takes the same
-                        recessive treatment as the rest of the cluster. */}
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={handleSummaryAction}
-                      disabled={
-                        summaryWorking || retranscribing || !canSummarizeMeeting
-                      }
-                      aria-label={summaryActionLabel}
-                      className={cn(MEETING_QUIET_CONTROL_CLASS, "h-9 w-9 p-0")}
-                    >
-                      {summaryWorking ? (
-                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                      ) : summaryLifecycle.kind === "completed" ? (
-                        <RefreshCw className="h-3.5 w-3.5" />
-                      ) : summaryLifecycle.kind === "failed" ? (
-                        <RefreshCw className="h-3.5 w-3.5" />
-                      ) : (
-                        <Sparkles className="h-3.5 w-3.5" />
-                      )}
-                    </Button>
-                  </MeetingControlTooltip>
-                )}
-                {/* Everything past summarize is occasional or destructive, so
-                    it lives one level down instead of adding more identical
-                    squares next to the primary action. */}
-                {!isLive && (
-                  <AlertDialog
-                    open={confirmingAction !== null}
-                    onOpenChange={(open) => {
-                      if (!open) setConfirmingAction(null);
-                    }}
-                  >
-                    <DropdownMenu>
-                      <MeetingControlTooltip label="more meeting actions">
-                        <DropdownMenuTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            aria-label="more meeting actions"
-                            className={cn(
-                              MEETING_QUIET_CONTROL_CLASS,
-                              "h-9 w-9 p-0",
-                            )}
-                          >
-                            <MoreHorizontal className="h-3.5 w-3.5" />
-                          </Button>
-                        </DropdownMenuTrigger>
-                      </MeetingControlTooltip>
-                      <DropdownMenuContent align="end" className="w-56">
-                        <DropdownMenuItem
-                          disabled={resuming}
-                          onSelect={() => void onResume()}
-                        >
-                          {resuming ? (
-                            <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
-                          ) : (
-                            <Play className="mr-2 h-3.5 w-3.5" />
-                          )}
-                          {resuming ? "resuming meeting" : "resume meeting"}
-                        </DropdownMenuItem>
-                        <DropdownMenuItem
-                          disabled={retranscribing || summaryWorking}
-                          onSelect={() => setConfirmingAction("retranscribe")}
-                        >
-                          {retranscribing ? (
-                            <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
-                          ) : (
-                            <AudioLines className="mr-2 h-3.5 w-3.5" />
-                          )}
-                          retranscribe saved audio
-                        </DropdownMenuItem>
-                        <DropdownMenuItem
-                          disabled={exporting}
-                          onSelect={() => void handleExport()}
-                        >
-                          {exporting ? (
-                            <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
-                          ) : (
-                            <Download className="mr-2 h-3.5 w-3.5" />
-                          )}
-                          export to mp4
-                        </DropdownMenuItem>
-                        <DropdownMenuSeparator />
-                        <DropdownMenuItem
-                          onSelect={() => setConfirmingAction("delete")}
-                        >
-                          <Trash2 className="mr-2 h-3.5 w-3.5" />
-                          delete meeting
-                        </DropdownMenuItem>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                    {confirmingAction === "retranscribe" ? (
-                      <AlertDialogContent>
-                        <AlertDialogHeader>
-                          <AlertDialogTitle>
-                            retranscribe meeting
-                          </AlertDialogTitle>
-                          <AlertDialogDescription>
-                            rebuild the transcript from saved audio. this
-                            replaces the current transcript and refreshes the
-                            summary when automatic summary is on.
-                          </AlertDialogDescription>
-                        </AlertDialogHeader>
-                        <AlertDialogFooter>
-                          <AlertDialogCancel>cancel</AlertDialogCancel>
-                          <AlertDialogAction
-                            onClick={() => void handleRetranscribe()}
-                          >
-                            retranscribe
-                          </AlertDialogAction>
-                        </AlertDialogFooter>
-                      </AlertDialogContent>
-                    ) : confirmingAction === "delete" ? (
-                      <AlertDialogContent>
-                        <AlertDialogHeader>
-                          <AlertDialogTitle>delete meeting</AlertDialogTitle>
-                          <AlertDialogDescription>
-                            your notes and transcript will be permanently
-                            deleted.
-                          </AlertDialogDescription>
-                        </AlertDialogHeader>
-                        <AlertDialogFooter>
-                          <AlertDialogCancel>cancel</AlertDialogCancel>
-                          <AlertDialogAction
-                            variant="destructive"
-                            onClick={() => void handleDelete()}
-                          >
-                            delete
-                          </AlertDialogAction>
-                        </AlertDialogFooter>
-                      </AlertDialogContent>
-                    ) : null}
-                  </AlertDialog>
-                )}
-
+            {isLive && (
+              <TooltipProvider delayDuration={200}>
+                <div className="flex shrink-0 items-center justify-end">
                 {isLive && (
                   <MeetingControlTooltip label={stopActionLabel}>
                     <Button
@@ -2012,8 +2035,9 @@ export function NoteView({
                     </Button>
                   </MeetingControlTooltip>
                 )}
-              </div>
-            </TooltipProvider>
+                </div>
+              </TooltipProvider>
+            )}
           </div>
         </div>
         {isLive && (
@@ -2022,6 +2046,7 @@ export function NoteView({
           </div>
         )}
       </footer>
+      )}
     </div>
   );
 }

--- a/apps/screenpipe-app-tauri/lib/dev/browser-engine-mock.ts
+++ b/apps/screenpipe-app-tauri/lib/dev/browser-engine-mock.ts
@@ -103,10 +103,20 @@ export function mockLocalApiResponse(
     return Response.json([]);
   }
   if (url.pathname === "/tags/autocomplete") return Response.json([]);
+  // Receipts reads `windows` straight off this body without validating it, so
+  // the harness has to return the real shape rather than an empty object.
+  if (url.pathname === "/activity-summary") {
+    return Response.json({ windows: [], total_active_seconds: 0 });
+  }
   if (url.pathname === "/meetings/status") {
     return Response.json({ active: false, manualActive: false });
   }
-  if (url.pathname === "/meetings") return Response.json([]);
+  // One finished, synthetic meeting so the meeting note surface can be opened
+  // and screenshotted in `bun run dev:web` without pointing the harness at a
+  // real database. Content is invented; do not make it look like real capture.
+  if (url.pathname === "/meetings") {
+    return Response.json(scenario === "empty" ? [] : [mockMeeting()]);
+  }
   if (url.pathname === "/memories") return Response.json(emptyPage);
   if (url.pathname === "/artifacts") {
     return Response.json({ ...emptyPage, sources: [] });
@@ -131,6 +141,33 @@ export function mockLocalApiResponse(
   if (method === "DELETE") return Response.json({ success: true });
   if (method !== "GET") return Response.json({ success: true });
   return Response.json(scenario === "empty" ? emptyPage : { data: [] });
+}
+
+// Invented content only. This exists so the meeting note surface renders in
+// the browser harness; it must never be mistaken for captured data.
+function mockMeeting() {
+  const start = new Date(Date.now() - 75 * 60 * 1000);
+  const end = new Date(start.getTime() + 21 * 60 * 1000);
+  return {
+    id: 1,
+    meeting_start: start.toISOString(),
+    meeting_end: end.toISOString(),
+    meeting_app: "google meet",
+    title: "sample meeting",
+    attendees: JSON.stringify(["sample person", "another person"]),
+    note: [
+      "first note line from the sample meeting",
+      "",
+      "second note line, long enough to show the reading measure the note",
+      "editor uses for body text",
+      "",
+      "## Summary",
+      "",
+      "A sample summary so the summary tab has something to render.",
+    ].join("\n"),
+    detection_source: "auto",
+    created_at: start.toISOString(),
+  };
 }
 
 function isLocalEngineUrl(url: URL, apiPort: number): boolean {


### PR DESCRIPTION
## Problem

Reading a finished meeting cost about **250px of chrome and 11 always-visible controls** before a word of the note, and most of it was reassurance rather than information.

- The footer's resting state was `meeting saved` / `notes and transcript saved locally` beside a permanent checkmark. 80px, permanently, to say nothing changed.
- `✓ saved 07:46` never cleared. `setSaveState` is only ever called with `saving`/`saved`/`error`, so the first autosave pinned a timestamp there for the session.
- The SUMMARY tab carried a filled dot on **every** summarized meeting. A dot means "this needs you"; leaving it lit forever teaches people to stop reading dots.
- Date, time and source were bordered pills. Only attendees was ever clickable.
- The tab row drew a rule directly on top of the header's full-bleed rule.
- The footer transcript toggle was a third way to do what the TRANSCRIPT tab does: `transcriptOpen` is literally `activeTab === "transcript"` (`note-view.tsx:667`).

## Before / after

Real renders of the meeting note surface at rest, same fixture and viewport.

![meeting note chrome before and after](https://raw.githubusercontent.com/screenpipe/screenpipe/assets/meeting-chrome-20260814/docs/assets/meeting-chrome-before-after.png)

**At rest the footer is now gone entirely** and the actions live on the tab rule as icons.

## What the usage data said

30 days of PostHog, desktop only, internal accounts excluded, distinct persons (not distinct_ids). 651 people opened a meeting note in 30d; 175 on the current UI (Aug 8–14), which is the denominator below.

| control | people | % of openers |
|---|---:|---:|
| back to meetings | 90 | 51.4% |
| tab: summary | 87 | 49.7% |
| tab: notes | 80 | 45.7% |
| tab: transcript | 80 | 45.7% |
| title edit | 40 | 22.9% |
| **⋯ more meeting actions** | 37 | 21.1% |
| attendees pill | 31 | 17.7% |
| show / hide transcript | 24 / 20 | 13.7% / 11.4% |
| **share: copy transcript** | 17 | 9.7% |
| summarize | 15 | 8.6% |
| **share: chevron** | 4 | 2.3% |
| share: copy full meeting | 2 | 1.1% |

What changed because of it:

- **Share was the loudest control on the rule and the least used.** It is icon-only now; the word returns only to confirm a copy.
- **The ⋯ overflow is used ~2x more than any share action**, so it earns a place on the rule.
- **All three tabs stay** — they are within 4 points of each other, and summary is marginally the most used, not notes.
- **Attendees and title editing stay visible** — both are real at 18% and 23%.
- **Show/hide transcript is redundant** with the transcript tab at 46%, confirming the duplicate toggle removal.

Two honest caveats on the data, both worth fixing separately:
1. **Radix `DropdownMenuItem` renders as `div[role="menuitem"]`, which PostHog autocapture does not capture** — 0 of 826,890 desktop autocaptures in 30d have that role. So resume / retranscribe / export / delete record **zero clicks because they are uninstrumented**, not because they are unused. Their last 23 days as top-level buttons put them at 3–5% of openers.
2. The surface was rebuilt three times inside the window, so a raw 30d rank blends three UIs. The table is Aug 8+ only.

## Fix

No capability removed, no `aria-label` changed.

- Footer renders only for recording, summarizing, failure, saving, or the inactivity prompt. Otherwise it does not exist.
- Successful saves go quiet after 4s; errors persist.
- Only in-flight work and failures put a dot on the SUMMARY tab.
- Date/time/source become one muted line; attendees keeps its box.
- The tab row no longer draws a rule inside the header.
- Duplicate footer transcript toggle deleted.
- Summarize and ⋯ moved onto the tab rule and share went icon-only, all sharing `MEETING_RULE_ACTION_CLASS` so the row reads as one band.

## Testing

- `bun run typecheck` clean.
- `bun x vitest run components/meeting-notes` — **112 passed**, including new tests for the summary-tab dot and for share naming the action only while confirming it.
- Two existing tests updated to the new contract, with the reasoning in the diff: the bottom-rule test, and the share-label test (the accessible name still carries the scope; only the visible word went away).
- `bun run lint:effects` — no new findings. The one error is pre-existing on `main` (`jsx-a11y/no-autofocus` rule-not-found in `attendees-pill.tsx`, untouched here).
- Real-app renders via `bun run dev:web` at base and head, plus a DOM probe confirming `footer` count is 0 at rest and all controls are still reachable.

**Not run:** the packaged WebdriverIO E2E. Flagged below.

## Risk to review

`meeting-summary-recovery.spec.ts` waits for `$("footer")` to contain `meeting saved`. **That string is now gone**, so this spec needs updating — its intent ("the failed refresh no longer promises an automatic summary") is better expressed as the footer being absent. I did not rewrite it because I cannot run a packaged E2E here and did not want to hand you an unverified edit to a high-criticality spec.

Related: the same spec queries `button[aria-label="retranscribe saved audio"]`, but that control has been a Radix menu item since Aug 8, and menu items are `div[role="menuitem"]`. That selector likely does not resolve on `main` today either. Worth checking whether this spec is already red before treating it as a gate.

## Follow-ups

- Instrument the overflow and share menu items explicitly rather than relying on autocapture, which cannot see Radix menu items and silently breaks on every rename.
- Typing-idle fade for the remaining chrome (Granola fades header and top bar ~1s after typing starts, restores on `mousemove`). Deliberately not mixed into a subtraction PR.
- Consider collapsing TRANSCRIPT out of the tab bar into a toggle, the way both Granola and Wispr Flow do.

## Dev harness

`bun run dev:web` returned an empty meeting list, so this surface could not be opened or screenshotted without pointing at a real database. First commit adds one synthetic meeting and the `/activity-summary` body that `Receipts` reads without validating. Invented content only, so meeting UI work no longer needs captured data in a screenshot.
