### PR TITLE
fix(overlay): stop AppKit's second mover stranding the drag-to-pin pill

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder.swift
+++ b/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder.swift
@@ -698,6 +698,65 @@ func overlayAttachmentY(
     )
 }
 
+/// How much of the chip has to stay on a display while it is being dragged.
+/// The collapsed pill is 16pt tall, so this keeps a whole one in view: enough
+/// to see what you are holding and to grab it again.
+let kMinDraggedPillVisible: CGFloat = 20
+
+/// Shortest distance from a point to a rect, 0 when inside.
+private func distanceSquared(from point: NSPoint, to rect: NSRect) -> CGFloat {
+    let dx = max(rect.minX - point.x, 0, point.x - rect.maxX)
+    let dy = max(rect.minY - point.y, 0, point.y - rect.maxY)
+    return dx * dx + dy * dy
+}
+
+/// Panel origin for a drag in progress, pulled back so the chip cannot leave
+/// the desktop.
+///
+/// Without this the panel origin just tracks the cursor, and a drag off the
+/// left edge parks the pill in negative space. That is survivable while the
+/// drop still snaps — the snap puts it back — but it is the reason a *missed*
+/// drop made the pill vanish rather than merely sit somewhere odd. Clamping
+/// means even a drag that ends badly leaves something on screen to grab.
+///
+/// The clamp is per display, not against the bounding box of all of them: two
+/// screens of different heights leave dead space in that box which belongs to
+/// no display, and a pill clamped into it is just as gone. When the chip
+/// centre leaves every screen it is pulled into the nearest one.
+func clampedDragOrigin(
+    panelOrigin: NSPoint,
+    pillCentreOffset: CGVector,
+    screens: [NSRect],
+    minVisible: CGFloat = kMinDraggedPillVisible
+) -> NSPoint {
+    guard !screens.isEmpty else { return panelOrigin }
+    let centre = NSPoint(
+        x: panelOrigin.x + pillCentreOffset.dx,
+        y: panelOrigin.y + pillCentreOffset.dy
+    )
+    // On a display already: leave the drag alone, so normal dragging is
+    // untouched and only the escape is corrected.
+    if screens.contains(where: { NSMouseInRect(centre, $0, false) }) {
+        return panelOrigin
+    }
+    guard let target = screens.min(by: {
+        distanceSquared(from: centre, to: $0) < distanceSquared(from: centre, to: $1)
+    }) else { return panelOrigin }
+
+    // Never inset past the middle of a small display, which would push the
+    // centre back out the far side.
+    let insetX = min(minVisible, target.width / 2)
+    let insetY = min(minVisible, target.height / 2)
+    let clamped = NSPoint(
+        x: min(max(centre.x, target.minX + insetX), target.maxX - insetX),
+        y: min(max(centre.y, target.minY + insetY), target.maxY - insetY)
+    )
+    return NSPoint(
+        x: clamped.x - pillCentreOffset.dx,
+        y: clamped.y - pillCentreOffset.dy
+    )
+}
+
 func overlayHoverRect(
     in bounds: NSRect,
     expanded: Bool,
@@ -1983,7 +2042,15 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
         p.backgroundColor = .clear
         p.hasShadow = false
         p.hidesOnDeactivate = false
-        p.isMovableByWindowBackground = true
+        // Off, deliberately. AppKit's own background drag is a second mover
+        // that knows nothing about the drag stage: no threshold, no landing
+        // targets, and no snap or persist on release. Whenever it won the
+        // gesture the pill simply stayed where it was let go — "it does not pin
+        // to a location, I can drag it anywhere" — and a drag past a screen
+        // edge left it stranded off the desktop with the stored anchor
+        // untouched, so it came back only on the next launch. `DraggableHosting-
+        // View` is the one mover now, and it always ends in `endPillDrag`.
+        p.isMovableByWindowBackground = false
         p.acceptsMouseMovedEvents = true
         p.isReleasedWhenClosed = false
         p.sharingType = .readOnly
@@ -2581,7 +2648,13 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
         // Apply whatever the meeting pushed while the card was glued, before
         // the settle so the animation aims at the card's real destination.
         refreshTranscriptPanelVisibility()
-        guard let (landed, screen) = droppedAnchor() else { return }
+        guard let (landed, screen) = droppedAnchor() else {
+            // No screen could be resolved at all — every display went away
+            // mid-drag, say. Re-apply the stored anchor so the pill is put back
+            // somewhere real rather than left where the gesture dropped it.
+            positionPanel(animated: false)
+            return
+        }
 
         let display = displayIdentifier(for: screen)
         let changed = landed != overlayAnchor || display != overlayDisplay
@@ -2599,6 +2672,12 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
     }
 
     /// Anchor the pill would land on right now, with the screen it belongs to.
