### PR TITLE
telemetry: report the accessibility pipeline like vision and audio

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -18,29 +18,29 @@ results and `cargo llvm-cov` data on top when judging release confidence.
 
 ### Tauri E2E
 
-- Mapped specs: 116
-- Declared test blocks: 333
-- Weighted coverage points: 260.8
+- Mapped specs: 117
+- Declared test blocks: 334
+- Weighted coverage points: 261.3
 
 | Platform | Specs | Declared tests | Weighted points | Layers | Features | Critical score |
 | --- | --- | --- | --- | --- | --- | --- |
 | windows | 89 | 288 | 235.3 | 15 | 93 | 92% |
-| macos | 112 | 296 | 231.6 | 17 | 97 | 90% |
+| macos | 113 | 297 | 232.1 | 17 | 99 | 90% |
 | linux | 79 | 248 | 206.0 | 14 | 89 | 88% |
 
 ### Core Engine
 
 - Mapped suites: 32
 - Mapped Rust files: 323
-- Active test blocks: 3134
+- Active test blocks: 3136
 - Ignored/manual test blocks: 137
-- Weighted coverage points: 2577.3
+- Weighted coverage points: 2578.7
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 3003 | 132 | 2517.3 | 21 | 11 | 100% |
-| macos | 29 | 3056 | 112 | 2527.7 | 22 | 11 | 100% |
-| linux | 25 | 2676 | 105 | 2221.1 | 20 | 11 | 100% |
+| windows | 29 | 3005 | 132 | 2518.7 | 21 | 11 | 100% |
+| macos | 29 | 3058 | 112 | 2529.1 | 22 | 11 | 100% |
+| linux | 25 | 2678 | 105 | 2222.5 | 20 | 11 | 100% |
 
 ## Refresh
 

--- a/crates/screenpipe-engine/src/server.rs
+++ b/crates/screenpipe-engine/src/server.rs
@@ -731,6 +731,40 @@ impl SCServer {
                 }
             });
 
+            // Spawn periodic accessibility pipeline metrics reporter (every 60s).
+            //
+            // `record_tree_walk` has always accumulated these counters on every
+            // production walk, and its own doc comment says they exist so "the
+            // health endpoint AND analytics surface real ax_* counters instead of
+            // zeros" — but only `/health` ever read them. The cost of the one
+            // subsystem large enough to rival capture was measured per-process and
+            // then discarded unless someone curled localhost on that exact machine.
+            //
+            // That gap is load-bearing: vision and audio both report, so fleet
+            // analysis can price them, and a11y could only be reasoned about by
+            // elimination. Emitting the existing snapshot costs one mutex read a
+            // minute and makes walk volume, walk latency and truncation visible
+            // next to the pipelines they compete with for the same cores.
+            //
+            // Counts and latencies only. `total_text_chars` is a character count,
+            // never the text — nothing here can carry window titles or content.
+            tokio::spawn(async move {
+                let mut interval = tokio::time::interval(Duration::from_secs(60));
+                loop {
+                    interval.tick().await;
+                    let snap = crate::ui_recorder::tree_walker_snapshot();
+                    // Same shape as the vision/audio reporters: stay silent until
+                    // the pipeline has actually done work, so idle installs and
+                    // platforms without a11y don't emit a stream of zeros.
+                    if snap.walks_total > 0 {
+                        analytics::capture_event_nonblocking(
+                            "a11y_pipeline_health",
+                            crate::ui_recorder::a11y_health_payload(&snap),
+                        );
+                    }
+                }
+            });
+
             // Permanent subscriber that forwards allowlisted piggyback telemetry
             // (meeting summaries + mic capture health) from the in-process events
             // bus to PostHog. Runs in both CLI and app-embedded modes since it's

--- a/crates/screenpipe-engine/src/ui_recorder.rs
+++ b/crates/screenpipe-engine/src/ui_recorder.rs
@@ -474,6 +474,36 @@ pub fn tree_walker_snapshot() -> TreeWalkerSnapshot {
         .unwrap_or_default()
 }
 
