### PR TITLE
fix(overlay): drag a live meeting as one object, stack the toast past the card

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder.swift
+++ b/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder.swift
@@ -672,6 +672,32 @@ func nearestAnchor(
     return best
 }
 
+/// Y origin for a panel hanging off the pill on the side the disclosure opens.
+///
+/// `stacked` is the height already claimed on that side by attachments nearer
+/// the pill. Without it every attachment measures from the same pill edge, so
+/// the transcript card and a notification both land in the same place and the
+/// toast covers the card's header row — which is precisely the case that
+/// matters, since "live transcript not flowing" only fires while a meeting is
+/// running and the card is up.
+func overlayAttachmentY(
+    pill: NSRect,
+    height: CGFloat,
+    gap: CGFloat,
+    stacked: CGFloat,
+    disclosureDown: Bool,
+    visible: NSRect,
+    edgeInset: CGFloat
+) -> CGFloat {
+    let preferred = disclosureDown
+        ? pill.minY - stacked - gap - height
+        : pill.maxY + stacked + gap
+    return min(
+        max(preferred, visible.minY + edgeInset),
+        visible.maxY - height - edgeInset
+    )
+}
+
 func overlayHoverRect(
     in bounds: NSRect,
     expanded: Bool,
@@ -1412,8 +1438,21 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
     private var dragStageScreen: NSScreen?
     #if OVERLAY_PREVIEW
     private var previewStageLocked = false
+    private var previewTranscriptTimer: Timer?
     #endif
     private var isDraggingPill = false
+    /// Offset from the panel origin to the pinned transcript card, frozen for
+    /// the length of a drag. Holding it constant moves the card rigidly with
+    /// the pill instead of recomputing an anchor and re-clamping it against the
+    /// screen on every mouse move, which is what made the card wobble behind
+    /// the chip rather than travel with it.
+    private var draggedTranscriptOffset: CGVector?
+    /// Same, for a toast that happens to be up when the drag starts.
+    private var draggedNotificationOffset: CGVector?
+    /// True for the length of the release animation. The attachments are
+    /// animated to their own destinations in the same group, so the per-move
+    /// chase in `windowDidMove` has to stay out of the way until it lands.
+    private var isSettlingPanel = false
     private var notificationPanel: NSPanel?
     private var notificationHostingView: NSHostingView<AnyView>?
     private var notificationTrackingView: ReminderTrackingView?
@@ -1781,6 +1820,72 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
             panel?.orderOut(nil)
         }
     }
