### PR TITLE
fix(chat): restore one-click home actions

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat/summary-cards.test.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/summary-cards.test.tsx
@@ -18,17 +18,6 @@ describe("SummaryCards", () => {
     vi.clearAllMocks();
   });
 
-/**
- * The built-in extras beyond the two featured cards now sit behind a `more`
- * disclosure, so an empty chat opens with one obvious action instead of eight.
- * These assertions are about ordering and dispatch, which are unchanged — they
- * just have to open the shelf first, the way a user would.
- */
-function revealBuiltInShelf(): void {
-  const more = screen.queryByTestId("summary-cards-more");
-  if (more) fireEvent.click(more);
-}
-
   it("prioritizes cards from the saved onboarding goal", () => {
     render(
       <SummaryCards
@@ -40,8 +29,6 @@ function revealBuiltInShelf(): void {
         userGoalCategory="work_patterns"
       />,
     );
-
-    revealBuiltInShelf();
 
     const cards = screen.getAllByTestId(/^summary-card-/);
     expect(cards.slice(0, 4).map((card) => card.dataset.testid)).toEqual([
@@ -76,8 +63,6 @@ function revealBuiltInShelf(): void {
       <SummaryCards {...props} userGoalCategory="meeting_follow_through" />,
     );
 
-    revealBuiltInShelf();
-
     const cards = screen.getAllByTestId(/^summary-card-/);
     expect(cards.slice(0, 4).map((card) => card.dataset.testid)).toEqual([
       "summary-card-missed-todos",
@@ -87,7 +72,7 @@ function revealBuiltInShelf(): void {
     ]);
   });
 
-  it("opens with one obvious action and keeps the built-in extras behind more", () => {
+  it("keeps every built-in action directly available", () => {
     render(
       <SummaryCards
         onSendMessage={vi.fn()}
@@ -99,19 +84,12 @@ function revealBuiltInShelf(): void {
       />,
     );
 
-    // Only the hero and its one alternative. Eight simultaneous targets on an
-    // empty chat is the clutter this disclosure exists to remove.
-    expect(screen.getAllByTestId(/^summary-card-/)).toHaveLength(2);
-    expect(screen.queryByText("Meeting Prep")).not.toBeInTheDocument();
-
-    fireEvent.click(screen.getByTestId("summary-cards-more"));
-
-    expect(screen.getAllByTestId(/^summary-card-/).length).toBeGreaterThan(2);
+    expect(screen.getAllByTestId(/^summary-card-/)).toHaveLength(4);
     expect(screen.getByText("Meeting Prep")).toBeInTheDocument();
     expect(screen.queryByTestId("summary-cards-more")).not.toBeInTheDocument();
   });
 
-  it("never hides the user's own saved templates behind the disclosure", () => {
+  it("keeps the user's saved templates alongside the built-in actions", () => {
     render(
       <SummaryCards
         onSendMessage={vi.fn()}
@@ -129,7 +107,6 @@ function revealBuiltInShelf(): void {
       />,
     );
 
-    // Progressive disclosure hides our defaults, never the user's own work.
     expect(screen.getByText("Client recap")).toBeInTheDocument();
     expect(screen.getByText("+ custom")).toBeInTheDocument();
   });
@@ -145,8 +122,6 @@ function revealBuiltInShelf(): void {
         onDeleteCustomTemplate={vi.fn()}
       />,
     );
-
-    revealBuiltInShelf();
 
     const cards = [
       ["automate-my-work", "⚡ Automate My Work"],

--- a/apps/screenpipe-app-tauri/components/chat/summary-cards.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/summary-cards.tsx
@@ -108,9 +108,6 @@ export function SummaryCards({
 }: SummaryCardsProps) {
   const [showAll, setShowAll] = useState(false);
   const [showBuilder, setShowBuilder] = useState(false);
-  // Progressive disclosure (DESIGN.md core value): the quick-action shelf is
-  // opt-in so a new chat presents one obvious action, not eight.
-  const [showMore, setShowMore] = useState(false);
   const [editingTemplate, setEditingTemplate] = useState<CustomTemplate | null>(null);
   // Curated home grid — kept deliberately small to reduce cognitive load.
   // Order matters. Definitions come from the app bundle (FALLBACK_TEMPLATES)
@@ -242,7 +239,7 @@ export function SummaryCards({
           column's edges (brick fill) instead of leaving a ragged right edge. */}
       <div className="w-full max-w-lg mb-4 flex flex-wrap items-center gap-1">
         {/* Template-backed chips (Time Breakdown, Missed To-Dos) */}
-        {showMore && featured.slice(2).map((pipe) => (
+        {featured.slice(2).map((pipe) => (
           <button
             key={pipe.name}
             data-testid={`summary-card-${pipe.name}`}
@@ -253,7 +250,7 @@ export function SummaryCards({
           </button>
         ))}
         {/* Quick summary chips */}
-        {showMore && [
+        {[
           { label: "Meeting Prep", prompt: "Summarize context I'll need for upcoming meetings" },
           { label: "Blockers", prompt: "What problems, errors, or blockers did I encounter?" },
         ].map((qt) => (
@@ -276,19 +273,6 @@ export function SummaryCards({
             {qt.label}
           </button>
         ))}
-        {!showMore && (
-          <button
-            type="button"
-            data-testid="summary-cards-more"
-            onClick={() => {
-              posthog.capture("home_card_clicked", { kind: "more_disclosure" });
-              setShowMore(true);
-            }}
-            className="grow px-2 py-0.5 text-[11px] font-mono tracking-wide bg-muted/20 hover:bg-foreground hover:text-background border border-border/30 hover:border-foreground text-muted-foreground/70 transition-all duration-150 cursor-pointer"
-          >
-            more
-          </button>
-        )}
         {/* User's saved templates — chips slightly fainter than built-ins with
             a pin glyph marking them as user-owned. Full text and management
             (edit/delete) live in the edit dialog. */}


### PR DESCRIPTION
## problem

The progressive disclosure added in #6284 made Time Breakdown, Missed To-Dos, Meeting Prep, and Blockers require `more` plus a second click. The disclosure state also reset whenever the home surface remounted, adding friction to repeat use.

## change

- render all four goal-ordered home cards immediately
- keep Meeting Prep and Blockers directly available
- remove the transient `showMore` state and disclosure event
- update the component tests to pin one-click availability and direct dispatch

## visual

```text
before                              after
┌────────────────────────────┐      ┌────────────────────────────┐
│ primary action             │      │ primary action             │
├────────────────────────────┤      ├────────────────────────────┤
│ secondary action           │      │ secondary action           │
├──────────────┬─────────────┤      ├──────────────┬─────────────┤
│ more         │ + custom    │      │ action 3     │ action 4    │
└──────────────┴─────────────┘      ├──────────────┼─────────────┤
        ↓ click more                 │ meeting prep │ blockers    │
        ↓ click action               └──────────────┴─────────────┘

two clicks for hidden actions       one click for every action
```

## testing

- `bun x vitest run components/chat/summary-cards.test.tsx --config vitest.config.ts` — 11 passed
- `bun run typecheck`
- `bun x eslint components/chat/summary-cards.tsx components/chat/summary-cards.test.tsx`
- `git diff --check origin/main...HEAD`