+/// Shape the snapshot into the `a11y_pipeline_health` analytics payload.
+///
+/// Split out from the reporter task in `server.rs` purely so it is reachable
+/// from a test: a spawned 60s interval loop is not, and a payload that silently
+/// mapped the wrong counter would look identical in fleet data to a subsystem
+/// that behaves differently than we think.
+///
+/// Counts, durations and rates only. `total_text_chars` is a character count,
+/// never the text, so nothing here can carry a window title or its contents.
+pub fn a11y_health_payload(snap: &TreeWalkerSnapshot) -> serde_json::Value {
+    serde_json::json!({
+        "walks_total": snap.walks_total,
+        // stored vs deduped prices the walk that produced nothing new: work
+        // performed with nothing retained.
+        "walks_stored": snap.walks_stored,
+        "walks_deduped": snap.walks_deduped,
+        "walks_empty": snap.walks_empty,
+        "walks_error": snap.walks_error,
+        "walks_truncated": snap.walks_truncated,
+        "walks_truncated_timeout": snap.walks_truncated_timeout,
+        "walks_truncated_max_nodes": snap.walks_truncated_max_nodes,
+        "truncation_rate": snap.truncation_rate,
+        "avg_walk_duration_ms": snap.avg_walk_duration_ms,
+        "max_walk_duration_ms": snap.max_walk_duration_ms,
+        "avg_nodes_per_walk": snap.avg_nodes_per_walk,
+        "max_depth_reached": snap.max_depth_reached,
+        "total_text_chars": snap.total_text_chars,
+    })
+}
+
 /// Coarse-grained UI-recorder state — the one-field summary the UI cares
 /// about most. Derived from the per-modality bools below; included
 /// alongside them so consumers can pick the granularity that fits.
@@ -2422,5 +2452,97 @@ mod tests {
         assert_eq!(snap.truncation_rate, 0.0);
         assert_eq!(snap.avg_walk_duration_ms, 0);
         assert_eq!(snap.avg_nodes_per_walk, 0);
+    }
+
+    /// Every counter must reach the payload under its own name. A wrong mapping
+    /// here is invisible in fleet data — it reads as a subsystem behaving
+    /// differently rather than as a reporting bug — so pin all of them.
+    #[test]
+    fn a11y_payload_carries_every_counter() {
+        let mut acc = TreeWalkerAccumulator::default();
+        apply(
+            &mut acc,
+            TreeWalkOutcome::Stored {
+                duration_ms: 40,
+                node_count: 900,
+                max_depth: 12,
+                text_chars: 3000,
+                truncated: true,
+                truncated_timeout: true,
+                truncated_max_nodes: false,
+            },
+        );
+        apply(
+            &mut acc,
+            TreeWalkOutcome::Deduped {
+                duration_ms: 20,
+                node_count: 100,
+                max_depth: 4,
+                text_chars: 500,
+                truncated: false,
+                truncated_timeout: false,
+                truncated_max_nodes: false,
+            },
+        );
+        apply(&mut acc, TreeWalkOutcome::Empty);
+        apply(&mut acc, TreeWalkOutcome::Error);
+
+        let snap = acc.snapshot();
+        let payload = a11y_health_payload(&snap);
+
+        assert_eq!(payload["walks_total"], 4);
+        assert_eq!(payload["walks_stored"], 1);
+        assert_eq!(payload["walks_deduped"], 1);
+        assert_eq!(payload["walks_empty"], 1);
+        assert_eq!(payload["walks_error"], 1);
+        assert_eq!(payload["walks_truncated"], 1);
+        assert_eq!(payload["walks_truncated_timeout"], 1);
+        assert_eq!(payload["walks_truncated_max_nodes"], 0);
+        assert_eq!(payload["truncation_rate"], 0.25);
+        // averages divide by walks_total, including the empty/error walks that
+        // contribute no duration or nodes: (40+20)/4 and (900+100)/4.
+        assert_eq!(payload["avg_walk_duration_ms"], 15);
+        assert_eq!(payload["max_walk_duration_ms"], 40);
+        assert_eq!(payload["avg_nodes_per_walk"], 250);
+        assert_eq!(payload["max_depth_reached"], 12);
+        assert_eq!(payload["total_text_chars"], 3500);
+    }
+
+    /// The payload is counts and durations. Nothing added to it may carry
+    /// captured content — a window title reaching PostHog would be a privacy
+    /// incident, not a bug — so assert the key set exactly.
+    #[test]
+    fn a11y_payload_exposes_no_free_text() {
+        let payload = a11y_health_payload(&TreeWalkerAccumulator::default().snapshot());
+        let object = payload.as_object().expect("payload is an object");
+
+        for (key, value) in object {
+            assert!(
+                value.is_number(),
+                "{key} is not numeric — only counts, durations and rates may be reported",
+            );
+        }
+
+        let mut keys: Vec<&str> = object.keys().map(String::as_str).collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            [
+                "avg_nodes_per_walk",
+                "avg_walk_duration_ms",
+                "max_depth_reached",
+                "max_walk_duration_ms",
+                "total_text_chars",
+                "truncation_rate",
+                "walks_deduped",
+                "walks_empty",
+                "walks_error",
+                "walks_stored",
+                "walks_total",
+                "walks_truncated",
+                "walks_truncated_max_nodes",
+                "walks_truncated_timeout",
+            ],
+        );
     }
 }

