### PR TITLE
perf(a11y): stop walking Apple's screenshot UI and bound unbounded AX reads

### DIFF
--- a/crates/screenpipe-a11y/src/platform/macos.rs
+++ b/crates/screenpipe-a11y/src/platform/macos.rs
@@ -33,6 +33,43 @@ use objc2_app_kit::NSPasteboard;
 /// and cause a SIGABRT in CFDictionarySetValue / __CFBasicHashRehash.
 static AX_QUERY_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
 
+/// Process-wide ceiling for any AX call that does not set its own timeout.
+///
+/// macOS defaults to roughly 6s per message. AX reads are synchronous IPC
+/// serviced on the *target app's* main thread, so an unbounded read against a
+/// busy app stalls that app's UI — including drag loops — for as long as we are
+/// willing to wait. Several focus-path reads (`focused_app`, `focused_window`,
+/// `focused_ui_element`, `element_at_pos`) run straight off AX notifications
+/// with no debounce and previously inherited that 6s default.
+///
+/// 1s is deliberately looser than the 0.1–0.2s per-element bounds the walker
+/// sets, so it only ever acts as a backstop: `AXUIElementSetMessagingTimeout`
+/// on a specific element still overrides it for that element.
+const AX_DEFAULT_TIMEOUT_SECS: f32 = 1.0;
+
+/// Apply [`AX_DEFAULT_TIMEOUT_SECS`] as this process's default AX timeout.
+///
+/// Passing the system-wide element to `AXUIElementSetMessagingTimeout` sets the
+/// default for every message the app sends, so this only needs to land once —
+/// hence the `Once`, which also keeps it off the hot notification path.
+pub(crate) fn ensure_global_ax_timeout() {
+    static INIT: std::sync::Once = std::sync::Once::new();
+    INIT.call_once(|| {
+        let sys = ax::UiElement::sys_wide();
+        match sys.set_messaging_timeout_secs(AX_DEFAULT_TIMEOUT_SECS) {
+            Ok(()) => debug!(
+                "AX default messaging timeout set to {}s (was the ~6s system default)",
+                AX_DEFAULT_TIMEOUT_SECS
+            ),
+            Err(e) => warn!(
+                "failed to set AX default messaging timeout: {:?} — unbounded AX reads \
+                 can stall the target app's main thread for ~6s",
+                e
+            ),
+        }
+    });
+}
+
 /// Process-wide ground truth for macOS Input Monitoring, learned from the ONE
 /// real CGEventTap we create in `run_event_tap` / `run_activity_only_tap`.
 ///
@@ -261,6 +298,9 @@ impl UiRecorder {
                 perms.input_monitoring
             );
         }
+
+        // Bound every AX read this process makes before any of them can run.
+        ensure_global_ax_timeout();
 
         let (tx, rx) = bounded::<UiEvent>(self.config.max_buffer_size);
         let stop = Arc::new(AtomicBool::new(false));
