### PR TITLE
fix(security): isolate remote webviews and MCP HTTP

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/capabilities/main.json
+++ b/apps/screenpipe-app-tauri/src-tauri/capabilities/main.json
@@ -1,21 +1,19 @@
 {
   "identifier": "migrated",
-  "description": "permissions that were migrated from v1",
+  "description": "native permissions for trusted local screenpipe UI webviews",
   "local": true,
-  "windows": [
-    "*"
+  "webviews": [
+    "main",
+    "home",
+    "search",
+    "onboarding",
+    "chat",
+    "permission-recovery",
+    "shortcut-reminder",
+    "notification-inbox",
+    "notification-panel",
+    "viewer-*"
   ],
-  "remote": {
-    "urls": [
-      "http://localhost:*",
-      "https://api.openai.com/*",
-      "https://*.openai.com/*",
-      "https://api.screenpipe.com/*",
-      "https://*.anthropic.com/*",
-      "https://*.ollama.ai/*",
-      "https://*"
-    ]
-  },
   "permissions": [
     "core:event:allow-listen",
     "core:event:default",

--- a/apps/screenpipe-app-tauri/src-tauri/src/owned_browser.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/owned_browser.rs
@@ -1350,6 +1350,7 @@ mod normalize_url_tests {
     use super::{
         build_eval_result_script, normalize_url, session_host_key,
         session_prompt_in_flight_timeout_error, session_prompt_timeout_error, OwnedBrowserState,
+        WEBVIEW_LABEL,
     };
 
     #[test]
@@ -1420,6 +1421,29 @@ mod normalize_url_tests {
         assert!(script.contains("\"eval-id-1\""));
         assert!(script.contains("window.__SP_OB_CHUNK__"));
         assert!(script.contains("id: window.__SP_OB_ID__ || \"\""));
+    }
+
+    #[test]
+    fn owned_browser_is_excluded_from_native_capabilities() {
+        let capability: serde_json::Value =
+            serde_json::from_str(include_str!("../capabilities/main.json"))
+                .expect("main capability must remain valid JSON");
+
+        assert!(
+            capability.get("remote").is_none(),
+            "remote origins must never inherit the trusted UI capability"
+        );
+        assert!(
+            capability.get("windows").is_none(),
+            "a window capability would apply to every child webview in that window"
+        );
+
+        let webviews = capability["webviews"]
+            .as_array()
+            .expect("trusted UI capability must name explicit webviews");
+        assert!(webviews.iter().any(|label| label == "home"));
+        assert!(!webviews.iter().any(|label| label == "*"));
+        assert!(!webviews.iter().any(|label| label == WEBVIEW_LABEL));
     }
 
     // The `document.title` result-transport logic (inline + chunked) and the

--- a/packages/screenpipe-mcp/src/http-server.test.ts
+++ b/packages/screenpipe-mcp/src/http-server.test.ts
@@ -6,8 +6,11 @@ import { describe, it, expect } from "vitest";
 import {
   buildHttpServer,
   CliError,
+  isAllowedLocalHost,
+  isAllowedLocalOrigin,
   isAuthorized,
   isLoopbackRequest,
+  isTrustedHttpBoundary,
   parseArgs,
   runFromArgv,
 } from "./http-server";
@@ -181,7 +184,81 @@ describe("isAuthorized", () => {
   });
 });
 
+describe("HTTP browser boundary", () => {
+  it("accepts exact loopback hosts and local browser origins", () => {
+    expect(isAllowedLocalHost("localhost:3031")).toBe(true);
+    expect(isAllowedLocalHost("127.0.0.1:3031")).toBe(true);
+    expect(isAllowedLocalHost("[::1]:3031")).toBe(true);
+    expect(isAllowedLocalOrigin("http://localhost:1420")).toBe(true);
+    expect(isAllowedLocalOrigin("https://127.0.0.1:3031")).toBe(true);
+  });
+
+  it("rejects attacker hosts, prefix tricks, and foreign origins", () => {
+    expect(isAllowedLocalHost("attacker.example")).toBe(false);
+    expect(isAllowedLocalHost("localhost.evil.example")).toBe(false);
+    expect(isAllowedLocalOrigin("https://attacker.example")).toBe(false);
+    expect(isAllowedLocalOrigin("http://localhost.evil.example")).toBe(false);
+    expect(isAllowedLocalOrigin("null")).toBe(false);
+  });
+
+  it("blocks DNS rebinding on loopback while preserving authenticated LAN mode", () => {
+    expect(
+      isTrustedHttpBoundary(
+        { headers: { host: "attacker.example", origin: "https://attacker.example" } },
+        "127.0.0.1"
+      )
+    ).toBe(false);
+    expect(
+      isTrustedHttpBoundary({ headers: { host: "127.0.0.1:3031" } }, "127.0.0.1")
+    ).toBe(true);
+    expect(
+      isTrustedHttpBoundary({ headers: { host: "192.168.1.20:3031" } }, "0.0.0.0")
+    ).toBe(true);
+    expect(
+      isTrustedHttpBoundary(
+        { headers: { host: "192.168.1.20:3031", origin: "https://attacker.example" } },
+        "0.0.0.0"
+      )
+    ).toBe(false);
+  });
+});
+
 describe("buildHttpServer", () => {
+  it("rejects foreign browser origins before health or MCP handling", async () => {
+    const server = buildHttpServer({
+      mcpPort: 0,
+      screenpipePort: 3030,
+      host: "127.0.0.1",
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("expected server.address() to return a bound port");
+    }
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${address.port}/health`, {
+        headers: { origin: "https://attacker.example" },
+      });
+      expect(response.status).toBe(403);
+      expect(response.headers.get("access-control-allow-origin")).toBeNull();
+
+      const preflight = await fetch(`http://127.0.0.1:${address.port}/mcp`, {
+        method: "OPTIONS",
+        headers: { origin: "http://localhost:1420" },
+      });
+      expect(preflight.status).toBe(204);
+      expect(preflight.headers.get("access-control-allow-origin")).toBe(
+        "http://localhost:1420"
+      );
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    }
+  });
+
   it("persists initialized sessions so tools/list works on the next request", async () => {
     const server = buildHttpServer({
       mcpPort: 0,

--- a/packages/screenpipe-mcp/src/http-server.ts
+++ b/packages/screenpipe-mcp/src/http-server.ts
@@ -14,8 +14,9 @@
  * Expose to your LAN (requires --api-key):
  *   npx ts-node src/http-server.ts --listen-on-lan --api-key <secret>
  *
- * Loopback callers are always allowed without auth. Non-loopback callers
- * must send `Authorization: Bearer <secret>` whenever --api-key is set.
+ * Loopback callers are allowed without auth only through an exact local
+ * Host/Origin boundary. Non-loopback callers must send
+ * `Authorization: Bearer <secret>` whenever --api-key is set.
  */
 
 import { createServer, type IncomingMessage, type ServerResponse } from "http";
@@ -118,6 +119,53 @@ export function isLoopbackRequest(req: { socket: { remoteAddress?: string } }): 
   if (addr === "127.0.0.1" || addr === "::1") return true;
   if (addr.startsWith("::ffff:127.")) return true;
   return false;
+}
+
+const LOCAL_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1"]);
+
+function normalizedHostname(value: string, origin: boolean): string | undefined {
+  try {
+    const url = origin ? new URL(value) : new URL(`http://${value}`);
+    const hostname = url.hostname.toLowerCase();
+    return hostname.startsWith("[") && hostname.endsWith("]")
+      ? hostname.slice(1, -1)
+      : hostname;
+  } catch {
+    return undefined;
+  }
+}
+
+export function isAllowedLocalHost(host: string | undefined): boolean {
+  if (!host) return false;
+  const hostname = normalizedHostname(host, false);
+  return hostname !== undefined && LOCAL_HOSTNAMES.has(hostname);
+}
+
+export function isAllowedLocalOrigin(origin: string | undefined): boolean {
+  if (!origin) return true;
+  try {
+    const url = new URL(origin);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return false;
+    const hostname = normalizedHostname(origin, true);
+    return hostname !== undefined && LOCAL_HOSTNAMES.has(hostname);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Browser boundary for the HTTP transport. A loopback bind is still reachable
+ * from arbitrary websites, and DNS rebinding preserves the attacker's Host.
+ * CLI/stdio clients normally omit Origin but still send an exact local Host.
+ * LAN mode may use a LAN Host, but remains bearer-gated by isAuthorized.
+ */
+export function isTrustedHttpBoundary(
+  req: { headers: { host?: string; origin?: string } },
+  bindHost: string
+): boolean {
+  if (!isAllowedLocalOrigin(req.headers.origin)) return false;
+  if (bindHost !== "0.0.0.0" && !isAllowedLocalHost(req.headers.host)) return false;
+  return true;
 }
 
 /**
@@ -321,8 +369,17 @@ export function buildHttpServer(config: CliConfig) {
   >();
 
   return createServer(async (req: IncomingMessage, res: ServerResponse) => {
-    // CORS
-    res.setHeader("Access-Control-Allow-Origin", "*");
+    if (!isTrustedHttpBoundary(req, config.host)) {
+      res.writeHead(403, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "forbidden origin or host" }));
+      return;
+    }
+
+    // Echo only a validated local origin. Non-browser callers do not need CORS.
+    if (req.headers.origin) {
+      res.setHeader("Access-Control-Allow-Origin", req.headers.origin);
+      res.setHeader("Vary", "Origin");
+    }
     res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
     res.setHeader(
       "Access-Control-Allow-Headers",


### PR DESCRIPTION
## Summary
- grant native Tauri permissions only to named, trusted local screenpipe webviews
- keep owned-browser, login, OAuth, and other remote webviews outside privileged IPC
- reject foreign Host and Origin requests before MCP HTTP route handling and replace wildcard CORS with validated origin echo
- add regression coverage for both trust boundaries

## Verification
- `bun run typecheck` in `packages/screenpipe-mcp`
- `bun run test` in `packages/screenpipe-mcp` (79 passed)
- `rustfmt --edition 2021 --check apps/screenpipe-app-tauri/src-tauri/src/owned_browser.rs`
- Tauri configuration and changed Rust source compiled locally; the large desktop test binary was terminated by the local runner during final linking, so CI remains the final desktop gate

## Follow-up
SFTP host-key verification should remain a separate change because it needs an explicit pinning or trust-on-first-use flow rather than silently changing connection behavior.