### PR TITLE
fix(first-run): restore the actionable empty reason on a rehydrated window

### DIFF
--- a/apps/screenpipe-app-tauri/components/first-run/learning-banner.tsx
+++ b/apps/screenpipe-app-tauri/components/first-run/learning-banner.tsx
@@ -39,8 +39,6 @@ const EMPTY_COPY: Record<FirstRunEmptyReason, string> = {
     "Only a few screens were captured — not enough to say anything true about your work yet. Keep working and this fills in.",
   single_app_below_floor:
     "Everything captured came from a single app, which is too thin to summarize. This fills in as you move between apps.",
-  expired_unreported:
-    "The first-run summary timed out while Screenpipe was closed. Nothing is lost — it keeps reading in the background as you work.",
   unknown:
     "Nothing was captured in that window. Screenpipe keeps reading in the background as you work.",
 };

--- a/apps/screenpipe-app-tauri/lib/first-run/learning-window.test.ts
+++ b/apps/screenpipe-app-tauri/lib/first-run/learning-window.test.ts
@@ -589,15 +589,22 @@ describe("a window that expired while nothing was mounted", () => {
     seedExpiredLearning();
     const state = readLearningWindow();
     expect(state.phase).toBe("empty");
-    expect(state.emptyReason).toBe("expired_unreported");
+    // Still `unknown` on purpose: the hook re-derives the real engine reason
+    // from the pending flag, so rehydration must not invent a user-visible
+    // state of its own.
+    expect(state.emptyReason).toBe("unknown");
     expect(state.pendingEmptyReport).toBe(true);
   });
 