--- a/docs/coverage/CORE.md
+++ b/docs/coverage/CORE.md
@@ -9,10 +9,10 @@ confidence, and criticality.
 - Tracked crates: screenpipe-engine, screenpipe-db, screenpipe-sqlite-coordinator, screenpipe-audio, screenpipe-screen, screenpipe-a11y
 - Mapped suites: 32
 - Mapped Rust files: 323
-- Active test blocks: 3134
+- Active test blocks: 3136
 - Ignored/manual test blocks: 137
-- Declared test blocks: 3271
-- Weighted coverage points: 2577.3
+- Declared test blocks: 3273
+- Weighted coverage points: 2578.7
 
 Confidence weights: strong=1.0, partial=0.7, conditional=0.4, smoke=0.3.
 Criticality weights: high=1.0, medium=0.7, low=0.4.
@@ -23,15 +23,15 @@ are explicitly enabled in a runtime lane.
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 3003 | 132 | 2517.3 | 21 | 11 | 100% |
-| macos | 29 | 3056 | 112 | 2527.7 | 22 | 11 | 100% |
-| linux | 25 | 2676 | 105 | 2221.1 | 20 | 11 | 100% |
+| windows | 29 | 3005 | 132 | 2518.7 | 21 | 11 | 100% |
+| macos | 29 | 3058 | 112 | 2529.1 | 22 | 11 | 100% |
+| linux | 25 | 2678 | 105 | 2222.5 | 20 | 11 | 100% |
 
 ## Crate Summary
 
 | Crate | Suites | Integration files | Source unit files | Active tests | Ignored tests | Weighted points | Flows |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| screenpipe-engine | 10 | 19 | 103 | 1496 | 42 | 1147.0 | 10 |
+| screenpipe-engine | 10 | 19 | 103 | 1498 | 42 | 1148.4 | 10 |
 | screenpipe-db | 5 | 52 | 14 | 447 | 16 | 424.2 | 9 |
 | screenpipe-sqlite-coordinator | 1 | 0 | 2 | 16 | 0 | 16.0 | 2 |
 | screenpipe-audio | 6 | 25 | 51 | 591 | 43 | 517.4 | 5 |