+    ///
+    /// Nothing here may return nil for a pill that is merely in a strange
+    /// place: an early return would leave the panel exactly where the drag
+    /// abandoned it, which is the failure this whole path exists to prevent.
+    /// `screenContaining` falls back through the panel's screen to the main
+    /// one, so a drop into a gap between displays still resolves.
     private func droppedAnchor() -> (OverlayAnchor, NSScreen)? {
         guard let center = currentPillCenter(),
               let screen = screenContaining(center) else { return nil }
@@ -2724,6 +2803,22 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
             hosting.rootView = AnyView(view)
         } else {
             let hosting = DraggableHostingView(rootView: AnyView(view))
+            hosting.pillCentreOffset = { [weak self] in
+                guard let self = self, let panel = self.panel else {
+                    return CGVector(dx: 0, dy: 0)
+                }
+                let rect = overlayHoverRect(
+                    in: panel.frame,
+                    expanded: false,
+                    disclosureDown: self.metrics.disclosureDown,
+                    horizontal: self.metrics.horizontal,
+                    scale: gOverlayScale
+                )
+                return CGVector(
+                    dx: rect.midX - panel.frame.minX,
+                    dy: rect.midY - panel.frame.minY
+                )
+            }
             hosting.onDragStarted = { [weak self] in
                 guard let self = self else { return }
                 self.pillHovering = false
@@ -3232,8 +3327,19 @@ private class DraggableHostingView<Content: View>: NSHostingView<Content> {
     var onDragStarted: (() -> Void)?
     /// Called once the user releases, so the controller can snap and persist.
     var onDragEnded: (() -> Void)?
+    /// Centre of the visible chip relative to the panel origin. Supplied by the
+    /// controller because only it knows the current metrics; used to clamp the
+    /// chip rather than the whole panel, most of which is empty space for the
+    /// expanded dock.
+    var pillCentreOffset: (() -> CGVector)?
 
     private var dragMonitor: Any?
+    /// Global twin of `dragMonitor`. A local monitor only sees events routed to
+    /// this app, and the overlay's whole job is to be used while another app is
+    /// frontmost — release the button over that app and the closing mouseUp can
+    /// land there instead. Without this the drag never ended: no snap, no
+    /// persist, and the pill sat wherever it was abandoned.
+    private var globalDragMonitor: Any?
     private var dragStartLocation: NSPoint = .zero
     /// True between the threshold crossing and mouseUp. Doubles as the flag
     /// that the closing mouseUp must be swallowed, so SwiftUI's button does not
@@ -3245,9 +3351,28 @@ private class DraggableHostingView<Content: View>: NSHostingView<Content> {
     private var grabOffset = CGVector(dx: 0, dy: 0)
 
     deinit {
+        removeDragMonitors()
+    }
+
+    private func removeDragMonitors() {
         if let m = dragMonitor {
             NSEvent.removeMonitor(m)
+            dragMonitor = nil
         }
+        if let m = globalDragMonitor {
+            NSEvent.removeMonitor(m)
+            globalDragMonitor = nil
+        }
+    }
+
+    /// End the gesture exactly once, whichever monitor noticed the release
+    /// first. Both are always torn down here, so a drag can never leave a
+    /// monitor armed for the next press to trip over.
+    private func finishDrag() {
+        removeDragMonitors()
+        guard isDragging else { return }
+        isDragging = false
+        onDragEnded?()
     }
 
     override func mouseDown(with event: NSEvent) {
@@ -3257,28 +3382,38 @@ private class DraggableHostingView<Content: View>: NSHostingView<Content> {
 
         guard let window = window else { return }
 
-        if let m = dragMonitor {
-            NSEvent.removeMonitor(m)
-            dragMonitor = nil
-        }
+        removeDragMonitors()
 
         isDragging = false
         dragStartLocation = event.locationInWindow
         let dragThreshold: CGFloat = 4.0
 
+        // Sees the release when it happens over another app. Global monitors
+        // cannot consume the event, which is fine: the click it would leak to
+        // SwiftUI belongs to whatever is under the cursor, not to us.
+        globalDragMonitor = NSEvent.addGlobalMonitorForEvents(
+            matching: [.leftMouseDragged, .leftMouseUp]
+        ) { [weak self] event in
+            guard let self = self else { return }
+            switch event.type {
+            case .leftMouseUp:
+                self.finishDrag()
+            case .leftMouseDragged where self.isDragging:
+                self.moveWindow(under: NSEvent.mouseLocation)
+            default:
+                break
+            }
+        }
+
         dragMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDragged, .leftMouseUp]) { [weak self] event in
             guard let self = self else { return event }
             switch event.type {
             case .leftMouseUp:
-                if let m = self.dragMonitor {
-                    NSEvent.removeMonitor(m)
-                    self.dragMonitor = nil
-                }
-                if self.isDragging {
+                let wasDragging = self.isDragging
+                self.finishDrag()
+                if wasDragging {
                     // Drag just ended — swallow so SwiftUI's button doesn't see
                     // mouseUp and fire its action.
-                    self.isDragging = false
-                    self.onDragEnded?()
                     return nil
                 }
                 // Normal click — let the event reach SwiftUI.
@@ -3313,12 +3448,22 @@ private class DraggableHostingView<Content: View>: NSHostingView<Content> {
         }
     }
 
-    /// Keep the grabbed point of the panel pinned under the cursor. Screen
-    /// coordinates throughout, so crossing onto another display just works.
+    /// Keep the grabbed point of the panel pinned under the cursor, but never
+    /// let the chip itself leave the desktop. Screen coordinates throughout, so
+    /// crossing onto another display just works.
     private func moveWindow(under mouse: NSPoint) {
         guard let window = window else { return }
+        let raw = NSPoint(x: mouse.x - grabOffset.dx, y: mouse.y - grabOffset.dy)
+        let offset = pillCentreOffset?() ?? CGVector(
+            dx: window.frame.width / 2,
+            dy: window.frame.height / 2
+        )
         window.setFrameOrigin(
-            NSPoint(x: mouse.x - grabOffset.dx, y: mouse.y - grabOffset.dy)
+            clampedDragOrigin(
+                panelOrigin: raw,
+                pillCentreOffset: offset,
+                screens: NSScreen.screens.map { $0.frame }
+            )
         )
     }
 }

--- a/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder_tests.swift
+++ b/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder_tests.swift
@@ -331,6 +331,116 @@ private func testWireContract() {
     expect(actual == expected, "anchor raw values drifted: \(actual)")
 }
 
+/// A drag inside a display must be left exactly alone. The clamp is a fence at
+/// the edge of the desktop, not a magnet, so ordinary dragging still tracks the
+/// cursor pixel for pixel.
+private func testClampLeavesOnScreenDragsAlone() {
+    let screens = [NSRect(x: 0, y: 0, width: 1920, height: 1080)]
+    let offset = CGVector(dx: 100, dy: 20)
+    for origin in [
+        NSPoint(x: 0, y: 0),
+        NSPoint(x: 400, y: 300),
+        NSPoint(x: 1500, y: 900),
+    ] {
+        let clamped = clampedDragOrigin(
+            panelOrigin: origin, pillCentreOffset: offset, screens: screens
+        )
+        expect(clamped == origin, "clamp moved an on-screen drag at \(origin) to \(clamped)")
+    }
+}
+
+/// The reported bug: drag left, let go, the pill is gone. The clamp is what
+/// guarantees something stays grabbable even when the drop misbehaves.
+private func testClampKeepsPillOnDesktop() {
+    let screens = [NSRect(x: 0, y: 0, width: 1920, height: 1080)]
+    let offset = CGVector(dx: 100, dy: 20)
+
+    let farLeft = clampedDragOrigin(
+        panelOrigin: NSPoint(x: -4000, y: 500),
+        pillCentreOffset: offset,
+        screens: screens
+    )
+    expectClose(farLeft.x + offset.dx, kMinDraggedPillVisible, "chip centre pulled to left edge")
+    expectClose(farLeft.y + offset.dy, 520, "clamp left the vertical position alone")
+
+    // Every other direction, including diagonally past a corner.
+    let cases: [(NSPoint, String)] = [
+        (NSPoint(x: 9000, y: 500), "right"),
+        (NSPoint(x: 400, y: -3000), "below"),
+        (NSPoint(x: 400, y: 9000), "above"),
+        (NSPoint(x: -9000, y: 9000), "past the top-left corner"),
+    ]
+    for (origin, label) in cases {
+        let clamped = clampedDragOrigin(
+            panelOrigin: origin, pillCentreOffset: offset, screens: screens
+        )
+        let centre = NSPoint(x: clamped.x + offset.dx, y: clamped.y + offset.dy)
+        expect(
+            NSMouseInRect(centre, screens[0], false),
+            "chip dragged \(label) ended off the desktop at \(centre)"
+        )
+    }
+}
+
+/// With two displays the chip is pulled into the nearer one, and dead space in
+/// the bounding box of both is never a valid resting place: clamping to that
+/// box would leave the pill in a region no display can draw.
+private func testClampPicksNearestDisplay() {
+    // Side by side, second one shorter, so y in 720..<1080 beyond x=1920 is
+    // inside the bounding box but on no display.
+    let screens = [
+        NSRect(x: 0, y: 0, width: 1920, height: 1080),
+        NSRect(x: 1920, y: 0, width: 1280, height: 720),
+    ]
+    let offset = CGVector(dx: 10, dy: 10)
+
+    let intoSecond = clampedDragOrigin(
+        panelOrigin: NSPoint(x: 4000, y: 300),
+        pillCentreOffset: offset,
+        screens: screens
+    )
+    let secondCentre = NSPoint(x: intoSecond.x + offset.dx, y: intoSecond.y + offset.dy)
+    expect(
+        NSMouseInRect(secondCentre, screens[1], false),
+        "chip past the right edge should land on the second display, got \(secondCentre)"
+    )
+
+    let deadSpace = clampedDragOrigin(
+        panelOrigin: NSPoint(x: 2400, y: 900),
+        pillCentreOffset: offset,
+        screens: screens
+    )
+    let deadCentre = NSPoint(x: deadSpace.x + offset.dx, y: deadSpace.y + offset.dy)
+    expect(
+        screens.contains { NSMouseInRect(deadCentre, $0, false) },
+        "chip in the gap above the shorter display stayed off every screen at \(deadCentre)"
+    )
+}
+
+/// A display smaller than twice the inset must not have the chip pushed out the
+/// opposite side by the inset itself.
+private func testClampSurvivesTinyDisplay() {
+    let tiny = [NSRect(x: 0, y: 0, width: 24, height: 24)]
+    let offset = CGVector(dx: 5, dy: 5)
+    let clamped = clampedDragOrigin(
+        panelOrigin: NSPoint(x: -500, y: -500), pillCentreOffset: offset, screens: tiny
+    )
+    let centre = NSPoint(x: clamped.x + offset.dx, y: clamped.y + offset.dy)
+    expect(
+        NSMouseInRect(centre, tiny[0], false),
+        "chip left a display smaller than the inset, at \(centre)"
+    )
+}
+
+/// No displays at all (all asleep mid-drag) must not crash or teleport.
+private func testClampWithoutDisplaysIsIdentity() {
+    let origin = NSPoint(x: 123, y: 456)
+    let clamped = clampedDragOrigin(
+        panelOrigin: origin, pillCentreOffset: CGVector(dx: 1, dy: 2), screens: []
+    )
+    expect(clamped == origin, "clamp with no displays should be identity, got \(clamped)")
+}
+
 @main
 struct ShortcutReminderTests {
     static func main() {
@@ -344,6 +454,11 @@ struct ShortcutReminderTests {
         testAttachmentStacking()
         testAttachmentStaysOnScreen()
         testWireContract()
+        testClampLeavesOnScreenDragsAlone()
+        testClampKeepsPillOnDesktop()
+        testClampPicksNearestDisplay()
+        testClampSurvivesTinyDisplay()
+        testClampWithoutDisplaysIsIdentity()
 
         if failures.isEmpty {
             print("shortcut overlay geometry: \(checks) checks passed")


### PR DESCRIPTION
## Problem

Drag-to-pin is unreliable on macOS. Reported as: the pill does not pin to a
location, it can be dragged anywhere and left there, and dragging it toward the
left edge made it disappear until the app was restarted.

## Root cause (fixed here)

`shortcut_reminder.swift` still had `isMovableByWindowBackground = true` on the
reminder panel. That gives AppKit its own window-drag path running alongside
the instrumented one from #6262. AppKit's mover has no threshold, no landing
targets, and no snap or persist on release, so when it won the gesture the pill
stayed where it was let go and the stored anchor was never updated. #6262 fixed
the instrumented mover and left this one enabled.

The clearest evidence is the drag stage. On HEAD the whole gesture runs with
**one** window on screen: the landing targets are never drawn at all, which is
the "targets never showed" half of the report.

## What this PR changes

1. `isMovableByWindowBackground = false`, so `DraggableHostingView` is the only
   mover and every drag ends in `endPillDrag`.
2. New `clampedDragOrigin` keeps the chip on a real display mid-drag. Clamped
   per display rather than to the bounding box of all of them, since screens of
   differing heights leave dead space belonging to no display.
3. A global event monitor beside the local one. A local monitor only sees
   events routed to this app, and the overlay is built to be used while another
   app is frontmost, so a release over that app could be missed entirely.
4. The one remaining early return in `endPillDrag` re-applies the stored anchor
   instead of leaving the panel where the gesture abandoned it.

## Measurements

Synthetic HID drags against the standalone `OVERLAY_PREVIEW` build in a Tart
VM, single 1920x1022 display. Grab the chip at `top-center`, release at the far
left edge. Same gesture every run; only the source differs.

| run | panel after release | windows during drag | anchor emitted |
|---|---|---|---|
| HEAD, run A | `x=-79 y=223` (81 of 160pt on screen) | 1 | none |
| HEAD, run B | `x=520 y=210` | 1 | `top-center` (unchanged) |
| this PR, run A | `x=185 y=374` | 2 (stage drawn) | `left-center` |
| this PR, run B | `x=377 y=281` | 1 | `top-center` (unchanged) |

Two things improve and are worth having on their own:

- **The pill stops leaving the desktop.** HEAD run A parks it at `x=-79` with
  half of it gone. Every run on this PR ends `clipped_px=0`.
- **When the instrumented path engages, the drag stage is drawn and the anchor
  decision is right**: dragging left picks `left-center`, which HEAD never did.

## What is NOT fixed, and I am not claiming it is

**The pill still does not come to rest on its anchor.** In run A above it ends
at `x=185` when `left-center` should put it at `x≈4`. Sampling the settle every
350ms for 5s shows the panel completely static from the first sample onward, so
this is not an animation still in flight and not something moving it afterwards.
`endPillDrag` runs and `positionPanel(animated:)` is called, but the panel does
not arrive at `anchoredPanelOrigin`.

**Engagement is non-deterministic.** Run B on this PR behaves like HEAD: one
window, no stage, anchor unchanged, pill parked. Same binary, same gesture as
run A.

So the reported "does not pin to a location" is **not** demonstrated fixed. The
double mover was real and is gone, but at least one more defect sits behind it,
either in how `positionPanel` applies the anchored origin or in what still wins
the gesture. That is the next thing to chase, and it may want its own PR.

I also cannot rule out the harness contributing: synthetic `CGEvent` drags on a
VM that has been at load 300+ may not faithfully reproduce a human drag, and
the run-to-run variance is consistent with that. A human drag on real hardware
would settle it quickly.

## Validation

- `scripts/test-shortcut-overlay.sh`: **164 checks pass**, including 5 new clamp
  tests covering off-left, off-right, above, below, past a corner, dual-display
  dead space, a display smaller than the inset, and no displays at all.
  On-screen drags are asserted byte-identical, so the clamp is a fence at the
  edge rather than a magnet.
- Both targets compile: the app target and `-DOVERLAY_PREVIEW`.
- Rebased onto current `main` (after #6275, which also touches this file). Its
  `refreshTranscriptPanelVisibility()` and the attachment-dragging offsets are
  preserved; `moveDraggedAttachments` reads the panel's real origin, so glued
  attachments follow the clamped position with no extra work.

## Gaps

- Single display only. The multi-monitor path and `overlayDisplay` persistence
  are untested here.
- These Swift tests do not run in CI. `scripts/test-shortcut-overlay.sh` is
  local-only, same as when #6262 added the file. Worth wiring into a macOS job;
  left out to keep this scoped.
- Windows and Linux drag paths untouched.
