### PR TITLE
fix(meetings): move the replay strip and related items to the summary tab

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -18,14 +18,14 @@ results and `cargo llvm-cov` data on top when judging release confidence.
 
 ### Tauri E2E
 
-- Mapped specs: 116
-- Declared test blocks: 333
-- Weighted coverage points: 260.8
+- Mapped specs: 117
+- Declared test blocks: 334
+- Weighted coverage points: 261.3
 
 | Platform | Specs | Declared tests | Weighted points | Layers | Features | Critical score |
 | --- | --- | --- | --- | --- | --- | --- |
 | windows | 89 | 288 | 235.3 | 15 | 93 | 92% |
-| macos | 112 | 296 | 231.6 | 17 | 97 | 90% |
+| macos | 113 | 297 | 232.1 | 17 | 99 | 90% |
 | linux | 79 | 248 | 206.0 | 14 | 89 | 88% |
 
 ### Core Engine

--- a/apps/screenpipe-app-tauri/components/meeting-notes/meeting-workspace.test.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/meeting-workspace.test.tsx
@@ -210,6 +210,51 @@ describe("meeting summary surface", () => {
     expect(onGenerate).toHaveBeenCalledOnce();
   });
 
+  // The replay scrubber and the "related during this meeting" list used to
+  // render under the note editor, below a draft of unbounded length. They are
+  // evidence for the summary, so they now hang off the summary tab — after the
+  // summary text, inside the same centered shell, and selectable.
+  it("renders meeting evidence after the summary, not before it", () => {
+    render(
+      <MeetingSummarySurface
+        note={"## Summary\nThe team agreed to ship."}
+        state="ready"
+        detail="saved locally"
+        onGenerate={vi.fn()}
+        canGenerate
+        activity={<div data-testid="evidence">replay the moment</div>}
+      />,
+    );
+
+    const activity = screen.getByTestId("meeting-summary-activity");
+    expect(screen.getByTestId("evidence")).toBeVisible();
+    expect(activity).toHaveClass("select-text");
+    expect(activity.closest(".max-w-3xl")).not.toBeNull();
+
+    // Order matters: the summary is the answer, the evidence supports it.
+    const column = screen.getByTestId("meeting-summary-reading-column");
+    expect(
+      column.compareDocumentPosition(activity) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("leaves no evidence container behind when a meeting has none", () => {
+    render(
+      <MeetingSummarySurface
+        note={"## Summary\nThe team agreed to ship."}
+        state="ready"
+        detail="saved locally"
+        onGenerate={vi.fn()}
+        canGenerate
+      />,
+    );
+
+    expect(
+      screen.queryByTestId("meeting-summary-activity"),
+    ).not.toBeInTheDocument();
+  });
+
   it("offers a truthful empty state before a summary exists", () => {
     render(
       <MeetingSummarySurface

--- a/apps/screenpipe-app-tauri/components/meeting-notes/meeting-workspace.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/meeting-workspace.tsx
@@ -162,6 +162,7 @@ export function MeetingSummarySurface({
   streamedSummary,
   onGenerate,
   canGenerate,
+  activity,
 }: {
   note: string;
   state: "idle" | "working" | "ready" | "attention";
@@ -169,6 +170,11 @@ export function MeetingSummarySurface({
   streamedSummary?: string;
   onGenerate: () => void;
   canGenerate: boolean;
+  // Replay scrubber and the "related during this meeting" list. They are
+  // evidence for the summary — what was on screen and open while it was
+  // written — so they belong under it. Under the note editor they sat below a
+  // draft of unbounded length, which is a place nobody scrolls to.
+  activity?: React.ReactNode;
 }) {
   const savedSummary = extractMeetingSummary(note);
   const isStreaming = state === "working" && Boolean(streamedSummary?.trim());
@@ -274,6 +280,15 @@ export function MeetingSummarySurface({
             </div>
           )}
         </div>
+
+        {activity && (
+          <div
+            data-testid="meeting-summary-activity"
+            className="mt-10 select-text space-y-6"
+          >
+            {activity}
+          </div>
+        )}
       </div>
     </section>
   );

--- a/apps/screenpipe-app-tauri/components/meeting-notes/note-view.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/note-view.tsx
@@ -1831,27 +1831,6 @@ export function NoteView({
               transcriptOpen={transcriptOpen}
               onTranscriptToggle={() => setTranscriptOpen((open) => !open)}
             />
-
-            {/* `activity` is cast from an HTTP body, not validated, so a
-                payload missing `audio_summary` used to throw here and take the
-                whole note — text, transcript, controls — to the global error
-                boundary over a supporting strip. Degrade instead. */}
-            {meetingCtx?.activity && (
-              <div className="mt-10 select-text space-y-6">
-                {Array.isArray(
-                  meetingCtx.activity.audio_summary?.top_transcriptions,
-                ) && (
-                  <ReplayStrip
-                    meetingId={meeting.id}
-                    segments={
-                      meetingCtx.activity.audio_summary.top_transcriptions
-                    }
-                    timeRange={meetingCtx.activity.time_range}
-                  />
-                )}
-                <Receipts activity={meetingCtx.activity} />
-              </div>
-            )}
           </div>
         </section>
 
@@ -1883,6 +1862,32 @@ export function NoteView({
             onGenerate={handleSummaryAction}
             canGenerate={
               canSummarizeMeeting && !summaryWorking && !retranscribing
+            }
+            // Mounted with the tab rather than always: the strip pulls the
+            // meeting's transcript rows and frame samples, and opening a
+            // meeting to read notes or the transcript should not pay for
+            // evidence nobody asked to see.
+            activity={
+              // `activity` is cast from an HTTP body, not validated, so a
+              // payload missing `audio_summary` used to throw here and take
+              // the whole surface to the global error boundary over a
+              // supporting strip. Degrade instead.
+              meetingCtx?.activity ? (
+                <>
+                  {Array.isArray(
+                    meetingCtx.activity.audio_summary?.top_transcriptions,
+                  ) && (
+                    <ReplayStrip
+                      meetingId={meeting.id}
+                      segments={
+                        meetingCtx.activity.audio_summary.top_transcriptions
+                      }
+                      timeRange={meetingCtx.activity.time_range}
+                    />
+                  )}
+                  <Receipts activity={meetingCtx.activity} />
+                </>
+              ) : null
             }
           />
         )}

--- a/apps/screenpipe-app-tauri/lib/dev/browser-engine-mock.ts
+++ b/apps/screenpipe-app-tauri/lib/dev/browser-engine-mock.ts
@@ -106,7 +106,10 @@ export function mockLocalApiResponse(
   // Receipts reads `windows` straight off this body without validating it, so
   // the harness has to return the real shape rather than an empty object.
   if (url.pathname === "/activity-summary") {
-    return Response.json({ windows: [], total_active_seconds: 0 });
+    if (scenario === "empty") {
+      return Response.json({ windows: [], total_active_seconds: 0 });
+    }
+    return Response.json(mockActivitySummary());
   }
   if (url.pathname === "/meetings/status") {
     return Response.json({ active: false, manualActive: false });
@@ -126,6 +129,19 @@ export function mockLocalApiResponse(
   }
   if (url.pathname === "/search") {
     const appName = url.searchParams.get("app_name");
+    // The meeting scrubber pages this endpoint for the meeting's transcript;
+    // page two onward must come back empty or it loops to its cap.
+    if (
+      scenario !== "empty" &&
+      url.searchParams.get("content_type") === "audio"
+    ) {
+      const offset = Number(url.searchParams.get("offset")) || 0;
+      const data = offset > 0 ? [] : mockMeetingAudioRows();
+      return Response.json({
+        data,
+        pagination: { limit: data.length, offset, total: data.length },
+      });
+    }
     if (scenario !== "empty" && appName) {
       const limit = Number(url.searchParams.get("limit")) || 36;
       const offset = Number(url.searchParams.get("offset")) || 0;
@@ -143,11 +159,95 @@ export function mockLocalApiResponse(
   return Response.json(scenario === "empty" ? emptyPage : { data: [] });
 }
 
+// One window shared by the meeting row, its activity summary and its audio
+// rows, so the scrubber's bounds, tick marks and caption all agree.
+function mockMeetingWindow() {
+  const start = new Date(Date.now() - 75 * 60 * 1000);
+  const end = new Date(start.getTime() + 21 * 60 * 1000);
+  return { start, end };
+}
+
+/** Synthetic transcript turns spread across the meeting window. Timestamps
+ *  are derived, not stored, so the fixture stays inside the window no matter
+ *  when the harness is opened. */
+const MOCK_MEETING_TURNS: ReadonlyArray<{
+  at: number;
+  device: "input" | "output";
+  speaker: string;
+  text: string;
+}> = [
+  { at: 0.04, device: "output", speaker: "sample person", text: "Let's start with where the rollout actually stands." },
+  { at: 0.18, device: "input", speaker: "me", text: "Capture is stable on the two machines we watched all week." },
+  { at: 0.33, device: "output", speaker: "another person", text: "What happens when someone reopens the meeting a day later?" },
+  { at: 0.47, device: "input", speaker: "me", text: "They get the saved summary, and the transcript stays intact underneath it." },
+  { at: 0.61, device: "output", speaker: "sample person", text: "Good. Put the evidence next to the summary so nobody has to trust it blind." },
+  { at: 0.76, device: "input", speaker: "me", text: "Agreed — the replay strip and the open tabs belong on that tab." },
+  { at: 0.91, device: "output", speaker: "another person", text: "Then we can send the summary out without a second pass." },
+];
+
+function mockMeetingAudioRows() {
+  const { start, end } = mockMeetingWindow();
+  const span = end.getTime() - start.getTime();
+  return MOCK_MEETING_TURNS.map((turn, index) => ({
+    type: "Audio",
+    content: {
+      chunk_id: 5_000 + index,
+      transcription: turn.text,
+      timestamp: new Date(start.getTime() + span * turn.at).toISOString(),
+      file_path: `/sample/audio/chunk-${5_000 + index}.mp4`,
+      device_type: turn.device,
+      speaker:
+        turn.device === "input"
+          ? null
+          : { id: 700 + index, name: turn.speaker },
+    },
+  }));
+}
+
+/** Full-shape activity summary for the sample meeting: the scrubber needs
+ *  `audio_summary` + `time_range`, and the related list needs `windows` and
+ *  `edited_files`. Returning the trimmed `{ windows: [] }` body meant neither
+ *  could be seen — or reviewed — in the harness. */
+function mockActivitySummary() {
+  const { start, end } = mockMeetingWindow();
+  const span = end.getTime() - start.getTime();
+  return {
+    apps: [
+      { name: "Google Chrome", frame_count: 412, minutes: 12, first_seen: start.toISOString(), last_seen: end.toISOString() },
+      { name: "Cursor", frame_count: 188, minutes: 6, first_seen: start.toISOString(), last_seen: end.toISOString() },
+    ],
+    windows: [
+      { app_name: "Google Chrome", window_name: "Rollout plan — sample doc", browser_url: "https://example.com/docs/rollout-plan", minutes: 8, frame_count: 240 },
+      { app_name: "Google Chrome", window_name: "Sample tracker — board", browser_url: "https://example.com/board/sample", minutes: 4, frame_count: 120 },
+      { app_name: "Cursor", window_name: "meeting-workspace.tsx", browser_url: "", minutes: 6, frame_count: 188 },
+      { app_name: "Slack", window_name: "#sample-channel", browser_url: "", minutes: 2, frame_count: 44 },
+    ],
+    edited_files: [
+      { path: "/sample/project/components/meeting-notes/note-view.tsx", frame_count: 96 },
+      { path: "/sample/notes/rollout-plan.md", frame_count: 31 },
+    ],
+    audio_summary: {
+      segment_count: MOCK_MEETING_TURNS.length,
+      speakers: [
+        { name: "sample person", segment_count: 3 },
+        { name: "another person", segment_count: 2 },
+      ],
+      top_transcriptions: MOCK_MEETING_TURNS.map((turn) => ({
+        transcription: turn.text,
+        speaker: turn.speaker,
+        device: turn.device,
+        timestamp: new Date(start.getTime() + span * turn.at).toISOString(),
+      })),
+    },
+    total_frames: 600,
+    time_range: { start: start.toISOString(), end: end.toISOString() },
+  };
+}
+
 // Invented content only. This exists so the meeting note surface renders in
 // the browser harness; it must never be mistaken for captured data.
 function mockMeeting() {
-  const start = new Date(Date.now() - 75 * 60 * 1000);
-  const end = new Date(start.getTime() + 21 * 60 * 1000);
+  const { start, end } = mockMeetingWindow();
   return {
     id: 1,
     meeting_start: start.toISOString(),


### PR DESCRIPTION
## Problem

The replay scrubber ("replay the moment") and the "related during this meeting"
list rendered inside the **notes** tab, under the note editor. The editor holds
a draft of unbounded length and carries a `min-h-[45vh]` floor, so on a short
note both sections sat roughly 700px below the last line of text — past the
fold, under blank space, in the one tab whose job is writing.

They are evidence *for the summary*: what was on screen, which tabs were open,
which files were touched while it was written. That is the tab people open when
they want to trust the summary or send it on.

## Where found

Reported from the meeting view on the installed app. Reproduced in the browser
harness against the sample meeting.

## Fix

- `MeetingSummarySurface` gains an `activity` slot, rendered after the summary
  reading column, inside the same centered shell, selectable.
- `note-view` passes the strip + receipts into that slot instead of the notes
  panel. The existing "degrade instead of throwing" guard around the unvalidated
  `audio_summary` body moves with it.
- Mounting now follows the tab. The strip pulls the meeting's transcript rows
  and up to 500 frame samples on mount; previously every meeting open paid for
  that whether or not anyone looked. Repeat visits to the summary tab re-fetch —
  the trade is deliberate, and the strip already has loading states.

## Harness

`/activity-summary` in the browser dev mock returned a trimmed
`{ windows: [] }`, so neither surface rendered in `bun run dev:web` and this
change could not be seen without a real database. It now serves a full-shape
synthetic activity summary (windows, edited files, audio summary, time range)
plus the matching `content_type=audio` rows. Invented content only — the
transcript turns are about this very change.

## Before / after

**notes tab** — the strip used to live down here, after the empty draft area:

| before | after |
| --- | --- |
| <img src="https://raw.githubusercontent.com/screenpipe/screenpipe/e55fab1d5df616abe18ff94c288139a2397efeea/shots/before-notes.png" width="420"> | <img src="https://raw.githubusercontent.com/screenpipe/screenpipe/e55fab1d5df616abe18ff94c288139a2397efeea/shots/after-notes.png" width="420"> |

**summary tab** — summary first, then the evidence that backs it:

| before | after |
| --- | --- |
| <img src="https://raw.githubusercontent.com/screenpipe/screenpipe/e55fab1d5df616abe18ff94c288139a2397efeea/shots/before-summary.png" width="420"> | <img src="https://raw.githubusercontent.com/screenpipe/screenpipe/e55fab1d5df616abe18ff94c288139a2397efeea/shots/after-summary.png" width="420"> |

Screenshots are the browser harness with synthetic data, so no capture history
appears in them. Frame thumbnails are empty because `<img>` requests bypass the
mock's `fetch` patch; that is the harness, not the change.

## Validation

- `tsc --noEmit` clean
- 133 tests pass across `components/meeting-notes` + `lib/dev`, including three
  new ones: the slot renders after the reading column and inside the shell, and
  no empty evidence container is left behind when a meeting has none
- `bun run lint:effects`: 0 errors (412 pre-existing warnings, unchanged)
- `bun run e2e:coverage:check`: up to date
- Live in `bun run dev:web`: notes panel contains neither section, summary panel
  contains both, verified by querying the mounted panels

Not verified: a packaged desktop build. This is source only.

## Second commit: inherited coverage staleness

`coverage:all:check` failed on first CI, and not because of this change. `a8c2f282c`
(on main, before this branch) added a macOS e2e spec without regenerating the unified
dashboard, so the gate fails on every branch cut after it. Second commit regenerates it
— counts only, no spec changes: mapped specs 116 → 117, declared blocks 333 → 334,
macOS features 97 → 99. Same repair as `6d1aa954b`.

The first Linux Wayland E2E run was cancelled inside `Install Wayland test dependencies`
after 30 minutes, before any test executed — runner/apt, not this diff. The new push
reruns it.