+
+    /// Pill and pinned card on screen together, which `setPreviewMeeting`
+    /// deliberately is not: it hides the pill so a screenshot picks the card.
+    /// This is the state the drag glue and the attachment stack are about — the
+    /// pill is the thing being dragged, and a notification arriving here is a
+    /// meeting alert landing while the meeting it is about is still running.
+    func setPreviewPinnedMeeting() {
+        DispatchQueue.main.async { [self] in
+            disconnectMeetingEventsWebSocket()
+            metrics.meetingActive = true
+            metrics.activeMeetingId = 42
+            metrics.meetingApp = "zoom"
+            metrics.meetingTranscriptItems = [
+                "so the overlay follows the pill now",
+                "right, and the toast stacks past the card",
+                "that was the part that overlapped",
+                "shipping it today",
+            ].enumerated().map { index, text in
+                MeetingOverlayTranscriptItem(
+                    meetingId: 42,
+                    itemId: "preview-\(index)",
+                    deviceName: index.isMultiple(of: 2) ? "system audio" : "macbook microphone",
+                    deviceType: index.isMultiple(of: 2) ? "output" : "input",
+                    speakerName: index.isMultiple(of: 2) ? "speaker 1" : "you",
+                    text: text,
+                    capturedAt: "2026-08-14T18:0\(index):00Z",
+                    isFinal: true
+                )
+            }
+            metrics.meetingPinned = true
+            refreshTranscriptPanelVisibility()
+            startPreviewTranscriptFeed()
+        }
+    }
+
+    /// A meeting that is actually live keeps pushing transcript deltas, and
+    /// each one lands in `refreshTranscriptPanelVisibility` — including while
+    /// the pill is being dragged. Reproducing that here is the whole point:
+    /// without a feed the preview is a still life and the drag looks fine.
+    private func startPreviewTranscriptFeed() {
+        previewTranscriptTimer?.invalidate()
+        var line = 0
+        previewTranscriptTimer = Timer.scheduledTimer(
+            withTimeInterval: 0.7, repeats: true
+        ) { [weak self] _ in
+            guard let self = self else { return }
+            line += 1
+            self.metrics.meetingTranscriptItems.append(
+                MeetingOverlayTranscriptItem(
+                    meetingId: 42,
+                    itemId: "preview-live-\(line)",
+                    deviceName: line.isMultiple(of: 2) ? "system audio" : "macbook microphone",
+                    deviceType: line.isMultiple(of: 2) ? "output" : "input",
+                    speakerName: line.isMultiple(of: 2) ? "speaker 1" : "you",
+                    text: "live line \(line) arriving while you drag",
+                    capturedAt: "2026-08-14T18:00:00Z",
+                    isFinal: true
+                )
+            )
+            if self.metrics.meetingTranscriptItems.count > 50 {
+                self.metrics.meetingTranscriptItems.removeFirst()
+            }
+            // Same call the websocket makes for every delta.
+            self.refreshTranscriptPanelVisibility()
+        }
+    }
 #endif
 
     private func openMeetingNote() {
@@ -1919,6 +2024,11 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
 
     private func setPillHovering(_ hovering: Bool) {
         pillHovering = hovering
+        // A drag walks the pill under a cursor that is holding still relative
+        // to it, and AppKit reports that as a stream of enter/exit. Acting on
+        // it re-expands the dock and re-opens a disclosure tooltip on top of
+        // the card being dragged. Record the state, act on it at the drop.
+        guard !isDraggingPill else { return }
         if hovering {
             hoverHideWorkItem?.cancel()
             hoverHideWorkItem = nil
@@ -1933,6 +2043,10 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
     }
 
     private func updateHoveredControl(at point: NSPoint?) {
+        guard !isDraggingPill else {
+            metrics.hoveredControl = nil
+            return
+        }
         guard metrics.isHovering, let point = point else {
             metrics.hoveredControl = nil
             return
@@ -2028,6 +2142,9 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
 
     private func setTranscriptHovering(_ hovering: Bool) {
         transcriptHovering = hovering
+        // Same as the pill: the card is travelling with the cursor, so its own
+        // enter/exit during a drag says nothing about intent.
+        guard !isDraggingPill else { return }
         if hovering {
             hoverHideWorkItem?.cancel()
             hoverHideWorkItem = nil
@@ -2101,14 +2218,25 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
             && (hovering || metrics.meetingPinned)
         guard shouldShow else {
             transcriptPanel?.orderOut(nil)
+            draggedTranscriptOffset = nil
+            // The toast measured itself past a card that just left.
+            positionNotificationPanelIfVisible()
             return
         }
+        // A live meeting pushes a transcript delta every few seconds, and each
+        // one lands here. Mid-drag that meant re-rendering the card and
+        // re-clamping it against a pill that is still moving, which is what
+        // made dragging a pinned meeting stutter. The card is already glued to
+        // the pill for the length of the gesture; leave it alone and let the
+        // drop apply whatever arrived meanwhile.
+        if isDraggingPill { return }
         if transcriptPanel == nil {
             createTranscriptPanel()
         }
         updateTranscriptContent()
         positionTranscriptPanel()
         gatedOrderFront(transcriptPanel)
+        positionNotificationPanelIfVisible()
     }
 
     private func createTranscriptPanel() {
@@ -2164,31 +2292,80 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
         }
     }
 
-    private func positionTranscriptPanel() {
-        guard let panel = panel, let transcriptPanel = transcriptPanel else { return }
-        let visible = panel.screen?.visibleFrame ?? NSScreen.main?.visibleFrame ?? panel.frame
-        let width = transcriptPanel.frame.width
-        let height = transcriptPanel.frame.height
-        // Anchor to the *visible* bar, not the window. The window stays at the
-        // expanded size while the resting chip is only 16pt of it, so anchoring
-        // to the window edge left a ~46pt hole between the chip and the card.
-        // This is the same rect the hover tracking uses, so the two stay in sync.
-        let anchor = overlayHoverRect(
-            in: panel.frame,
+    /// Rect of the visible bar the attachments hang off, for a given panel
+    /// frame. Anchoring to the *visible* bar rather than the window matters:
+    /// the window stays at the expanded size while the resting chip is only
+    /// 16pt of it, so anchoring to the window edge leaves a ~46pt hole. This is
+    /// the same rect the hover tracking uses, so the two stay in sync.
+    private func attachmentAnchorRect(in panelFrame: NSRect) -> NSRect {
+        overlayHoverRect(
+            in: panelFrame,
             expanded: metrics.isHovering || metrics.forceExpanded,
             disclosureDown: metrics.disclosureDown,
             horizontal: metrics.horizontal,
             scale: gOverlayScale
         )
+    }
+
+    /// Height the transcript card claims on the disclosure side, or 0 when it
+    /// is not on screen. Anything stacked past the card offsets by this.
+    private func transcriptStackHeight() -> CGFloat {
+        guard let card = transcriptPanel, card.isVisible else { return 0 }
+        return card.frame.height
+    }
+
+    /// Where the card belongs for a given panel frame. Split out from the
+    /// setter so the release animation can aim at the destination instead of
+    /// chasing the pill one `windowDidMove` at a time.
+    private func transcriptOrigin(forPanelFrame panelFrame: NSRect, visible: NSRect) -> NSPoint? {
+        guard let transcriptPanel = transcriptPanel else { return nil }
+        let width = transcriptPanel.frame.width
+        let height = transcriptPanel.frame.height
+        let anchor = attachmentAnchorRect(in: panelFrame)
         let centeredX = anchor.midX - width / 2
         let x = min(max(centeredX, visible.minX + 4), visible.maxX - width - 4)
         // Butt the card against the bar: dead space here is a gap in the hover
         // corridor, and the pointer crossing it reads as leaving both surfaces.
-        let preferredY = metrics.disclosureDown
-            ? anchor.minY - height
-            : anchor.maxY
-        let y = min(max(preferredY, visible.minY + 4), visible.maxY - height - 4)
-        transcriptPanel.setFrameOrigin(NSPoint(x: x, y: y))
+        let y = overlayAttachmentY(
+            pill: anchor,
+            height: height,
+            gap: 0,
+            stacked: 0,
+            disclosureDown: metrics.disclosureDown,
+            visible: visible,
+            edgeInset: 4
+        )
+        return NSPoint(x: x, y: y)
+    }
+
+    private func positionTranscriptPanel() {
+        guard let panel = panel, let transcriptPanel = transcriptPanel else { return }
+        let visible = visibleFrame(for: panel)
+        guard let origin = transcriptOrigin(forPanelFrame: panel.frame, visible: visible) else {
+            return
+        }
+        transcriptPanel.setFrameOrigin(origin)
+        reglueIfDragging(transcriptPanel, into: &draggedTranscriptOffset)
+    }
+
+    /// Re-freeze an attachment's drag offset after something placed it by
+    /// geometry mid-gesture — a toast arriving, a hover exit landing. Without
+    /// this the panel keeps the position it was just given while the pill walks
+    /// away from it, and the glue only picks it up if it was already visible
+    /// when the drag started.
+    private func reglueIfDragging(_ attachment: NSPanel, into offset: inout CGVector?) {
+        guard isDraggingPill, let panel = panel, attachment.isVisible else { return }
+        offset = CGVector(
+            dx: attachment.frame.minX - panel.frame.minX,
+            dy: attachment.frame.minY - panel.frame.minY
+        )
+    }
+
+    private func visibleFrame(for panel: NSPanel, on screen: NSScreen? = nil) -> NSRect {
+        screen?.visibleFrame
+            ?? panel.screen?.visibleFrame
+            ?? NSScreen.main?.visibleFrame
+            ?? panel.frame
     }
 
     /// Disclosure direction follows the pinned anchor rather than the live
@@ -2310,17 +2487,40 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
         let origin = anchoredPanelOrigin(for: overlayAnchor, on: screen)
 
         if animated {
+            // Attachments travel in the same group, aimed at where they belong
+            // once the pill has landed. Letting them chase the animated frame
+            // through `windowDidMove` instead makes a pinned card lag the chip
+            // for the length of the settle and arrive a beat late.
+            let settled = NSRect(origin: origin, size: panel.frame.size)
+            let visible = visibleFrame(for: panel, on: screen)
+            let cardDestination = transcriptPanel?.isVisible == true
+                ? transcriptOrigin(forPanelFrame: settled, visible: visible)
+                : nil
+            let toastDestination = notificationPanel?.isVisible == true
+                ? notificationOrigin(forPanelFrame: settled, visible: visible)
+                : nil
+
+            isSettlingPanel = true
             NSAnimationContext.runAnimationGroup { context in
                 context.duration = kSnapDur
                 context.timingFunction = CAMediaTimingFunction(
                     controlPoints: kSnapCurve.0, kSnapCurve.1, kSnapCurve.2, kSnapCurve.3
                 )
                 panel.animator().setFrameOrigin(origin)
+                if let cardDestination = cardDestination {
+                    transcriptPanel?.animator().setFrameOrigin(cardDestination)
+                }
+                if let toastDestination = toastDestination {
+                    notificationPanel?.animator().setFrameOrigin(toastDestination)
+                }
+            } completionHandler: { [weak self] in
+                self?.isSettlingPanel = false
             }
-        } else {
-            panel.setFrameOrigin(origin)
+            positionDisclosurePanel()
+            return
         }
 
+        panel.setFrameOrigin(origin)
         positionDisclosurePanel()
         if transcriptPanel?.isVisible == true {
             positionTranscriptPanel()
@@ -2338,8 +2538,33 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
         metrics.forceExpanded = false
         metrics.hoveredControl = nil
         disclosurePanel?.orderOut(nil)
+        glueAttachmentsToDrag()
         showDragStage()
         updateDragStage()
+    }
+
+    /// Settle the attachments against the collapsed chip once, then freeze
+    /// their offsets so the rest of the gesture is pure translation.
+    private func glueAttachmentsToDrag() {
+        guard let panel = panel else { return }
+        // The pill just collapsed from the 30pt dock to the 16pt chip, so the
+        // attachments belong a few points closer before anything is frozen.
+        if transcriptPanel?.isVisible == true {
+            positionTranscriptPanel()
+        }
+        if notificationPanel?.isVisible == true {
+            positionNotificationPanel()
+        }
+        let origin = panel.frame.origin
+        func frozenOffset(_ attachment: NSPanel?) -> CGVector? {
+            guard let attachment = attachment, attachment.isVisible else { return nil }
+            return CGVector(
+                dx: attachment.frame.minX - origin.x,
+                dy: attachment.frame.minY - origin.y
+            )
+        }
+        draggedTranscriptOffset = frozenOffset(transcriptPanel)
+        draggedNotificationOffset = frozenOffset(notificationPanel)
     }
 
     /// Snap to the nearest anchor, persist it, and let the panel settle there.
@@ -2350,7 +2575,12 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
         if previewStageLocked { return }
         #endif
         isDraggingPill = false
+        draggedTranscriptOffset = nil
+        draggedNotificationOffset = nil
         hideDragStage()
+        // Apply whatever the meeting pushed while the card was glued, before
+        // the settle so the animation aims at the card's real destination.
+        refreshTranscriptPanelVisibility()
         guard let (landed, screen) = droppedAnchor() else { return }
 
         let display = displayIdentifier(for: screen)
@@ -2495,16 +2725,21 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
         } else {
             let hosting = DraggableHostingView(rootView: AnyView(view))
             hosting.onDragStarted = { [weak self] in
-                self?.pillHovering = false
-                self?.transcriptHovering = false
-                self?.transcriptPanel?.orderOut(nil)
-                self?.beginPillDrag()
+                guard let self = self else { return }
+                self.pillHovering = false
+                self.transcriptHovering = false
+                // A pinned card is part of what is being dragged, so it travels
+                // with the pill. Only the card that hover opened goes away with
+                // the hover, along with the rest of the hover UI.
+                if !self.metrics.meetingPinned {
+                    self.transcriptPanel?.orderOut(nil)
+                }
+                self.beginPillDrag()
             }
             hosting.onDragEnded = { [weak self] in
+                // `endPillDrag` restores the card against the pill's new home
+                // and rides it in on the settle.
                 self?.endPillDrag()
-                // Dragging collapses hover UI, but a pinned card is meant to stay:
-                // bring it back against the pill's new home.
-                self?.refreshTranscriptPanelVisibility()
             }
             hosting.frame = contentView.bounds
             hosting.autoresizingMask = [.width, .height]
@@ -2639,25 +2874,17 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
         positionNotificationPanel()
     }
 
-    /// Sit the notification against the pill on the side the disclosure opens,
-    /// aligned to the pill's edge so it visibly belongs to it.
-    private func positionNotificationPanel() {
-        guard let panel = panel, let toast = notificationPanel else { return }
-        let visible = panel.screen?.visibleFrame ?? NSScreen.main?.visibleFrame ?? panel.frame
+    /// Where the toast belongs for a given panel frame. Same rect the
+    /// transcript card hangs off, offset past the card when one is on screen so
+    /// the two attachments stack outward from the pill instead of landing on
+    /// each other. The win32 pill gets this for free by laying every block out
+    /// in one window, edge-outward; here they are separate panels at the same
+    /// level, so the offset has to be explicit.
+    private func notificationOrigin(forPanelFrame panelFrame: NSRect, visible: NSRect) -> NSPoint? {
+        guard let toast = notificationPanel else { return nil }
         let width = toast.frame.width
         let height = toast.frame.height
-        // Anchor to the *visible* bar, not the window. The window stays at the
-        // expanded size while the resting chip is only 16pt of it, so anchoring
-        // Y to the window edge left a ~46pt hole between the chip and the toast
-        // even though X was already measured off the chip. Same rect the
-        // transcript card uses, so the two attachments hang the same way.
-        let pill = overlayHoverRect(
-            in: panel.frame,
-            expanded: metrics.isHovering || metrics.forceExpanded,
-            disclosureDown: metrics.disclosureDown,
-            horizontal: metrics.horizontal,
-            scale: gOverlayScale
-        )
+        let pill = attachmentAnchorRect(in: panelFrame)
 
         let preferredX: CGFloat
         switch metrics.horizontal {
@@ -2667,11 +2894,28 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
         }
         let margin = anchorMargin(scale: gOverlayScale)
         let x = min(max(preferredX, visible.minX + margin), visible.maxX - width - margin)
-        let preferredY = metrics.disclosureDown
-            ? pill.minY - height - margin
-            : pill.maxY + margin
-        let y = min(max(preferredY, visible.minY + margin), visible.maxY - height - margin)
-        toast.setFrameOrigin(NSPoint(x: x, y: y))
+        let y = overlayAttachmentY(
+            pill: pill,
+            height: height,
+            gap: margin,
+            stacked: transcriptStackHeight(),
+            disclosureDown: metrics.disclosureDown,
+            visible: visible,
+            edgeInset: margin
+        )
+        return NSPoint(x: x, y: y)
+    }
+
+    /// Sit the notification against the pill on the side the disclosure opens,
+    /// aligned to the pill's edge so it visibly belongs to it.
+    private func positionNotificationPanel() {
+        guard let panel = panel, let toast = notificationPanel else { return }
+        guard let origin = notificationOrigin(
+            forPanelFrame: panel.frame,
+            visible: visibleFrame(for: panel)
+        ) else { return }
+        toast.setFrameOrigin(origin)
+        reglueIfDragging(toast, into: &draggedNotificationOffset)
     }
 
     /// Grow out of the pill instead of appearing on top of it.
@@ -2730,20 +2974,48 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
     }
 
     func windowDidMove(_ notification: Notification) {
+        // The settle animates the panel and every attachment together, to
+        // destinations already computed from where the pill is landing. Chasing
+        // the animated frame from here would fight it frame by frame.
+        guard !isSettlingPanel else { return }
+
+        // The drag loop runs its own tracking, so this is the only signal that
+        // the pill moved while the user is still holding it. Attachments ride
+        // along on a frozen offset: rigid, and no geometry recomputed per move.
+        // The pinned anchor cannot change mid-drag, so nothing else here has
+        // anything to do until the drop.
+        if isDraggingPill {
+            moveDraggedAttachments()
+            updateDragStage()
+            return
+        }
+
         updateDisclosureDirection()
         positionDisclosurePanel()
+
         if notificationPanel?.isVisible == true {
             positionNotificationPanel()
-        }
-        // performDrag runs its own tracking loop, so this is the only signal
-        // that the pill moved while the user is still holding it.
-        if isDraggingPill {
-            updateDragStage()
         }
         // A pinned card outlives the drag, so it has to follow the chip instead
         // of being left behind at the old anchor.
         if transcriptPanel?.isVisible == true {
             positionTranscriptPanel()
+        }
+    }
+
+    /// Keep the attachments glued to the pill for the length of a drag.
+    private func moveDraggedAttachments() {
+        guard let panel = panel else { return }
+        let origin = panel.frame.origin
+        if let offset = draggedTranscriptOffset, let card = transcriptPanel, card.isVisible {
+            card.setFrameOrigin(
+                NSPoint(x: origin.x + offset.dx, y: origin.y + offset.dy)
+            )
+        }
+        if let offset = draggedNotificationOffset, let toast = notificationPanel, toast.isVisible {
+            toast.setFrameOrigin(
+                NSPoint(x: origin.x + offset.dx, y: origin.y + offset.dy)
+            )
         }
     }
 }

--- a/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder_preview.swift
+++ b/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder_preview.swift
@@ -23,7 +23,8 @@ struct ShortcutReminderPreview {
 
         let arguments = Array(CommandLine.arguments.dropFirst())
         if arguments.contains("--help") || arguments.contains("-h") {
-            print("usage: preview-shortcut-overlay.sh [--once] [--expanded] [--meeting] [--notification]")
+            print("usage: preview-shortcut-overlay.sh [--once] [--expanded] [--meeting]")
+            print("       [--pinned-meeting] [--notification]")
             print("       [--size small|medium|large]")
             print("       [--anchor top-center|right-center|bottom-center|left-center]")
             print("       [--drag-stage [--highlight <anchor>]]")
@@ -60,7 +61,9 @@ struct ShortcutReminderPreview {
         payloadJSON.withCString { pointer in
             _ = shortcutShow(pointer)
         }
-        if arguments.contains("--meeting") {
+        if arguments.contains("--pinned-meeting") {
+            ShortcutReminderController.shared.setPreviewPinnedMeeting()
+        } else if arguments.contains("--meeting") {
             ShortcutReminderController.shared.setPreviewMeeting()
         } else if arguments.contains("--expanded") {
             ShortcutReminderController.shared.setPreviewExpanded(true)

--- a/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder_tests.swift
+++ b/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder_tests.swift
@@ -252,6 +252,76 @@ private func testTieBreaksToCurrent() {
     }
 }
 
+/// The transcript card and a notification are separate panels at the same
+/// window level, both hanging off the same pill edge. Stacking is the only
+/// thing keeping the toast off the card's header row — and the alert that
+/// brought this up ("live transcript not flowing") only ever fires while a
+/// meeting is running, so the card is up by definition.
+private func testAttachmentStacking() {
+    let card = NSSize(width: 320, height: 142)
+    let toast = NSSize(width: 340, height: 34)
+    let margin = anchorMargin(scale: 1)
+
+    for disclosureDown in [true, false] {
+        // Pill at the top edge opens downward, and vice versa.
+        let pill = disclosureDown
+            ? NSRect(x: 949, y: visible.maxY - 4 - 16, width: 22, height: 16)
+            : NSRect(x: 949, y: visible.minY + 4, width: 22, height: 16)
+        let side = disclosureDown ? "down" : "up"
+
+        let cardY = overlayAttachmentY(
+            pill: pill, height: card.height, gap: 0, stacked: 0,
+            disclosureDown: disclosureDown, visible: visible, edgeInset: 4
+        )
+        // Butted against the bar: a gap here is a hole in the hover corridor.
+        expectClose(
+            disclosureDown ? cardY + card.height : cardY,
+            disclosureDown ? pill.minY : pill.maxY,
+            "card butts the pill (\(side))"
+        )
+
+        let toastY = overlayAttachmentY(
+            pill: pill, height: toast.height, gap: margin, stacked: card.height,
+            disclosureDown: disclosureDown, visible: visible, edgeInset: margin
+        )
+        let cardRect = NSRect(x: 949, y: cardY, width: card.width, height: card.height)
+        let toastRect = NSRect(x: 949, y: toastY, width: toast.width, height: toast.height)
+        expect(
+            !cardRect.intersects(toastRect),
+            "toast overlaps the transcript card (\(side)): \(toastRect) vs \(cardRect)"
+        )
+        // Past the card, not merely clear of it: the two read as one stack.
+        expectClose(
+            disclosureDown ? cardRect.minY - toastRect.maxY : toastRect.minY - cardRect.maxY,
+            margin,
+            "toast sits one margin past the card (\(side))"
+        )
+
+        // With no card up, the toast keeps hanging straight off the pill.
+        let aloneY = overlayAttachmentY(
+            pill: pill, height: toast.height, gap: margin, stacked: 0,
+            disclosureDown: disclosureDown, visible: visible, edgeInset: margin
+        )
+        expectClose(
+            disclosureDown ? pill.minY - (aloneY + toast.height) : aloneY - pill.maxY,
+            margin,
+            "lone toast hangs off the pill (\(side))"
+        )
+    }
+}
+
+/// Stacking must not push an attachment off the display; the clamp wins.
+private func testAttachmentStaysOnScreen() {
+    let tall: CGFloat = 900
+    let pill = NSRect(x: 949, y: visible.maxY - 4 - 16, width: 22, height: 16)
+    let y = overlayAttachmentY(
+        pill: pill, height: tall, gap: 4, stacked: 600,
+        disclosureDown: true, visible: visible, edgeInset: 4
+    )
+    expect(y >= visible.minY + 4, "stacked attachment ran off the bottom: \(y)")
+    expect(y + tall <= visible.maxY - 4, "stacked attachment ran off the top: \(y)")
+}
+
 /// Anchor raw values are a wire contract with Rust
 /// (`SHORTCUT_OVERLAY_ANCHORS` in `commands/native_actions.rs`). Renaming one
 /// silently stops persistence, so pin them here too.
@@ -271,6 +341,8 @@ struct ShortcutReminderTests {
         testLegacyCornersMigrate()
         testNearestAnchor()
         testTieBreaksToCurrent()
+        testAttachmentStacking()
+        testAttachmentStaysOnScreen()
         testWireContract()
 
         if failures.isEmpty {


### PR DESCRIPTION
## Problem

Two things the pinned meeting card gets wrong on macOS, both from real use.

**1. Dragging the pill with a meeting pinned is not smooth.** The card is ordered out at drag start — but a live meeting pushes a transcript delta every few seconds, and every delta lands in `refreshTranscriptPanelVisibility`, which puts the card straight back on screen mid-gesture, re-renders its SwiftUI content and re-clamps it against a pill that is still moving. The card blinks out, pops back a beat later somewhere else, then chases the chip one `windowDidMove` at a time. The pill also keeps re-expanding under its own cursor: a drag walks the window under a pointer that is holding still relative to it, AppKit reports that as a stream of enter/exit, and the disclosure tooltip reopens on top of the card being dragged.

**2. The meeting alert lands on the card.** The transcript card and a notification are separate `NSPanel`s at the same window level, both anchored to the same pill edge with only a `4 * scale` margin, so the 340x34 toast covers the 320x142 card's header row — pin, note and stop. Not an edge case: `handle_transcript_stall` ("live transcript not flowing", `meeting_stall_notifications.rs`) only fires *while* a meeting is running, so the card is up by definition.

## Where found

Reported by Louis. Reproduced against the real panels with the preview harness at `--pinned-meeting`, with a transcript feed running so the deltas that drive the bug actually arrive.

## Reproduction and pre-fix failure

Same harness against `main` and against this branch, same drag, same live feed, on a blank stand-in desktop so no real screen content is captured.

**Drag, before** — the card is gone at drag start, back a beat later:

![drag before](https://raw.githubusercontent.com/screenpipe/screenpipe/media/overlay-meeting-live-smoothness/overlay-meeting-live/drag-before.gif)

**Drag, after** — pill, card and toast travel as one object and land together:

![drag after](https://raw.githubusercontent.com/screenpipe/screenpipe/media/overlay-meeting-live-smoothness/overlay-meeting-live/drag-after.gif)

Same four timestamps, before on top, after on the bottom. Frame 1 is the moment the drag starts:

![drag frames](https://raw.githubusercontent.com/screenpipe/screenpipe/media/overlay-meeting-live-smoothness/overlay-meeting-live/drag-frames.png)

**Toast, before (left) and after (right)** — the alert buried under the card's header, versus stacked past it:

![toast stacking](https://raw.githubusercontent.com/screenpipe/screenpipe/media/overlay-meeting-live-smoothness/overlay-meeting-live/toast-stacking.png)

## Root cause

- Attachments are placed by measuring from the same pill edge, with no notion of what already occupies that side, so the card and the toast resolve to the same place.
- The card's position during a drag is recomputed from live geometry on every event that touches it, and every transcript delta is such an event.
- Hover state is taken at face value during a drag, when it only reflects the window moving under a stationary cursor.

## Fix

- `overlayAttachmentY` — one pure function for "hang this off the pill", taking the height already claimed on that side. Card: butted, offset 0. Toast: one margin past the card when the card is up, unchanged when it is not. Pill → card → toast, the edge-outward order the win32 pill gets for free by laying every block out in one window.
- A pinned card is part of what is being dragged. Its offset is frozen once against the collapsed chip and the rest of the gesture is pure translation — no anchor recomputed, no re-clamping. Deltas and hover events are held until the drop.
- The release animates the pill and its attachments to their own destinations in one group, instead of letting them chase the animated frame.
- Anything that appears or is repositioned mid-drag re-glues itself rather than being left behind.

Unchanged: an unpinned hover card still closes with the hover that opened it, capture health still outranks meeting UI, and the toast does not move when no card is on screen.

## Validation

- `scripts/test-shortcut-overlay.sh` — 151 checks pass. New: card butts the pill, toast sits exactly one margin past the card and never intersects it (both disclosure directions), a lone toast still hangs straight off the pill, stacking cannot push an attachment off screen.
- Both compile paths built: with `-DOVERLAY_PREVIEW` (harness) and without (production).
- Real panels driven end to end for the media above; each drag landed and persisted its anchor (`set_overlay_anchor` in the harness log).

Not covered: win32 and the webview overlay are untouched — win32 already stacks correctly and the webview renders no notifications. No signed build, release or installed canary; this is source only.

## Harness

`preview-shortcut-overlay.sh --pinned-meeting` — pill and pinned card together with a transcript feed running, which is the state both bugs need and the state `--meeting` deliberately is not (it hides the pill so a screenshot picks the card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