@@ -2044,6 +2084,13 @@ fn get_string_attr(elem: &ax::UiElement, attr: &ax::Attr) -> Option<String> {
 
 fn get_focused_window_title(pid: i32) -> Option<String> {
     let app = ax::UiElement::with_app_pid(pid);
+
+    // Runs on every AX focus notification with no debounce, so it is the most
+    // frequent unbounded read we make. Match the 0.1s the click/context paths
+    // already use rather than leaning on the 1s process default: a slow app
+    // should cost us a missing title, not a stalled observer thread.
+    let _ = app.set_messaging_timeout_secs(0.1);
+
     let focused = app.attr_value(ax::attr::focused_window()).ok()?;
 
     if focused.get_type_id() == ax::UiElement::type_id() {

--- a/crates/screenpipe-a11y/src/tree/macos.rs
+++ b/crates/screenpipe-a11y/src/tree/macos.rs
@@ -28,7 +28,30 @@ const EXCLUDED_APPS: &[&str] = &[
     "keychain access",
     "screenpipe",
     "loginwindow",
+    // Apple's screenshot UI (Cmd+Shift+3/4/5). `screencaptureui` is the process
+    // name, "screenshot" the localized app name; which one reaches us depends on
+    // whether the caller resolved the pid via proc_name or NSRunningApplication.
+    //
+    // Excluded for latency, not privacy. Pressing the shortcut makes this app
+    // frontmost, and mouse-down maps to `CaptureTrigger::Click`, so the walk
+    // fires exactly while the user is dragging the selection. Every AX read is
+    // synchronous IPC serviced on the *target's* main thread — the same thread
+    // drawing the selection rectangle — so walking it stutters the drag it is
+    // trying to observe. The overlay is a crosshair and a toolbar: no text worth
+    // indexing. Screen frames are unaffected; this skips the a11y walk only.
+    "screencaptureui",
+    "screenshot",
 ];
+
+/// Substring match against the lowercased app name, matching the two call sites
+/// that gate a11y capture. Broad by design: `EXCLUDED_APPS` entries are brand or
+/// process fragments, so "screenshot" also covers third-party screenshot tools.
+/// That is the intended trade — none of them carry indexable a11y text.
+fn is_excluded_app(app_lower: &str) -> bool {
+    EXCLUDED_APPS
+        .iter()
+        .any(|excluded| app_lower.contains(excluded))
+}
 
 /// Known browser app names (lowercase). Matches vision crate's list.
 const BROWSER_NAMES: &[&str] = &[
@@ -757,9 +780,7 @@ fn check_focused_window_filters_inner(
     };
     let window_name = get_string_attr(&window, ax::attr::title()).unwrap_or_default();
     let app_lower = app_name.to_lowercase();
-    let excluded = EXCLUDED_APPS
-        .iter()
-        .any(|excluded| app_lower.contains(excluded));
+    let excluded = is_excluded_app(&app_lower);
 
     let native_incognito =
         if config.ignore_incognito_windows {
@@ -799,9 +820,9 @@ impl MacosTreeWalker {
                 None => return Ok(TreeWalkResult::NotFound),
             };
 
-        // Skip excluded apps (password managers, etc.)
+        // Skip excluded apps (password managers, screenshot overlays, etc.)
         let app_lower = app_name.to_lowercase();
-        if EXCLUDED_APPS.iter().any(|ex| app_lower.contains(ex)) {
+        if is_excluded_app(&app_lower) {
             return Ok(TreeWalkResult::Skipped(SkipReason::ExcludedApp));
         }
 
@@ -2456,6 +2477,12 @@ fn frontmost_pid_via_window_server() -> Option<i32> {
 fn resolve_focused_ax_app(
     capture_app_identity: bool,
 ) -> Option<(Retained<ax::UiElement>, i32, String, Option<String>)> {
+    // The walker runs from the engine's capture pipeline, which can be live
+    // without `MacosUiRecorder::start`. Bound AX here too so `focused_app()` /
+    // `pid()` below can never inherit the ~6s system default. `Once`, so this
+    // is an atomic load after the first walk.
+    crate::platform::macos::ensure_global_ax_timeout();
+
     // The AX system-wide focusedApplication is not just *empty* for
     // Chromium/Electron apps that haven't materialized their AX tree — it
     // can go STALE, still reporting the previously focused app. A walker
@@ -2803,6 +2830,46 @@ fn fill_ax_props(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn apple_screenshot_ui_is_excluded_from_walks() {
+        // Both spellings reach `is_excluded_app` depending on whether the pid
+        // was resolved via proc_name or NSRunningApplication.localizedName.
+        assert!(is_excluded_app("screencaptureui"));
+        assert!(is_excluded_app("screenshot"));
+        // Case is normalized by the callers, which lowercase before matching.
+        assert!(is_excluded_app(&"Screenshot".to_lowercase()));
+    }
+
+    #[test]
+    fn excluded_apps_still_cover_credential_managers_and_self() {
+        for app in [
+            "1password",
+            "bitwarden",
+            "lastpass",
+            "dashlane",
+            "keepassxc",
+            "keychain access",
+            "screenpipe",
+            "loginwindow",
+        ] {
+            assert!(is_excluded_app(app), "{app} should stay excluded");
+        }
+    }
+
+    #[test]
+    fn ordinary_apps_are_not_excluded() {
+        for app in [
+            "safari",
+            "google chrome",
+            "slack",
+            "code",
+            "notion",
+            "figma",
+        ] {
+            assert!(!is_excluded_app(app), "{app} must still be walked");
+        }
+    }
 
     #[test]
     fn test_should_skip_role() {


### PR DESCRIPTION
## Problem

Taking a screenshot on macOS (Cmd+Shift+4) feels laggy while dragging the selection, and the drag of the bottom-right resize handle in particular stutters.

Pressing the shortcut makes Apple's `screencaptureui` frontmost. Mouse-down maps to `CaptureTrigger::Click` (`ui_recorder.rs:1203-1238`), which runs a capture plus `walk_accessibility_tree` on the frontmost app (`event_driven_capture.rs:2941-2947`). That app is the screenshot overlay, and it is not in `EXCLUDED_APPS`.

AX reads are synchronous IPC serviced on the **target app's main thread**, which is the same thread drawing the selection rectangle. So the walk stalls the interaction it is trying to observe.

Several focus-path reads also set no messaging timeout and inherited the macOS ~6s per-message default:

| Site | Call |
|---|---|
| `platform/macos.rs:2045` | `get_focused_window_title`, runs on every focus notification with no debounce |
| `platform/macos.rs:1680` | `get_focused_app_info`: `sys_wide().focused_app()` / `.pid()` |
| `platform/macos.rs:2081` | `get_focused_element_context`: `focused_ui_element()` |
| `platform/macos.rs:1828` | `element_at_pos` hit test, runs *before* its own 0.1s timeout is applied |
| `tree/macos.rs:2489` | `resolve_focused_ax_app`, runs before the walk root sets `element_timeout_secs` |

## Where it was found

Diagnosing a live report of slow screenshot dragging. Confirmed against the running instance rather than inferred from source: screenpipe holds accessibility rows for `app_name: "Screenshot"` with `focused: true`, so the overlay is an active walk target today.

## Before / after

```
BEFORE                                  AFTER

user presses Cmd+Shift+4                user presses Cmd+Shift+4
  screencaptureui becomes frontmost       screencaptureui becomes frontmost
  |                                       |
  mouse-down -> CaptureTrigger::Click     mouse-down -> CaptureTrigger::Click
  |                                       |
  walk_accessibility_tree(screencaptureui)  is_excluded_app("screenshot") -> true
  |                                       |
  +-- focused_app()        no timeout     +-- Skipped(ExcludedApp)   ~0ms
  +-- focused_window()     no timeout     |
  +-- focused_ui_element() no timeout     screencaptureui main thread stays free
  +-- element_at_pos()     no timeout     |
  |     each up to ~6s, synchronous,      selection rect tracks the cursor
  |     on screencaptureui's MAIN thread
  |
  selection rect starves -> visible stutter

any other slow app (unchanged path):
  focused_window() ... up to ~6s          focused_window() ... capped at 0.1s
  other unbounded AX reads ... ~6s        capped at 1s process default
```

## Root cause

Two independent issues, both in the a11y path (not the capture stream):

1. Apple's screenshot UI was never excluded from accessibility walks.
2. Focus-path AX reads had no messaging timeout, so a busy or stalled target app could hold our observer thread, and our request could hold *their* main thread, for seconds.

## Fix

1. Add `screencaptureui` and `screenshot` to `EXCLUDED_APPS`. The overlay is a crosshair and a toolbar, so there is no indexable a11y text to lose. This skips the **a11y walk only**; screen frames and OCR are unaffected.
2. Set a 1s process-wide AX messaging default once via the system-wide element (`AXUIElementSetMessagingTimeout` on the system-wide element sets the app-wide default). It is deliberately looser than the walker's existing 0.1-0.2s per-element bounds, which still override it, so it only ever acts as a backstop, including for future call sites.
3. Give `get_focused_window_title` an explicit 0.1s matching its siblings, since it is the most frequent unbounded read.

Also extracts `is_excluded_app` so both gate sites share one implementation and the list becomes unit-testable.

## Validation

- 254 lib tests pass, including 3 new ones covering the screenshot entries, the existing credential-manager entries, and a negative case so the broad substring match cannot silently swallow ordinary apps.
- 8 live e2e tree-walker tests pass (`cargo test -p screenpipe-a11y`).
- `cargo fmt` clean, `cargo clippy -p screenpipe-a11y --all-targets` reports no new warnings on changed lines.
- `test_sustained_cpu_load` failed once mid-development at a machine load average of 418 and passed on re-run at load 19. Environmental, not this change.

## What this does not claim

The mechanism is source-backed and the screenshot UI is confirmed as a walk target, but I did not measure a walk landing inside a specific laggy drag, so the causal link to the reported symptom is not proven. Two other contributors were identified during diagnosis and are deliberately **not** in this PR:

- an always-on 2 fps SCK stream per display that converts every frame (full-frame scalar BGRA to RGBA) whether or not a consumer wants it
- 8 threads observed wedged in `SCShareableContent` against a nominal cap of 4, caused by a check-then-spawn race in `sck-rs` where the counter only increments after a 5s timeout, so concurrent callers never see each other

Both are separate PRs.

## Considered and rejected

Adding the screenshot UI to the recorder-side `excluded_apps` in `config.rs:228`. That list gates event capture, not tree walking, so it would drop clicks and keystrokes during screenshots without addressing the cost, which is the walk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
