### PR TITLE
docs(db): unix-excl does not put the WAL index in process memory

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/db_self_heal.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/db_self_heal.rs
@@ -5,15 +5,19 @@
 //! Launch-time self-heal for transient SQLite hard faults.
 //!
 //! A `SQLITE_IOERR_SHORT_READ` (extended code 522) under heavy concurrent load
-//! desyncs the WAL index in memory. Every pool is torn down and the database is
-//! durably quarantined, which is correct while the faulted process is still
-//! running: its `-shm` mapping cannot be trusted.
+//! desyncs the WAL index against the WAL it describes. Every pool is torn down
+//! and the database is durably quarantined, which is correct while the faulted
+//! process is still running: its live view of `-shm` cannot be trusted. (That
+//! index is file-backed even under `unix-excl` — see the VFS note in
+//! `screenpipe-db`'s `db/setup.rs`.)
 //!
-//! The quarantine is *cross-launch*, though, and that part over-fires. A fresh
-//! process has a fresh WAL index, so the poisoning is gone before the first
-//! read. Three separate incidents (2026-07-02, 2026-08-05, 2026-08-11) all ended
-//! the same way: `PRAGMA quick_check` returned `ok` on the quarantined file, and
-//! the "recovery" rebuilt a database that was never damaged. In the meantime
+//! The quarantine is *cross-launch*, though, and that part over-fires. Once
+//! every handle is gone the index no longer outlives the fault: the first
+//! connection in a fresh process rebuilds it from the WAL, so the desync is
+//! gone before the first read. Three separate incidents (2026-07-02,
+//! 2026-08-05, 2026-08-11) all ended the same way: `PRAGMA quick_check`
+//! returned `ok` on the quarantined file, and the "recovery" rebuilt a
+//! database that was never damaged. In the meantime
 //! recording stayed off — hours, in the 2026-08-11 case, because nothing resumes
 //! until a human notices the tray and runs a repair.
 //!

