### PR TITLE
fix(chat): sanitize hosted regional denial errors

### DIFF
--- a/apps/screenpipe-app-tauri/lib/chat/__tests__/provider-errors.test.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/__tests__/provider-errors.test.ts
@@ -53,6 +53,23 @@ describe("provider error copy", () => {
     expect(presentation?.message).not.toContain("account_not_in_good_standing");
   });
 
+  it("maps the gateway regional denial to friendly, non-retryable copy", () => {
+    const raw = `Error: 403 data: {"error":{"message":"Cloud AI models aren't available in your country or region (the provider rejected the request). Connect a local model like Ollama in Settings → AI to keep using chat.","type":"api_error","code":"403"}}\n\ndata: [DONE]`;
+    const presentation = buildProviderErrorPresentation(raw, {
+      provider: "screenpipe-cloud",
+      model: "auto",
+    });
+
+    expect(presentation).toEqual({
+      kind: "provider",
+      message: "Cloud AI models aren't available in your country or region (the provider rejected the request). Connect a local model like Ollama in Settings → AI to keep using chat.",
+      retryable: false,
+    });
+    expect(presentation?.message).not.toContain("Error: 403");
+    expect(presentation?.message).not.toContain("data:");
+    expect(presentation?.message).not.toContain("[DONE]");
+  });
+
   it("does not classify an ordinary provider error as a safety refusal", () => {
     expect(SafetyRefusalError.from("Connection error.")).toBeNull();
     expect(

--- a/apps/screenpipe-app-tauri/lib/chat/__tests__/provider-errors.test.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/__tests__/provider-errors.test.ts
@@ -12,6 +12,8 @@ import {
   SafetyRefusalError,
 } from "../provider-errors";
 
+const regionalDenialRaw = `Error: 403 data: {"error":{"message":"Cloud AI models aren't available in your country or region (the provider rejected the request). Connect a local model like Ollama in Settings → AI to keep using chat.","type":"api_error","code":"403"}}\n\ndata: [DONE]`;
+
 describe("provider error copy", () => {
   it.each([
     "Provider finish_reason: content_filter",
@@ -53,22 +55,41 @@ describe("provider error copy", () => {
     expect(presentation?.message).not.toContain("account_not_in_good_standing");
   });
 
-  it("maps the gateway regional denial to friendly, non-retryable copy", () => {
-    const raw = `Error: 403 data: {"error":{"message":"Cloud AI models aren't available in your country or region (the provider rejected the request). Connect a local model like Ollama in Settings → AI to keep using chat.","type":"api_error","code":"403"}}\n\ndata: [DONE]`;
-    const presentation = buildProviderErrorPresentation(raw, {
-      provider: "screenpipe-cloud",
-      model: "auto",
-    });
+  it.each(["screenpipe-cloud", "pi"])(
+    "maps the gateway regional denial for hosted alias %s to friendly, non-retryable copy",
+    (provider) => {
+      const presentation = buildProviderErrorPresentation(regionalDenialRaw, {
+        provider,
+        model: "auto",
+      });
 
-    expect(presentation).toEqual({
-      kind: "provider",
-      message: "Cloud AI models aren't available in your country or region (the provider rejected the request). Connect a local model like Ollama in Settings → AI to keep using chat.",
-      retryable: false,
-    });
-    expect(presentation?.message).not.toContain("Error: 403");
-    expect(presentation?.message).not.toContain("data:");
-    expect(presentation?.message).not.toContain("[DONE]");
-  });
+      expect(presentation).toEqual({
+        kind: "provider",
+        message: "Cloud AI models aren't available in your country or region (the provider rejected the request). Connect a local model like Ollama in Settings → AI to keep using chat.",
+        retryable: false,
+      });
+      expect(presentation?.message).not.toContain("Error: 403");
+      expect(presentation?.message).not.toContain("data:");
+      expect(presentation?.message).not.toContain("[DONE]");
+    },
+  );
+
+  it.each([
+    ["custom", { provider: "custom", model: "auto" }],
+    ["acp", { provider: "acp", model: "auto" }],
+    ["anthropic", { provider: "anthropic", model: "auto" }],
+    ["missing", undefined],
+  ] as const)(
+    "does not let the regional-denial phrase hijack non-hosted preset %s",
+    (_label, preset) => {
+      const presentation = buildProviderErrorPresentation(regionalDenialRaw, preset);
+
+      expect(presentation?.message ?? "").not.toContain(
+        "Cloud AI models aren't available in your country or region",
+      );
+      expect(presentation === null || presentation.retryable).toBe(true);
+    },
+  );
 
   it("does not classify an ordinary provider error as a safety refusal", () => {
     expect(SafetyRefusalError.from("Connection error.")).toBeNull();

--- a/apps/screenpipe-app-tauri/lib/chat/provider-errors.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/provider-errors.ts
@@ -17,6 +17,8 @@ const MIN_AGENT_CONTEXT_TOKENS = 32_768;
 const tokenFormatter = new Intl.NumberFormat("en-US");
 const SAFETY_REFUSAL_MESSAGE =
   "The selected model declined this request because of its safety policy. This is not a screenpipe outage. Start a new chat and revise the request with clear authorized context, or ask for high-level guidance.";
+const CLOUD_REGIONAL_DENIAL_MESSAGE =
+  "Cloud AI models aren't available in your country or region (the provider rejected the request). Connect a local model like Ollama in Settings → AI to keep using chat.";
 
 export type ProviderErrorPresentation = {
   kind: "provider" | "safety_refusal";
@@ -356,6 +358,17 @@ export function buildProviderErrorPresentation(
   const standingMessage = buildAccountStandingMessage(errorStr);
   if (standingMessage) {
     return { kind: "provider", message: standingMessage, retryable: false };
+  }
+
+  // The hosted gateway already provides safe recovery copy for geo-blocked
+  // regions, but Pi wraps it in raw SSE framing. Match the stable sentence and
+  // return our own constant so transport details and any suffix stay inert.
+  if (
+    errorStr
+      .toLowerCase()
+      .includes("cloud ai models aren't available in your country or region")
+  ) {
+    return { kind: "provider", message: CLOUD_REGIONAL_DENIAL_MESSAGE, retryable: false };
   }
 
   // A coding agent's own service refusing the user, before the generic provider

--- a/apps/screenpipe-app-tauri/lib/chat/provider-errors.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/provider-errors.ts
@@ -364,6 +364,7 @@ export function buildProviderErrorPresentation(
   // regions, but Pi wraps it in raw SSE framing. Match the stable sentence and
   // return our own constant so transport details and any suffix stay inert.
   if (
+    isHostedScreenpipeProvider(preset?.provider) &&
     errorStr
       .toLowerCase()
       .includes("cloud ai models aren't available in your country or region")


### PR DESCRIPTION
## Source feedback

- Internal feedback task: `t_8bce0762`
- Feedback identity: Discord message `1538619865907208323`
- Reported platform: Windows 10.0.26100, app 2.6.29

## Root cause

The hosted gateway's persistent regional-denial response reached chat wrapped in raw HTTP/SSE transport framing. The provider error presenter did not recognize that hosted response, so users saw the raw transport error and were offered a retry that could not resolve a regional availability restriction.

## Fix

- Recognize the stable hosted regional-denial signature and replace the transport payload with local, user-facing copy.
- Mark that persistent denial as non-retryable.
- Scope classification through `isHostedScreenpipeProvider`, covering both hosted aliases (`screenpipe-cloud` and `pi`) without allowing custom, ACP, Anthropic, or missing-provider errors to be misclassified.
- Return only a local constant, so raw SSE framing and any untrusted suffix are not rendered.

This covers the full provider surface: both hosted aliases are positive cases, while every neighboring non-hosted/missing-provider path has explicit negative regression coverage.

## RED / GREEN evidence

- RED: the initial focused regression returned no provider presentation; after the first implementation, four non-hosted/missing-provider counterexamples exposed over-broad classification.
- GREEN: provider-error tests pass, 48/48, including both hosted aliases and custom/ACP/Anthropic/missing-preset negatives.

## Test plan

- `bun x vitest run --config vitest.config.ts lib/chat/__tests__/provider-errors.test.ts` — 48/48 passed
- `bun x vitest run --config vitest.config.ts lib/chat` — 26 files / 351 tests passed
- `bun run typecheck` — passed
- `bun x eslint lib/chat/provider-errors.ts lib/chat/__tests__/provider-errors.test.ts` — passed
- `git diff --check origin/main..af3fde55a50e7cad33b3db45c0e4fb1811e7f780` — passed
- Broad `bun run test` — Vitest 356 files / 3,743 tests and Bun 236/236 passed

## Platform scope

The source report was Windows, but the changed TypeScript error-presentation path is platform-independent. There are no native, capture, database, or per-frame changes.

## Visual evidence

Non-visual error-presentation change; ASCII before/after:

```text
Before: Chat -> raw "Error: 403 data: ... [DONE]" -> Retry
After:  Chat -> friendly regional-availability message -> no Retry
```

## Risk assessment

Low. The change is limited to provider error presentation, gated to hosted providers, and protected by positive and adversarial negative tests. It adds no dependency and does not change request execution or provider selection.