@@ -69,19 +69,19 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | db-search | 2 suites / 111 active / 9 ignored / 111.0 pts | 2 suites / 111 active / 9 ignored / 111.0 pts | 2 suites / 111 active / 9 ignored / 111.0 pts |
 | engine-lifecycle | 6 suites / 208 active / 1 ignored / 183.6 pts | 6 suites / 208 active / 1 ignored / 183.6 pts | 5 suites / 202 active / 1 ignored / 181.9 pts |
 | local-api | 2 suites / 339 active / 9 ignored / 239.1 pts | 2 suites / 339 active / 9 ignored / 239.1 pts | 2 suites / 339 active / 9 ignored / 239.1 pts |
-| meeting | 6 suites / 1435 active / 19 ignored / 1173.7 pts | 6 suites / 1435 active / 19 ignored / 1173.7 pts | 4 suites / 1144 active / 15 ignored / 905.2 pts |
+| meeting | 6 suites / 1437 active / 19 ignored / 1175.1 pts | 6 suites / 1437 active / 19 ignored / 1175.1 pts | 4 suites / 1146 active / 15 ignored / 906.6 pts |
 | ocr | 4 suites / 124 active / 7 ignored / 118.3 pts | 4 suites / 128 active / 7 ignored / 123.8 pts | 3 suites / 119 active / 6 ignored / 114.8 pts |
 | os-integration | 1 suites / 6 active / 0 ignored / 1.7 pts | 1 suites / 6 active / 0 ignored / 1.7 pts | - |
 | performance | 13 suites / 1405 active / 67 ignored / 1235.4 pts | 14 suites / 1503 active / 70 ignored / 1274.6 pts | 13 suites / 1405 active / 67 ignored / 1235.4 pts |
-| pipes | 1 suites / 463 active / 3 ignored / 324.1 pts | 1 suites / 463 active / 3 ignored / 324.1 pts | 1 suites / 463 active / 3 ignored / 324.1 pts |
-| privacy | 5 suites / 878 active / 36 ignored / 714.2 pts | 5 suites / 927 active / 16 ignored / 719.1 pts | 5 suites / 853 active / 14 ignored / 691.7 pts |
+| pipes | 1 suites / 465 active / 3 ignored / 325.5 pts | 1 suites / 465 active / 3 ignored / 325.5 pts | 1 suites / 465 active / 3 ignored / 325.5 pts |
+| privacy | 5 suites / 880 active / 36 ignored / 715.6 pts | 5 suites / 929 active / 16 ignored / 720.5 pts | 5 suites / 855 active / 14 ignored / 693.1 pts |
 | real-app | - | 1 suites / 98 active / 3 ignored / 39.2 pts | - |
 | speaker | 2 suites / 348 active / 8 ignored / 348.0 pts | 2 suites / 348 active / 8 ignored / 348.0 pts | 2 suites / 348 active / 8 ignored / 348.0 pts |
 | storage | 3 suites / 499 active / 29 ignored / 401.8 pts | 3 suites / 499 active / 29 ignored / 401.8 pts | 3 suites / 499 active / 29 ignored / 401.8 pts |
-| sync | 1 suites / 463 active / 3 ignored / 324.1 pts | 1 suites / 463 active / 3 ignored / 324.1 pts | 1 suites / 463 active / 3 ignored / 324.1 pts |
+| sync | 1 suites / 465 active / 3 ignored / 325.5 pts | 1 suites / 465 active / 3 ignored / 325.5 pts | 1 suites / 465 active / 3 ignored / 325.5 pts |
 | timeline | 4 suites / 977 active / 33 ignored / 791.3 pts | 4 suites / 977 active / 33 ignored / 791.3 pts | 4 suites / 977 active / 33 ignored / 791.3 pts |
 | transcription | 5 suites / 712 active / 40 ignored / 561.0 pts | 5 suites / 712 active / 40 ignored / 561.0 pts | 5 suites / 712 active / 40 ignored / 561.0 pts |
