### PR TITLE
fix(ai-gateway): defer response handling to gateway policy

### DIFF
--- a/packages/ai-gateway/src/services/cloudflare-ai-gateway.ts
+++ b/packages/ai-gateway/src/services/cloudflare-ai-gateway.ts
@@ -181,7 +181,6 @@ export async function getHostedChatGatewayConnection(
 
 	const defaultHeaders: Record<string, string | null> = {
 		'cf-aig-metadata': JSON.stringify(context),
-		'cf-aig-skip-cache': 'true',
 		'cf-aig-collect-log-payload': 'false',
 		'cf-aig-max-attempts': '1',
 		'cf-aig-byok-alias': 'default',

--- a/packages/ai-gateway/src/test/cloudflare-ai-gateway.unit.test.ts
+++ b/packages/ai-gateway/src/test/cloudflare-ai-gateway.unit.test.ts
@@ -85,7 +85,7 @@ describe('Cloudflare hosted-chat metadata', () => {
 });
 
 describe('Cloudflare provider-native connection', () => {
-	it('uses the Workers binding, BYOK, metadata-only logs, and disables Gateway retries/cache', async () => {
+	it('uses the Workers binding, BYOK, metadata-only logs, and disables Gateway retries', async () => {
 		const calls: string[] = [];
 		const env = {
 			HOSTED_CHAT_GATEWAY_MODE: 'cloudflare',
@@ -109,7 +109,7 @@ describe('Cloudflare provider-native connection', () => {
 		expect(connection.defaultHeaders.Authorization).toBeNull();
 		expect(connection.defaultHeaders['cf-aig-byok-alias']).toBe('default');
 		expect(connection.defaultHeaders['cf-aig-authorization']).toBe('Bearer local-oauth-token');
-		expect(connection.defaultHeaders['cf-aig-skip-cache']).toBe('true');
+		expect(connection.defaultHeaders).not.toHaveProperty('cf-aig-skip-cache');
 		expect(connection.defaultHeaders['cf-aig-max-attempts']).toBe('1');
 		expect(connection.defaultHeaders['cf-aig-collect-log-payload']).toBe('false');
 		expect(JSON.parse(connection.defaultHeaders['cf-aig-metadata']!)).toEqual(context);


### PR DESCRIPTION
## description

Removes the hard-coded cf-aig-skip-cache request override from the hosted Cloudflare connection so response handling inherits the centrally managed policy for each Gateway environment. Existing metadata, payload logging, BYOK, and retry controls are unchanged. The connection contract test now pins that boundary.

Request-specific policy in application code was overriding the control-plane setting and required a source deploy to change centrally managed behavior.

Related issue: none

## AI assistance and human ownership

- AI tool(s) used: Codex
- autonomy level: agent
- what I personally verified: human verification pending; Codex inspected the focused diff and ran the tests listed below

- [ ] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [ ] The problem statement, rationale, and replies to maintainers are my own.

## evidence type

- [x] Backend change — regression tests and relevant results

## before

    Hosted request -> hard-coded request override -> AI Gateway

## after

    Hosted request -> AI Gateway-managed response policy

## how to test

1. From packages/ai-gateway, run: bun test src/test/cloudflare-ai-gateway.unit.test.ts --timeout=10000
   Result: 11 passed, 0 failed.
2. From packages/ai-gateway, run: bun test --timeout=10000
   Result: 956 passed, 0 failed.