--- a/crates/screenpipe-connect/src/remote_sync.rs
+++ b/crates/screenpipe-connect/src/remote_sync.rs
@@ -628,8 +628,8 @@ pub async fn sync_to_remote_with_opts(
 /// Open a short-lived sqlx pool against the live DB and run `VACUUM INTO`
 /// to produce a self-contained snapshot at `dest`. SQLite's WAL mode lets
 /// our connection coexist with the engine's writer pool; on macOS it joins
-/// the recorder's unix-excl domain and process-local WAL index. The pool is
-/// dropped before we return — important because we then SFTP the snapshot.
+/// the recorder's unix-excl locking domain. The pool is dropped before we
+/// return — important because we then SFTP the snapshot.
 async fn snapshot_db(live_db: &Path, dest: &Path) -> Result<()> {
     let url = format!("sqlite://{}", live_db.to_string_lossy());
     let mut opts = SqliteConnectOptions::from_str(&url)
@@ -639,9 +639,11 @@ async fn snapshot_db(live_db: &Path, dest: &Path) -> Result<()> {
     {
         opts = opts.read_only(true);
     }
-    // The recorder uses unix-excl on macOS so its WAL index lives in process
-    // memory instead of an APFS-backed `-shm` mapping. Snapshot connections
-    // run in that same process and must join the same VFS/locking domain.
+    // The recorder uses unix-excl on macOS, which takes one exclusive lock on
+    // the database file and makes later OS locking in-process bookkeeping.
+    // The `-shm` WAL index is still file-backed. Snapshot connections run in
+    // that same process and must join the same VFS/locking domain, or they
+    // would do real POSIX locking against handles that no longer lock at all.
     #[cfg(target_os = "macos")]
     {
         opts = opts.vfs("unix-excl");

--- a/crates/screenpipe-db/src/db/setup.rs
+++ b/crates/screenpipe-db/src/db/setup.rs
@@ -207,14 +207,27 @@ impl DatabaseManager {
             .pragma("mmap_size", config.mmap_size.to_string());
         // macOS delivers an uncatchable SIGBUS when APFS invalidates a page in
         // SQLite's file-backed WAL index after the `-shm` file was shortened.
-        // `unix-excl` keeps the WAL index in process memory and takes one OS
-        // lock for the recorder process, while SQLite still coordinates all
-        // SQLx connections internally. Screenpipe already requires exclusive
-        // ownership for live capture, recovery, and maintenance operations.
+        // `unix-excl` does NOT move that index into process memory: in the
+        // bundled SQLite (3.51.3) `unixOpenSharedMemory` always creates the
+        // `-shm` file, and a heap wal-index requires `locking_mode=EXCLUSIVE`,
+        // which this database deliberately never sets. What `unix-excl` does
+        // is take one real exclusive lock on the database file the first time
+        // any lock is attempted and turn every later OS locking operation into
+        // in-process bookkeeping (`unixFileLock`). That is what keeps another
+        // process from attaching and shortening `-shm` underneath us, while
+        // every connection in this process shares the one shm node for the
+        // inode. Screenpipe already requires exclusive ownership for live
+        // capture, recovery, and maintenance operations.
+        //
+        // Do not restate this as "the WAL index lives in memory". That claim
+        // was wrong, and `db.sqlite-shm` existing on disk is normal, not
+        // evidence that some other opener touched the database.
         #[cfg(target_os = "macos")]
         if !is_in_memory {
             connect_options = connect_options.vfs("unix-excl");
-            info!("macOS capture database using unix-excl VFS with a process-local WAL index");
+            info!(
+                "macOS capture database using unix-excl VFS with a process-exclusive database lock"
+            );
         }
         for (pragma, value) in screenpipe_config::WAL_SAFETY_PRAGMAS {
             connect_options = connect_options.pragma(pragma, value);
@@ -247,18 +260,22 @@ impl DatabaseManager {
 
         // Every file-backed query connection enables query_only. Non-macOS
         // builds also open the file with mode=ro as an independent physical
-        // barrier. macOS keeps all unix-excl handles physically RW so they
-        // share one process-local WAL index instead of reopening `-shm`.
-        // In-memory test databases remain writable for fixtures that seed them
-        // directly.
+        // barrier. macOS keeps all unix-excl handles physically RW so every
+        // connection shares one shm node under the same exclusive-lock
+        // regime, rather than splitting into two locking modes over the same
+        // `-shm`. In-memory test databases remain writable for fixtures that
+        // seed them directly.
         let read_connect_options = if is_in_memory {
             connect_options.clone()
         } else {
             let options = connect_options.clone().pragma("query_only", "ON");
-            // A read-only unix-excl handle falls back to POSIX file locks and a
-            // file-backed WAL index. Keep macOS query handles physically RW so
-            // every connection shares the process-local WAL index; query_only
-            // remains the connection-level write barrier.
+            // `unixFileLock` only takes the one-shot exclusive lock when
+            // UNIXFILE_EXCL is set and UNIXFILE_RDONLY is not, so opening a
+            // handle `mode=ro` drops it out of the exclusive regime and back
+            // onto real POSIX locks — against sibling handles that are no
+            // longer doing OS-level locking at all. Keep macOS query handles
+            // physically RW so every connection stays in one regime;
+            // query_only remains the connection-level write barrier.
             #[cfg(not(target_os = "macos"))]
             let options = options.read_only(true);
             options


### PR DESCRIPTION
## Problem

Three comment sites claim the macOS `unix-excl` VFS "keeps the WAL index in process memory" instead of an APFS-backed `-shm` mapping. That is false for the SQLite we bundle.

It is not a cosmetic error. It inverts an incident signal: it makes a `db.sqlite-shm` file on disk look like proof that a foreign opener attached to the capture database, when its presence is completely normal.

## Where found, and the evidence

Found while triaging a live `SQLITE_IOERR_SHORT_READ` (extended code 522) quarantine on a 16.58 GB capture database. I used the comment as fact, saw `db.sqlite-shm` present, and concluded a non-`unix-excl` opener had touched the database. That conclusion was wrong, and the comment is why.

Verified against the amalgamation we actually link, `libsqlite3-sys = "=0.37.0"` with feature `bundled`, which is SQLite 3.51.3:

- `unixOpenSharedMemory` always calls `robust_open(zShm, O_RDWR|O_CREAT|O_NOFOLLOW, ...)`. There is no `UNIXFILE_EXCL` branch that skips creating the file. `UNIXFILE_EXCL` appears in exactly four places in the amalgamation, and none of them is in that function.
- A heap wal-index is selected by `sqlite3WalOpen(pPager->pVfs, pPager->fd, pPager->zWal, pPager->exclusiveMode, ...)`. The `bNoShm` argument is `pPager->exclusiveMode`, which comes from `PRAGMA locking_mode=EXCLUSIVE`. We never set that in production, and `sqlite_architecture_invariants_test` explicitly asserts maintenance does not contain it.

So the WAL index is file-backed on macOS as well.

What `unix-excl` actually buys is `unixFileLock`: one real exclusive lock on the database file the first time any lock is attempted, after which every OS locking operation becomes in-process bookkeeping. That is what stops another process from attaching and shortening `-shm` underneath the recorder, and it is a good reason to keep the VFS.

Worth noting the amalgamation does carry a comment describing the no-`-shm` optimisation. The comment is there, the branch is not. Reading the comment and not the code is how this landed in the first place.

## Reproduction

```
grep -n "UNIXFILE_EXCL" .../libsqlite3-sys-0.37.0/sqlite3/sqlite3.c
# 4 hits: the #define, unixFileLock, unixIsSharingShmNode, unixOpen. None in unixOpenSharedMemory.

grep -rn "locking_mode" --include=*.rs crates/
# no production hits
```

Then run the app on macOS and `ls ~/.screenpipe/db.sqlite-shm`. The file is there, created by the recorder itself.

## Root cause

The comment describes an optimisation that requires `locking_mode=EXCLUSIVE`, which this database deliberately never sets, and attributes it to the VFS instead.

## Fix

Comments and one `info!` string. No behaviour change, no code path touched.

Every existing decision stays, now with an accurate reason:

- `setup.rs` keeps macOS query handles physically RW. The real reason is that `unixFileLock` takes its one-shot exclusive lock only when `UNIXFILE_EXCL` is set and `UNIXFILE_RDONLY` is not, so opening `mode=ro` drops that handle back onto real POSIX locking against siblings that are no longer doing OS-level locking at all. That is a sharper argument for the current code than the one it replaces.
- `remote_sync.rs` still joins the recorder's VFS and locking domain for the `VACUUM INTO` snapshot pool.
- `db_self_heal.rs` still resolves a 522 quarantine without a rebuild. A fresh process does get a usable index, because the first connection rebuilds it from the WAL, not because it lives in memory. Its incident evidence is untouched.

`setup.rs` also gains an explicit note not to restate the claim, and that `db.sqlite-shm` on disk is normal rather than evidence of another opener.

## Before / after

Before:

```
// `unix-excl` keeps the WAL index in process memory and takes one OS
// lock for the recorder process, while SQLite still coordinates all
// SQLx connections internally.
info!("macOS capture database using unix-excl VFS with a process-local WAL index");
```

After:

```
// `unix-excl` does NOT move that index into process memory: in the
// bundled SQLite (3.51.3) `unixOpenSharedMemory` always creates the
// `-shm` file, and a heap wal-index requires `locking_mode=EXCLUSIVE`,
// which this database deliberately never sets. What `unix-excl` does
// is take one real exclusive lock on the database file the first time
// any lock is attempted and turn every later OS locking operation into
// in-process bookkeeping (`unixFileLock`).
info!("macOS capture database using unix-excl VFS with a process-exclusive database lock");
```

## Validation

- `cargo check -p screenpipe-db -p screenpipe-connect` clean
- `cargo test -p screenpipe-db --test sqlite_architecture_invariants_test` 2 passed, 0 failed. This one matters: it greps production source text, so comment edits can break it.
- `rustfmt --edition 2021 --check` clean on all three files
- No remaining occurrences of the claim in any `.rs` or `.md`

Gaps, stated plainly:

- `db_self_heal.rs` is in `src-tauri`, which is excluded from the workspace and has no CI test job, so `cargo check` never compiled it. It is a doc comment, so the risk is nil, but it was not built.
- I did not re-verify the original SIGBUS motivation for adopting `unix-excl`. That rationale is preserved as written.

## Not in scope

This does not fix the 522 itself. Closing that needs the WAL length, frame count, and failing read offset captured at fault time, and nothing records those today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)