### PR TITLE
fix(updater): honor failed install cooldown after restart

### DIFF
--- a/apps/screenpipe-app-tauri/e2e/mock-updates/packaged-update-restart.e2e.ts
+++ b/apps/screenpipe-app-tauri/e2e/mock-updates/packaged-update-restart.e2e.ts
@@ -57,6 +57,7 @@ const WORKDIR = path.join(DIR, '.packaged-e2e');
 const DATA_DIR = path.join(WORKDIR, 'data');
 const APP_INSTALL_DIR = path.join(WORKDIR, 'installed');
 const RESULTS_DIR = path.join(APP_ROOT, 'e2e', 'results');
+const MANIFEST_PATH = path.join(DIR, 'manifest.json');
 
 const NEW_VERSION = '9.9.9';
 const API_PORT = 3061;
@@ -298,7 +299,7 @@ async function main(): Promise<void> {
   mkdirSync(DATA_DIR, { recursive: true });
 
   // Update server (subprocess; killed in teardown).
-  const serve = Bun.spawn(['bun', HARNESS, 'serve'], {
+  let serve = Bun.spawn(['bun', HARNESS, 'serve'], {
     cwd: APP_ROOT,
     stdout: 'ignore',
     stderr: 'ignore',
@@ -438,6 +439,32 @@ async function main(): Promise<void> {
     log('simulating a failed install (marker from == running version)…');
     killWorkdirApp();
     await sleep(1500);
+
+    // Point the already-signed local manifest at the exact version recorded
+    // in the failed marker. The artifact bytes do not matter: a correctly
+    // seeded cooldown must stop before the download request.
+    serve.kill();
+    await serve.exited;
+    const failedManifest = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'));
+    failedManifest.version = '10.0.0';
+    await Bun.write(MANIFEST_PATH, `${JSON.stringify(failedManifest, null, 2)}\n`);
+    serve = Bun.spawn(['bun', HARNESS, 'serve'], {
+      cwd: APP_ROOT,
+      stdout: 'ignore',
+      stderr: 'ignore',
+    });
+    await waitFor('failed-version update manifest', 15_000, async () => {
+      try {
+        const res = await fetch(`http://127.0.0.1:${UPDATE_SERVER_PORT}/`, {
+          signal: AbortSignal.timeout(1000),
+        });
+        if (!res.ok) return null;
+        const manifest = (await res.json()) as { version?: string };
+        return manifest.version === '10.0.0' ? true : null;
+      } catch {
+        return null;
+      }
+    });
     await Bun.write(
       path.join(DATA_DIR, 'update-attempt.json'),
       JSON.stringify({
@@ -450,12 +477,19 @@ async function main(): Promise<void> {
     const failedBoot = await waitFor('app up after synthetic failed attempt', 60_000, fetchState);
     check(
       'failed attempt surfaced in menu',
-      failedBoot.menu_text === "Update didn't apply — click to retry",
+      failedBoot.menu_text === 'Update failed — click to retry',
       failedBoot.menu_text,
     );
     check('failed-attempt menu is clickable', failedBoot.menu_enabled);
-    const failLog = await todayLog();
+    const failLog = await waitFor('automatic retry blocked by cooldown', 60_000, async () => {
+      const current = await todayLog();
+      return current.includes('recently failed to install; skipping auto-download') ? current : null;
+    });
     check('log: failed attempt detected', failLog.includes('previous update install did NOT apply'));
+    check(
+      'automatic retry was blocked before re-download',
+      failLog.includes('update v10.0.0 recently failed to install; skipping auto-download'),
+    );
     check(
       'marker consumed (single-shot)',
       !existsSync(path.join(DATA_DIR, 'update-attempt.json')),

--- a/apps/screenpipe-app-tauri/e2e/mock-updates/updater-harness.ts
+++ b/apps/screenpipe-app-tauri/e2e/mock-updates/updater-harness.ts
@@ -76,7 +76,7 @@ function ensureSigning(): void {
   if (!existsSync(PRIVATE_KEY)) {
     console.info('[updater-local] generating dev minisign keypair…');
     const gen = Bun.spawnSync(
-      ['bun', 'x', 'tauri', 'signer', 'generate', '-w', PRIVATE_KEY, '--ci', '--password', SIGNING_PASSWORD],
+      ['bun', 'run', 'tauri', 'signer', 'generate', '-w', PRIVATE_KEY, '--ci', '--password', SIGNING_PASSWORD],
       { cwd: APP_ROOT, stdin: 'ignore', stderr: 'inherit', stdout: 'inherit' },
     );
     if (gen.exitCode !== 0) throw new Error('tauri signer generate failed (exit ' + gen.exitCode + ')');
@@ -123,7 +123,7 @@ function cmdBuild(argv: string[]): void {
 
   const features = ['official-build', ...extraFeatures].join(',');
   let env: Record<string, string | undefined> = { ...process.env };
-  let tauriArgs = ['bun', 'x', 'tauri', 'build', '--features', features, '--config', cfgE2e];
+  let tauriArgs = ['bun', 'run', 'tauri', 'build', '--features', features, '--config', cfgE2e];
 
   if (appVersion) {
     if (!/^\d+\.\d+\.\d+$/.test(appVersion)) {

--- a/apps/screenpipe-app-tauri/src-tauri/src/updates.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/updates.rs
@@ -506,6 +506,12 @@ fn consume_update_attempt_marker(app: &tauri::AppHandle) -> Option<UpdateAttempt
     }
 }
 
+fn initial_failed_update(
+    failed_attempt: Option<&UpdateAttempt>,
+) -> Option<(String, std::time::Instant)> {
+    failed_attempt.map(|attempt| (attempt.to_version.clone(), std::time::Instant::now()))
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Tray update flow
 // ─────────────────────────────────────────────────────────────────────────────
@@ -791,6 +797,7 @@ impl UpdatesManager {
 
         // Did the previous process quit to apply an update that never landed?
         let failed_attempt = consume_update_attempt_marker(app);
+        let last_failed_update = initial_failed_update(failed_attempt.as_ref());
 
         let update_menu_item = if is_enterprise_build(app) {
             None
@@ -819,7 +826,7 @@ impl UpdatesManager {
             app: app.clone(),
             update_menu_item,
             is_checking: AtomicBool::new(false),
-            last_failed_update: Arc::new(Mutex::new(None)),
+            last_failed_update: Arc::new(Mutex::new(last_failed_update)),
         })
     }
 
@@ -1697,6 +1704,25 @@ mod tests {
     use super::*;
 
     const HOUR: Duration = Duration::from_secs(3600);
+    #[test]
+    fn failed_boot_attempt_seeds_the_automatic_retry_cooldown() {
+        let attempt = UpdateAttempt {
+            from_version: "2.6.21".into(),
+            to_version: "2.6.23".into(),
+            ts_epoch_secs: 1_786_749_757,
+        };
+        let failed = initial_failed_update(Some(&attempt));
+
+        let (version, failed_at) = failed
+            .as_ref()
+            .expect("the failed target version must seed the cooldown at boot");
+        assert_eq!(version, "2.6.23");
+        assert!(failed_version_in_cooldown(
+            Some((version.as_str(), failed_at.elapsed())),
+            "2.6.23",
+            UPDATE_FAILURE_COOLDOWN,
+        ));
+    }
 
     #[test]
     fn sweep_removes_installer_leftovers_only() {


### PR DESCRIPTION
## Root cause

On boot, screenpipe consumes a failed update-attempt marker and changes the tray label, but initializes `last_failed_update` to `None`. The next automatic check therefore bypasses the existing six-hour failed-version cooldown and can immediately download and attempt the same version again.

This patch seeds the failed target version into the existing cooldown during manager construction. Manual retry remains available from the enabled tray item. The underlying filesystem install failure is still unknown; this repair prevents the immediate automatic repeat loop rather than claiming installation recovery.

## Privacy-safe production signal

- Sentry organization/project: `mediar/screenpipe-app`
- Issue: `SCREENPIPE-APP-K7` / `7672727860`, unresolved, handled error
- UTC window: `2026-08-14T03:57:28.803Z` to `2026-08-15T03:57:28.803Z`
- Aggregate: 3 affected users, 618 events
- No raw event payload, customer data, token, or private path is retained

## Exact source

- Baseline: `e17496cd86e0ead42230b169e238caffa753ebb5`
- Patch: `95bbbc9a2e0810fcdf6dae262cb2dfce80d0fb92`
- Patch tree: `41dd62950e4cf17950864a69c1bb4a8194374a8c`

## Verification matrix

| Gate | Evidence |
|---|---|
| Baseline packaged macOS updater | Expected failure: automatic retry began, menu reached `Downloading update... 40%`, cooldown assertion timed out; 34 passed, 2 failed before abort |
| Focused Rust regression | 1 passed, 0 failed |
| Updater Rust suite | 40 passed, 0 failed |
| App TypeScript | `bun run typecheck`, exit 0 |
| App build check | `cargo check --bin screenpipe-app` passed on the identical source tree |
| Patched packaged macOS updater | Three clean deterministic runs: 39 passed, 0 failed each |
| Format/diff | Focused rustfmt and `git diff --check` passed |
| Platform | macOS arm64 only; no cross-platform inference |

Repository-wide `cargo fmt --check` and strict clippy remain red on broad untouched baseline drift. This PR does not patch unrelated baseline CI.

## Local video evidence

- Before: `/Users/louisbeaumont/Documents/Codex/2026-08-05/cre/outputs/hourly-sentry-fixes/SCREENPIPE-APP-K7/95bbbc9a2e0810fcdf6dae262cb2dfce80d0fb92/baseline.mp4`
- After: `/Users/louisbeaumont/Documents/Codex/2026-08-05/cre/outputs/hourly-sentry-fixes/SCREENPIPE-APP-K7/95bbbc9a2e0810fcdf6dae262cb2dfce80d0fb92/patch.mp4`
- Manifest/checksums: `/Users/louisbeaumont/Documents/Codex/2026-08-05/cre/outputs/hourly-sentry-fixes/SCREENPIPE-APP-K7/95bbbc9a2e0810fcdf6dae262cb2dfce80d0fb92/manifest.json` and `SHA256SUMS`

Both videos use the same synthetic `packaged-updater` scenario, 1280x720 viewport, and cooldown assertion. Videos are local-only and are not committed or uploaded.

## Risk and rollback

Risk is limited to suppressing automatic re-download of the same failed version for the existing six-hour cooldown after restart. A newer version is not suppressed, and the tray remains enabled for manual retry. Rollback is a single revert of `95bbbc9a2e0810fcdf6dae262cb2dfce80d0fb92`.

## Evidence checklist

- [x] Fresh authenticated Sentry inventory and aggregate join
- [x] Deduplicated against open/merged PRs, issues, branches, commits, and available Sentry metadata
- [x] Baseline failed for the expected reason
- [x] Minimal source repair plus regression coverage
- [x] Exact-head focused tests and package typecheck
- [x] Three clean deterministic packaged E2E runs
- [x] Matched privacy-safe before/after videos and checksums
- [x] Final diff, worktree, and privacy inspection
- [ ] Exact-head required hosted CI green
- [ ] Merge, deployment, public release, installed canary, and affected-user recovery
