### PR TITLE
fix(drm): react immediately to DRM pause and resume transitions

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -32,15 +32,15 @@ results and `cargo llvm-cov` data on top when judging release confidence.
 
 - Mapped suites: 32
 - Mapped Rust files: 330
-- Active test blocks: 3205
+- Active test blocks: 3207
 - Ignored/manual test blocks: 137
-- Weighted coverage points: 2628.4
+- Weighted coverage points: 2629.8
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 3066 | 132 | 2565.0 | 21 | 11 | 100% |
-| macos | 29 | 3124 | 112 | 2577.4 | 22 | 11 | 100% |
-| linux | 25 | 2740 | 105 | 2268.3 | 20 | 11 | 100% |
+| windows | 29 | 3068 | 132 | 2566.4 | 21 | 11 | 100% |
+| macos | 29 | 3126 | 112 | 2578.8 | 22 | 11 | 100% |
+| linux | 25 | 2742 | 105 | 2269.6 | 20 | 11 | 100% |
 
 ## Refresh
 

--- a/apps/screenpipe-app-tauri/src-tauri/src/tray_monitor_preview.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/tray_monitor_preview.rs
@@ -58,6 +58,29 @@ enum PreviewUpdate {
     Unchanged,
 }
 
+/// Why a bootstrap attempt ended the way it did. Returned so tests can assert
+/// *which* branch ran, rather than only that `preview_capture_expected_from`
+/// computes the right boolean: the tray preview is the only caller of
+/// `ensure_monitor_stream` in the tree, so "did this reach SCK?" is the whole
+/// DRM-pause invariant and it needs to be observable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BootstrapOutcome {
+    /// An intentional pause (screen lock, post-wake, DRM, schedule) is active,
+    /// so no SCK stream was opened.
+    SkippedPaused,
+    /// The user switched this display off in the tray, so it must never get a
+    /// preview stream regardless of pause state.
+    UserDisabled,
+    /// A latched frame already exists — a stream is live, nothing to do.
+    AlreadyStreaming,
+    /// A previous attempt failed and its backoff window has not elapsed.
+    BackoffPending,
+    /// Monitor is not present (disconnected, or a synthetic id in tests).
+    MonitorMissing,
+    /// `ensure_monitor_stream` was actually called.
+    Attempted { started: bool },
+}
+
 static CACHE: Lazy<Mutex<HashMap<u32, CachedPreview>>> = Lazy::new(|| Mutex::new(HashMap::new()));
 static PLACEHOLDER: Lazy<Image<'static>> = Lazy::new(|| {
     let mut rgba = vec![36u8; (PREVIEW_WIDTH * PREVIEW_HEIGHT * 4) as usize];
@@ -264,7 +287,7 @@ async fn drain_bootstrap_requests(rx: &mpsc::Receiver<u32>, app: &AppHandle) {
         return;
     }
     for monitor_id in pending {
-        bootstrap_sck_stream(monitor_id).await;
+        let _ = bootstrap_sck_stream(monitor_id).await;
         if should_refresh_menu(refresh_monitor_from_sck(monitor_id)) {
             queue_menu_refresh(app);
         }
@@ -327,22 +350,22 @@ fn queue_sck_bootstrap(monitor_id: u32) {
     }
 }
 
