### PR TITLE
fix(e2e): restore onboarding after the first-run learning window suite

### DIFF
--- a/apps/screenpipe-app-tauri/e2e/specs/first-run-learning-window.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/first-run-learning-window.spec.ts
@@ -142,6 +142,20 @@ const learningState = (over: Record<string, unknown> = {}) => ({
     await waitForAppReady();
   });
 
+  // Several tests below call `reset_onboarding` to look like a user who has
+  // not finished setup. The app process is shared by the whole suite and the
+  // onboarding store is global, so leaving it reset does not end with this
+  // file: `ShowRewindWindow::Main` returns the onboarding window while
+  // onboarding is incomplete (window/show.rs), so every later spec that waits
+  // for a `main` / `main-window` handle never gets one. That is how one
+  // missing hook here reddened main-window, main-window-close-reopen,
+  // main-overlay-visibility, tray-search and window-lifecycle, and burned
+  // ~20 minutes of the job budget on their retries. Same restore as
+  // screen-recording-restart.spec.ts.
+  after(async () => {
+    await invokeOrThrow("complete_onboarding").catch(() => {});
+  });
+
   it("shows a live countdown while it is learning", async () => {
     await openHomeWith(learningState());
 


### PR DESCRIPTION
## Problem

The `E2E Tests` publish blocker has been red on every main push since Aug 14. It is not failing — it is being **cancelled at the 120-minute job ceiling**, so the gate reports a truncated run rather than a result.

The job was ~3 minutes short of finishing: 110 of 112 specs had run when the runner killed it.

- Latest main run: [31886934099](https://github.com/screenpipe/screenpipe/actions/runs/31886934099) — `Linux E2E Tests (run)` cancelled at exactly 120m
- Same shape on `21e00c9a0`, `e17496cd8`, `dbdd7dc5a` — predates the onboarding commits

## Where found

19 specs failed in that run. Grouping their errors, one message dominates:

| count | error |
|---|---|
| **20** | `Main window handle did not appear (main, main-window)` |
| 12 | `expect(received).not.toContain("onboarding")` |
| 8 | `stage extraction looks wrong` |
| … | 13 other distinct one-off failures |

## Reproduction and pre-fix failure

The app log during those failures says it outright:

```
show_main_window called
showing window: "onboarding"
show_main_window succeeded, window label: onboarding
```

`show_main_window` handed back the **onboarding** window, so the `main` handle the specs wait for never appears.

Timeline within the run:

| spec | window | result |
|---|---|---|
| `0-51 first-run-learning-window` | 14:12:57 → 14:16:04 | FAILED (calls `reset_onboarding`) |
| `0-61 main-overlay-visibility` | 14:20:23 → 14:24:31 | FAILED — first `Main window handle did not appear` at 14:21:24 |
| `0-62 main-window-close-reopen` | → 14:28:39 | FAILED |
| `0-63 main-window` | → 14:34:08 | FAILED |
| `0-100 tray-search` | → 15:14:05 | FAILED |
| `0-104 window-lifecycle` | → 15:18:59 | FAILED |

Every overlay spec **before** 0-51 passes. Every one **after** it fails.

## Root cause

`first-run-learning-window.spec.ts` calls `reset_onboarding` in three tests — including the last one, `"never renders for a user who did not just finish setup"` — and never restores it. There is no `after` hook.

The app process is shared by the whole suite and the onboarding store is global, so the reset outlives the file. In `window/show.rs:748`:

```rust
ShowRewindWindow::Main => {
    if !onboarding_store.is_completed {
        return ShowRewindWindow::Onboarding.show(app);
    }
```

`window-lifecycle` makes it unambiguous — the failing test is literally named *"routes **completed** onboarding back to Home without creating an onboarding window"*, and it fails because onboarding is no longer completed.

The seed only runs once per app process (`E2E seed: onboarding marked complete` appears exactly once in the 14k-line log, at 13:33:19), so nothing re-arms it.

At four attempts each (`specFileRetries: 3`) those five specs burned **~22 minutes**. That is the budget overrun.

## Fix

One `after` hook restoring onboarding, the same way `screen-recording-restart.spec.ts:34` already does:

```ts
after(async () => {
  await invokeOrThrow("complete_onboarding").catch(() => {});
});
```

`onboarding-trust-affordances.spec.ts` also resets without restoring, but its `canRun = !seedFlags.includes("onboarding")` skips it whenever the onboarding seed is present — which is every CI run. Left alone.

## Validation

- `bun run typecheck` — clean
- `bun run e2e:coverage:check` — up to date
- `bunx biome check` on the changed file — no diagnostics
- `git diff --check` — clean

The bug reproduces only in the full ordered Linux suite against a shared app process, so **this PR's own Linux E2E run is the end-to-end proof**. What to look for: `main-overlay-visibility`, `main-window-close-reopen`, `main-window`, `tray-search`, `window-lifecycle` green, and the job completing instead of being cancelled.

## Scope — this does not turn the gate green

13 specs still fail for unrelated, individually distinct reasons (`acp-backend`, `acp-onboarding-ux`, `capture-stall-stage-marker`, four `chat-*`, `connected-share`, `live-view-pinch-zoom`, `meeting-overlay-pin`, `meeting-summary-recovery`, `search-bugs-4645`, and a `settings-sections` copy assertion expecting `"screen recording"` in a section that now reads `"screen capture quality, monitors, and power"`).

This buys back ~18 minutes and stops the cancellation, so those 13 get **reported** instead of hidden behind a truncated run. They need separate triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
