### PR TITLE
fix(onboarding): stop asking managed deployments where they heard about us

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -18,14 +18,14 @@ results and `cargo llvm-cov` data on top when judging release confidence.
 
 ### Tauri E2E
 
-- Mapped specs: 116
-- Declared test blocks: 333
-- Weighted coverage points: 260.8
+- Mapped specs: 117
+- Declared test blocks: 334
+- Weighted coverage points: 261.3
 
 | Platform | Specs | Declared tests | Weighted points | Layers | Features | Critical score |
 | --- | --- | --- | --- | --- | --- | --- |
 | windows | 89 | 288 | 235.3 | 15 | 93 | 92% |
-| macos | 112 | 296 | 231.6 | 17 | 97 | 90% |
+| macos | 113 | 297 | 232.1 | 17 | 99 | 90% |
 | linux | 79 | 248 | 206.0 | 14 | 89 | 88% |
 
 ### Core Engine

--- a/apps/screenpipe-app-tauri/app/onboarding/page.test.tsx
+++ b/apps/screenpipe-app-tauri/app/onboarding/page.test.tsx
@@ -363,6 +363,35 @@ describe("enterprise onboarding authentication", () => {
     expect(screen.queryByText("plan selection")).not.toBeInTheDocument();
   });
 
+  // Regression: acquisition asks which marketing channel the user arrived from.
+  // A managed deployment has no such channel — an administrator pushed the
+  // install — so asking both lengthens an IT rollout and files those installs
+  // under a channel they never came from. It shipped unfiltered and stayed that
+  // way for over a week, because the only check that objected was a desktop E2E
+  // nobody could read through the other red jobs.
+  it("does not ask managed onboarding where it heard about screenpipe", async () => {
+    mocks.enterprisePolicy.isManagedAuthenticated = true;
+
+    render(<OnboardingPage />);
+
+    await waitFor(() =>
+      expect(mocks.setOnboardingStep).toHaveBeenCalledWith("permissions"),
+    );
+    expect(mocks.setOnboardingStep).not.toHaveBeenCalledWith("acquisition");
+  });
+
+  // A device that saved mid-acquisition on an older build still has to grant
+  // permissions, so it resumes there rather than skipping ahead to the engine.
+  it("resumes a managed install saved on acquisition at permissions", async () => {
+    onboardingData.currentStep = "acquisition";
+
+    render(<OnboardingPage />);
+
+    expect(
+      await screen.findByRole("button", { name: "finish permissions" }),
+    ).toBeInTheDocument();
+  });
+
   it("does not collect payment from an existing cardless trial", async () => {
     mocks.enterprisePolicy.isManagedDeployment = false;
     mocks.settings.user = {
@@ -444,6 +473,10 @@ describe("enterprise onboarding authentication", () => {
     },
   );
 
+  // The point of this one is that a verified credential advances at all. It
+  // asserted "acquisition" for as long as the managed flow asked which
+  // marketing channel the device came from, so the destination was wrong and
+  // the unit test agreed with it. Only the desktop E2E objected.
   it("advances after either enterprise credential is verified", async () => {
     mocks.enterprisePolicy.authenticationState = "authenticated";
     mocks.enterprisePolicy.isManagedAuthenticated = true;
@@ -451,7 +484,7 @@ describe("enterprise onboarding authentication", () => {
     render(<OnboardingPage />);
 
     await waitFor(() =>
-      expect(mocks.setOnboardingStep).toHaveBeenCalledWith("acquisition"),
+      expect(mocks.setOnboardingStep).toHaveBeenCalledWith("permissions"),
     );
   });
 

--- a/apps/screenpipe-app-tauri/app/onboarding/page.tsx
+++ b/apps/screenpipe-app-tauri/app/onboarding/page.tsx
@@ -202,10 +202,16 @@ export default function OnboardingPage() {
     () =>
       SLIDE_ORDER.filter(
         (s) =>
+          // Nobody on a managed deployment "heard about" screenpipe: their
+          // administrator pushed it. Asking anyway adds a step to an IT
+          // rollout and files those installs under a marketing channel they
+          // never came from, so the attribution this step exists to collect is
+          // worse for having been asked.
+          (s !== "acquisition" || !isManagedDeployment) &&
           (s !== "timeline" || timelineChoiceVisible) &&
           (s !== "plan" || shouldShowPlanSelection),
       ),
-    [shouldShowPlanSelection, timelineChoiceVisible],
+    [isManagedDeployment, shouldShowPlanSelection, timelineChoiceVisible],
   );
   // Read by the hydration-gated restore effect below. Assigned during render,
   // per the ref-mirror rule in CLAUDE.md.
@@ -270,10 +276,15 @@ export default function OnboardingPage() {
           // A saved step must not resume onto a slide that this device or its
           // managed policy is no longer eligible to see.
           const mappedSlide =
-            (mapped === "timeline" && !timelineChoiceVisibleRef.current) ||
-            (mapped === "plan" && !shouldShowPlanSelection)
-              ? "engine"
-              : mapped;
+            mapped === "acquisition" && isManagedDeployment
+              ? // A managed install saved mid-acquisition, from a build that
+                // still asked, resumes at the step that follows it rather than
+                // at the engine: permissions still have to be granted.
+                "permissions"
+              : (mapped === "timeline" && !timelineChoiceVisibleRef.current) ||
+                  (mapped === "plan" && !shouldShowPlanSelection)
+                ? "engine"
+                : mapped;
           setCurrentSlide(mappedSlide);
         }
       }


### PR DESCRIPTION
## Problem

The acquisition step asks which marketing channel the user arrived from — search engine, friend or colleague, reddit, hacker news, and so on.

Nobody on a managed deployment arrived from one. Their administrator pushed the install. Asking anyway does two things, both bad:

- it adds a step to an IT rollout, on the screen right after an employee types the org key their admin gave them
- it files those installs under a marketing channel they never came from, so the attribution the step exists to collect is *worse* for having been asked

`SLIDE_ORDER` is `login → acquisition → permissions → …`, and `visibleOrder` filtered only `timeline` and `plan`. `acquisition` was never excluded for managed deployments, and `acquisition-step.tsx` has no enterprise awareness of its own. The orchestrator's own comment a few lines down already states the intent — "Hidden enterprise deployments only need authentication + permissions" — but only the *hidden* path acted on it.

## Where found

Not from a report. I was checking whether the E2E failures on PR #6302 were mine, found they reproduce on `main`, and pulled the thread.

`zz-enterprise-license-prompt.spec.ts` activates a license and asserts the app lands on permissions. It fails with `body did not include "permissions"` and retries four times, because activation lands on the acquisition survey instead. That is a real product statement, and it was correct.

## Why it survived a week

Two independent reasons, and the combination is the actual lesson:

**The E2E gate is not gating.** Zero passes in the last 100 E2E runs on `main` (58 failure, 42 cancelled), spanning 2026-08-13T17:38Z to 2026-08-16T01:01Z — the entire retrievable window. A permanently red check cannot distinguish a new regression from the standing noise, so this one was invisible inside it.

**The unit test agreed with the bug.** `advances after either enterprise credential is verified` asserted that a verified enterprise credential advances into `"acquisition"`. The test's point is that a verified credential advances *at all*; the destination was wrong and the test locked it in. So the cheap check said pass, the expensive check said fail, and the expensive one was drowned out.

## Fix

Two changes, both mirroring patterns already in the file:

- `visibleOrder` excludes `acquisition` when `isManagedDeployment`, alongside the existing `timeline` and `plan` filters
- the restore mapping sends a device saved mid-acquisition to `permissions`, not `engine` — permissions still have to be granted. This reuses the existing "a saved step must not resume onto a slide that this device or its managed policy is no longer eligible to see" branch

Consumer onboarding is untouched: `acquisition` still runs for everyone who is not on a managed deployment.

## Validation

- `app/onboarding/page.test.tsx` — 42 passed, including two new regression tests
- `bun run typecheck` clean, `biome check` clean on both files
- **Guard verified to bite**: neutralizing the `visibleOrder` filter fails exactly 2 tests (the new one and the corrected pre-existing one), then restores clean. A guard nobody has watched fail is not a guard.

Not verified: I did not run the enterprise E2E spec locally against a real managed deployment. CI on this PR is the check for that, and it is the specific thing this PR should turn green.

## Before / after

```
before (managed, org key)      after (managed, org key)
─────────────────────────      ────────────────────────
activate this device           activate this device
        ↓                              ↓
how did you hear about us?     permissions
  search engine                        ↓
  friend or colleague          (engine, then done)
  reddit / hacker news …
        ↓
permissions
```

## Scope note

Kept separate from #6302 deliberately. #6302 is a CPU/memory PR whose E2E is red for this reason; bundling them would leave its E2E red until it merged, which is circular. Merging this first gives #6302 a clean signal.
