### PR TITLE
fix(ux): expose Live Views directly in the main sidebar

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -19,14 +19,14 @@ results and `cargo llvm-cov` data on top when judging release confidence.
 ### Tauri E2E
 
 - Mapped specs: 117
-- Declared test blocks: 334
-- Weighted coverage points: 261.3
+- Declared test blocks: 335
+- Weighted coverage points: 262.3
 
 | Platform | Specs | Declared tests | Weighted points | Layers | Features | Critical score |
 | --- | --- | --- | --- | --- | --- | --- |
-| windows | 89 | 288 | 235.3 | 15 | 93 | 92% |
-| macos | 113 | 297 | 232.1 | 17 | 99 | 90% |
-| linux | 79 | 248 | 206.0 | 14 | 89 | 88% |
+| windows | 89 | 289 | 236.3 | 15 | 93 | 92% |
+| macos | 113 | 298 | 233.1 | 17 | 99 | 90% |
+| linux | 79 | 249 | 207.0 | 14 | 89 | 88% |
 
 ### Core Engine
 

--- a/apps/screenpipe-app-tauri/app/(main)/home/page.tsx
+++ b/apps/screenpipe-app-tauri/app/(main)/home/page.tsx
@@ -8,7 +8,7 @@ import {
   Settings as SettingsIcon,
   TimerReset,
   Plus,
-  Brain,
+  LayoutDashboard,
   MonitorPlay,
   HelpCircle,
   PanelLeftClose,
@@ -55,7 +55,7 @@ import { usePlatform } from "@/lib/hooks/use-platform";
 import { useIsFullscreen } from "@/lib/hooks/use-is-fullscreen";
 import { FeedbackSection } from "@/components/settings/feedback-section";
 import { PipeStoreView } from "@/components/pipe-store";
-import { BrainSection } from "@/components/settings/brain-section";
+import { BrainSection, openLiveViewsOverview } from "@/components/settings/brain-section";
 import { ConnectionsSection } from "@/components/settings/connections-section";
 import { MeetingNotesSection } from "@/components/meeting-notes";
 import { StandaloneChat } from "@/components/standalone-chat";
@@ -997,7 +997,7 @@ function HomeContent() {
     // Each click allocates a new session id (empty rows are not reused — that
     // felt like opening an old recent).
     home: { label: "Chat", icon: <Plus className="h-3.5 w-3.5" /> },
-    brain: { label: "Brain", icon: <Brain className="h-3.5 w-3.5" /> },
+    brain: { label: "Live Views", icon: <LayoutDashboard className="h-3.5 w-3.5" /> },
     meetings: { label: "Meetings", icon: <CalendarClock className="h-3.5 w-3.5" /> },
     pipes: { label: "Scheduled", icon: <TimerReset className="h-3.5 w-3.5" /> },
     timeline: { label: "Timeline", icon: <MonitorPlay className="h-3.5 w-3.5" /> },
@@ -1140,6 +1140,7 @@ function HomeContent() {
           },
           goToSection: (id) => {
             void setActiveSection(id);
+            if (id === "brain") openLiveViewsOverview();
           },
           toggleSidebar,
           openSettings,
@@ -1306,6 +1307,10 @@ function HomeContent() {
                   // The "home" slot is the New Chat affordance — clicking it
                   // (from any view) always spawns a new chat session.
                   if (id === "home") startNewChat();
+                  // "Live Views" is a direct destination (#5622): always land
+                  // on the overview tab, never on whichever Brain tab
+                  // (Memories/Artifacts) was last active.
+                  if (id === "brain") openLiveViewsOverview();
                 }}
                 onMove={(id, toIndex) =>
                   persistSidebarLayout(

--- a/apps/screenpipe-app-tauri/components/command-palette.tsx
+++ b/apps/screenpipe-app-tauri/components/command-palette.tsx
@@ -6,9 +6,9 @@
 import React, { useState } from "react";
 import type { LucideIcon } from "lucide-react";
 import {
-  Brain,
   CalendarClock,
   Keyboard,
+  LayoutDashboard,
   MessageSquare,
   MonitorPlay,
   PanelLeft,
@@ -113,7 +113,7 @@ const SECTION_ACTION_IDS: Record<SidebarNavId, CommandPaletteActionId> = {
 
 const SECTION_ICONS: Record<SidebarNavId, LucideIcon> = {
   home: MessageSquare,
-  brain: Brain,
+  brain: LayoutDashboard,
   meetings: CalendarClock,
   pipes: TimerReset,
   timeline: MonitorPlay,

--- a/apps/screenpipe-app-tauri/components/settings/__tests__/brain-section.filter.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/brain-section.filter.test.tsx
@@ -148,7 +148,11 @@ vi.mock("@/components/ui/use-toast", () => ({
   useToast: () => ({ toast: vi.fn() }),
 }));
 
-import { BrainSection, resetBrainViewStateForTests } from "../brain-section";
+import {
+  BrainSection,
+  openLiveViewsOverview,
+  resetBrainViewStateForTests,
+} from "../brain-section";
 import { localFetch } from "@/lib/api";
 import { emit } from "@tauri-apps/api/event";
 import { useChatStore } from "@/lib/stores/chat-store";
@@ -655,6 +659,54 @@ describe("BrainSection type filter", () => {
     await waitFor(() =>
       expect(screen.getByTestId("brain-scroll-container").scrollTop).toBe(320),
     );
+  });
+
+  // #5622: the Home sidebar's "Live Views" item is a direct destination, so
+  // it must always land on the overview tab — never on whichever tab
+  // (Memories/Artifacts) Brain was last showing.
+  it("always opens on the Live Views overview when opened via the sidebar, even after Memories/Artifacts was last active", async () => {
+    const firstRender = render(<BrainSection />);
+    await waitFor(() => expect(memoryRows().length).toBe(8));
+
+    selectBrainView("artifacts");
+    await waitFor(() => expect(artifactRows().length).toBe(5));
+
+    // Simulate leaving Brain for another sidebar section: the component
+    // unmounts, and module-level view state is all that survives.
+    firstRender.unmount();
+
+    // The sidebar's onSelect handler calls this before the section (re)mounts.
+    openLiveViewsOverview();
+
+    render(<BrainSection />);
+    await waitFor(() =>
+      expect(screen.getByTestId("brain-view-switcher")).toHaveAttribute(
+        "aria-label",
+        "switch Brain view, current: Live Views",
+      ),
+    );
+    expect(memoryRows().length).toBe(0);
+    expect(artifactRows().length).toBe(0);
+  });
+
+  it("re-syncs an already-mounted Brain section back to Live Views on repeat sidebar clicks", async () => {
+    render(<BrainSection />);
+    await waitFor(() => expect(memoryRows().length).toBe(8));
+
+    selectBrainView("memories");
+    await waitFor(() => expect(memoryRows().length).toBe(8));
+
+    // BrainSection is still mounted (the user never left it) — clicking the
+    // sidebar item again must still force the overview tab, not no-op.
+    openLiveViewsOverview();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("brain-view-switcher")).toHaveAttribute(
+        "aria-label",
+        "switch Brain view, current: Live Views",
+      ),
+    );
+    expect(memoryRows().length).toBe(0);
   });
 
   it("edits memory tags from the edit dialog", async () => {

--- a/apps/screenpipe-app-tauri/components/settings/brain-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/brain-section.tsx
@@ -253,6 +253,21 @@ export function resetBrainViewStateForTests() {
   brainViewState.scrollTopByType.overview = 0;
 }
 
+// The Home sidebar's "Live Views" item is a direct destination, not just a
+// rename of the old "Brain" entry — it must always land on this tab, never
+// on whichever tab (Memories/Artifacts) was last active (#5622). Setting the
+// module var alone covers a not-yet-mounted BrainSection (the next mount
+// reads it); the event covers an already-mounted one, since flipping the var
+// alone wouldn't trigger a re-render.
+export const LIVE_VIEWS_SIDEBAR_OPEN_EVENT = "screenpipe:live-views-sidebar-open";
+
+export function openLiveViewsOverview(): void {
+  brainViewState.typeFilter = "overview";
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new Event(LIVE_VIEWS_SIDEBAR_OPEN_EVENT));
+  }
+}
+
 function timeAgo(iso: string): string {
   const ms = Date.now() - new Date(iso).getTime();
   if (!Number.isFinite(ms) || ms < 0) return "just now";
@@ -645,6 +660,13 @@ export function BrainSection() {
     window.addEventListener(ONBOARDING_BRAIN_HANDOFF_EVENT, openOverview);
     return () =>
       window.removeEventListener(ONBOARDING_BRAIN_HANDOFF_EVENT, openOverview);
+  }, [switchTypeFilter]);
+
+  useEffect(() => {
+    const openOverview = () => switchTypeFilter("overview");
+    window.addEventListener(LIVE_VIEWS_SIDEBAR_OPEN_EVENT, openOverview);
+    return () =>
+      window.removeEventListener(LIVE_VIEWS_SIDEBAR_OPEN_EVENT, openOverview);
   }, [switchTypeFilter]);
 
   // debounce search

--- a/apps/screenpipe-app-tauri/e2e/COVERAGE.md
+++ b/apps/screenpipe-app-tauri/e2e/COVERAGE.md
@@ -7,8 +7,8 @@ and layer declared in the manifest, weighted by confidence and criticality.
 - Manifest: `e2e/coverage-map.json`
 - Specs directory: `e2e/specs`
 - Mapped specs: 117
-- Declared test blocks: 334
-- Weighted coverage points: 261.3
+- Declared test blocks: 335
+- Weighted coverage points: 262.3
 
 Confidence weights: strong=1.0, partial=0.7, conditional=0.4, smoke=0.3.
 Criticality weights: high=1.0, medium=0.7, low=0.4.
@@ -19,9 +19,9 @@ can execute more runtime cases than this number shows.
 
 | Platform | Specs | Declared tests | Weighted points | Layers | Features | Critical score |
 | --- | --- | --- | --- | --- | --- | --- |
-| windows | 89 | 288 | 235.3 | 15 | 93 | 92% |
-| macos | 113 | 297 | 232.1 | 17 | 99 | 90% |
-| linux | 79 | 248 | 206.0 | 14 | 89 | 88% |
+| windows | 89 | 289 | 236.3 | 15 | 93 | 92% |
+| macos | 113 | 298 | 233.1 | 17 | 99 | 90% |
+| linux | 79 | 249 | 207.0 | 14 | 89 | 88% |
 
 ## Runtime Results
 
@@ -39,13 +39,13 @@ pass/fail/skip counts.
 | capture-ocr | 2 specs / 16 tests / 6.4 pts | 8 specs / 12 tests / 4.8 pts | 1 specs / 3 tests / 1.2 pts |
 | chat-ai | 25 specs / 51 tests / 37.6 pts | 37 specs / 73 tests / 51.7 pts | 24 specs / 50 tests / 37.1 pts |
 | entitlement | - | 1 specs / 1 tests / 1.0 pts | - |
-| local-api | 25 specs / 114 tests / 95.0 pts | 32 specs / 101 tests / 84.5 pts | 20 specs / 82 tests / 73.2 pts |
+| local-api | 25 specs / 115 tests / 96.0 pts | 32 specs / 102 tests / 85.5 pts | 20 specs / 83 tests / 74.2 pts |
 | notifications | 4 specs / 25 tests / 16.3 pts | 3 specs / 5 tests / 3.4 pts | 2 specs / 4 tests / 3.1 pts |
 | onboarding | 9 specs / 37 tests / 32.8 pts | 11 specs / 39 tests / 34.2 pts | 9 specs / 37 tests / 32.8 pts |
 | os-integration | 7 specs / 30 tests / 25.5 pts | 14 specs / 27 tests / 16.0 pts | 2 specs / 13 tests / 9.4 pts |
 | performance | 2 specs / 44 tests / 44.0 pts | 4 specs / 34 tests / 30.5 pts | 1 specs / 29 tests / 29.0 pts |
-| pipes | 6 specs / 19 tests / 19.0 pts | 8 specs / 25 tests / 25.0 pts | 6 specs / 19 tests / 19.0 pts |
-| real-ui-e2e | 63 specs / 189 tests / 156.0 pts | 76 specs / 194 tests / 159.2 pts | 59 specs / 167 tests / 143.3 pts |
+| pipes | 6 specs / 20 tests / 20.0 pts | 8 specs / 26 tests / 26.0 pts | 6 specs / 20 tests / 20.0 pts |
+| real-ui-e2e | 63 specs / 190 tests / 157.0 pts | 76 specs / 195 tests / 160.2 pts | 59 specs / 168 tests / 144.3 pts |
 | settings | 14 specs / 38 tests / 35.0 pts | 16 specs / 33 tests / 28.7 pts | 13 specs / 30 tests / 27.0 pts |
 | storage-privacy | 9 specs / 40 tests / 31.3 pts | 9 specs / 26 tests / 25.1 pts | 6 specs / 19 tests / 18.1 pts |
 | tauri-command | 18 specs / 50 tests / 39.1 pts | 26 specs / 61 tests / 46.6 pts | 18 specs / 52 tests / 40.2 pts |
@@ -108,7 +108,7 @@ pass/fail/skip counts.
 | app-lifecycle.spec.ts | windows, macos, linux | real-ui-e2e, window-lifecycle | app-launch, home-navigation, webview-stability, route-churn, browser-storage | high | strong | mixed | 14 | Home webview, routing, reload, focus, resize, and storage stability. |
 | artifacts-api.spec.ts | windows, macos, linux | local-api | local-api-auth, artifacts | medium | strong | api | 7 | CRUD coverage for artifact registration, validation, unified listing, upsert, and delete. |
 | audio-fallback.spec.ts | macos | audio-device, settings, notifications | audio-device-health, settings-recording, notifications | medium | conditional | real-user-flow | 1 | Opt-in macOS cloud audio fallback seed. |
-| brain-overview.spec.ts | windows, macos, linux | real-ui-e2e, local-api, pipes | brain, brain-overview, brain-canvas, artifacts, pipes | high | strong | real-user-flow | 5 | Deletes the last dashboard at 800x600, scrolls to the final starter template, verifies the real local builder keeps its generated dashboard on review through save, requires four AI-proposed Blocks to be visible on an empty Canvas before acceptance, and samples the native Canvas viewport across an AI-added Block focus to prove eased intermediate movement instead of a teleport. Also renders source-backed selectable and fixed-period Live Views, verifies dashboard switching stays available during refresh, omits fixed-period controls from view and Customize, exercises durable Canvas notes, connections, keyboard movement, navigation restore, deletion cleanup, and checks layout bounds from 800x600 through 1920x1080. |
+| brain-overview.spec.ts | windows, macos, linux | real-ui-e2e, local-api, pipes | brain, brain-overview, brain-canvas, artifacts, pipes | high | strong | real-user-flow | 6 | Deletes the last dashboard at 800x600, scrolls to the final starter template, verifies the real local builder keeps its generated dashboard on review through save, requires four AI-proposed Blocks to be visible on an empty Canvas before acceptance, and samples the native Canvas viewport across an AI-added Block focus to prove eased intermediate movement instead of a teleport. Also renders source-backed selectable and fixed-period Live Views, verifies dashboard switching stays available during refresh, omits fixed-period controls from view and Customize, exercises durable Canvas notes, connections, keyboard movement, navigation restore, deletion cleanup, and checks layout bounds from 800x600 through 1920x1080. |
 | brain-section.spec.ts | windows, macos, linux | real-ui-e2e | brain, artifacts, memories, viewer-deeplink | medium | strong | real-user-flow | 10 | Brain coverage for filters, search, delete flows, selection pruning, add memory, and inline artifact markdown preview. |
 | capture-frequency-floor.spec.ts | macos | capture-ocr, settings, real-ui-e2e | capture-ocr, settings-recording, restart-flow | high | conditional | real-user-flow | 1 | macOS fixed screenshot cadence regression: persists the 1s setting before immediate Apply & Restart, then verifies real capture attempts and frame writes. |
 | capture-loop-liveness.spec.ts | macos | capture-ocr, local-api, os-integration | app-launch, capture-ocr | high | conditional | api | 1 | Opt-in macOS fault injection wedges a visual-change probe; asserts the bounded probe keeps the capture loop and its /health heartbeat live (no false stale/incident). |

--- a/apps/screenpipe-app-tauri/e2e/specs/brain-overview.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/brain-overview.spec.ts
@@ -142,6 +142,15 @@ async function selectDashboard(viewId: string) {
   );
 }
 
+/** Switch the Brain tab via its dropdown switcher (Live Views / Memories / Artifacts). */
+async function selectBrainView(view: "overview" | "memories" | "artifacts") {
+  const switcher = await waitForTestId("brain-view-switcher", 10_000);
+  await switcher.click();
+  const option = await $(`[data-testid="brain-filter-${view}"]`);
+  await option.waitForDisplayed({ timeout: t(5_000) });
+  await option.click();
+}
+
 async function openDashboardMenu() {
   await browser.waitUntil(
     async () => {
@@ -2462,5 +2471,91 @@ Refresh the assigned Live View output targets from source-backed activity.
     expect(deletedCanvas).toBeNull();
     await invokeOrThrow("delete_brain_view", { id: SELECTABLE_VIEW_ID });
     await invokeOrThrow("delete_brain_view", { id: FIXED_VIEW_ID });
+  });
+
+  // #5622: the Home sidebar exposes "Live Views" as a direct destination —
+  // clicking it must always open the Live Views overview (not whichever tab
+  // Brain was last showing), while the selected dashboard keeps surviving
+  // navigation away and back, exactly as it already does today.
+  it("sidebar Live Views always opens the overview and keeps the selected dashboard across navigation", async () => {
+    await waitForAppReady();
+    await openHomeWithDiagnostics();
+
+    const viewIdA = "sidebar-nav-e2e-a";
+    const viewIdB = "sidebar-nav-e2e-b";
+    const viewRequest = (id: string, title: string) => ({
+      id,
+      title,
+      expectedRevision: null,
+      timeRange: "7d",
+      periodPolicy: { type: "selectable.v1" as const, values: ["7d", "30d"] },
+      slots: [],
+    });
+
+    // A WDIO retry reuses the same app process — start from a known
+    // dashboard set so the assertions below don't depend on state a
+    // previous attempt (or an earlier test) left behind.
+    const existingViews = await invokeOrThrow<BrainView[]>("list_brain_views");
+    for (const view of existingViews) {
+      await invokeOrThrow("delete_brain_view", { id: view.id });
+    }
+    await invokeOrThrow("save_brain_view", {
+      request: viewRequest(viewIdA, "Sidebar nav e2e A"),
+    });
+    await invokeOrThrow("save_brain_view", {
+      request: viewRequest(viewIdB, "Sidebar nav e2e B"),
+    });
+
+    try {
+      const brainNav = await waitForTestId("nav-brain", 10_000);
+      expect(await brainNav.getText()).toContain("Live Views");
+      await brainNav.click();
+      await waitForTestId("section-brain", 15_000);
+
+      // Opens directly on the Live Views overview, not Memories/Artifacts.
+      await waitForTestId("overview-dashboard-selector", 15_000);
+
+      // Switch dashboard — the state that must survive the round trip below.
+      await selectDashboard(viewIdB);
+
+      // Switch to Memories, the tab a user would "discover" per the issue.
+      await selectBrainView("memories");
+      await browser.waitUntil(
+        async () =>
+          (await $("[data-testid='brain-view-switcher']").getAttribute(
+            "aria-label",
+          )) === "switch Brain view, current: Memories",
+        { timeout: t(5_000), timeoutMsg: "did not switch to Memories tab" },
+      );
+
+      // Navigate away and back via the sidebar, exactly like a real user.
+      const pipesNav = await waitForTestId("nav-pipes", 10_000);
+      await pipesNav.click();
+      await waitForTestId("section-pipes", 15_000);
+
+      const brainNavAgain = await waitForTestId("nav-brain", 10_000);
+      await brainNavAgain.click();
+      await waitForTestId("section-brain", 15_000);
+
+      // Regression guard for #5622: even though Memories was the last active
+      // tab, the sidebar's "Live Views" entry must land back on the
+      // overview — not silently reopen Memories.
+      const selector = await waitForTestId("overview-dashboard-selector", 15_000);
+      await browser.waitUntil(
+        async () =>
+          (await $("[data-testid='brain-view-switcher']").getAttribute(
+            "aria-label",
+          )) === "switch Brain view, current: Live Views",
+        { timeout: t(5_000), timeoutMsg: "did not return to the Live Views tab" },
+      );
+
+      // The previously selected dashboard remains selected and switchable.
+      expect(await selector.getValue()).toBe(viewIdB);
+      await selectDashboard(viewIdA);
+      expect(await selector.getValue()).toBe(viewIdA);
+    } finally {
+      await invokeOrThrow("delete_brain_view", { id: viewIdA }).catch(() => {});
+      await invokeOrThrow("delete_brain_view", { id: viewIdB }).catch(() => {});
+    }
   });
 });


### PR DESCRIPTION
## Summary

Fixes #5622. Saved dashboards are called "Live Views", but the main sidebar exposed only a generic "Brain" destination — users had to open Brain and then discover the Live Views tab before switching dashboards.

- Renamed the sidebar item's **label** from "Brain" to "Live Views" and swapped its icon to `LayoutDashboard` (matching the icon already used for the Live Views tab inside Brain). The nav **id** stays `"brain"` so persisted sidebar layout/hidden-section policy (enterprise `hiddenSections`) keep working unchanged.
- Clicking "Live Views" (from the sidebar or the ⌘K command palette) now always opens the overview tab directly — even if the section was last showing Memories or Artifacts. Implemented via a small exported `openLiveViewsOverview()` + event in `brain-section.tsx`, following the same pattern already used for the onboarding handoff. No new dashboard state was added — dashboard selection/switching continues to be handled entirely by `BrainOverview`'s existing `selectedLiveViewDashboardId()` localStorage-backed logic.
- Memories and Artifacts remain reachable via the existing in-section tab switcher — untouched.

## Test plan

- [x] `bun x vitest run brain-section.filter` — 26/26 pass (2 new tests added: forcing overview on a fresh mount, and re-syncing an already-mounted section)
- [x] `bun x vitest run command-palette` — 14/14 pass (unchanged palette navigation behavior)
- [x] `bun x tsc --noEmit` — clean
- [x] Added e2e coverage in `e2e/specs/brain-overview.spec.ts`: sidebar → Live Views → switch dashboard → navigate away (Pipes) → back, asserting it reopens on the overview (not Memories) and the dashboard selection survived
- [x] Manually verified in the browser via `bun run dev:web` (mock Tauri + mock engine): switched Brain to Memories tab, navigated to Scheduled, clicked "Live Views" again — landed directly on the previously-selected dashboard's overview, not Memories

### Before / after

```
before                              after
Brain                                Live Views
  -> Live Views                        -> selected dashboard (direct)
     -> dashboard selector             -> dashboard selector remains visible
```