### PR TITLE
chore(coverage): regenerate the unified report

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -18,14 +18,14 @@ results and `cargo llvm-cov` data on top when judging release confidence.
 
 ### Tauri E2E
 
-- Mapped specs: 116
-- Declared test blocks: 333
-- Weighted coverage points: 260.8
+- Mapped specs: 117
+- Declared test blocks: 334
+- Weighted coverage points: 261.3
 
 | Platform | Specs | Declared tests | Weighted points | Layers | Features | Critical score |
 | --- | --- | --- | --- | --- | --- | --- |
 | windows | 89 | 288 | 235.3 | 15 | 93 | 92% |
-| macos | 112 | 296 | 231.6 | 17 | 97 | 90% |
+| macos | 113 | 297 | 232.1 | 17 | 99 | 90% |
 | linux | 79 | 248 | 206.0 | 14 | 89 | 88% |
 
 ### Core Engine


### PR DESCRIPTION
## Problem

`Code Quality & Optimization` is red on main at `a8c2f28`. The failing job is `Coverage dashboards current` → [run 31904507623](https://github.com/screenpipe/screenpipe/actions/runs/31904507623/job/95060150253):

```
Coverage report is up to date: e2e/COVERAGE.md
Core coverage report is up to date: ../../docs/coverage/CORE.md
error: Unified coverage report is stale. Run: bun ../../docs/coverage/scripts/generate-unified-coverage-report.ts
```

Two of the three dashboards were already current. Only the aggregate was behind — #6284 added a spec and did not regenerate it.

## Fix

Ran the generator the error message names. Generated output, no hand edits:

| | before | after |
|---|---|---|
| mapped specs | 116 | 117 |
| declared test blocks | 333 | 334 |
| weighted points | 260.8 | 261.3 |
| macos specs / tests / points | 112 / 296 / 231.6 | 113 / 297 / 232.1 |

## Validation

`bun run coverage:all:check` — all three reports current:

```
Coverage report is up to date: e2e/COVERAGE.md
Core coverage report is up to date: ../../docs/coverage/CORE.md
Unified coverage report is up to date: ../../COVERAGE.md
```

Branched from `a8c2f28` so the regeneration reflects main exactly, not my in-flight E2E branch. Independent of #6289 and safe to merge on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)