### PR TITLE
fix(chat): name MCP startup failures, shrink composer footer, ring the usage chip

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat/standalone/acp-config-selector.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/acp-config-selector.tsx
@@ -4,7 +4,7 @@
 "use client";
 
 import { useState } from "react";
-import { Loader2, SlidersHorizontal } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { Switch } from "@/components/ui/switch";
 import {
@@ -177,7 +177,6 @@ export function AcpConfigSelector({
 
   return (
     <ComposerSettingsPopover
-      icon={SlidersHorizontal}
       label={triggerLabel}
       title={`Agent configuration${triggerLabel === "config" ? "" : `: ${triggerLabel}`}`}
       ariaLabel="Agent configuration"

--- a/apps/screenpipe-app-tauri/components/chat/standalone/chat-composer.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/chat-composer.tsx
@@ -73,7 +73,7 @@ export function ChatComposer({
 
         <form
           onSubmit={input.onSubmit}
-          className="px-5 sm:px-6 pb-4 pt-3 relative"
+          className="px-5 sm:px-6 pb-3 pt-2 relative"
           onPaste={input.onPaste}
           data-firstrun-target="composer"
         >

--- a/apps/screenpipe-app-tauri/components/chat/standalone/composer-controls-row.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/composer-controls-row.tsx
@@ -48,8 +48,11 @@ export function ComposerControlsRow({
   const acpAgentId = modelControls.activePreset?.acpAgent?.id ?? null;
 
   return (
+    // Every control here is h-7, matching the settings-popover triggers that
+    // were already that size. The row is chrome under the thing people came to
+    // type in, so it stays one compact line rather than a second toolbar.
     <div
-      className="flex items-center gap-1.5 px-1 pt-2"
+      className="flex items-center gap-1.5 px-1 pt-1.5"
       data-firstrun-target="composer-controls"
     >
       <Popover
@@ -62,7 +65,7 @@ export function ComposerControlsRow({
             size="icon"
             variant="ghost"
             className={cn(
-              "h-8 w-8 text-muted-foreground hover:text-foreground hover:bg-muted/50 relative shrink-0",
+              "h-7 w-7 text-muted-foreground hover:text-foreground hover:bg-muted/50 relative shrink-0",
               filters.hasActiveFilters && "text-foreground bg-muted/50",
             )}
             title="Add attachments and filters"
@@ -124,7 +127,7 @@ export function ComposerControlsRow({
         compact
         showModelOnly
         containerClassName="w-[180px] max-w-[42vw] min-w-[120px] shrink-0 gap-0"
-        triggerClassName="h-8 border-0 bg-transparent px-1.5 text-xs text-muted-foreground shadow-none hover:bg-muted/50 hover:text-foreground"
+        triggerClassName="h-7 border-0 bg-transparent px-1.5 text-xs text-muted-foreground shadow-none hover:bg-muted/50 hover:text-foreground"
         onPresetSaved={modelControls.onPresetSaved}
         controlledPresetId={
           modelControls.activePreset?.id ??
@@ -166,7 +169,7 @@ export function ComposerControlsRow({
         onClick={sendButton.isStopMode ? sendButton.onStop : undefined}
         data-firstrun-target="send"
         className={cn(
-          "h-8 w-8 transition-all duration-200 relative",
+          "h-7 w-7 transition-all duration-200 relative",
           "bg-foreground text-background hover:bg-foreground/80",
         )}
         title={

--- a/apps/screenpipe-app-tauri/components/chat/standalone/composer-input-box.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/composer-input-box.tsx
@@ -79,7 +79,7 @@ export function ComposerInputBox({
           autoCorrect="off"
           rows={1}
           className={cn(
-            "w-full min-h-[44px] border-0 bg-transparent px-3 text-sm font-mono placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 caret-foreground resize-none overflow-y-auto scrollbar-minimal py-2.5",
+            "w-full min-h-[38px] border-0 bg-transparent px-3 text-sm font-mono placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 caret-foreground resize-none overflow-y-auto scrollbar-minimal py-2",
             input.connectionChip ? "pr-7" : "pr-3",
           )}
           style={{

--- a/apps/screenpipe-app-tauri/components/chat/standalone/composer-settings-popover.test.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/composer-settings-popover.test.tsx
@@ -67,10 +67,22 @@ describe("composer settings control", () => {
     render(<ThinkingLevelSelector sessionId={SESSION} />);
     const pi = screen.getByTestId("thinking-level-trigger");
 
-    // Same shell, so identical layout classes: height, gap, padding, the width
-    // cap that keeps a long model name from pushing the send button around.
+    // Same shell, so identical layout classes: height, padding, the width cap
+    // that keeps a long model name from pushing the send button around.
     expect(pi.className).toBe(acpClass);
-    expect(acpClass).toContain("max-w-[160px]");
+    expect(acpClass).toContain("max-w-[190px]");
+  });
+
+  // Claude and Codex both name the model in plain text. A glyph in front of a
+  // value that already names itself is a second thing to parse in a row that
+  // already holds four controls.
+  it("names the value with no leading glyph on either trigger", () => {
+    renderAcp();
+    expect(screen.getByTestId("acp-config-trigger").querySelector("svg")).toBeNull();
+    cleanup();
+
+    render(<ThinkingLevelSelector sessionId={SESSION} />);
+    expect(screen.getByTestId("thinking-level-trigger").querySelector("svg")).toBeNull();
   });
 
   it("names the active value on both triggers", () => {

--- a/apps/screenpipe-app-tauri/components/chat/standalone/composer-settings-popover.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/composer-settings-popover.tsx
@@ -4,7 +4,6 @@
 "use client";
 
 import type { ReactNode } from "react";
-import type { LucideIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Popover,
@@ -22,6 +21,10 @@ import { cn } from "@/lib/utils";
  * two had different widths and different popover anatomy, so picking a coding
  * agent silently rearranged the row.
  *
+ * The trigger is the value alone. Claude and Codex both name the model in
+ * plain text with no glyph, and next to three other controls that reads as
+ * one line of state instead of a row of buttons.
+ *
  * Native `<select>` on purpose, for both. The OS draws their menu above the
  * webview; Radix menus get painted over on Windows. It also degrades better
  * than a hand-rolled list when an adapter advertises a long model catalog.
@@ -35,7 +38,6 @@ const FIELD_CONTROL =
   "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring";
 
 export function ComposerSettingsPopover({
-  icon: Icon,
   label,
   title,
   ariaLabel,
@@ -46,7 +48,6 @@ export function ComposerSettingsPopover({
   disabled = false,
   children,
 }: {
-  icon: LucideIcon;
   /** The active value, named on the trigger so it is readable before opening. */
   label: string;
   title: string;
@@ -67,12 +68,16 @@ export function ComposerSettingsPopover({
           variant="ghost"
           size="sm"
           disabled={disabled}
-          className="h-7 max-w-[160px] gap-1.5 px-2 text-xs text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+          // No leading glyph: the value IS the affordance, the way Claude reads
+          // "Opus 5 · Fast  High" and Codex reads "5.6 Sol  Extra High". An icon
+          // in front of a value that already names itself is a second thing to
+          // parse, and this row has four controls competing for one line. The
+          // freed width goes to the label so fewer names truncate.
+          className="h-7 max-w-[190px] px-2 text-xs text-muted-foreground hover:bg-muted/50 hover:text-foreground"
           title={title}
           aria-label={ariaLabel}
           data-testid={triggerTestId}
         >
-          <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden />
           <span className="truncate font-medium">{label}</span>
         </Button>
       </PopoverTrigger>

--- a/apps/screenpipe-app-tauri/components/thinking-level-selector.tsx
+++ b/apps/screenpipe-app-tauri/components/thinking-level-selector.tsx
@@ -5,7 +5,6 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from "react";
-import { Brain } from "lucide-react";
 import { commands } from "@/lib/utils/tauri";
 import { usePiThinkingLevel } from "@/lib/hooks/use-pi-thinking-level";
 import { ComposerSettingsPopover } from "@/components/chat/standalone/composer-settings-popover";
@@ -125,7 +124,6 @@ export function ThinkingLevelSelector({ streaming = false, sessionId = null }: T
   // rearrange the composer row. The trigger keeps naming the active level.
   return (
     <ComposerSettingsPopover
-      icon={Brain}
       label={currentLabel}
       title={disabledReason || "Thinking level: controls reasoning depth"}
       ariaLabel="Thinking level"

--- a/apps/screenpipe-app-tauri/components/usage/usage-meter.tsx
+++ b/apps/screenpipe-app-tauri/components/usage/usage-meter.tsx
@@ -23,8 +23,76 @@ const FILL_BY_STATE: Record<UsageAllowanceState, string> = {
   reached: "bg-red-500",
 };
 
+/** The same three states as the bars, as a stroke, so the composer ring and the
+ *  rows it opens are never two different readings of one number. */
+const STROKE_BY_STATE: Record<UsageAllowanceState, string> = {
+  ok: "stroke-blue-500",
+  approaching: "stroke-amber-500",
+  reached: "stroke-red-500",
+};
+
 export function usageFillClass(state: UsageAllowanceState): string {
   return FILL_BY_STATE[state];
+}
+
+export function usageStrokeClass(state: UsageAllowanceState): string {
+  return STROKE_BY_STATE[state];
+}
+
+const RING_RADIUS = 7;
+const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
+
+/**
+ * The bar's shape for places with no room for a bar — currently the composer,
+ * where a ring reads at a glance and costs a single icon slot.
+ *
+ * Presentational on purpose: it lives inside a button that already names the
+ * value, and a widget role nested in a control is worse for screen readers than
+ * no role at all.
+ */
+export function UsageRing({
+  percent,
+  state,
+  className,
+}: {
+  /** 0-100; clamped here so a stale over-100 reading can't overdraw the arc. */
+  percent: number;
+  state: UsageAllowanceState;
+  className?: string;
+}) {
+  const clamped = Math.min(100, Math.max(0, percent));
+  return (
+    <svg
+      viewBox="0 0 20 20"
+      className={cn("h-4 w-4 shrink-0 -rotate-90", className)}
+      aria-hidden
+      data-testid="usage-ring"
+      data-usage-state={state}
+    >
+      <circle
+        cx="10"
+        cy="10"
+        r={RING_RADIUS}
+        fill="none"
+        strokeWidth="3"
+        className="stroke-current opacity-20"
+      />
+      <circle
+        cx="10"
+        cy="10"
+        r={RING_RADIUS}
+        fill="none"
+        strokeWidth="3"
+        strokeLinecap="round"
+        strokeDasharray={RING_CIRCUMFERENCE}
+        strokeDashoffset={RING_CIRCUMFERENCE * (1 - clamped / 100)}
+        className={cn(
+          "transition-[stroke-dashoffset] duration-300",
+          usageStrokeClass(state),
+        )}
+      />
+    </svg>
+  );
 }
 
 export function UsageMeter({

--- a/apps/screenpipe-app-tauri/components/usage/usage-popover.test.tsx
+++ b/apps/screenpipe-app-tauri/components/usage/usage-popover.test.tsx
@@ -139,3 +139,57 @@ describe("UsagePopover", () => {
     });
   });
 });
+
+describe("UsagePopover trigger ring", () => {
+  const originalAllowances = mocks.query.usage.hosted_ai.allowances;
+
+  afterEach(() => {
+    mocks.query.usage.hosted_ai.allowances = originalAllowances;
+  });
+
+  // The composer has one icon slot to spare, so the arc carries the glance and
+  // the exact number lives in the panel, the tooltip and the accessible name.
+  it("draws the tightest allowance as an arc and still names the number", () => {
+    render(<UsagePopover />);
+
+    const trigger = screen.getByTestId("usage-popover-trigger");
+    expect(trigger.getAttribute("aria-label")).toBe("AI usage, 62% used");
+    expect(trigger.getAttribute("title")).toBe("AI usage: 62% used");
+
+    const ring = screen.getByTestId("usage-ring");
+    const arc = ring.querySelectorAll("circle")[1];
+    const circumference = 2 * Math.PI * 7;
+    expect(Number(arc.getAttribute("stroke-dasharray"))).toBeCloseTo(circumference, 5);
+    // 62% used leaves 38% of the circle undrawn.
+    expect(Number(arc.getAttribute("stroke-dashoffset"))).toBeCloseTo(
+      circumference * 0.38,
+      5,
+    );
+  });
+
+  it("reddens as the tightest allowance runs out", () => {
+    const stateFor = (used: number) => {
+      mocks.query.usage.hosted_ai.allowances = [
+        { ...originalAllowances[0], used_percent: used, remaining_percent: 100 - used },
+      ];
+      const view = render(<UsagePopover />);
+      const state = screen.getByTestId("usage-ring").getAttribute("data-usage-state");
+      view.unmount();
+      return state;
+    };
+
+    expect(stateFor(30)).toBe("ok");
+    expect(stateFor(85)).toBe("approaching");
+    expect(stateFor(100)).toBe("reached");
+  });
+
+  it("cannot overdraw the arc on a stale over-100 reading", () => {
+    mocks.query.usage.hosted_ai.allowances = [
+      { ...originalAllowances[0], used_percent: 140, remaining_percent: 0 },
+    ];
+    render(<UsagePopover />);
+
+    const arc = screen.getByTestId("usage-ring").querySelectorAll("circle")[1];
+    expect(Number(arc.getAttribute("stroke-dashoffset"))).toBe(0);
+  });
+});

--- a/apps/screenpipe-app-tauri/components/usage/usage-popover.tsx
+++ b/apps/screenpipe-app-tauri/components/usage/usage-popover.tsx
@@ -13,6 +13,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { UsageLimitsPanel } from "@/components/usage/usage-limits-panel";
+import { UsageRing } from "@/components/usage/usage-meter";
 import { quotaPlanLabel } from "@/lib/chat/quota-errors";
 import {
   formatUsagePercent,
@@ -50,23 +51,27 @@ export function UsagePopover() {
         <Button
           type="button"
           variant="ghost"
-          size="sm"
+          size="icon"
           className={cn(
-            "h-8 gap-1.5 px-2 text-xs hover:bg-muted/50 hover:text-foreground",
-            // The chip only earns full contrast once the tightest allowance is
+            "h-7 w-7 hover:bg-muted/50 hover:text-foreground",
+            // The ring only earns full contrast once the tightest allowance is
             // actually worth acting on; otherwise it stays background noise.
             state === "ok"
               ? "text-muted-foreground"
-              : "text-foreground font-medium",
+              : "text-foreground",
           )}
+          // The arc is the glance; the exact number belongs to the panel it
+          // opens, and to anyone who hovers or uses a screen reader.
+          title={percent ? `AI usage: ${percent} used` : "AI usage unavailable"}
           aria-label={percent ? `AI usage, ${percent} used` : "AI usage unavailable"}
           data-testid="usage-popover-trigger"
           data-state-usage={state}
         >
-          <Activity className="h-3.5 w-3.5" aria-hidden />
-          <span className="hidden font-mono tabular-nums sm:inline">
-            {percent ?? "—"}
-          </span>
+          {tightest ? (
+            <UsageRing percent={tightest.used_percent} state={state} />
+          ) : (
+            <Activity className="h-3.5 w-3.5" aria-hidden />
+          )}
         </Button>
       </PopoverTrigger>
       <PopoverContent

--- a/apps/screenpipe-app-tauri/lib/chat/__tests__/tool-presentation.test.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/__tests__/tool-presentation.test.ts
@@ -436,3 +436,70 @@ describe("presentToolActivity — ACP tool calls", () => {
     );
   });
 });
+
+describe("MCP server startup diagnostics", () => {
+  // codex-acp reports each MCP server that could not start as a failed tool
+  // call named `mcp__<server>__startup`. Stripping the prefix left a bare
+  // "Startup", so a user with several unauthenticated servers saw a stack of
+  // identical anonymous rows and had to expand one to learn which server.
+  it("names the server instead of collapsing to an anonymous 'Startup'", () => {
+    expect(
+      presentToolActivity({
+        toolName: "mcp__Notion__startup",
+        args: {},
+        isError: true,
+      }).completedLabel,
+    ).toBe("Notion MCP server failed to start");
+  });
+
+  it("keeps two failing servers distinguishable", () => {
+    const labelFor = (server: string) =>
+      presentToolActivity({
+        toolName: `mcp__${server}__startup`,
+        args: {},
+        isError: true,
+      }).completedLabel;
+    expect(labelFor("Notion")).not.toBe(labelFor("figma"));
+  });
+
+  it("does not call a server that started fine a failure", () => {
+    expect(
+      presentToolActivity({ toolName: "mcp__linear__startup", args: {} }).completedLabel,
+    ).toBe("Started the linear MCP server");
+  });
+
+  it("labels the in-flight state as startup, not generic work", () => {
+    expect(
+      presentToolActivity({ toolName: "mcp__dropboxmcp__startup", args: {} }).runningLabel,
+    ).toBe("Starting the dropboxmcp MCP server");
+  });
+
+  // Only the exact `__startup` suffix is a diagnostic; a real MCP tool that
+  // merely mentions startup stays on the humanized path.
+  it("leaves a real MCP tool alone", () => {
+    expect(
+      presentToolActivity({ toolName: "mcp__acme__startup-check", args: {} }).completedLabel,
+    ).toBe("Startup check");
+  });
+});
+
+describe("adapter relay tags in tool results", () => {
+  // codex-acp prefixes messages it relays from codex with its own name. The
+  // actionable sentence is what the user needs; the tag only delays it.
+  it("drops the adapter's relay tag and keeps the actionable message", () => {
+    expect(
+      formatToolResult(
+        "[codex-acp forwarded startup error] MCP server `Notion` failed to start: " +
+          "The Notion MCP server is not logged in. Run `codex mcp login Notion`.",
+      ),
+    ).toBe(
+      "MCP server `Notion` failed to start: The Notion MCP server is not logged in. " +
+        "Run `codex mcp login Notion`.",
+    );
+  });
+
+  it("leaves an ordinary result untouched", () => {
+    expect(formatToolResult("[warn] disk almost full")).toBe("[warn] disk almost full");
+    expect(formatToolResult("plain output")).toBe("plain output");
+  });
+});

--- a/apps/screenpipe-app-tauri/lib/chat/tool-presentation.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/tool-presentation.ts
@@ -439,10 +439,16 @@ export function summarizeToolResult(result: string | undefined, family: string):
   return "JSON response returned";
 }
 
+// Adapters stamp their own name onto messages they relay from the underlying
+// agent (codex-acp: "[codex-acp forwarded startup error] …"). Which adapter
+// relayed a message is plumbing; the sentence after it is the part the user
+// has to act on, so the tag only pushes it off the first line.
+const ADAPTER_RELAY_TAG_RE = /^\[[a-z0-9_-]+ forwarded [a-z ]+\]\s*/i;
+
 export function formatToolResult(result: string | undefined): string | undefined {
   if (!result) return undefined;
   const json = parseToolResultJson(result);
-  if (!json) return result;
+  if (!json) return result.replace(ADAPTER_RELAY_TAG_RE, "");
   return JSON.stringify(json, null, 2);
 }
 
@@ -679,6 +685,17 @@ function bareMcpName(toolName: string): string {
   return toolName.replace(MCP_PREFIX_RE, "");
 }
 
+// codex-acp reports an MCP server that could not start as a failed tool call
+// named `mcp__<server>__startup`. It emits one per server on every turn, so a
+// user with several unauthenticated servers gets a stack of them.
+const MCP_STARTUP_RE = /^mcp__([a-z0-9_.-]+)__startup$/i;
+
+/** The server name behind an `mcp__<server>__startup` diagnostic, if that's what
+ *  this is. Never a real tool the agent chose to call. */
+export function mcpStartupServerName(toolName: string): string | null {
+  return toolName.match(MCP_STARTUP_RE)?.[1] ?? null;
+}
+
 /**
  * If `toolName` is a screenpipe MCP tool, synthesize the equivalent local curl
  * command from its rawInput args, so the existing curl classifier and endpoint
@@ -786,6 +803,21 @@ export function presentToolActivity(toolCall: PresentableToolCall): ToolActivity
           ? `${type} subagent`
           : "subagent";
     return activity(title, title);
+  }
+
+  // An MCP server that failed to start is a setup problem, not a step the agent
+  // took. Naming the server is the whole point: `mcp__<server>__startup` strips
+  // down to a bare "Startup", so several failing servers rendered as a stack of
+  // identical anonymous rows and the one fact worth reading was only visible
+  // after expanding one of them.
+  const mcpStartupServer = mcpStartupServerName(rawName);
+  if (mcpStartupServer) {
+    return activity(
+      `Starting the ${mcpStartupServer} MCP server`,
+      toolCall.isError
+        ? `${mcpStartupServer} MCP server failed to start`
+        : `Started the ${mcpStartupServer} MCP server`,
+    );
   }
 
   // screenpipe MCP tools mirror the local REST endpoints — reuse the curl path.


### PR DESCRIPTION
Three fixes to the chrome under the chat.

![before / after](https://raw.githubusercontent.com/screenpipe/screenpipe/assets-composer-mcp-usage/composer-mcp-usage-before-after.png)

*Rendered from the real components (`UsageRing`, `presentToolActivity`) on a throwaway preview route, deleted before this PR.*

---

## 1. MCP startup failures were five identical anonymous rows

**Problem.** Running Codex with several MCP servers configured produced a stack
of grey rows all reading exactly `Startup`, one per failing server, with no way
to tell them apart without expanding each one.

**Where found.** A user's chat, five `✕ Startup` rows in a single turn. Expanding
the fifth revealed:
`[codex-acp forwarded startup error] MCP server \`Notion\` failed to start: The Notion MCP server is not logged in. Run \`codex mcp login Notion\`.`

**Reproduction.** Configure two MCP servers in `~/.codex/config.toml` that cannot
start (an OAuth server you have not logged into is enough), open a Codex ACP
chat, send anything. Before this change both rows read `Startup`.

**Root cause.** `@agentclientprotocol/codex-acp` reports each server that failed
to start as a failed tool call titled `mcp__<server>__startup`
(`createMcpStartupToolCallUpdate`). `presentToolActivity` falls through to
`humanizeToolName`, which strips the `mcp__<server>__` prefix — leaving `startup`
→ `Startup`. The server name, the one distinguishing fact, is the part that got
stripped.

**Fix.** Recognise the `mcp__<server>__startup` shape before the humanize
fallback and name the server: `Notion MCP server failed to start`. A server that
starts fine reads `Started the Notion MCP server`; in flight it reads
`Starting the Notion MCP server`. Only the exact `__startup` suffix matches, so a
real MCP tool like `mcp__acme__startup-check` is untouched.

Separately, `formatToolResult` now drops an adapter's relay tag
(`[codex-acp forwarded startup error] `) so the sentence the user has to act on
leads the expanded body instead of trailing plumbing.

## 2. The composer footer was 20px taller than it needed to be

**Problem.** The chrome under the input took more vertical space than the input.

**Fix.** Every control in the row is now `h-7`, matching the settings-popover
triggers (`ComposerSettingsPopover`) that were already that size — the row was
previously 32px only because the Plus, preset and send buttons disagreed with
the two selectors next to them. Form and textarea padding tighten to match.

Measured on the real markup: **114px → 94px (-18%)**. No control loses its label,
tooltip or hit affordance beyond the 4px.

## 3. The usage chip is a ring

**Problem.** An `Activity` glyph plus `58%` spent two slots in a crowded row to
say one thing, and the glyph carried no state.

**Fix.** A `UsageRing` whose arc is the usage and whose colour is the existing
allowance state. The exact number stays in the panel it opens, plus a new
`title` tooltip and the unchanged accessible name, so nothing is encoded in the
arc alone.

Colour reuses the deliberate exception already documented in `usage-meter.tsx`
(blue → amber → red at the same `usageAllowanceState` thresholds as the bars),
so the ring and the rows it opens can never be two different readings of one
number. The ring is `aria-hidden`: it sits inside a button that already names
the value, and a widget role nested in a control is worse than no role.

## 4. The settings trigger dropped its glyph

Claude names the model `Opus 5 · Fast  High`, Codex `5.6 Sol  Extra High` — plain
text, no icon. Ours put a `SlidersHorizontal` in front of a value that already
names itself, in a row holding four controls on one line.

The `icon` prop is removed from `ComposerSettingsPopover` rather than left as a
dead optional, so both call sites (ACP config, raw-Pi thinking level) lose their
`Brain` / `SlidersHorizontal` imports too. The freed 30px goes to the label cap
(160px → 190px) so fewer model names truncate.

## Validation

- `bunx vitest run components/usage lib/chat/__tests__/tool-presentation.test.ts components/chat/standalone lib/chat` → **441 passed**, 12 new.
  - 9 pre-existing failures in `free-plan-wall.test.tsx` / `free-wall.test.ts`, all
    `window.localStorage.clear()` in their own `beforeEach` under this node's
    experimental localStorage. Neither file references any file in this diff.
- `bun run typecheck` clean.
- `bunx eslint` on every changed source file: clean. `bunx knip` clean.
- Rendered the real components in a browser to measure the height delta and
  confirm the colour ramp (screenshot above).

## Not in scope

The underlying MCP servers still fail — that is the user's own
`~/.codex/config.toml` (unauthenticated OAuth servers). This PR makes the failure
legible, it does not authenticate anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

