### PR TITLE
fix: close onboarding bypasses

### DIFF
--- a/apps/screenpipe-app-tauri/components/onboarding/permissions-step.test.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/permissions-step.test.tsx
@@ -166,6 +166,11 @@ describe("onboarding permission wheel", () => {
     expect(
       screen.getByText("Three permissions turn on recording.")
     ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", {
+        name: /continue without all permissions/i,
+      })
+    ).toBeNull();
   });
 
   it("advances focus and refocuses the window when the poller detects a grant", async () => {

--- a/apps/screenpipe-app-tauri/components/onboarding/permissions-step.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/permissions-step.tsx
@@ -139,7 +139,6 @@ export default function PermissionsStep({
   const [requesting, setRequesting] = useState(false);
   const [screenRestartRequired, setScreenRestartRequired] = useState(false);
   const [restarting, setRestarting] = useState(false);
-  const [showSkip, setShowSkip] = useState(false);
   const hasAdvancedRef = useRef(false);
   const mountTimeRef = useRef(Date.now());
   const statusesRef = useRef<Record<string, boolean>>({});
@@ -333,12 +332,6 @@ export default function PermissionsStep({
     }
   }, [allRequiredGranted, isPlatformLoading, handleNextSlide, statuses]);
 
-  // Show skip after 8s
-  useEffect(() => {
-    const timer = setTimeout(() => setShowSkip(true), 8000);
-    return () => clearTimeout(timer);
-  }, []);
-
   // Handle grant click with immediate refresh
   const handleGrant = async (perm: PermissionDef) => {
     if (requesting || perm.id !== focusedPerm?.id) return;
@@ -445,28 +438,6 @@ export default function PermissionsStep({
               copy, because this step auto-advances on non-mac and would leave
               Windows and Linux told nothing. */}
           <TrustDisclosure surface="permissions" />
-
-          {/* Skip link */}
-          {showSkip && !allRequiredGranted && (
-            <motion.button
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              onClick={() => {
-                posthog.capture("onboarding_permission_skipped", {
-                  time_spent_ms: Date.now() - mountTimeRef.current,
-                  statuses,
-                  unresolved_permissions: activePermissions
-                    .filter((permission) => statuses[permission.id] !== true)
-                    .map((permission) => permission.id),
-                });
-                hasAdvancedRef.current = true;
-                handleNextSlide();
-              }}
-              className="mt-5 font-mono text-[10px] text-muted-foreground/50 hover:text-foreground transition-colors"
-            >
-              continue without all permissions →
-            </motion.button>
-          )}
         </>
       )}
     </motion.div>

--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -2488,14 +2488,15 @@ async fn main() {
                         }
                     }
                     // Defer off the event stack so run handler stays panic-free.
-                    // Open the settings/app window (not the timeline overlay).
+                    // Showing Onboarding is the app-entry gate: it focuses setup
+                    // while incomplete and routes to Home once complete.
                     if crate::enterprise_policy::is_app_ui_hidden() || crate::headless::is_dormant()
                     {
                         return;
                     }
                     let app = app_handle.app_handle().clone();
                     let _ = app_handle.app_handle().run_on_main_thread(move || {
-                        let _ = ShowRewindWindow::Home { page: None }.show(&app);
+                        let _ = ShowRewindWindow::Onboarding.show(&app);
                     });
                 }
                 _ => {}

--- a/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
@@ -878,7 +878,8 @@ fn create_dynamic_menu(
 ) -> Result<tauri::menu::Menu<Wry>> {
     let mut menu_builder = MenuBuilder::new(app);
 
-    // During onboarding: show minimal menu (version + skip + quit)
+    // During onboarding: show only version and quit. Setup cannot be bypassed
+    // from the tray.
     if !data.onboarding_completed && !data.app_ui_hidden {
         menu_builder = menu_builder
             .item(
@@ -893,8 +894,6 @@ fn create_dynamic_menu(
                 .enabled(false)
                 .build(app)?,
             )
-            .item(&PredefinedMenuItem::separator(app)?)
-            .item(&MenuItemBuilder::with_id("skip_onboarding", "Skip onboarding").build(app)?)
             .item(&PredefinedMenuItem::separator(app)?)
             .item(&MenuItemBuilder::with_id("quit", "Quit screenpipe").build(app)?);
 
@@ -1266,7 +1265,9 @@ fn setup_tray_click_handlers(main_tray: &TrayIcon) -> Result<()> {
                         let app_inner = app.clone();
                         let _ = app.run_on_main_thread(move || {
                             crate::headless::wake_from_tray(&app_inner);
-                            let _ = ShowRewindWindow::Home { page: None }.show(&app_inner);
+                            // Showing Onboarding is the app-entry gate: it focuses
+                            // setup while incomplete and routes to Home once complete.
+                            let _ = ShowRewindWindow::Onboarding.show(&app_inner);
                         });
                     });
                 }
@@ -1293,7 +1294,6 @@ fn handle_menu_event(app_handle: &AppHandle, event: tauri::menu::MenuEvent) {
                 | "settings"
                 | "upgrade"
                 | "onboarding"
-                | "skip_onboarding"
         )
     {
         info!(
@@ -1698,21 +1698,6 @@ fn handle_menu_event(app_handle: &AppHandle, event: tauri::menu::MenuEvent) {
                     .open_url("https://cal.com/team/screenpipe/chat", None::<&str>);
             });
         }
-        "skip_onboarding" => {
-            let app = app_handle.clone();
-            let _ = app_handle.run_on_main_thread(move || {
-                crate::headless::wake_from_tray(&app);
-                info!("skip onboarding requested from tray menu");
-                let _ = OnboardingStore::update(&app, |onboarding| {
-                    onboarding.complete();
-                });
-                // Close onboarding window if open
-                if let Some(win) = app.get_webview_window("onboarding") {
-                    let _ = win.close();
-                }
-                let _ = post_skip_onboarding_window().show(&app);
-            });
-        }
         "onboarding" => {
             let app = app_handle.clone();
             let _ = app_handle.run_on_main_thread(move || {
@@ -1930,27 +1915,9 @@ fn to_accelerator(shortcut: &str) -> String {
         .replace("CommandOrControl", "CmdOrCtrl")
 }
 
-/// Where "Skip onboarding" lands. Setup ends at Home, exactly like finishing
-/// onboarding normally (`commands::complete_onboarding`). `ShowRewindWindow::Main`
-/// renders `/overlay`, the timeline, which is the wrong destination for a fresh
-/// install because nothing has been captured yet.
-fn post_skip_onboarding_window() -> ShowRewindWindow {
-    ShowRewindWindow::Home {
-        page: Some("home".to_string()),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn skip_onboarding_lands_on_home_not_the_timeline() {
-        match post_skip_onboarding_window() {
-            ShowRewindWindow::Home { page } => assert_eq!(page.as_deref(), Some("home")),
-            other => panic!("skip onboarding must land on Home, got {other:?}"),
-        }
-    }
 
     #[test]
     fn recording_status_text_distinguishes_meetings_only_audio_states() {

--- a/apps/screenpipe-app-tauri/src-tauri/src/window/show.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/window/show.rs
@@ -533,6 +533,9 @@ impl ShowRewindWindow {
                 if onboarding_store.is_completed {
                     return ShowRewindWindow::Home { page: None }.show(app);
                 }
+                window.show().ok();
+                crate::window::focus_window(&window);
+                return Ok(window);
             }
 
             if id.label() == RewindWindowId::Search.label() {


### PR DESCRIPTION
## Summary

- remove the tray menu action that marked onboarding complete
- route macOS dock reopen and Windows tray left-click through the onboarding completion gate
- focus the existing onboarding window when setup is incomplete
- remove the permissions-step escape link

## Before / after

```text
Before                              After
tray: version / skip / quit         tray: version / quit
dock or tray click -> Home          click -> Onboarding until complete
permissions -> continue anyway      permissions -> required grants only
```

## Validation

- `bun x vitest run --config vitest.config.ts components/onboarding/permissions-step.test.tsx` (13 passed)
- `cargo build --features e2e --bins --features tauri/custom-protocol`
- `git diff --check`