-async fn bootstrap_sck_stream(monitor_id: u32) {
+async fn bootstrap_sck_stream(monitor_id: u32) -> BootstrapOutcome {
     if !preview_capture_expected() {
-        return;
+        return BootstrapOutcome::SkippedPaused;
     }
     if user_disabled_monitor_ids().contains(&monitor_id) {
-        return;
+        return BootstrapOutcome::UserDisabled;
     }
     if screenpipe_screen::stream_invalidation::peek_monitor_frame(monitor_id).is_some() {
         clear_bootstrap_backoff(monitor_id);
-        return;
+        return BootstrapOutcome::AlreadyStreaming;
     }
     // Re-checked here as well as at queue time: a request can sit in the
     // channel across a tick, and this is the only place that actually touches
     // ScreenCaptureKit.
     if !bootstrap_ready(monitor_id, Instant::now()) {
-        return;
+        return BootstrapOutcome::BackoffPending;
     }
     let Some(monitor) = screenpipe_screen::monitor::get_monitor_by_id(monitor_id).await else {
         let delay = record_bootstrap_failure(monitor_id, Instant::now());
@@ -350,16 +373,16 @@ async fn bootstrap_sck_stream(monitor_id: u32) {
             "tray preview: monitor {} not found for SCK bootstrap (retrying in {:?})",
             monitor_id, delay
         );
-        return;
+        return BootstrapOutcome::MonitorMissing;
     };
-    if screenpipe_screen::stream_invalidation::ensure_monitor_stream(
+    let started = screenpipe_screen::stream_invalidation::ensure_monitor_stream(
         monitor_id,
         monitor.width(),
         monitor.height(),
         &[],
     )
-    .await
-    {
+    .await;
+    if started {
         clear_bootstrap_backoff(monitor_id);
     } else {
         let delay = record_bootstrap_failure(monitor_id, Instant::now());
@@ -368,6 +391,7 @@ async fn bootstrap_sck_stream(monitor_id: u32) {
             monitor_id, delay
         );
     }
+    BootstrapOutcome::Attempted { started }
 }
 
 fn apply_rgba_preview(monitor_id: u32, frame: &RgbaImage) -> PreviewUpdate {
@@ -452,6 +476,28 @@ mod tests {
     use super::*;
     use image::Rgba;
 
+    /// Serializes every test that touches `CACHE` or the process-global DRM
+    /// flag. Required because the pause path calls `clear_cached_previews()`,
+    /// which wipes the whole map — without this, the lifecycle test below can
+    /// clear an entry another test just seeded and turn its expected
+    /// `Unchanged` into a `FirstFrame`.
+    static PREVIEW_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn preview_test_lock() -> std::sync::MutexGuard<'static, ()> {
+        PREVIEW_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    /// Restores the global DRM flag when the lifecycle test ends, including on
+    /// a failed assertion — a leaked `drm_content_paused() == true` would
+    /// silently disable previews for every later test in this binary.
+    struct DrmStateGuard;
+
+    impl Drop for DrmStateGuard {
+        fn drop(&mut self) {
+            screenpipe_engine::drm_detector::set_drm_paused(false);
+        }
+    }
+
     #[test]
     fn preview_dimensions_match_icon_height() {
         assert_eq!(PREVIEW_HEIGHT as f64, PREVIEW_ICON_HEIGHT);
@@ -476,6 +522,7 @@ mod tests {
 
     #[test]
     fn apply_preview_distinguishes_first_update_and_unchanged_frames() {
+        let _lock = preview_test_lock();
         let monitor_id = u32::MAX - 17;
         CACHE
             .lock()
@@ -506,6 +553,7 @@ mod tests {
 
     #[test]
     fn background_poll_stops_after_first_preview_is_cached() {
+        let _lock = preview_test_lock();
         let monitor_id = u32::MAX - 18;
         CACHE
             .lock()
@@ -544,6 +592,7 @@ mod tests {
 
     #[test]
     fn disabling_a_display_drops_its_cached_preview() {
+        let _lock = preview_test_lock();
         let kept = u32::MAX - 31;
         let disabled_id = u32::MAX - 32;
         let frame = RgbaImage::from_pixel(2, 2, Rgba([4, 5, 6, 255]));
@@ -575,6 +624,7 @@ mod tests {
     /// attempt must wait, and a success must restore immediate readiness.
     #[test]
     fn failed_bootstrap_defers_the_next_attempt() {
+        let _lock = preview_test_lock();
         let monitor_id = u32::MAX - 33;
         clear_bootstrap_backoff(monitor_id);
         let now = Instant::now();
@@ -601,6 +651,7 @@ mod tests {
 
     #[test]
     fn resuming_from_an_intentional_pause_clears_backoff() {
+        let _lock = preview_test_lock();
         let monitor_id = u32::MAX - 34;
         clear_bootstrap_backoff(monitor_id);
         let now = Instant::now();
@@ -611,5 +662,119 @@ mod tests {
         clear_cached_previews();
 
         assert!(bootstrap_ready(monitor_id, now));
+    }
+
+    /// Full `normal -> DRM -> clear` lifecycle over the *real* process-global
+    /// DRM flag, asserting the two properties that matter:
+    ///
+    ///   1. While DRM is active, nothing can reopen a capture stream. The tray
+    ///      preview thread is the only caller of `ensure_monitor_stream` in the
+    ///      tree, so gating it is what makes the DRM pause a real pause rather
+    ///      than a teardown the tray immediately undoes on its next 400ms tick.
+    ///   2. When DRM clears, the preview path fully recovers — nothing is
+    ///      permanently torn down, and no relaunch is needed.
+    ///
+    /// The predicate truth-table lives in
+    /// `preview_never_bootstraps_capture_during_intentional_pause_states`; this
+    /// test covers the transition sequence and the recovery that a truth-table
+    /// cannot express.
+    ///
+    /// Uses a synthetic monitor id so the post-clear phase stops at the monitor
+    /// lookup (`MonitorMissing`) instead of opening a real ScreenCaptureKit
+    /// stream on CI. Reaching `MonitorMissing` is itself the assertion: it is
+    /// strictly past the pause gate, so the gate let it through.
+    ///
+    /// The bootstrap backoff added in #6121 is reset explicitly between phases.
+    /// A failed lookup records a retry window, and `BackoffPending` would
+    /// otherwise mask the outcome this test is actually asserting.
+    #[tokio::test]
+    async fn drm_lifecycle_blocks_stream_reopen_during_pause_and_recovers_after() {
+        let _lock = preview_test_lock();
+        let _drm_guard = DrmStateGuard;
+        let monitor_id = u32::MAX - 19;
+        clear_bootstrap_backoff(monitor_id);
+
+        // ── normal ────────────────────────────────────────────────────────
+        screenpipe_engine::drm_detector::set_drm_paused(false);
+        assert!(
+            preview_capture_expected(),
+            "baseline must be unpaused — another test leaked a pause flag, \
+             or this machine reported screen-locked/post-wake/schedule-paused"
+        );
+        assert_eq!(
+            bootstrap_sck_stream(monitor_id).await,
+            BootstrapOutcome::MonitorMissing,
+            "with no pause active, bootstrap must get past the gate"
+        );
+
+        let frame = RgbaImage::from_pixel(2, 2, Rgba([4, 5, 6, 255]));
+        assert_eq!(
+            apply_rgba_preview(monitor_id, &frame),
+            PreviewUpdate::FirstFrame
+        );
+        assert!(has_cached_preview(monitor_id));
+
+        // ── DRM ───────────────────────────────────────────────────────────
+        // Drop the retry window the failed lookup above earned, so a
+        // SkippedPaused below can only come from the DRM gate. The gates are
+        // ordered pause-before-backoff, and this keeps the assertion honest if
+        // that order ever changes.
+        clear_bootstrap_backoff(monitor_id);
+        screenpipe_engine::drm_detector::set_drm_paused(true);
+        assert!(!preview_capture_expected());
+        assert_eq!(
+            bootstrap_sck_stream(monitor_id).await,
+            BootstrapOutcome::SkippedPaused,
+            "DRM pause must stop the tray from reopening an SCK stream that \
+             the monitor watcher just tore down"
+        );
+
+        // The menu-rebuild path must also refuse, and must drop the stale
+        // frames so the tray can't keep showing DRM content post-pause.
+        sync_refresh_monitors(&[monitor_id]);
+        assert!(
+            !has_cached_preview(monitor_id),
+            "cached previews must be dropped while DRM is paused"
+        );
+
+        // Still blocked after repeated ticks — the gate is state-based, not a
+        // one-shot that a later poll can slip past.
+        assert_eq!(
+            bootstrap_sck_stream(monitor_id).await,
+            BootstrapOutcome::SkippedPaused
+        );
+
+        // ── clear ─────────────────────────────────────────────────────────
+        screenpipe_engine::drm_detector::set_drm_paused(false);
+        assert!(
+            preview_capture_expected(),
+            "clearing DRM must re-enable preview capture"
+        );
+        // Tearing down for the pause also dropped the retry window, so
+        // recovery is immediate rather than gated behind a backoff the
+        // monitor earned before the pause began.
+        assert!(
+            bootstrap_ready(monitor_id, Instant::now()),
+            "resuming from a DRM pause must not serve out a stale backoff"
+        );
+        assert_eq!(
+            bootstrap_sck_stream(monitor_id).await,
+            BootstrapOutcome::MonitorMissing,
+            "bootstrap must be permitted again after DRM clears — the pause \
+             is reversible, not a permanent shutdown"
+        );
+
+        // And the cache is usable again, not wedged by the pause.
+        assert_eq!(
+            apply_rgba_preview(monitor_id, &frame),
+            PreviewUpdate::FirstFrame
+        );
+        assert!(has_cached_preview(monitor_id));
+
+        CACHE
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(&monitor_id);
+        clear_bootstrap_backoff(monitor_id);
     }
 }

--- a/crates/screenpipe-engine/src/drm_detector.rs
+++ b/crates/screenpipe-engine/src/drm_detector.rs
@@ -33,9 +33,42 @@ use tracing::{debug, info};
 /// Global flag — when `true`, all monitors skip screen capture.
 static DRM_CONTENT_PAUSED: AtomicBool = AtomicBool::new(false);
 
-/// Global reference to the UI recorder's stop flag.
-/// Set during startup so the DRM detector can stop the UI recorder
-/// (which holds native event taps that keep Screen Recording active).
+/// Fired every time `DRM_CONTENT_PAUSED` actually transitions (not on every
+/// call to `set_drm_paused` — only when the value changes). The monitor
+/// watcher's backstop loop otherwise only wakes on a display-reconfiguration
+/// event or a 60s timer (tuned for monitor hotplug detection) — neither of
+/// which fires when the user merely switches focus to a DRM app/tab. Without
+/// this notify, the full VisionManager/audio teardown can lag up to 60s
+/// behind the fast per-monitor `release_capture_stream()` reaction, leaving
+/// DRM content blacked out far longer than expected. Single-consumer
+/// (`notify_one`), matching `sleep_monitor`'s
+/// `DISPLAY_RECONFIG_NOTIFY`/`SCREEN_UNLOCK_NOTIFY`.
+static DRM_STATE_NOTIFY: tokio::sync::Notify = tokio::sync::Notify::const_new();
+
+/// Handle to the DRM state-change notify. Await `.notified()` on it to be
+/// woken immediately the next time DRM pause state actually flips, instead
+/// of waiting for the monitor watcher's normal polling cadence.
+pub fn drm_state_notify() -> &'static tokio::sync::Notify {
+    &DRM_STATE_NOTIFY
+}
+
+/// Global reference to the UI recorder's stop flag, registered during startup
+/// by the desktop app (`capture_session.rs` — the CLI never registers one, so
+/// [`stop_ui_recorder`] is a no-op there).
+///
+/// NOTE: this is deliberately **not** wired into the DRM pause path. An
+/// earlier version of this comment claimed the UI recorder "holds native
+/// event taps that keep Screen Recording active" — that is incorrect. The
+/// macOS UI recorder (`screenpipe-a11y`) uses a `LISTEN_ONLY` `CGEventTap`
+/// plus Accessibility/NSWorkspace/NSPasteboard; it never opens a
+/// ScreenCaptureKit session, and its tap gates on the *Input Monitoring* TCC
+/// permission (`cg::event::access::listen_preflight`), not Screen Recording.
+/// Stopping it therefore releases no SCK handle and cannot lift a DRM
+/// blackout, while permanently ending click/scroll/app-focus/clipboard
+/// capture for the rest of the session (the flag is write-once and the
+/// DRM-clear path has no way to restart it). The SCK release that actually
+/// matters happens in `VisionManager::stop` (`invalidate_streams`) and the
+/// per-monitor `release_capture_stream()` in `event_driven_capture`.
 static UI_RECORDER_STOP_FLAG: Lazy<Mutex<Option<Arc<AtomicBool>>>> = Lazy::new(|| Mutex::new(None));
 
 /// Register the UI recorder's stop flag so DRM detector can stop it.
@@ -60,13 +93,16 @@ pub fn drm_content_paused() -> bool {
     DRM_CONTENT_PAUSED.load(Ordering::SeqCst)
 }
 
-/// Set the DRM pause state. Logs transitions.
+/// Set the DRM pause state. Logs transitions and wakes the monitor watcher
+/// immediately on an actual transition (see `DRM_STATE_NOTIFY`).
 pub fn set_drm_paused(paused: bool) {
     let was_paused = DRM_CONTENT_PAUSED.swap(paused, Ordering::SeqCst);
     if paused && !was_paused {
         info!("DRM content detected — pausing screen capture");
+        DRM_STATE_NOTIFY.notify_one();
     } else if !paused && was_paused {
         info!("DRM content no longer focused — resuming screen capture");
+        DRM_STATE_NOTIFY.notify_one();
     }
 }
 
@@ -745,6 +781,69 @@ mod tests {
         assert!(drm_content_paused());
         set_drm_paused(false);
         assert!(!drm_content_paused());
+    }
+
+    /// `DRM_STATE_NOTIFY` is a single process-wide static, so a prior test's
+    /// `notify_one()` can leave an unconsumed permit sitting on it — the next
+    /// `.notified()` anywhere would then return immediately for a reason
+    /// that has nothing to do with the transition under test. Callers must
+    /// hold `DRM_FLAG_LOCK` (serializes against every other test that calls
+    /// `set_drm_paused`) and drain any stale permit before asserting.
+    async fn drain_stale_drm_notify() {
+        let _ = tokio::time::timeout(
+            std::time::Duration::from_millis(1),
+            drm_state_notify().notified(),
+        )
+        .await;
+    }
+
+    /// Regression test for the ~60s delay observed live on crunchyroll.com:
+    /// DRM was detected and the fast per-monitor capture-stream release fired
+    /// within ~250ms, but the monitor watcher's full teardown (vision stop
+    /// and SCK audio stop — the calls that actually release ScreenCaptureKit)
+    /// only ran on its next backstop tick — up to 60s later, since switching
+    /// focus to a browser tab doesn't fire a display-reconfiguration event. Both
+    /// `set_drm_paused(true)` and `set_drm_paused(false)` must wake a pending
+    /// `drm_state_notify().notified()` immediately.
+    #[tokio::test]
+    async fn test_set_drm_paused_wakes_pending_notify_on_transition() {
+        let _lock = DRM_FLAG_LOCK.lock().unwrap();
+        DRM_CONTENT_PAUSED.store(false, Ordering::SeqCst);
+        drain_stale_drm_notify().await;
+
+        // Pause: false -> true must wake a waiter.
+        let notified = drm_state_notify().notified();
+        set_drm_paused(true);
+        tokio::time::timeout(std::time::Duration::from_secs(1), notified)
+            .await
+            .expect("set_drm_paused(true) must notify waiters on a false->true transition");
+
+        // Resume: true -> false must also wake a waiter.
+        let notified = drm_state_notify().notified();
+        set_drm_paused(false);
+        tokio::time::timeout(std::time::Duration::from_secs(1), notified)
+            .await
+            .expect("set_drm_paused(false) must notify waiters on a true->false transition");
+    }
+
+    /// Calling `set_drm_paused` with the value it's already set to must NOT
+    /// notify — otherwise the monitor watcher would wake on every capture
+    /// tick while DRM content stays focused, not just on the transition.
+    #[tokio::test]
+    async fn test_set_drm_paused_noop_call_does_not_notify() {
+        let _lock = DRM_FLAG_LOCK.lock().unwrap();
+        DRM_CONTENT_PAUSED.store(true, Ordering::SeqCst);
+        drain_stale_drm_notify().await;
+
+        let notified = drm_state_notify().notified();
+        set_drm_paused(true); // already true — must be a no-op, no notify
+        let woke = tokio::time::timeout(std::time::Duration::from_millis(200), notified).await;
+        assert!(
+            woke.is_err(),
+            "set_drm_paused(true) called when already true must not notify waiters"
+        );
+
+        DRM_CONTENT_PAUSED.store(false, Ordering::SeqCst);
     }
 
     #[test]

--- a/crates/screenpipe-engine/src/vision_manager/monitor_watcher.rs
+++ b/crates/screenpipe-engine/src/vision_manager/monitor_watcher.rs
@@ -1241,6 +1241,13 @@ pub async fn start_monitor_watcher(
             //   -  5s when the callback failed to register (fall back to the
             //      previous behavior so hot-plug detection doesn't silently
             //      regress to once-a-minute)
+            // Also wake immediately on a DRM state transition — switching
+            // focus to/from a DRM app or browser tab doesn't reconfigure any
+            // display, so without this branch the DRM pause/resume actions
+            // above (vision stop and SCK audio stop — the calls that actually
+            // release ScreenCaptureKit) only run on the next backstop tick,
+            // up to 60s after DRM was detected — long enough for the video to
+            // stay blacked out well past what a user would consider "fixed".
             #[cfg(target_os = "macos")]
             {
                 let watchdog = vision_watchdog_config();
@@ -1250,8 +1257,10 @@ pub async fn start_monitor_watcher(
                     watchdog.monitor_backstop.min(Duration::from_secs(5))
                 };
                 let notify = crate::sleep_monitor::display_reconfig_notify();
+                let drm_notify = drm_detector::drm_state_notify();
                 tokio::select! {
                     _ = notify.notified() => {}
+                    _ = drm_notify.notified() => {}
                     _ = tokio::time::sleep(backstop) => {}
                 }
             }

--- a/docs/coverage/CORE.md
+++ b/docs/coverage/CORE.md
@@ -9,10 +9,10 @@ confidence, and criticality.
 - Tracked crates: screenpipe-engine, screenpipe-db, screenpipe-sqlite-coordinator, screenpipe-audio, screenpipe-screen, screenpipe-a11y
 - Mapped suites: 32
 - Mapped Rust files: 330
-- Active test blocks: 3205
+- Active test blocks: 3207
 - Ignored/manual test blocks: 137
-- Declared test blocks: 3342
-- Weighted coverage points: 2628.4
+- Declared test blocks: 3344
+- Weighted coverage points: 2629.8
 
 Confidence weights: strong=1.0, partial=0.7, conditional=0.4, smoke=0.3.
 Criticality weights: high=1.0, medium=0.7, low=0.4.
@@ -23,15 +23,15 @@ are explicitly enabled in a runtime lane.
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 3066 | 132 | 2565.0 | 21 | 11 | 100% |
-| macos | 29 | 3124 | 112 | 2577.4 | 22 | 11 | 100% |
-| linux | 25 | 2740 | 105 | 2268.3 | 20 | 11 | 100% |
+| windows | 29 | 3068 | 132 | 2566.4 | 21 | 11 | 100% |
+| macos | 29 | 3126 | 112 | 2578.8 | 22 | 11 | 100% |
+| linux | 25 | 2742 | 105 | 2269.6 | 20 | 11 | 100% |
 
 ## Crate Summary
 
 | Crate | Suites | Integration files | Source unit files | Active tests | Ignored tests | Weighted points | Flows |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| screenpipe-engine | 10 | 19 | 109 | 1549 | 42 | 1185.0 | 10 |
+| screenpipe-engine | 10 | 19 | 109 | 1551 | 42 | 1186.4 | 10 |
 | screenpipe-db | 5 | 52 | 15 | 453 | 16 | 430.2 | 9 |
 | screenpipe-sqlite-coordinator | 1 | 0 | 2 | 17 | 0 | 17.0 | 2 |
 | screenpipe-audio | 6 | 25 | 51 | 591 | 43 | 517.4 | 5 |
@@ -69,19 +69,19 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | db-search | 2 suites / 112 active / 9 ignored / 112.0 pts | 2 suites / 112 active / 9 ignored / 112.0 pts | 2 suites / 112 active / 9 ignored / 112.0 pts |
 | engine-lifecycle | 6 suites / 210 active / 1 ignored / 185.3 pts | 6 suites / 210 active / 1 ignored / 185.3 pts | 5 suites / 204 active / 1 ignored / 183.6 pts |
 | local-api | 2 suites / 375 active / 9 ignored / 264.6 pts | 2 suites / 375 active / 9 ignored / 264.6 pts | 2 suites / 375 active / 9 ignored / 264.6 pts |
-| meeting | 6 suites / 1482 active / 19 ignored / 1207.2 pts | 6 suites / 1482 active / 19 ignored / 1207.2 pts | 4 suites / 1189 active / 15 ignored / 936.7 pts |
+| meeting | 6 suites / 1484 active / 19 ignored / 1208.6 pts | 6 suites / 1484 active / 19 ignored / 1208.6 pts | 4 suites / 1191 active / 15 ignored / 938.1 pts |
 | ocr | 4 suites / 125 active / 7 ignored / 119.0 pts | 4 suites / 129 active / 7 ignored / 124.5 pts | 3 suites / 120 active / 6 ignored / 115.5 pts |
 | os-integration | 1 suites / 6 active / 0 ignored / 1.7 pts | 1 suites / 6 active / 0 ignored / 1.7 pts | - |
 | performance | 13 suites / 1418 active / 67 ignored / 1246.9 pts | 14 suites / 1521 active / 70 ignored / 1288.1 pts | 13 suites / 1418 active / 67 ignored / 1246.9 pts |
-| pipes | 1 suites / 473 active / 3 ignored / 331.1 pts | 1 suites / 473 active / 3 ignored / 331.1 pts | 1 suites / 473 active / 3 ignored / 331.1 pts |
-| privacy | 5 suites / 890 active / 36 ignored / 723.2 pts | 5 suites / 944 active / 16 ignored / 730.1 pts | 5 suites / 868 active / 14 ignored / 702.1 pts |
+| pipes | 1 suites / 475 active / 3 ignored / 332.5 pts | 1 suites / 475 active / 3 ignored / 332.5 pts | 1 suites / 475 active / 3 ignored / 332.5 pts |
+| privacy | 5 suites / 892 active / 36 ignored / 724.6 pts | 5 suites / 946 active / 16 ignored / 731.5 pts | 5 suites / 870 active / 14 ignored / 703.5 pts |
 | real-app | - | 1 suites / 103 active / 3 ignored / 41.2 pts | - |
 | speaker | 2 suites / 348 active / 8 ignored / 348.0 pts | 2 suites / 348 active / 8 ignored / 348.0 pts | 2 suites / 348 active / 8 ignored / 348.0 pts |
 | storage | 3 suites / 509 active / 29 ignored / 410.6 pts | 3 suites / 509 active / 29 ignored / 410.6 pts | 3 suites / 509 active / 29 ignored / 410.6 pts |
-| sync | 1 suites / 473 active / 3 ignored / 331.1 pts | 1 suites / 473 active / 3 ignored / 331.1 pts | 1 suites / 473 active / 3 ignored / 331.1 pts |
+| sync | 1 suites / 475 active / 3 ignored / 332.5 pts | 1 suites / 475 active / 3 ignored / 332.5 pts | 1 suites / 475 active / 3 ignored / 332.5 pts |
 | timeline | 4 suites / 1023 active / 33 ignored / 825.6 pts | 4 suites / 1023 active / 33 ignored / 825.6 pts | 4 suites / 1023 active / 33 ignored / 825.6 pts |
 | transcription | 5 suites / 747 active / 40 ignored / 585.5 pts | 5 suites / 747 active / 40 ignored / 585.5 pts | 5 suites / 747 active / 40 ignored / 585.5 pts |
-| ui-events | 4 suites / 713 active / 28 ignored / 542.6 pts | 3 suites / 664 active / 5 ignored / 508.3 pts | 3 suites / 664 active / 5 ignored / 508.3 pts |
+| ui-events | 4 suites / 715 active / 28 ignored / 544.0 pts | 3 suites / 666 active / 5 ignored / 509.7 pts | 3 suites / 666 active / 5 ignored / 509.7 pts |
 | vision-capture | 5 suites / 533 active / 32 ignored / 420.1 pts | 5 suites / 537 active / 32 ignored / 425.6 pts | 4 suites / 528 active / 31 ignored / 416.6 pts |
 
 ## Critical Flow Matrix
@@ -139,7 +139,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | engine-db-recovery-cli | screenpipe-engine | windows, macos, linux | database, engine-lifecycle | engine-health-lifecycle, performance-liveness | high | strong | unit | 1 | 8 | 0 | Exact DB/WAL/SHM working-copy preservation, rollback on archive failure, and restart repair for crashes during the multi-file generation swap. |
 | engine-focus-os | screenpipe-engine | windows, macos | engine-lifecycle, os-integration | engine-health-lifecycle, performance-liveness | medium | conditional | unit | 3 | 6 | 0 | Platform focus-tracker parsing/helpers. These files are cfg-gated and only execute on their target OS. |
 | engine-local-api-search-integration | screenpipe-engine | windows, macos, linux | local-api, db-search | local-api-search | high | strong | integration | 1 | 7 | 5 | Active /search route test builds an audio-disabled router, seeds captured-screen-shaped OCR data into an in-memory DB, and asserts the HTTP response and pagination. |
-| engine-meeting-privacy-sync | screenpipe-engine | windows, macos, linux | meeting, privacy, ui-events, pipes, sync | meeting-live-notes, privacy-and-redaction, accessibility-ui-events, performance-liveness | medium | strong | unit | 31 | 473 | 3 | Unit-heavy coverage for privacy filter policy, capture exclusions, UI recorder safety, pipes/live-view/structured-output helpers, sync helpers, and CLI parsing. Meeting detection moved to the engine-meeting-watcher suite. |
+| engine-meeting-privacy-sync | screenpipe-engine | windows, macos, linux | meeting, privacy, ui-events, pipes, sync | meeting-live-notes, privacy-and-redaction, accessibility-ui-events, performance-liveness | medium | strong | unit | 31 | 475 | 3 | Unit-heavy coverage for privacy filter policy, capture exclusions, UI recorder safety, pipes/live-view/structured-output helpers, sync helpers, and CLI parsing. Meeting detection moved to the engine-meeting-watcher suite. |
 | engine-meeting-watcher | screenpipe-engine | windows, macos | meeting | meeting-live-notes | high | strong | mixed | 9 | 218 | 3 | Successor of src/meeting_detector.rs and src/meeting_telemetry.rs. Audio-process and UI-scan backend state machines, candidate resolution, shared telemetry, and a scored trajectory eval. ui_scan/macos.rs and ui_scan/windows.rs are cfg-gated and only execute on their target OS; both backends are null on Linux. |
 | engine-retention-storage | screenpipe-engine | windows, macos, linux | storage, engine-lifecycle, performance | engine-health-lifecycle, performance-liveness | medium | strong | mixed | 5 | 38 | 0 | Local retention deletion (including lean-mode heavy-text stripping), cloud archive watermarking, atomic state-file replacement, and the low-disk capture monitor. |
 | engine-telemetry-observability | screenpipe-engine | windows, macos, linux | engine-lifecycle, performance | engine-health-lifecycle, performance-liveness | medium | strong | unit | 6 | 30 | 0 | PostHog capture gating, telemetry context shaping, piggyback telemetry forwarding, crash-log helpers, resource monitoring, and the recording-coverage reliability metric. |
@@ -357,7 +357,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | engine-meeting-privacy-sync | screenpipe-engine | src/connections_api.rs | source | 87 | 0 | 87 |
 | engine-telemetry-observability | screenpipe-engine | src/crash_log.rs | source | 4 | 0 | 4 |
 | engine-retention-storage | screenpipe-engine | src/disk_pressure.rs | source | 11 | 0 | 11 |
-| engine-meeting-privacy-sync | screenpipe-engine | src/drm_detector.rs | source | 19 | 2 | 21 |
+| engine-meeting-privacy-sync | screenpipe-engine | src/drm_detector.rs | source | 21 | 2 | 23 |
 | engine-capture-timeline | screenpipe-engine | src/event_driven_capture.rs | source | 86 | 0 | 86 |
 | engine-meeting-privacy-sync | screenpipe-engine | src/external_memory_sync.rs | source | 12 | 0 | 12 |
 | engine-capture-timeline | screenpipe-engine | src/focus_aware_controller.rs | source | 14 | 0 | 14 |


### PR DESCRIPTION
## description

Closes a ~60s lag in the monitor watcher loop where teardown (VisionManager stop + SCK audio stop) was waiting for monitor hotplug / 60s backstop ticks.

Recording demo:

Immediate DRM pause and resume transitions (<500ms) when switching focus to and from a DRM streaming tab:

https://github.com/user-attachments/assets/3c9130c6-799b-4a58-a1ed-3822fe27321b

## AI assistance and human ownership

read the [AI-assisted contribution policy](https://github.com/screenpipe/screenpipe/blob/main/CONTRIBUTING.md#ai-assisted-contributions).

- AI tool(s) used (`none` if not used): Claude Opus 5 and Gemini 3.7 Flash
- autonomy level (`none`, `autocomplete`, `chat`, or `agent`): agent
- what I personally verified:

- [X] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [X] The problem statement, rationale, and replies to maintainers are my own.

## evidence type

check every category that applies and provide its required evidence below.

- [X] UI or behavior change — before/after recording

See above for the after recording.

- [X] Backend change — regression tests and relevant logs/results

After:

2026-08-15T18:35:34.916487Z  INFO screenpipe_engine::drm_detector: DRM content detected — pausing screen capture
...
2026-08-15T18:35:34.975127Z  INFO screenpipe_engine::vision_manager::manager: Stopping VisionManager

Before:

2026-08-15T19:22:04.516453Z  INFO screenpipe_engine::drm_detector: DRM content detected — pausing screen capture
 … 
 2026-08-15T19:22:53.809749Z  INFO screenpipe_engine::vision_manager::manager: Stopping VisionManager 

(Note that the delay was not fixed at 60s every time before. It was up to 60s but could be very short depending on circumstances.)

- [ ] Performance change — reproducible before/after benchmarks
- [ ] Docs, CI, or pure refactor — relevant checks and an explanation; no video required

## before

It's annoying to record a demo where you have to wait for one minute doing nothing in it. But if you insist I can do it. Seeing logs is more interesting.

## after

See the video recording above for what happens with the changes.

## how to test

1. Launch screenpipe like this on a terminal: `cargo run --bin screenpipe -- record --pause-on-drm-content --debug >sp.log` 

2.  Wait for the end of the build and for the app to start.

3. Switch to a window with DRM content in it, and wait for about 1 minutes for the timeout to trigger.

4. Switch back to the terminal and use Control-C to kill screenpipe.

5. Run `grep 'pausing screen capture' sp.log` and then `grep 'Stopping VisionManager' sp.log` in the terminal.

6. Look at the difference between the timestamps.

## desktop app checklist (if applicable)

Not applicable.