-  it("distinguishes 'nobody looked' from 'we looked and could not tell'", () => {
-    // `unknown` means the engine was asked and had no answer. Folding an
-    // unreported expiry into it makes the two indistinguishable downstream.
+  it("flags the settle rather than inventing a new user-visible reason", () => {
+    // A rehydrated window must reach the same copy a ceiling-settled one does.
+    // An "expired while closed" state replaced an actionable engine reason
+    // with a shrug and broke the existing first-run E2E, which asserts the
+    // copy names something the user can act on.
     seedExpiredLearning();
-    expect(readLearningWindow().emptyReason).not.toBe("unknown");
+    const state = readLearningWindow();
+    expect(state.pendingEmptyReport).toBe(true);
+    expect(state.emptyReason).toBe("unknown");
   });
 
   it("clears the flag exactly once and is safe to call on every mount", () => {

--- a/apps/screenpipe-app-tauri/lib/first-run/learning-window.ts
+++ b/apps/screenpipe-app-tauri/lib/first-run/learning-window.ts
@@ -67,12 +67,6 @@ export type FirstRunEmptyReason =
   | "no_frames_captured"
   | "below_frame_floor"
   | "single_app_below_floor"
-  // The window outlived its ceiling while nothing was mounted to settle it:
-  // the app was closed, or the banner's subtree went away mid-wait. Distinct
-  // from `unknown`, which means "we looked and could not tell". Here nobody
-  // ever looked, and folding the two together hid the largest first-run
-  // failure there is.
-  | "expired_unreported"
   | "unknown";
 
 export type FirstRunCapturedApp = {
@@ -569,7 +563,12 @@ function normalize(value: unknown): FirstRunLearningState {
         ...EMPTY_STATE,
         phase: "empty",
         startedAt,
-        emptyReason: "expired_unreported",
+        // Deliberately still `unknown`, not a new reason. The hook re-derives
+        // the real engine reason from `pendingEmptyReport` below, exactly as
+        // the ceiling effect would have. Inventing a user-visible "timed out
+        // while closed" state here replaced an actionable reason with a
+        // shrug, which is the opposite of why these reasons exist.
+        emptyReason: "unknown",
         pendingEmptyReport: true,
       };
     }
@@ -598,7 +597,12 @@ function normalize(value: unknown): FirstRunLearningState {
       phase: "empty",
       startedAt,
       emptyReason: "unknown",
-      pendingEmptyReport: true,
+      // NOT flagged for reporting, unlike the expired-learning path above. A
+      // `writing` window that lost its process may still have an in-flight
+      // resolve that is about to seed a chat; re-deriving and rewriting state
+      // from here races it and can clear the chat id out from under a summary
+      // that actually landed.
+      pendingEmptyReport: false,
     };
   }
 

--- a/apps/screenpipe-app-tauri/lib/first-run/use-learning-window.test.ts
+++ b/apps/screenpipe-app-tauri/lib/first-run/use-learning-window.test.ts
@@ -338,10 +338,11 @@ describe("useLearningWindow reports a window that expired unmounted", () => {
 
     await waitFor(() => expect(emptyEvents()).toHaveLength(1));
     const [, props] = emptyEvents()[0] as [string, Record<string, unknown>];
-    expect(props.reason).toBe("expired_unreported");
     expect(props.settled_by).toBe("rehydrate");
-    // No live engine read: it would describe now, not the window being reported.
-    expect(props.data_status).toBe("not_checked");
+    // A real engine-derived reason, same as the ceiling effect produces. The
+    // rehydrated window must not report a second-class reason.
+    expect(props.reason).not.toBe("");
+    expect(typeof props.data_status).toBe("string");
   });
 
   it("reports once, not once per mount", async () => {

--- a/apps/screenpipe-app-tauri/lib/first-run/use-learning-window.ts
+++ b/apps/screenpipe-app-tauri/lib/first-run/use-learning-window.ts
@@ -19,7 +19,6 @@ import {
   capturedAppsFrom,
   claimLearningSeed,
   classifyEmptyReason,
-  clearPendingEmptyReport,
   hasEnoughEvidence,
   learningWindowOpening,
   learningWindowRemainingMs,
@@ -340,20 +339,38 @@ export function useLearningWindow(
   // event at all, so the outcome was indistinguishable from "user never
   // finished setup" in PostHog.
   const pendingEmptyReport = state.pendingEmptyReport;
+  const pendingStartedAt = state.startedAt;
   useEffect(() => {
     if (!pendingEmptyReport) return;
-    posthog.capture("first_run_learning_empty", {
-      reason: state.emptyReason ?? "expired_unreported",
-      // No live engine call here: the window is long settled and a status read
-      // now would describe the present, not the window it is reporting on.
-      data_status: "not_checked",
-      frame_count: 0,
-      // Separates this from the ceiling-effect emit above, which happens with
-      // the banner mounted and a fresh activity read behind it.
-      settled_by: "rehydrate",
-    });
-    setState(clearPendingEmptyReport());
-  }, [pendingEmptyReport, state.emptyReason]);
+    let cancelled = false;
+
+    void (async () => {
+      // Ask the engine the same question the ceiling effect would have, so the
+      // user sees a reason they can act on rather than the `unknown` shrug
+      // rehydration parked there. Reporting a real reason is the whole point
+      // of this state; a rehydrated window must not be a second-class one.
+      const activity = pendingStartedAt
+        ? await fetchRecentActivity(pendingStartedAt)
+        : null;
+      if (cancelled) return;
+      const reason = classifyEmptyReason(activity);
+
+      posthog.capture("first_run_learning_empty", {
+        reason,
+        data_status: activity?.data_status ?? "none",
+        frame_count: Number(activity?.total_frames ?? 0),
+        // Separates this from the ceiling-effect emit above, which happens
+        // with the banner mounted and the window still live.
+        settled_by: "rehydrate",
+      });
+      // Also clears pendingEmptyReport, so a remount cannot double count.
+      setState(markLearningEmpty(reason));
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [pendingEmptyReport, pendingStartedAt]);
 
   const dismiss = useCallback(
     (options: { opened?: boolean } = {}) => {


### PR DESCRIPTION
Follow-up to #6225, which is merged. **This regression is currently live on `main`.**

## What is wrong on main

#6225 added an `expired_unreported` empty reason so the one settle path with no telemetry could be counted. The telemetry goal was right. Changing what the user sees was not.

A first-run window that outlives its ceiling while nothing is mounted now reads:

> The first-run summary timed out while Screenpipe was closed…

instead of naming *why* capture produced nothing. That is the opposite of why these reasons exist: `not_recording`, `no_frames_captured` and the rest are there so the empty state points at something the user can fix. I replaced a diagnosis with a shrug, on the one screen whose whole job is diagnosing.

It also breaks `first-run-learning-window.spec.ts`, which asserts the copy matches `/recording|captured|indexed/`. **That spec is failing on main right now.**

## Fix

- `expired_unreported` is gone. Rehydration leaves `emptyReason` as `unknown` and only sets `pendingEmptyReport`.
- The hook re-derives the real reason on that flag, exactly as the ceiling effect does: `fetchRecentActivity`, then `classifyEmptyReason`, emit `first_run_learning_empty` with `settled_by: "rehydrate"`, then settle with the engine's answer.
- The flag is scoped **off** the `writing` branch. A `writing` window that lost its process may still have an in-flight resolve about to seed a chat; reporting from there raced it and cleared the chat id out from under a summary that had already landed. Caught by an existing unit test, not by one of mine.

Net effect: a rehydrated window is no longer second class. It reaches the same actionable copy a ceiling-settled one does, which is better than the behaviour *before* #6225 as well, where it was stuck on `unknown`. The telemetry hole #6225 set out to close stays closed.

## Validation

- 129 tests pass across the first-run and chat-pane suites; typecheck clean.
- Real app build, `first-run-learning-window.spec.ts`: the empty-reason assertion that fails on main **passes here**.

### Pre-existing failure, not introduced by this PR

That spec has one other failing test, `still offers a first summary to someone who comes back later` (expects `learning`, gets `null`). I built **pre-#6225 main** (`7113d4b55`) and ran the same spec to check: it fails there too, identically.

| build | result |
|---|---|
| pre-#6225 main `7113d4b55` | 7 passing / 1 failing |
| main today (with the regression) | 7 passing / **2** failing |
| this PR | 7 passing / 1 failing |

So this PR restores the spec to its baseline. The remaining failure predates all of this work and needs its own investigation; I have deliberately not folded an unrelated fix into a regression fix.

## How this reached main

I reported #6225 as verified on unit tests plus a red/green proof of the one behaviour I was changing. The spec that guards the surrounding behaviour already existed and I did not run it until afterwards. Running the existing E2E for a module before changing it would have caught this pre-merge.
