### PR TITLE
fix(chat): prevent fresh Pi startup aborts

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat/standalone/hooks/__tests__/pi-active-turn.test.ts
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/hooks/__tests__/pi-active-turn.test.ts
@@ -16,14 +16,41 @@ describe("Pi active-turn detection", () => {
       isLoading: true,
       isStreaming: false,
       assistantMessageId: null,
+      backendBusy: false,
+      startedDuringPreflight: false,
+    })).toBe(false);
+  });
+
+  it("does not abort from stale frontend state after starting an idle Pi session", () => {
+    expect(hasAuthoritativeActivePiTurn({
+      isLoading: false,
+      isStreaming: true,
+      assistantMessageId: "stale-assistant",
+      backendBusy: false,
+      startedDuringPreflight: true,
+    })).toBe(false);
+  });
+
+  it("does not mistake startup RPC activity for a turn after starting Pi", () => {
+    expect(hasAuthoritativeActivePiTurn({
+      isLoading: false,
+      isStreaming: true,
+      assistantMessageId: "stale-assistant",
+      backendBusy: true,
+      startedDuringPreflight: true,
     })).toBe(false);
   });
 
   it.each([
     { isStreaming: true, assistantMessageId: null },
     { isStreaming: false, assistantMessageId: "assistant-1" },
-  ])("preserves interruption for an authoritative active turn", (state) => {
-    expect(hasAuthoritativeActivePiTurn({ isLoading: false, ...state })).toBe(true);
+  ])("preserves interruption when the backend confirms active Pi work", (state) => {
+    expect(hasAuthoritativeActivePiTurn({
+      isLoading: false,
+      backendBusy: true,
+      startedDuringPreflight: false,
+      ...state,
+    })).toBe(true);
   });
 
   it("uses authoritative turn state in the interruption path", () => {
@@ -34,5 +61,7 @@ describe("Pi active-turn detection", () => {
     expect(start).toBeGreaterThan(-1);
     expect(end).toBeGreaterThan(start);
     expect(source.slice(start, end)).toContain("hasAuthoritativeActivePiTurn({");
+    expect(source.slice(start, end)).toContain("backendBusy:");
+    expect(source.slice(start, end)).toContain("startedDuringPreflight,");
   });
 });

--- a/apps/screenpipe-app-tauri/components/chat/standalone/hooks/use-pi-send-transport.ts
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/hooks/use-pi-send-transport.ts
@@ -41,14 +41,22 @@ type LivePiSessionCheck =
 export function hasAuthoritativeActivePiTurn({
   isStreaming,
   assistantMessageId,
+  backendBusy,
+  startedDuringPreflight,
 }: {
   // `isLoading` is intentionally accepted but ignored: send preflight uses it
   // for immediate UI feedback before any backend turn exists.
   isLoading: boolean;
   isStreaming: boolean;
   assistantMessageId: string | null;
+  backendBusy: boolean;
+  startedDuringPreflight: boolean;
 }): boolean {
-  return isStreaming || assistantMessageId !== null;
+  return (
+    !startedDuringPreflight &&
+    backendBusy &&
+    (isStreaming || assistantMessageId !== null)
+  );
 }
 
 export async function awaitPendingPiPresetSwitch(
@@ -211,11 +219,16 @@ export function usePiSendTransport(options: PiSendTransportOptions) {
     }
   }
 
-  async function interruptActivePiTurn() {
+  async function interruptActivePiTurn(
+    liveSession: LivePiSessionCheck,
+    startedDuringPreflight: boolean,
+  ) {
     const hasActiveTurn = hasAuthoritativeActivePiTurn({
       isLoading,
       isStreaming,
       assistantMessageId: piMessageIdRef.current,
+      backendBusy: liveSession.running && liveSession.info.busy,
+      startedDuringPreflight,
     });
     if (!hasActiveTurn) return;
 
@@ -301,6 +314,7 @@ export function usePiSendTransport(options: PiSendTransportOptions) {
     // not immediately started a second time, and a failed one cannot reuse the
     // stale provider.
     let liveSession: Awaited<ReturnType<typeof checkLivePiSession>>;
+    let startedDuringPreflight = false;
     try {
       liveSession = await checkLivePiSession(piSessionIdRef.current, setPiInfo);
     } catch (e) {
@@ -387,6 +401,7 @@ export function usePiSendTransport(options: PiSendTransportOptions) {
                 providerConfig,
               );
               if (result.status === "ok" && result.data.running) {
+                startedDuringPreflight = !liveSession.running && !liveSession.indeterminate;
                 setPiInfo(result.data);
                 piSessionSyncedRef.current = false;
                 piCrashCountRef.current = 0;
@@ -505,7 +520,7 @@ export function usePiSendTransport(options: PiSendTransportOptions) {
         return;
       }
 
-      await interruptActivePiTurn();
+      await interruptActivePiTurn(liveSession, startedDuringPreflight);
     } catch (e) {
       setIsLoading(false);
       throw e;


### PR DESCRIPTION
## Bug description

Source feedback: Discord intake `t_3db83048`, message `1538619377149153293` (Windows 10, app 2.6.23). A newly started Pi chat session could be aborted during send preflight before the prompt was written.

## Root cause

Frontend streaming/message markers can outlive the backend work they describe. The preflight interruption decision trusted those stale markers without requiring authoritative backend busy state. Conversely, simply adding the broad backend `busy` flag was insufficient because startup thinking/state RPCs can transiently report busy for the session this same preflight just started.

## Fix

- Require both a frontend turn marker and authoritative backend busy state before interrupting work.
- Track a session definitively started from stopped by the current preflight and exempt only that fresh start from interruption.
- Keep indeterminate and already-running sessions interruptible when backend work is confirmed.

This covers the whole standalone Pi send-preflight surface because the corrected predicate and fresh-start state live in the shared transport path used before prompt dispatch; regression tests exercise stale idle state, startup RPC busy state, pre-existing active work, and indeterminate liveness.

## RED / GREEN evidence

- RED: restoring the frontend-only predicate fails the stale-idle regression.
- RED: using only `backendBusy && frontendMarker` fails the startup-RPC regression.
- GREEN: focused active-turn suite: 1 file / 6 tests.
- GREEN: focused chat suite: 5 files / 25 tests.
- GREEN: full configured Vitest: 356 files / 3,739 tests.
- GREEN: Bun-native suite: 20 files / 236 tests.
- GREEN: TypeScript noEmit and focused ESLint.
- GREEN: headers, security scan, merge topology, diff, and clean-worktree checks.

## Visual evidence

```text
Before: fresh start -> startup reports busy -> preflight abort -> prompt never written
After:  fresh start -> marked started here -> no abort      -> prompt dispatched
Active: existing turn + backend busy     -> preflight abort -> existing work interrupted
```

## Platform scope and risk

Reported on Windows 10. The change is frontend TypeScript in the cross-platform standalone Pi transport; no platform-specific or native code changes. Risk is limited to the pre-send interruption decision. No packaged Windows manual E2E was available; deterministic control-flow regressions plus the complete configured frontend suites provide coverage.