### PR TITLE
fix(meeting): stop google meet's end page starting a phantom meeting on windows

### DIFF
--- a/crates/screenpipe-engine/src/meeting_watcher/shared/ignore.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/shared/ignore.rs
@@ -168,6 +168,63 @@ pub(crate) fn browser_window_matches_meeting(
     false
 }
 
+/// Why a Windows browser window was accepted as a meeting candidate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg(any(target_os = "windows", test))]
+pub(crate) enum WindowsTitleMatch {
+    /// A `browser_url_patterns` entry (e.g. `meet.google.com`) appeared
+    /// verbatim in the window title.
+    UrlPattern,
+    /// An anchored `browser_title_patterns` entry matched AND the title carries
+    /// a standalone Meet-code token.
+    AnchoredTitle,
+}
+
+/// Per-window decision for the Windows window-title sweep.
+///
+/// Windows exposes no per-tab URL, so both checks run against the window title:
+///
+/// - `browser_url_patterns` must appear verbatim with boundary matching — this
+///   keeps a real meeting host matching while closing the `daily.co` ⊂
+///   `thedaily.com` substring leak.
+/// - Anchored `browser_title_patterns` are gated on a standalone Meet-code
+///   token, exactly as the macOS AX sweep gates them in
+///   `ax_window_matches_meeting`.
+///
+/// The code gate is what stops the post-call page from starting a meeting.
+/// Chrome titles both the "You left the meeting" end page and the Meet landing
+/// page `Meet - Google Chrome`, whereas a live call is titled after the calendar
+/// event ("Weekly Reflections - Google Chrome"), the bare meeting code, or
+/// `Meet – abc-defg-hij`. Ungated, the bare `Meet` anchor therefore fired almost
+/// exclusively on the states that are *not* a call, handing the audio-process
+/// detector a Meet candidate the instant the user landed on the end page. A
+/// browser candidate skips the call-signal check, so a Chrome mic session that
+/// outlived the call it belonged to was then enough to start a phantom meeting
+/// immediately after a real one ended. Requiring the code keeps the genuine
+/// URL-less pop-out and drops the idle states.
+#[cfg(any(target_os = "windows", test))]
+pub(crate) fn windows_browser_title_match(
+    title: &str,
+    profile: &MeetingDetectionProfile,
+) -> Option<WindowsTitleMatch> {
+    let ids = &profile.app_identifiers;
+    if ids
+        .browser_url_patterns
+        .iter()
+        .any(|p| browser_url_pattern_matches(title, p))
+    {
+        return Some(WindowsTitleMatch::UrlPattern);
+    }
+    if ids.browser_title_patterns.is_empty() || !title_contains_meeting_code(title) {
+        return None;
+    }
+    let title_lower = title.to_lowercase();
+    ids.browser_title_patterns
+        .iter()
+        .any(|p| browser_title_matches_pattern(&title_lower, p))
+        .then_some(WindowsTitleMatch::AnchoredTitle)
+}
+
 /// Per-window decision for the macOS AX window sweep, which sees each window's
 /// AXDocument (the page URL, when the browser exposes one — Safari does,
 /// Chrome mostly doesn't) and its title.
