### PR TITLE
perf: CPU and memory optimization pass (tracking)

### DIFF
--- a/crates/screenpipe-a11y/src/platform/macos.rs
+++ b/crates/screenpipe-a11y/src/platform/macos.rs
@@ -54,6 +54,13 @@ fn record_input_monitoring_truth(granted: bool) {
 }
 
 // Keycodes for clipboard operations (macOS)
+/// How long one AX run-loop slice waits when the mode is idle but healthy.
+const AX_RUN_LOOP_SLICE_SECS: f64 = 0.1;
+/// Yield for a full slice when `run_in_mode` returned without waiting at all.
+/// Matching the slice keeps a sourceless observer thread at roughly the same
+/// wake rate as a healthy idle one instead of at 100% of a core.
+const AX_RUN_LOOP_IDLE_BACKOFF: Duration = Duration::from_millis(100);
+
 const KEY_C: u16 = 8;
 const KEY_X: u16 = 7;
 const KEY_V: u16 = 9;
@@ -1613,7 +1620,30 @@ fn run_app_observer(
     };
 
     while !stop.load(Ordering::Acquire) {
-        cf::RunLoop::run_in_mode(run_loop_mode, 0.1, true);
+        let result = cf::RunLoop::run_in_mode(run_loop_mode, AX_RUN_LOOP_SLICE_SECS, true);
+
+        // `Finished` means this mode has no sources or timers left — the
+        // observed app exited, the observer was invalidated, or every
+        // `add_notification` above failed — and `Stopped` means someone called
+        // CFRunLoopStop. Both return *immediately* instead of waiting out the
+        // interval, so looping straight back into `run_in_mode` turns this
+        // thread into a spin at 100% of one core. Nothing re-adds a source
+        // unless `refresh_requested` fires, so it never recovers on its own.
+        //
+        // This is the shape behind the macOS pinned-core cohort: p98 CPU sits
+        // at ~112% (one saturated core) in every uptime bucket, and the pinned
+        // share climbs with uptime because a latched process never comes back
+        // — 99 users at a 55.8h median while their median peer sits near 8%.
+        //
+        // `HandledSource` must keep looping immediately; returning promptly
+        // after one source is the entire point of `return_after_source_handled`
+        // and is what keeps focus tracking responsive.
+        if matches!(
+            result,
+            cf::RunLoopRunResult::Finished | cf::RunLoopRunResult::Stopped
+        ) {
+            std::thread::sleep(AX_RUN_LOOP_IDLE_BACKOFF);
+        }
 
         if refresh_requested.swap(false, Ordering::SeqCst) {
             reattach_observer();

--- a/crates/screenpipe-a11y/src/platform/macos.rs
+++ b/crates/screenpipe-a11y/src/platform/macos.rs
@@ -54,6 +54,19 @@ fn record_input_monitoring_truth(granted: bool) {
 }
 
 // Keycodes for clipboard operations (macOS)
+/// Did `run_in_mode` come back without having waited at all?
+///
+/// `Finished` (no sources or timers left in this mode) and `Stopped`
+/// (`CFRunLoopStop`) both return immediately, so a caller that loops straight
+/// back in spins a core. `TimedOut` already waited out the slice, and
+/// `HandledSource` is the healthy busy path that must stay hot.
+fn ax_run_loop_returned_without_waiting(result: cf::RunLoopRunResult) -> bool {
+    matches!(
+        result,
+        cf::RunLoopRunResult::Finished | cf::RunLoopRunResult::Stopped
+    )
+}
+
 /// How long one AX run-loop slice waits when the mode is idle but healthy.
 const AX_RUN_LOOP_SLICE_SECS: f64 = 0.1;
 /// Yield for a full slice when `run_in_mode` returned without waiting at all.
@@ -1638,10 +1651,7 @@ fn run_app_observer(
         // `HandledSource` must keep looping immediately; returning promptly
         // after one source is the entire point of `return_after_source_handled`
         // and is what keeps focus tracking responsive.
-        if matches!(
-            result,
-            cf::RunLoopRunResult::Finished | cf::RunLoopRunResult::Stopped
-        ) {
+        if ax_run_loop_returned_without_waiting(result) {
             std::thread::sleep(AX_RUN_LOOP_IDLE_BACKOFF);
         }
 
@@ -2784,6 +2794,49 @@ extern "C" fn activity_only_callback(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The AX observer thread loops on `run_in_mode`. Two of the four results
+    /// come back instantly: `Finished` when the mode has no sources or timers
+    /// left, and `Stopped` after `CFRunLoopStop`. Looping straight back in on
+    /// either pins the thread at 100% of one core, and nothing re-adds a source
+    /// unless a refresh is requested, so it never recovers — the shape behind
+    /// ~99 macOS users sitting at one saturated core with a 55.8h median
+    /// uptime while their median peer used ~8%.
+    #[test]
+    fn instant_run_loop_returns_back_off_and_waiting_ones_do_not() {
+        assert!(
+            ax_run_loop_returned_without_waiting(cf::RunLoopRunResult::Finished),
+            "no sources left returns immediately — looping on it is the spin"
+        );
+        assert!(
+            ax_run_loop_returned_without_waiting(cf::RunLoopRunResult::Stopped),
+            "CFRunLoopStop returns immediately too"
+        );
+
+        // These two must never back off. `TimedOut` already waited out the
+        // slice, and delaying `HandledSource` would add latency to every focus
+        // change — returning promptly after one source is the entire point of
+        // `return_after_source_handled`.
+        assert!(
+            !ax_run_loop_returned_without_waiting(cf::RunLoopRunResult::TimedOut),
+            "TimedOut already waited the full slice"
+        );
+        assert!(
+            !ax_run_loop_returned_without_waiting(cf::RunLoopRunResult::HandledSource),
+            "HandledSource is the healthy busy path and must stay hot"
+        );
+    }
+
+    /// A sourceless observer thread should wake at roughly the same rate as a
+    /// healthy idle one, not faster.
+    #[test]
+    fn idle_backoff_matches_one_healthy_slice() {
+        assert_eq!(
+            AX_RUN_LOOP_IDLE_BACKOFF.as_secs_f64(),
+            AX_RUN_LOOP_SLICE_SECS,
+            "backoff drifting from the slice changes the sourceless wake rate"
+        );
+    }
 
     #[test]
     fn test_permission_check() {

--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -1859,7 +1859,7 @@ impl PiExecutor {
         // BufReader::lines() which crashes on invalid UTF-8 bytes.
         // See: toggl-sync crash "stream did not contain valid UTF-8".
         let mut reader = tokio::io::BufReader::new(child_stdout);
-        let mut stdout_buf = String::new();
+        let mut stdout_buf = BoundedOutput::default();
         let mut llm_error: Option<String> = None;
         let mut line_bytes = Vec::new();
 
@@ -1905,8 +1905,7 @@ impl PiExecutor {
                 }
             }
 
-            stdout_buf.push_str(&line);
-            stdout_buf.push('\n');
+            stdout_buf.push_line(&line);
         }
 
         let status = child.wait().await?;
@@ -1938,7 +1937,7 @@ impl PiExecutor {
         };
 
         Ok(AgentOutput {
-            stdout: stdout_buf,
+            stdout: stdout_buf.into_string(),
             stderr,
             success,
             pid,
@@ -2826,6 +2825,67 @@ pub fn describe_exit_status_code(code: i32) -> String {
         }
     }
     format!("exit code {code}")
+}
+
+/// Head bytes kept verbatim by [`BoundedOutput`] — enough for the run's setup.
+const BOUNDED_OUTPUT_HEAD: usize = 64 * 1024;
+/// Trailing bytes kept by [`BoundedOutput`] — where the result or error lands.
+const BOUNDED_OUTPUT_TAIL: usize = 192 * 1024;
+
+/// A run's captured stdout, bounded in memory while keeping both ends.
+///
+/// The agent's stdout was accumulated into an unbounded `String` for the whole
+/// run, so a long agent turn with large tool results held all of it resident.
+/// Nothing parses this buffer — the JSON events are decoded per line as they
+/// arrive and this is only the stored record — so eliding the middle costs no
+/// behavior.
+///
+/// Both ends are kept deliberately: the head carries the run's setup and the
+/// tail carries the result or the error, which are the two things anyone
+/// reading a failed run actually needs.
+#[derive(Default)]
+pub struct BoundedOutput {
+    head: String,
+    tail: String,
+    dropped: usize,
+}
+
+impl BoundedOutput {
+    pub fn push_line(&mut self, line: &str) {
+        // `self.tail.is_empty()` closes the head for good once anything has
+        // spilled. Without it a short line still fits the head's leftover
+        // capacity after longer lines have already gone to the tail, and the
+        // record silently reorders itself.
+        if self.tail.is_empty() && self.head.len() + line.len() + 1 <= BOUNDED_OUTPUT_HEAD {
+            self.head.push_str(line);
+            self.head.push('\n');
+            return;
+        }
+        self.tail.push_str(line);
+        self.tail.push('\n');
+        // Trim whole lines off the front so the tail stays a run of complete
+        // lines rather than resuming mid-token.
+        while self.tail.len() > BOUNDED_OUTPUT_TAIL {
+            let Some(cut) = self.tail.find('\n').map(|i| i + 1) else {
+                break;
+            };
+            self.dropped += cut;
+            self.tail.drain(..cut);
+        }
+    }
+
+    pub fn into_string(self) -> String {
+        if self.tail.is_empty() {
+            return self.head;
+        }
+        if self.dropped == 0 {
+            return self.head + &self.tail;
+        }
+        format!(
+            "{}\n...[{} bytes elided to bound memory]...\n{}",
+            self.head, self.dropped, self.tail
+        )
+    }
 }
 
 /// Last `max` bytes of a captured process stream, lossy-decoded and
@@ -5313,6 +5373,65 @@ mod tests {
             "stdout diagnostics must survive: {}",
             msg
         );
+    }
+
+    /// A normal run must round-trip byte-for-byte — this replaced an unbounded
+    /// `String`, so anything short has to look exactly as it did before.
+    #[test]
+    fn short_output_is_unchanged() {
+        let mut out = BoundedOutput::default();
+        out.push_line("{\"type\":\"start\"}");
+        out.push_line("{\"type\":\"agent_end\"}");
+        assert_eq!(
+            out.into_string(),
+            "{\"type\":\"start\"}\n{\"type\":\"agent_end\"}\n"
+        );
+    }
+
+    /// A long agent turn is bounded, and both ends survive: the head carries
+    /// the setup, the tail carries the result or error. Losing the tail would
+    /// be worse than the memory it saves — that is where failures land.
+    #[test]
+    fn long_output_is_bounded_and_keeps_both_ends() {
+        let mut out = BoundedOutput::default();
+        out.push_line("FIRST_LINE_MARKER");
+        for i in 0..40_000 {
+            out.push_line(&format!("{{\"tool_result\":{},\"padding\":\"{}\"}}", i, "x".repeat(64)));
+        }
+        out.push_line("LAST_LINE_MARKER");
+
+        let s = out.into_string();
+        assert!(
+            s.starts_with("FIRST_LINE_MARKER\n"),
+            "head must survive so the run's setup is still readable"
+        );
+        assert!(
+            s.trim_end().ends_with("LAST_LINE_MARKER"),
+            "tail must survive — the result and any error land there"
+        );
+        assert!(s.contains("bytes elided"), "elision must be visible, not silent");
+        assert!(
+            s.len() <= BOUNDED_OUTPUT_HEAD + BOUNDED_OUTPUT_TAIL + 128,
+            "bounded output grew to {} bytes",
+            s.len()
+        );
+    }
+
+    /// The tail is trimmed by whole lines, so it never resumes mid-JSON.
+    #[test]
+    fn elided_tail_starts_on_a_line_boundary() {
+        let mut out = BoundedOutput::default();
+        for i in 0..40_000 {
+            out.push_line(&format!("{{\"n\":{},\"pad\":\"{}\"}}", i, "y".repeat(64)));
+        }
+        let s = out.into_string();
+        let tail = s.rsplit("]...\n").next().unwrap();
+        for line in tail.lines().take(5) {
+            assert!(
+                line.starts_with('{') && line.ends_with('}'),
+                "tail line resumed mid-record: {line}"
+            );
+        }
     }
 
     #[test]

--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -5396,7 +5396,11 @@ mod tests {
         let mut out = BoundedOutput::default();
         out.push_line("FIRST_LINE_MARKER");
         for i in 0..40_000 {
-            out.push_line(&format!("{{\"tool_result\":{},\"padding\":\"{}\"}}", i, "x".repeat(64)));
+            out.push_line(&format!(
+                "{{\"tool_result\":{},\"padding\":\"{}\"}}",
+                i,
+                "x".repeat(64)
+            ));
         }
         out.push_line("LAST_LINE_MARKER");
 
@@ -5409,7 +5413,10 @@ mod tests {
             s.trim_end().ends_with("LAST_LINE_MARKER"),
             "tail must survive — the result and any error land there"
         );
-        assert!(s.contains("bytes elided"), "elision must be visible, not silent");
+        assert!(
+            s.contains("bytes elided"),
+            "elision must be visible, not silent"
+        );
         assert!(
             s.len() <= BOUNDED_OUTPUT_HEAD + BOUNDED_OUTPUT_TAIL + 128,
             "bounded output grew to {} bytes",


### PR DESCRIPTION
Rolling optimization PR. Each change is evidence-first: a measured population in telemetry, a mechanism proven in code, and a fix scoped to that mechanism. Ruled-out hypotheses are recorded so nobody re-walks them.

## 1. AX observer thread spins a core when its run loop empties

`CFRunLoopRunInMode` returns **immediately** — not after the interval — when the mode has no sources or timers (`Finished`) or when stopped (`Stopped`). The observer thread discarded that result and looped straight back in, so once the observed app exited, the observer was invalidated, or every `add_notification` failed, it became a tight `while` loop pinned at 100% of one core with no recovery path.

**Telemetry matches the shape exactly.** macOS p98 CPU sits at ~108-116% — one saturated core — in *every* uptime bucket, so the hazard is constant rather than gradual. The pinned share grows with uptime because a latched process never returns:

| uptime | users | cpu p50 | cpu p90 | cpu p98 |
|---|---|---|---|---|
| 0-6h | 1081 | 10.6 | 54.9 | 112.4 |
| 6-24h | 655 | 8.9 | 46.2 | 108.4 |
| 24-48h | 274 | 8.8 | **101.2** | 109.5 |
| 48h+ | 225 | 7.2 | **101.6** | 116.5 |

p90 locks to a tenth of a percent once it crosses. **99 macOS users** sit in that band at a **55.8h median uptime**, against ~8% for their median peer — these are the heaviest users, burning a full core continuously. Windows shows no such ceiling (p98 259-305%, multi-core), which is why this is macOS-only.

**Fix:** sleep one slice when the run loop returned without waiting. `HandledSource` still loops immediately — returning promptly after one source is the entire point of `return_after_source_handled` and is what keeps focus tracking responsive — and `TimedOut` already waited. Only the two returns-instantly cases back off, which is exactly the spin.

## Ruled out, with evidence

- **Gradual accumulation / leak** — median CPU *falls* with uptime (11.2% → 7.1%); long-running processes are typically more efficient.
- **Bounded SCK capture path** — correct: the semaphore permit is moved into the closure so a wedged uncancellable call keeps counting against the cap. A blocked thread also burns 0% CPU.
- **Frame linker actor** — `None => break` on channel close.
- **Monitor watcher** — `start_monitor_watcher` aborts the previous handle before replacing it.
- **A 0.4.40 regression** — the p90 jump I first flagged was a denominator artifact: same ~30-user absolute cohort against a smaller newer population.

## Verification

`cargo check -p screenpipe-a11y` clean. No behavior change on the healthy paths (`TimedOut`, `HandledSource`); the backoff is reachable only when `run_in_mode` returns without waiting.

Draft while I keep measuring — 2.6.29 adoption will show whether the pinned band shrinks.