-| ui-events | 4 suites / 702 active / 28 ignored / 534.6 pts | 3 suites / 653 active / 5 ignored / 500.3 pts | 3 suites / 653 active / 5 ignored / 500.3 pts |
+| ui-events | 4 suites / 704 active / 28 ignored / 536.0 pts | 3 suites / 655 active / 5 ignored / 501.7 pts | 3 suites / 655 active / 5 ignored / 501.7 pts |
 | vision-capture | 5 suites / 527 active / 32 ignored / 415.6 pts | 5 suites / 531 active / 32 ignored / 421.1 pts | 4 suites / 522 active / 31 ignored / 412.1 pts |
 
 ## Critical Flow Matrix
@@ -139,7 +139,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | engine-db-recovery-cli | screenpipe-engine | windows, macos, linux | database, engine-lifecycle | engine-health-lifecycle, performance-liveness | high | strong | unit | 1 | 8 | 0 | Exact DB/WAL/SHM working-copy preservation, rollback on archive failure, and restart repair for crashes during the multi-file generation swap. |
 | engine-focus-os | screenpipe-engine | windows, macos | engine-lifecycle, os-integration | engine-health-lifecycle, performance-liveness | medium | conditional | unit | 3 | 6 | 0 | Platform focus-tracker parsing/helpers. These files are cfg-gated and only execute on their target OS. |
 | engine-local-api-search-integration | screenpipe-engine | windows, macos, linux | local-api, db-search | local-api-search | high | strong | integration | 1 | 6 | 5 | Active /search route test builds an audio-disabled router, seeds captured-screen-shaped OCR data into an in-memory DB, and asserts the HTTP response and pagination. |
-| engine-meeting-privacy-sync | screenpipe-engine | windows, macos, linux | meeting, privacy, ui-events, pipes, sync | meeting-live-notes, privacy-and-redaction, accessibility-ui-events, performance-liveness | medium | strong | unit | 30 | 463 | 3 | Unit-heavy coverage for privacy filter policy, capture exclusions, UI recorder safety, pipes/live-view/structured-output helpers, sync helpers, and CLI parsing. Meeting detection moved to the engine-meeting-watcher suite. |
+| engine-meeting-privacy-sync | screenpipe-engine | windows, macos, linux | meeting, privacy, ui-events, pipes, sync | meeting-live-notes, privacy-and-redaction, accessibility-ui-events, performance-liveness | medium | strong | unit | 30 | 465 | 3 | Unit-heavy coverage for privacy filter policy, capture exclusions, UI recorder safety, pipes/live-view/structured-output helpers, sync helpers, and CLI parsing. Meeting detection moved to the engine-meeting-watcher suite. |
 | engine-meeting-watcher | screenpipe-engine | windows, macos | meeting | meeting-live-notes | high | strong | mixed | 9 | 216 | 3 | Successor of src/meeting_detector.rs and src/meeting_telemetry.rs. Audio-process and UI-scan backend state machines, candidate resolution, shared telemetry, and a scored trajectory eval. ui_scan/macos.rs and ui_scan/windows.rs are cfg-gated and only execute on their target OS; both backends are null on Linux. |
 | engine-retention-storage | screenpipe-engine | windows, macos, linux | storage, engine-lifecycle, performance | engine-health-lifecycle, performance-liveness | medium | strong | mixed | 5 | 38 | 0 | Local retention deletion (including lean-mode heavy-text stripping), cloud archive watermarking, atomic state-file replacement, and the low-disk capture monitor. |
 | engine-telemetry-observability | screenpipe-engine | windows, macos, linux | engine-lifecycle, performance | engine-health-lifecycle, performance-liveness | medium | strong | unit | 6 | 29 | 0 | PostHog capture gating, telemetry context shaping, piggyback telemetry forwarding, crash-log helpers, resource monitoring, and the recording-coverage reliability metric. |
@@ -423,7 +423,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | engine-meeting-privacy-sync | screenpipe-engine | src/sync_api.rs | source | 12 | 0 | 12 |
 | engine-meeting-privacy-sync | screenpipe-engine | src/sync_provider.rs | source | 4 | 0 | 4 |
 | engine-telemetry-observability | screenpipe-engine | src/telemetry_context.rs | source | 8 | 0 | 8 |