@@ -245,11 +302,12 @@ pub(crate) fn ax_window_matches_meeting(
 /// ("how-to-run-fast-fyi") does not count as standalone.
 ///
 /// A real Chrome/Edge Meet pop-out is titled "Meet – abc-defg-hij"; this is
-/// the gate `ax_window_matches_meeting` applies on top of the anchored
-/// `browser_title_patterns` fallback for URL-less windows. Byte-level scan is
+/// the gate `ax_window_matches_meeting` (macOS AX sweep) and
+/// `find_running_meeting_apps` (Windows window-title sweep) apply on top of the
+/// anchored `browser_title_patterns` fallback for URL-less windows. Byte-level scan is
 /// UTF-8 safe: multi-byte separators (the en dash above) have non-ASCII bytes,
 /// which neither form the code nor extend the token.
-#[cfg(any(target_os = "macos", test))]
+#[cfg(any(target_os = "macos", target_os = "windows", test))]
 pub(crate) fn title_contains_meeting_code(title: &str) -> bool {
     const CODE_LEN: usize = 12; // aaa-bbbb-ccc
     let bytes = title.as_bytes();

--- a/crates/screenpipe-engine/src/meeting_watcher/ui_scan/tests.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/ui_scan/tests.rs
@@ -2847,6 +2847,97 @@ fn ax_window_title_fallback_requires_meeting_code() {
 }
 
 #[test]
+fn windows_title_sweep_ignores_meet_end_and_landing_pages() {
+    // Windows has no per-tab URL, so the anchored `Meet` title pattern is the
+    // only thing this sweep can key on. Chrome titles the post-call ("You left
+    // the meeting") page and the Meet landing page identically — `Meet - Google
+    // Chrome` — so ungated they became meeting candidates. A browser candidate
+    // skips the call-signal check in the audio-process detector, so a Chrome mic
+    // session that outlived the call was then enough to start a phantom meeting
+    // the moment the user hit the end page.
+    let profiles = load_detection_profiles();
+    let meet = google_meet_profile(&profiles);
+
+    let non_call_titles = [
+        // Post-call "You left the meeting" page and the landing page.
+        "Meet - Google Chrome",
+        "Meet - Google Chrome — Personal",
+        "Meet and Microsoft​Edge",
+        // Ordinary pages that merely start with the anchor.
+        "Meet the Team | Acme - Google Chrome",
+        "Meet Kevin - YouTube - Google Chrome",
+        "Meet: quarterly planning - Google Chrome",
+    ];
+    for title in &non_call_titles {
+        assert_eq!(
+            windows_browser_title_match(title, meet),
+            None,
+            "non-call window title {:?} must NOT become a Meet candidate",
+            title
+        );
+    }
+}
+
+#[test]
+fn windows_title_sweep_still_matches_real_meet_windows() {
+    let profiles = load_detection_profiles();
+    let meet = google_meet_profile(&profiles);
+
+    // Chrome/Edge Meet pop-out: anchored title + standalone meeting code.
+    for title in &[
+        "Meet - abc-defg-hij - Google Chrome",
+        "Meet – abc-defg-hij",
+        "Meet - abc-defg-hij and 3 more pages - Personal - Microsoft​ Edge",
+    ] {
+        assert_eq!(
+            windows_browser_title_match(title, meet),
+            Some(WindowsTitleMatch::AnchoredTitle),
+            "live Meet pop-out {:?} must still match",
+            title
+        );
+    }
+
+    // A verbatim domain in the title still wins on the URL-pattern path, with
+    // or without a meeting code — this branch is unchanged by the code gate.
+    for title in &[
+        "meet.google.com/abc-defg-hij - Google Chrome",
+        "meet.google.com - Google Chrome",
+    ] {
+        assert_eq!(
+            windows_browser_title_match(title, meet),
+            Some(WindowsTitleMatch::UrlPattern),
+            "verbatim Meet domain in title {:?} must still match",
+            title
+        );
+    }
+}
+
+#[test]
+fn windows_title_sweep_ignores_calendar_named_calls_as_before() {
+    // Real in-call Chrome titles are the calendar event name, which never
+    // started with the `Meet` anchor and so never matched this sweep. The code
+    // gate does not change that: those calls are detected via DB frame evidence
+    // (`browser_window_matches_meeting`) and the UIA call-signal scan, both
+    // untouched here. Asserted so a future widening of the anchor is a
+    // deliberate, visible change.
+    let profiles = load_detection_profiles();
+    let meet = google_meet_profile(&profiles);
+
+    for title in &[
+        "Weekly Reflections (time change) - Google Chrome",
+        "Screenpipe troubleshooting with Rajat - Google Chrome",
+        "apd-yzrk-jxn - Google Chrome",
+    ] {
+        assert_eq!(
+            windows_browser_title_match(title, meet),
+            None,
+            "calendar-named / bare-code title {:?} is out of scope for this sweep",
+            title
+        );
+    }
+}
+
+#[test]
 fn title_contains_meeting_code_requires_standalone_lowercase_token() {
     // Real pop-out shapes.
     assert!(title_contains_meeting_code("Meet – abc-defg-hij"));

--- a/crates/screenpipe-engine/src/meeting_watcher/ui_scan/windows.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/ui_scan/windows.rs
@@ -536,25 +536,11 @@ pub fn find_running_meeting_apps(
                 continue;
             }
 
-            // url_patterns are matched against the window TITLE on Windows (no
-            // per-tab URL available). Boundary matching still applies — it keeps
-            // a real meeting host in a title matching while closing the
-            // `daily.co` ⊂ `thedaily.com` substring leak.
-            let url_match = profile
-                .app_identifiers
-                .browser_url_patterns
-                .iter()
-                .any(|p| browser_url_pattern_matches(title, p));
-            // See `browser_title_matches_pattern` for the matching rules.
-            let title_match = !profile.app_identifiers.browser_title_patterns.is_empty() && {
-                let title_lower = title.to_lowercase();
-                profile
-                    .app_identifiers
-                    .browser_title_patterns
-                    .iter()
-                    .any(|p| browser_title_matches_pattern(&title_lower, p))
-            };
-            if url_match || title_match {
+            // Pure decision, unit-tested in `shared::ignore` — see
+            // `windows_browser_title_match` for the URL-pattern / anchored-title
+            // rules and the Meet-code gate.
+            let matched = windows_browser_title_match(title, profile);
+            if matched.is_some() {
                 // Confirms screenpipe saw the meeting window; pairs with the
                 // scanner's UIA scan line via pid + profile_idx. DEBUG, not
                 // INFO: titles can contain sensitive context (URLs, attendee
@@ -565,8 +551,8 @@ pub fn find_running_meeting_apps(
                     pid,
                     proc_name.as_deref().unwrap_or("?"),
                     title,
-                    url_match,
-                    title_match
+                    matched == Some(WindowsTitleMatch::UrlPattern),
+                    matched == Some(WindowsTitleMatch::AnchoredTitle)
                 );
                 results.push(RunningMeetingApp {
                     pid: *pid,


### PR DESCRIPTION
## Problem

On Windows, leaving a Google Meet call immediately starts a **new phantom meeting**. You land on the "You left the meeting" end page and screenpipe begins recording a meeting that does not exist.

## Where found

Reported by Louis on Windows. Diagnosed from source plus **4,653 real captured Meet frames** (2026-07-09 → 2026-08-14, 67 distinct meeting codes) pulled from the local screenpipe DB.

## Root cause

Windows exposes **no per-tab URL** to the meeting watcher, so `find_running_meeting_apps` matches browser windows on the **title only**. For Google Meet the only usable key is the anchored `browser_title_patterns: ["Meet"]`.

`browser_title_matches_pattern` is a prefix match with a non-alphanumeric boundary, so:

| Chrome window title | state | matched before? |
|---|---|---|
| `Meet - Google Chrome` | **end page / landing** | ✅ yes |
| `Weekly Reflections (time change) - Google Chrome` | **live call** | ❌ no |
| `apd-yzrk-jxn - Google Chrome` | **live call** | ❌ no |
| `Meet - abc-defg-hij - Google Chrome` | live pop-out | ✅ yes |

Measured on the captured corpus:

- **0 of 887** in-call frames have a window title starting with `Meet`
- the **single most common end-page title is exactly `Meet`** (28 frames)

So the anchor was firing almost exclusively on the states that are *not* a call.

That match makes the browser a Meet candidate. The **audio-process detector is the default backend on Windows**, and its browser candidates skip the `requires_call_signal` gate that protects native ones (that gate is only consulted for `ResolvedMeetingCandidate::Native`). A Chrome mic session that outlives the call it belonged to is then sufficient to start a meeting — which is exactly the moment the user is sitting on the end page.

macOS never had this: `ax_window_matches_meeting` already gates the same anchored fallback behind a standalone Meet-code token (`title_contains_meeting_code`), added precisely to stop `Meet the Team - Acme`-shaped titles becoming live evidence. **That gate was simply never applied on the Windows path.**

## Fix

Apply the existing macOS gate to the Windows sweep, and extract the per-window decision out of Win32 code into a pure `windows_browser_title_match` in `shared::ignore` so it is unit-testable on every platform.

```
before:  title_patterns non-empty && anchored_match(title)
after:   title_patterns non-empty && title_contains_meeting_code(title) && anchored_match(title)
```

| title | before | after |
|---|---|---|
| `Meet - Google Chrome` (end page) | `AnchoredTitle` ❌ | `None` ✅ |
| `Meet - Google Chrome` (landing) | `AnchoredTitle` ❌ | `None` ✅ |
| `Meet Kevin - YouTube - Google Chrome` | `AnchoredTitle` ❌ | `None` ✅ |
| `Meet - abc-defg-hij - Google Chrome` (pop-out) | `AnchoredTitle` ✅ | `AnchoredTitle` ✅ |
| `meet.google.com/... - Google Chrome` | `UrlPattern` ✅ | `UrlPattern` ✅ |
| `Weekly Reflections - Google Chrome` | `None` | `None` (unchanged) |

No genuine detection is lost: the code-bearing pop-out title and the URL-pattern branch both still match, and calendar-named in-call titles never matched this sweep to begin with.

## Validation

- 3 new unit tests covering end page / landing / ordinary anchored titles, live pop-outs + URL patterns, and calendar-named calls.
- **Red/green proof**: with the gate removed, `windows_title_sweep_ignores_meet_end_and_landing_pages` fails with `left: Some(AnchoredTitle), right: None` on `"Meet - Google Chrome"` — the exact reported symptom. With the gate, it passes.
- Full `meeting_watcher` suite: **214 passed, 0 failed**.
- `cargo fmt -p screenpipe-engine --check` clean; `cargo clippy -p screenpipe-engine --lib` introduces no new warnings (the two `ignore.rs` doc warnings are byte-identical in `HEAD`).

**Not verified:** I could not cross-compile to Windows locally (`ring` needs MSVC headers, unrelated dep) and could not run a live Windows repro. Windows CI covers compilation; a real leave-a-call canary on Windows is still worth doing before this is called customer-recovered.

## Follow-up worth filing separately

While measuring this I found that on Windows the audio-process path likely **never** detects an ordinary in-call Meet tab. The title is the calendar event name, which matches neither `browser_url_patterns` (no URL in the Windows title) nor the `Meet` anchor — and `active_tab_url_candidates` is an explicit no-op on Windows. Only pop-outs and code-shaped titles resolve. Wiring the UIA URL probe would close that gap; this PR deliberately does not, since it is a separate change with its own false-positive surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
