### PR TITLE
fix(updater): add lifecycle telemetry

### DIFF
--- a/.github/workflows/sentry-cleanup.yml
+++ b/.github/workflows/sentry-cleanup.yml
@@ -226,6 +226,13 @@ jobs:
                   should_resolve, reason = should_resolve_version(current_version, event_version)
                   context = issue_context(issue, event, release_tag, full_ver, gap, reason)
 
+                  # This issue means the updater failed to advance the app, so
+                  # its old release is evidence of persistence, not staleness.
+                  if short_id == "SCREENPIPE-APP-K7":
+                      print(f"  SKIP [{short_id}] updater-verification {context} {event_count} events, {user_count} users - {title}")
+                      skipped_count += 1
+                      continue
+
                   # Skip if has assignee (someone is working on it)
                   if assignee:
                       print(f"  SKIP [{short_id}] has assignee {context} {event_count} events, {user_count} users - {title}")

--- a/apps/screenpipe-app-tauri/components/update-banner.tsx
+++ b/apps/screenpipe-app-tauri/components/update-banner.tsx
@@ -18,6 +18,15 @@ import { cn } from "@/lib/utils";
 import { screenpipeWebUrl } from "@/lib/web-url";
 import { enterpriseUpdateAuthHeaders } from "@/lib/enterprise-auth-recovery";
 import { flushPendingSettingsWrites } from "@/lib/hooks/use-settings";
