### PR TITLE
fix Anthropic BYOK connection validation

### DIFF
--- a/apps/screenpipe-app-tauri/lib/utils/ai-preset-connection.test.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/ai-preset-connection.test.ts
@@ -111,6 +111,16 @@ describe("testAiPresetConnection", () => {
       ),
     ).resolves.toMatchObject({ reply: "hi" });
 
+    expect(request).toHaveBeenCalledWith(
+      "https://api.anthropic.com/v1/messages",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-api-key": "k",
+          "anthropic-version": "2023-06-01",
+          "anthropic-dangerous-direct-browser-access": "true",
+        }),
+      }),
+    );
     expect(JSON.parse(request.mock.calls[0][1]!.body as string).stream).toBe(false);
   });
 

--- a/apps/screenpipe-app-tauri/lib/utils/ai-preset-connection.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/ai-preset-connection.ts
@@ -52,6 +52,7 @@ const headersForPreset = (
   if (preset.provider === "anthropic") {
     if (preset.apiKey) headers["x-api-key"] = preset.apiKey;
     headers["anthropic-version"] = "2023-06-01";
+    headers["anthropic-dangerous-direct-browser-access"] = "true";
   } else if (preset.apiKey) {
     headers.Authorization = `Bearer ${preset.apiKey}`;
   }


### PR DESCRIPTION
## Summary

- send Anthropic required direct-browser header during BYOK chat validation
- cover the Anthropic request headers in the shared connection-test regression

## Before / after

```text
BEFORE  POST /v1/messages
        x-api-key + anthropic-version
        -> 401: CORS requests must set anthropic-dangerous-direct-browser-access

AFTER   POST /v1/messages
        x-api-key + anthropic-version + anthropic-dangerous-direct-browser-access: true
        -> request reaches Anthropic authentication/model validation
```

## Test plan

- `bun x vitest run --config vitest.config.ts lib/utils/ai-preset-connection.test.ts` (6 tests passed)
- `git diff --check`