-| engine-meeting-privacy-sync | screenpipe-engine | src/ui_recorder.rs | source | 51 | 0 | 51 |
+| engine-meeting-privacy-sync | screenpipe-engine | src/ui_recorder.rs | source | 53 | 0 | 53 |
 | engine-capture-timeline | screenpipe-engine | src/video_cache.rs | source | 4 | 0 | 4 |
 | engine-capture-timeline | screenpipe-engine | src/video_utils.rs | source | 12 | 0 | 12 |
 | engine-capture-timeline | screenpipe-engine | src/vision_manager/manager.rs | source | 12 | 0 | 12 |


### PR DESCRIPTION
Closes #6305.

## Problem

`record_tree_walk` has accumulated walk counters on every production walk for as long as it has existed. Its own doc comment says why:

> so the health endpoint **and analytics** surface real `ax_*` counters instead of zeros

Only `/health` ever read them. `tree_walker_snapshot()` has exactly one caller outside its own module — `routes/health.rs`. So the cost of the one subsystem large enough to rival capture is measured per-process and then discarded, unless someone curls localhost on that exact machine.

## Why it matters

Vision and audio both report, so fleet data can price them. a11y could only ever be reasoned about by elimination — and that ran out of road twice this week, at the same wall:

**The Windows CPU gap.** Windows costs ~1.8x macOS at the median and 4x at p90 (p98 reaches 25.7% of machine). But macOS does *more* work in both instrumented pipelines: 836 vs 755 frames/hr, 470 vs 255 OCR/hr at 2x the per-call latency, and 980 vs 624 audio chunks. Whatever Windows spends the CPU on, it is not the parts that report.

**The leak cohort.** The app's own `leak_suspected` detector flags ~4.5% of users, flat across versions at a fixed 6h trend window. They sit at **477 MB/h and 202% CPU** against a 13.5% baseline — and their vision pipeline looks *healthy*: fewer frames captured, faster OCR, zero queue depth, zero drops.

Two independent investigations, both ending at the subsystem that reports nothing.

## Fix

One 60s reporter beside the existing vision and audio ones, emitting the snapshot that already exists. Same shape as its neighbours: gated on `analytics_enabled`, silent until `walks_total > 0` so idle installs and platforms without a11y don't emit a stream of zeros.

Zero new collection. The counters are already updated on every walk; this reads them once a minute.

`walks_stored` vs `walks_deduped` is the field most likely to settle it. A walk that keeps producing while retaining nothing is what a 477 MB/h growth curve with a healthy capture pipeline looks like.

## Privacy

Counts, durations and rates only. `total_text_chars` is a character count, never the text — nothing in the payload can carry a window title or its contents.

That is pinned by a test rather than by review: `a11y_payload_exposes_no_free_text` asserts every value is numeric and the key set is exact, so adding a string field to this payload fails the build. A window title reaching PostHog would be a privacy incident, not a bug.

## Validation

- `cargo test -p screenpipe-engine --lib ui_recorder` — 54 passed, including two new tests
- `a11y_payload_carries_every_counter` builds a snapshot from four real outcomes (stored, deduped, empty, error) and pins all 14 fields, including that averages divide by `walks_total` so empty and error walks dilute them
- `cargo fmt --check` clean, `cargo check -p screenpipe-engine` clean
- coverage dashboards regenerated

Payload construction is split out of the spawned task purely so it is reachable from a test — a 60s interval loop is not, and a payload that silently mapped the wrong counter would look identical in fleet data to a subsystem behaving differently than we think.

## What this does not do

It does not fix the CPU gap or the leak. It makes them attributable. I would rather ship the measurement than keep narrowing by elimination — the last two rounds of that produced confident statements about where the cost *isn't*, which is worth much less than one round of knowing where it is.

First thing to check once a build carrying this ships: whether flagged users show a different `walks_stored`/`walks_deduped` ratio, walk latency, or truncation rate than everyone else.