+import posthog from "posthog-js";
+
+function trackUpdateEvent(event: string, properties: Record<string, unknown>) {
+  try {
+    posthog.capture(event, properties);
+  } catch {
+    // Telemetry must never affect the updater.
+  }
+}
 
 interface UpdateInfo {
   version: string;
@@ -106,6 +115,7 @@ export function UpdateBanner({ className, compact = false, variant = "default" }
   const handleUpdate = async () => {
     setIsInstalling(true);
     const os = platform();
+    let failureStage = os === "windows" ? "download" : "verification";
 
     try {
       // A user can enable Auto-update and immediately click this banner. The
@@ -167,9 +177,17 @@ export function UpdateBanner({ className, compact = false, variant = "default" }
         }
 
         if (update?.available) {
-
-
-          await update.downloadAndInstall(undefined, downloadOptions);
+          await update.downloadAndInstall((event) => {
+            if (event.event === "Finished") {
+              failureStage = "install";
+              trackUpdateEvent("update_downloaded", {
+                target_version: update.version,
+              });
+              trackUpdateEvent("update_installation_started", {
+                target_version: update.version,
+              });
+            }
+          }, downloadOptions);
 
           toast({
             title: "update complete",
@@ -208,6 +226,10 @@ export function UpdateBanner({ className, compact = false, variant = "default" }
       }
     } catch (error) {
       console.error("failed to update:", error);
+      trackUpdateEvent("update_failed", {
+        stage: failureStage,
+        target_version: updateInfo?.version,
+      });
       setIsInstalling(false);
       toast({
         title: "update failed",

--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -2073,17 +2073,6 @@ async fn main() {
                 }
             }
 
-            // Initialize update check
-            let update_manager = start_update_check(&app_handle, 5)?;
-            app_handle.manage(update_manager.clone()); // Register for state::<Arc<UpdatesManager>>()
-
-            // Setup tray
-            if let Some(_) = app_handle.tray_by_id("screenpipe_main") {
-                if let Err(e) = tray::setup_tray(&app_handle, update_manager.update_now_menu_item_ref()) {
-                    error!("Failed to setup tray: {}", e);
-                }
-            }
-
             // Log tray icon position for diagnostics.
             // On notched MacBooks with many menu bar icons, the tray can land behind
             // the notch. Users can Cmd+drag it to a visible position.
@@ -2147,6 +2136,18 @@ async fn main() {
                     Err(e) => {
                         error!("Failed to start analytics: {}", e);
                     }
+                }
+            }
+
+            // Initialize update checks after analytics so boot-time updater
+            // lifecycle events can use the existing telemetry manager.
+            let update_manager = start_update_check(&app_handle, 5)?;
+            app_handle.manage(update_manager.clone()); // Register for state::<Arc<UpdatesManager>>()
+
+            // Setup tray
+            if let Some(_) = app_handle.tray_by_id("screenpipe_main") {
+                if let Err(e) = tray::setup_tray(&app_handle, update_manager.update_now_menu_item_ref()) {
+                    error!("Failed to setup tray: {}", e);
                 }
             }
 

--- a/apps/screenpipe-app-tauri/src-tauri/src/updates.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/updates.rs
@@ -25,6 +25,19 @@ use tokio::sync::oneshot;
 use tokio::sync::Mutex;
 use tokio::time::interval;
 
+/// Best-effort updater telemetry. It must never delay or affect updating.
+fn track_update_event(app: &tauri::AppHandle, event: &'static str, properties: serde_json::Value) {
+    let Some(analytics) = app.try_state::<Arc<crate::analytics::AnalyticsManager>>() else {
+        return;
+    };
+    let analytics = analytics.inner().clone();
+    tauri::async_runtime::spawn(async move {
+        if let Err(e) = analytics.send_event(event, Some(properties)).await {
+            warn!("failed to send updater telemetry event {}: {}", event, e);
+        }
+    });
+}
+
 // ---------------------------------------------------------------------------
 // Rollback: download a specific older version from R2 via the website API
 // ---------------------------------------------------------------------------
@@ -346,6 +359,11 @@ pub async fn restart_for_update(
     // detected instead of the app just quietly staying old.
     #[cfg(target_os = "macos")]
     if let Some(to_version) = crate::staged_update::staged_version() {
+        track_update_event(
+            &app,
+            "update_installation_started",
+            serde_json::json!({ "target_version": to_version }),
+        );
         record_update_attempt(&app, &to_version);
     }
 
@@ -791,6 +809,17 @@ impl UpdatesManager {
 
         // Did the previous process quit to apply an update that never landed?
         let failed_attempt = consume_update_attempt_marker(app);
+        if let Some(attempt) = &failed_attempt {
+            track_update_event(
+                app,
+                "update_failed",
+                serde_json::json!({
+                    "stage": "verification",
+                    "from_version": attempt.from_version,
+                    "target_version": attempt.to_version,
+                }),
+            );
+        }
 
         let update_menu_item = if is_enterprise_build(app) {
             None
@@ -932,6 +961,11 @@ impl UpdatesManager {
                 // issues or "endpoints not set" on source builds; neither is actionable.
                 // Sentry would just get noise.
                 warn!("updater check() error: {}", e);
+                track_update_event(
+                    &self.app,
+                    "update_failed",
+                    serde_json::json!({ "stage": "check" }),
+                );
             }
         }
         if let Ok(Some(update)) = check_result {
@@ -1003,6 +1037,15 @@ impl UpdatesManager {
             });
 
             let auto_update = load_auto_update_enabled(&self.app);
+            track_update_event(
+                &self.app,
+                "update_available",
+                serde_json::json!({
+                    "current_version": current_version,
+                    "target_version": update.version,
+                    "auto_update": auto_update,
+                }),
+            );
 
             if let Some(ref item) = self.update_menu_item {
                 item.set_enabled(true)?;
@@ -1119,12 +1162,16 @@ impl UpdatesManager {
                 Duration::from_secs(120),
                 Duration::from_secs(300),
             ];
+            let installation_started = Arc::new(AtomicBool::new(false));
             let download_result = {
                 let mut attempt: usize = 0;
                 loop {
                     let app_handle = self.app.clone();
                     let update_version = update.version.clone();
                     let menu_item = self.update_menu_item.clone();
+                    let telemetry_app = self.app.clone();
+                    let telemetry_version = update.version.clone();
+                    let installation_started_callback = installation_started.clone();
                     let mut downloaded: u64 = 0;
                     let mut last_pct: u8 = 0;
                     let on_chunk = move |chunk_len: usize, content_len: Option<u64>| {
@@ -1178,7 +1225,21 @@ impl UpdatesManager {
                         Err(e) => Err(e),
                     };
                     #[cfg(not(target_os = "macos"))]
-                    let result = update.download_and_install(on_chunk, || {}).await;
+                    let result = update
+                        .download_and_install(on_chunk, move || {
+                            installation_started_callback.store(true, Ordering::SeqCst);
+                            track_update_event(
+                                &telemetry_app,
+                                "update_downloaded",
+                                serde_json::json!({ "target_version": telemetry_version }),
+                            );
+                            track_update_event(
+                                &telemetry_app,
+                                "update_installation_started",
+                                serde_json::json!({ "target_version": telemetry_version }),
+                            );
+                        })
+                        .await;
 
                     match &result {
                         Ok(_) => break result,
@@ -1226,6 +1287,12 @@ impl UpdatesManager {
 
             match download_result {
                 Ok(_) => {
+                    #[cfg(target_os = "macos")]
+                    track_update_event(
+                        &self.app,
+                        "update_downloaded",
+                        serde_json::json!({ "target_version": update.version }),
+                    );
                     // Clear any prior failure marker — this version is good now.
                     *self.last_failed_update.lock().await = None;
                     *self.update_installed.lock().await = true;
@@ -1244,6 +1311,14 @@ impl UpdatesManager {
                         || err_str.contains("Unauthorized")
                         || err_str.contains("Forbidden")
                     {
+                        track_update_event(
+                            &self.app,
+                            "update_failed",
+                            serde_json::json!({
+                                "stage": "download",
+                                "target_version": update.version,
+                            }),
+                        );
                         warn!("update download requires authentication: {}", err_str);
                         if let Some(snap) = self.pending_update.lock().await.as_mut() {
                             snap.auth_required = true;
@@ -1278,6 +1353,19 @@ impl UpdatesManager {
                     // us from re-downloading this same broken bundle every 5 min
                     // (the auto-update download-loop fix).
                     warn!("update download failed after retries: {}", err_str);
+                    let failure_stage = if installation_started.load(Ordering::SeqCst) {
+                        "install"
+                    } else {
+                        "download"
+                    };
+                    track_update_event(
+                        &self.app,
+                        "update_failed",
+                        serde_json::json!({
+                            "stage": failure_stage,
+                            "target_version": update.version,
+                        }),
+                    );
                     *self.last_failed_update.lock().await =
                         Some((update.version.clone(), std::time::Instant::now()));
                     *self.update_available.lock().await = false;
@@ -1574,6 +1662,14 @@ fn check_whats_new(app: &tauri::AppHandle) {
     info!(
         "app upgraded from v{} to v{}, scheduling what's-new notification",
         old_version, current_version
+    );
+    track_update_event(
+        app,
+        "update_installed",
+        serde_json::json!({
+            "from_version": old_version,
+            "installed_version": current_version,
+        }),
     );
 
     tokio::spawn(async move {


### PR DESCRIPTION
Adds best-effort updater lifecycle telemetry for availability, download completion, install start, staged verification failures, and next-launch verified installs. Keeps telemetry off the updater critical path and records only version/stage metadata. Also excludes SCREENPIPE-APP-K7 from patch-gap Sentry cleanup. Validation: updater source passes rustfmt check and git diff --check; focused Cargo test compilation is blocked by the missing local bundled Windows bun-x86_64-pc-windows-msvc.exe resource. Closes #6308.