### PR TITLE
fix(share): stop the send dialog from being a fourth way to copy

### DIFF
--- a/apps/screenpipe-app-tauri/components/connected-share-dialog.test.tsx
+++ b/apps/screenpipe-app-tauri/components/connected-share-dialog.test.tsx
@@ -303,7 +303,10 @@ describe("ConnectedShareDialog", () => {
     ).toBe(false);
   });
 
-  it("keeps clipboard available and recovers when connection discovery fails", async () => {
+  // A failed check used to resolve to the clipboard, so the dialog quietly
+  // offered a local write under a button that says send. It now says it could
+  // not check and offers retry, and nothing is sendable until it succeeds.
+  it("stays unsendable and recovers when connection discovery fails", async () => {
     mocks.localFetch
       .mockRejectedValueOnce(new Error("local service unavailable"))
       .mockResolvedValueOnce(jsonResponse({ data: [] }));
@@ -315,13 +318,77 @@ describe("ConnectedShareDialog", () => {
     const error = await screen.findByTestId(
       "connected-share-connections-error",
     );
-    expect(error).toHaveTextContent("Clipboard still works");
-    expect(screen.getByRole("button", { name: "copy snapshot" })).toBeEnabled();
+    expect(error).toHaveTextContent("local service unavailable");
+    expect(
+      screen.queryByRole("button", { name: /copy snapshot/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("connected-share-confirm")).toBeDisabled();
 
     fireEvent.click(screen.getByRole("button", { name: "retry" }));
     await screen.findByTestId("connected-share-empty");
     expect(
       screen.queryByTestId("connected-share-connections-error"),
+    ).not.toBeInTheDocument();
+    // Still nothing connected, so still nothing to send to.
+    expect(screen.getByTestId("connected-share-confirm")).toBeDisabled();
+    expect(screen.getByTestId("connected-share-confirm")).toHaveTextContent(
+      "connect an app to send",
+    );
+  });
+
+  // `no destination` has two causes and they need opposite instructions.
+  // Telling someone to connect an app while two connected apps sit in the menu
+  // below is worse than saying nothing.
+  it("asks which app rather than which to connect when several are ready", async () => {
+    mocks.localFetch.mockImplementation(async (path: string) => {
+      if (path === "/connections") {
+        return jsonResponse({
+          data: [
+            { id: "slack", connected: true },
+            { id: "notion", connected: true },
+          ],
+        });
+      }
+      if (path === "/connections/slack/instances") {
+        return jsonResponse({ instances: [] });
+      }
+      if (path.startsWith("/connections/slack/conversations")) {
+        return jsonResponse({ channels: [] });
+      }
+      throw new Error(`unexpected request: ${path}`);
+    });
+
+    render(
+      <ConnectedShareDialog open onOpenChange={vi.fn()} artifact={artifact} />,
+    );
+
+    const row = await screen.findByTestId("connected-share-destination");
+    expect(row).toHaveTextContent("choose where this goes");
+    expect(row).not.toHaveTextContent("connect an app to send");
+
+    const confirm = screen.getByTestId("connected-share-confirm");
+    expect(confirm).toBeDisabled();
+    expect(confirm).toHaveTextContent("choose a destination");
+  });
+
+  // The clipboard had a destination row of its own, which made the send dialog
+  // a fourth way to copy — in a third serialization — behind a glyph that
+  // promises the snapshot leaves the machine.
+  it("offers no local destination", async () => {
+    render(
+      <ConnectedShareDialog open onOpenChange={vi.fn()} artifact={artifact} />,
+    );
+
+    await openDestinations();
+    await screen.findByTestId("connected-share-destination-slack");
+    expect(
+      screen.queryByTestId("connected-share-destination-copy"),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("menuitem", { name: /clipboard/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /copy snapshot/i }),
     ).not.toBeInTheDocument();
   });
 
@@ -518,11 +585,11 @@ describe("ConnectedShareDialog", () => {
 
       // Nothing is a peer of it until it is opened.
       expect(
-        screen.queryByTestId("connected-share-destination-copy"),
+        screen.queryByTestId("connected-share-destination-slack"),
       ).not.toBeInTheDocument();
       await openDestinations();
       expect(
-        await screen.findByTestId("connected-share-destination-copy"),
+        await screen.findByTestId("connected-share-destination-slack"),
       ).toBeVisible();
     });
   });

--- a/apps/screenpipe-app-tauri/components/connected-share-dialog.tsx
+++ b/apps/screenpipe-app-tauri/components/connected-share-dialog.tsx
@@ -15,7 +15,6 @@ import {
   Check,
   ChevronDown,
   ChevronUp,
-  Copy,
   ExternalLink,
   Loader2,
   Plus,
@@ -68,9 +67,20 @@ import {
   writeRememberedShare,
 } from "@/lib/connected-share-preference";
 import { showChatWithPrefill } from "@/lib/chat-utils";
-import { commands } from "@/lib/utils/tauri";
 
-type Destination = "slack" | "linear" | "copy" | "chat-linear" | "chat-notion";
+/**
+ * Where a reviewed snapshot can go.
+ *
+ * `copy` used to live here and it was the default: the state initialised to it,
+ * every open reset to it, and a failed connection check fell back to it. So the
+ * send button's default happy path was a clipboard write, and its primary
+ * action read `copy snapshot` — the same verb as the copy button two slots to
+ * its left on the same rule. The clipboard already had a dedicated control with
+ * three labelled payloads; this was a fourth, in a third serialization, behind
+ * a glyph that promises a destination. Destinations are now only things this
+ * dialog can send to, and `null` means nothing is connected yet.
+ */
+type Destination = "slack" | "linear" | "chat-linear" | "chat-notion";
 
 type SlackInstance = {
   instance: string | null;
@@ -229,7 +239,7 @@ export function ConnectedShareDialog({
   const [selectedSectionIds, setSelectedSectionIds] = useState<string[]>([]);
   const [message, setMessage] = useState("");
   const [slackMessage, setSlackMessage] = useState("");
-  const [destination, setDestination] = useState<Destination>("copy");
+  const [destination, setDestination] = useState<Destination | null>(null);
   const [availability, setAvailability] = useState(EMPTY_AVAILABILITY);
   const [connectionsLoading, setConnectionsLoading] = useState(true);
   const [connectionsChecked, setConnectionsChecked] = useState(false);
@@ -276,7 +286,9 @@ export function ConnectedShareDialog({
     if (!open) return;
     resetPreview(allSectionIds);
     setLinearTitle(artifact.title);
-    setDestination("copy");
+    // Stays null until the connection check says what is actually reachable.
+    // There is no longer a local destination to fall back to.
+    setDestination(null);
     setConnectionsError(null);
     setReceipt(null);
     setActionError(null);
@@ -333,14 +345,13 @@ export function ConnectedShareDialog({
         // recalled; the explicit final send still stands in front of the write.
         const remembered = readRememberedShare(artifact.surface);
         const connected: string[] = [
-          "copy",
           ...(ready.direct.slack ? ["slack"] : []),
           ...(ready.direct.linear ? ["linear"] : []),
           ...(ready.chat.linear ? ["chat-linear"] : []),
           ...(ready.chat.notion ? ["chat-notion"] : []),
         ];
         setDestination(
-          preferredShareDestination(remembered, connected) as Destination,
+          preferredShareDestination(remembered, connected) as Destination | null,
         );
         if (remembered?.target) setSlackTarget(remembered.target);
         if (remembered?.instance) setSlackInstance(remembered.instance);
@@ -348,7 +359,10 @@ export function ConnectedShareDialog({
       .catch((error) => {
         if (cancelled) return;
         setAvailability(EMPTY_AVAILABILITY);
-        setDestination("copy");
+        // A failed check used to silently become a clipboard write. Now it
+        // surfaces the error and offers retry instead of quietly doing
+        // something the user did not pick.
+        setDestination(null);
         setConnectionsError(
           didTimeout
             ? "Connection check timed out."
@@ -542,20 +556,6 @@ export function ConnectedShareDialog({
     );
   };
 
-  const copy = async () => {
-    await commands.copyTextToClipboard(message);
-    setReceipt({
-      title: "copied",
-      detail: "The reviewed snapshot is on your clipboard.",
-    });
-    posthog.capture("connected_share_completed", {
-      surface: artifact.surface,
-      destination: "copy",
-      section_count: selectedSectionIds.length,
-    });
-    toast({ title: "copied snapshot" });
-  };
-
   const sendToSlack = async () => {
     const channel = slackChannels.find((item) => item.id === slackTarget);
     const response = await localFetch("/connections/slack/send", {
@@ -636,7 +636,7 @@ export function ConnectedShareDialog({
   };
 
   const submit = async () => {
-    if (!outgoingMessage.trim() || sending) return;
+    if (!destination || !outgoingMessage.trim() || sending) return;
     setSending(true);
     setReceipt(null);
     setActionError(null);
@@ -646,7 +646,6 @@ export function ConnectedShareDialog({
       section_count: selectedSectionIds.length,
     });
     try {
-      if (destination === "copy") await copy();
       if (destination === "slack") await sendToSlack();
       if (destination === "linear") await sendToLinear();
       if (destination === "chat-linear") await prepareInChat("linear");
@@ -689,6 +688,7 @@ export function ConnectedShareDialog({
   };
 
   const canSubmit =
+    destination !== null &&
     outgoingMessage.trim().length > 0 &&
     outgoingMessage.length <= 39_000 &&
     selectedSectionIds.length > 0 &&
@@ -736,11 +736,6 @@ export function ConnectedShareDialog({
           },
         ]
       : []),
-    {
-      value: "copy" as Destination,
-      name: "Clipboard",
-      icon: <Copy className="h-4 w-4" />,
-    },
   ];
   const chatOptions: Array<{
     value: Destination;
@@ -767,11 +762,16 @@ export function ConnectedShareDialog({
       : []),
   ];
 
-  const currentOption =
-    [...directOptions, ...chatOptions].find(
-      (option) => option.value === destination,
-    ) ?? directOptions[directOptions.length - 1];
-  const currentIsChat = destination.startsWith("chat-");
+  const currentOption = [...directOptions, ...chatOptions].find(
+    (option) => option.value === destination,
+  );
+  const currentIsChat = destination?.startsWith("chat-") ?? false;
+  // "Nothing is connected" and "more than one thing is connected and you have
+  // not said which" are both `destination === null`, but they need opposite
+  // instructions. Telling someone to connect an app while Slack and Notion sit
+  // in the open menu below is the kind of wrong that erodes trust in the rest
+  // of the dialog.
+  const hasAnyDestination = directOptions.length + chatOptions.length > 0;
   // The second line of the destination row: which channel, team, or nothing.
   const currentTarget =
     destination === "slack"
@@ -783,18 +783,24 @@ export function ConnectedShareDialog({
           "choose a team")
         : currentIsChat
           ? "prepare a prompt in Chat"
-          : "this machine";
+          : hasAnyDestination
+            ? "choose where this goes"
+            : "connect an app to send";
 
+  // Every label is a send verb now. `copy snapshot` was the odd one out and it
+  // collided with the copy button on the same rule.
   const submitLabel =
-    destination === "copy"
-      ? "copy snapshot"
-      : destination === "slack"
-        ? "send to Slack"
-        : destination === "linear"
-          ? "create Linear issue"
-          : destination === "chat-linear"
-            ? "prepare Linear in Chat"
-            : "prepare Notion in Chat";
+    destination === "slack"
+      ? "send to Slack"
+      : destination === "linear"
+        ? "create Linear issue"
+        : destination === "chat-linear"
+          ? "prepare Linear in Chat"
+          : destination === "chat-notion"
+            ? "prepare Notion in Chat"
+            : hasAnyDestination
+              ? "choose a destination"
+              : "connect an app to send";
 
   const contentsSummary = `${
     selectedSectionIds.length === artifact.sections.length
@@ -838,7 +844,7 @@ export function ConnectedShareDialog({
                   connected apps could not be checked
                 </p>
                 <p className="mt-0.5 text-muted-foreground">
-                  {connectionsError} Clipboard still works.
+                  {connectionsError} Retry, or use copy on the rule above.
                 </p>
               </div>
             </div>
@@ -871,7 +877,7 @@ export function ConnectedShareDialog({
                   <span className="flex min-w-0 items-center gap-2">
                     {currentOption?.icon}
                     <span className="shrink-0 text-sm">
-                      {currentOption?.name}
+                      {currentOption?.name ?? "no destination"}
                     </span>
                     <span className="shrink-0 text-muted-foreground">·</span>
                     <span className="truncate text-xs text-muted-foreground">
@@ -956,8 +962,9 @@ export function ConnectedShareDialog({
                 className="text-[11px] text-muted-foreground"
                 data-testid="connected-share-empty"
               >
-                Nothing is connected for sharing yet. Clipboard works now, or
-                connect an app for the next snapshot.
+                Nothing is connected for sharing yet. Connect an app to send
+                this snapshot, or use copy on the rule above to put it on your
+                clipboard.
               </p>
             )}
             {currentIsChat && (
@@ -1152,7 +1159,7 @@ export function ConnectedShareDialog({
           <SummaryRow
             label="message"
             value={
-              destination.startsWith("chat-")
+              currentIsChat
                 ? "what Chat will review"
                 : destination === "slack"
                   ? "Slack-formatted"
@@ -1292,7 +1299,7 @@ export function ConnectedShareDialog({
           >
             {sending ? (
               <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-            ) : destination.startsWith("chat-") ? (
+            ) : currentIsChat ? (
               <Sparkles className="mr-1.5 h-3.5 w-3.5" />
             ) : (
               <Send className="mr-1.5 h-3.5 w-3.5" />

--- a/apps/screenpipe-app-tauri/components/meeting-notes/meeting-share-menu.test.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/meeting-share-menu.test.tsx
@@ -192,6 +192,34 @@ describe("meeting share control", () => {
     expect(onShare).toHaveBeenCalledWith("email");
   });
 
+  // `email summary` shipped inside the group headed `copy`, where it was the
+  // only row that wrote nothing to the clipboard — it opens a mailto: draft.
+  // The heading named a verb while the grouping followed the payload, so the
+  // one row that behaved differently was the one the label mispromised.
+  it("keeps the mail draft out of the group headed copy", async () => {
+    render(<MeetingShareMenu canShareSummary onShare={vi.fn()} />);
+
+    openMenu();
+
+    await screen.findByRole("menuitem", { name: /email summary/ });
+
+    // Both headings exist, so the mail draft has somewhere honest to live.
+    expect(screen.getByText("copy")).toBeVisible();
+    expect(screen.getByText("send")).toBeVisible();
+
+    // The clipboard rows come first, and the mail draft sorts after them —
+    // under `send`, not inside `copy`.
+    const labels = screen
+      .getAllByRole("menuitem")
+      .map((item) => item.textContent ?? "");
+    const lastClipboardIndex = labels.findLastIndex((label) =>
+      /^copy /.test(label),
+    );
+    const emailIndex = labels.findIndex((label) => /email summary/.test(label));
+    expect(lastClipboardIndex).toBeGreaterThanOrEqual(0);
+    expect(emailIndex).toBeGreaterThan(lastClipboardIndex);
+  });
+
   it("does not offer summary destinations mid-stream", async () => {
     render(<MeetingShareMenu canShareSummary={false} onShare={vi.fn()} />);
 

--- a/apps/screenpipe-app-tauri/components/meeting-notes/meeting-share-menu.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/meeting-share-menu.tsx
@@ -155,25 +155,32 @@ export function MeetingShareMenu({
 }) {
   const primary: MeetingShareAction = canShareSummary ? "summary" : "meeting";
   // `send` graduated to its own button, so it is no longer listed here.
-  const secondary: MeetingShareAction[] = canShareSummary
-    ? ["email", "transcript", "meeting"]
+  const clipboardActions: MeetingShareAction[] = canShareSummary
+    ? ["transcript", "meeting"]
     : ["transcript"];
+  // `email` opens a mailto: draft. It shipped inside the group headed `copy`,
+  // where it was the only row that wrote nothing to the clipboard — the group
+  // was organised by payload (the summary) while its label named a verb. It
+  // gets its own heading rather than a rename, because the distinction that
+  // matters when scanning is where the text ends up.
+  const mailActions: MeetingShareAction[] = canShareSummary ? ["email"] : [];
 
   const confirmed = copiedAction === primary;
   const PrimaryIcon = confirmed ? Check : ACTION_ICON[primary];
 
-  // The leftover copy destinations become an ordinary labelled group, so the
-  // menu has one shape and the renderer below has no special cases.
+  const toItems = (actions: MeetingShareAction[]) =>
+    actions.map((action) => ({
+      key: action,
+      label: ACTION_LABEL[action],
+      icon: ACTION_ICON[action],
+      onSelect: () => onShare(action),
+    }));
+
+  // The leftover copy destinations become ordinary labelled groups, so the menu
+  // has one shape and the renderer below has no special cases.
   const groups: MeetingMenuGroup[] = [
-    {
-      label: "copy",
-      items: secondary.map((action) => ({
-        key: action,
-        label: ACTION_LABEL[action],
-        icon: ACTION_ICON[action],
-        onSelect: () => onShare(action),
-      })),
-    },
+    { label: "copy", items: toItems(clipboardActions) },
+    { label: "send", items: toItems(mailActions) },
     ...moreGroups,
   ].filter((group) => group.items.length > 0);
 

--- a/apps/screenpipe-app-tauri/lib/__tests__/connected-share-preference.test.ts
+++ b/apps/screenpipe-app-tauri/lib/__tests__/connected-share-preference.test.ts
@@ -97,27 +97,32 @@ describe("remembered share destination", () => {
 describe("preferred destination", () => {
   it("reopens on the destination you last used", () => {
     expect(
-      preferredShareDestination({ destination: "slack" }, ["copy", "slack"]),
+      preferredShareDestination({ destination: "slack" }, ["slack", "linear"]),
     ).toBe("slack");
   });
 
   // Disconnecting an app must not strand the dialog on a destination that can
-  // no longer send.
-  it("falls back when the remembered app is no longer connected", () => {
+  // no longer send. It used to land on `copy`, which meant a dropped Slack
+  // connection silently turned a send into a clipboard write.
+  it("asks again when the remembered app is no longer connected", () => {
     expect(
-      preferredShareDestination({ destination: "slack" }, ["copy", "linear"]),
-    ).toBe("copy");
+      preferredShareDestination({ destination: "slack" }, ["linear"]),
+    ).toBeNull();
   });
 
   // Picking from a list of one is a question with a single answer.
   it("skips the picker when exactly one app is connected", () => {
-    expect(preferredShareDestination(null, ["copy", "slack"])).toBe("slack");
+    expect(preferredShareDestination(null, ["slack"])).toBe("slack");
   });
 
-  it("asks when there is a real choice, and when there is none", () => {
-    expect(preferredShareDestination(null, ["copy", "slack", "linear"])).toBe(
-      "copy",
-    );
-    expect(preferredShareDestination(null, ["copy"])).toBe("copy");
+  it("asks when there is a real choice", () => {
+    expect(preferredShareDestination(null, ["slack", "linear"])).toBeNull();
+  });
+
+  // Nothing connected is not a destination. The dialog has to say so rather
+  // than resolve to a local write nobody asked for.
+  it("has no destination when nothing is connected", () => {
+    expect(preferredShareDestination(null, [])).toBeNull();
+    expect(preferredShareDestination({ destination: "slack" }, [])).toBeNull();
   });
 });

--- a/apps/screenpipe-app-tauri/lib/connected-share-preference.ts
+++ b/apps/screenpipe-app-tauri/lib/connected-share-preference.ts
@@ -90,12 +90,18 @@ export function writeRememberedShare(
  *
  * What you used last, if it is still connected. Otherwise the only connected
  * destination when there is exactly one — picking from a list of one asks a
- * question with a single answer. Otherwise `copy`.
+ * question with a single answer. Otherwise nothing.
  *
  * Auto-select deliberately does not apply once a remembered destination has
  * gone missing. Someone who sends to Slack every week, whose Slack connection
  * then drops, should not find the dialog quietly pointed at Linear with a
  * confirm button under their cursor. A vanished destination means ask again.
+ *
+ * The fallback used to be `copy`, which made "we could not work out where this
+ * should go" indistinguishable from "send this to your clipboard" — and made
+ * the clipboard the resting state of a dialog whose button says send. There is
+ * no local destination now, so the honest answer is `null` and the dialog says
+ * so instead of quietly aiming somewhere.
  */
 const DESTINATION_APP: Record<string, string> = {
   slack: "Slack",
@@ -121,14 +127,11 @@ export function rememberedSendLabel(
 export function preferredShareDestination(
   remembered: RememberedShare | null,
   connected: readonly string[],
-  fallback = "copy",
-): string {
+): string | null {
   if (remembered) {
     return connected.includes(remembered.destination)
       ? remembered.destination
-      : fallback;
+      : null;
   }
-  const sendable = connected.filter((entry) => entry !== fallback);
-  if (sendable.length === 1) return sendable[0];
-  return fallback;
+  return connected.length === 1 ? connected[0] : null;
 }


### PR DESCRIPTION
## Problem

The meeting rule carries a `copy` button, a `send` button, and a `⋯` menu whose first group is headed `copy`. Opening the send dialog then lands on **Clipboard**.

That is not an accident of state. In `connected-share-dialog.tsx` the destination initialised to `"copy"`, every open reset to `"copy"`, and a failed connection check fell back to `"copy"`. So the send icon's default happy path was a clipboard write, and its primary button read **copy snapshot** — the same verb the copy button two slots to its left already owns.

Counting everything on this surface that ends in a clipboard write:

| path | renderer | payload |
|---|---|---|
| copy icon, summary exists | `copyMeetingSummary` | title + meta + summary, rich text |
| copy icon, no summary | `buildMeetingMarkdown` | full dump incl. transcript |
| `⋯` → copy meeting + transcript | `buildMeetingMarkdown` | same full dump |
| `⋯` → copy transcript | `copyMeetingTranscript` | transcript only |
| send → Clipboard → **copy snapshot** | `renderConnectedShareArtifact` | title + meta + note, plain markdown |

Five payloads, three serializations, one meeting. The fifth is a strict subset of the third, reachable only behind a glyph that promises the snapshot leaves the machine.

Two smaller things on the same surface:

- **`email summary` sat under the heading `copy` and writes nothing to the clipboard.** It opens a `mailto:` draft. The group was organised by payload (the summary) while its label named a verb, so the one row that behaved differently was the one the heading mispromised.
- **A dropped connection silently became a local write.** `preferredShareDestination` fell back to `"copy"`, so someone who sends to Slack every week and loses that connection would find the dialog pointed at their clipboard under a button that says send.

## Fix

Clipboard is not a destination. `Destination` loses its `copy` member, the clipboard submit path and its `Copy`/`commands` imports are deleted, and `preferredShareDestination` returns `null` instead of falling back — the dialog opens on the remembered app, or the only connected app, or nothing. Every submit label is a send verb.

`null` has two causes that need opposite instructions, so the destination row and the button distinguish *nothing is connected* from *several are connected and you have not picked*. Telling someone to connect an app while Slack and Notion sit in the open menu below is worse than saying nothing — the real render caught that, see the right-hand shot.

`email summary` moves to its own `send` group.

**Unchanged:** the copy button keeps its one-click default, and the `⋯` menu keeps the full payload list. The doc comment in `meeting-share-menu.tsx` argues that case on measured grounds and this PR does not relitigate it.

## Before / after

Real component renders, captured from the app's dev server with the local API stubbed — `main` at `fa7bd2059` on the left, this branch on the right. Not a packaged-app run.

**Send dialog**

![send dialog before and after](https://raw.githubusercontent.com/screenpipe/screenpipe/assets-share-dedup-c621c7/cmp-dialog.png)

**Overflow menu**

![overflow menu before and after](https://raw.githubusercontent.com/screenpipe/screenpipe/assets-share-dedup-c621c7/cmp-menu.png)

## Validation

- `vitest` 43 passed across the four affected files: `connected-share-dialog`, `meeting-share-menu`, `connected-share`, `connected-share-preference`
- `bun x tsc --noEmit` clean
- `next lint` on the three changed source files: no errors. One pre-existing `react-hooks/exhaustive-deps` warning on an effect whose dep array this PR does not touch
- `bun e2e/scripts/generate-coverage-report.ts --check` up to date

New tests: the dialog offers no local destination; a failed connection check stays unsendable and recovers on retry; several connected apps ask *which* rather than *which to connect*; the mail draft sorts outside the `copy` group.

## Not in scope

- **`canSend` is effectively "the note is non-empty"** (`note-view.tsx`), so a meeting with a summary and a full transcript but an empty note hides the send button entirely. Fixing it means teaching `createMeetingShareArtifact` to emit a summary section, which changes the artifact's privacy note. Separate PR.
- Prior analysis had this dialog at ~2 users/30d, so the case for shrinking this surface further is open — but that is a product call, not a cleanup.
