### PR TITLE
fix(connections): find Gmail with Google searches

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
@@ -30,6 +30,7 @@ import {
   CONNECTION_CATEGORY_BY_ID,
   CONNECTION_HARDCODED_DESCRIPTIONS,
   compareConnectionTiles,
+  connectionMatchesSearch,
   getSuggestedConnectionsForDevice,
   normalizeConnectionCategory,
   type ConnectionSuggestionTile,
@@ -4049,7 +4050,7 @@ export function ConnectionsSection({
     }
     const q = search.toLowerCase().trim();
     if (q) {
-      tiles = tiles.filter(t => t.name.toLowerCase().includes(q));
+      tiles = tiles.filter((tile) => connectionMatchesSearch(tile, q));
     }
     return [...tiles].sort(compareConnectionTiles);
   }, [allTiles, categoryFilter, search]);

--- a/apps/screenpipe-app-tauri/lib/constants/__tests__/connections-suggestions.test.ts
+++ b/apps/screenpipe-app-tauri/lib/constants/__tests__/connections-suggestions.test.ts
@@ -7,6 +7,7 @@ import {
   getSuggestedConnectionsForDevice,
   isSuggestedForThisDevice,
   compareConnectionTiles,
+  connectionMatchesSearch,
   type ConnectionSuggestionTile,
 } from "../connections";
 
@@ -82,5 +83,23 @@ describe("connection suggestions", () => {
     );
 
     expect(group.map((t) => t.id)).toEqual(["github", "linear"]);
+  });
+});
+
+describe("connection search", () => {
+  const gmail = tile("gmail", {
+    name: "Gmail",
+    description: "Read your Gmail inbox",
+  });
+
+  it.each(["gmail", "google", "google mail", "email", "mail"])(
+    "finds Gmail with %s",
+    (query) => {
+      expect(connectionMatchesSearch(gmail, query)).toBe(true);
+    },
+  );
+
+  it("does not match unrelated searches", () => {
+    expect(connectionMatchesSearch(gmail, "calendar")).toBe(false);
   });
 });

--- a/apps/screenpipe-app-tauri/lib/constants/connections.ts
+++ b/apps/screenpipe-app-tauri/lib/constants/connections.ts
@@ -152,6 +152,25 @@ export interface ConnectionSuggestionTile {
   description?: string;
 }
 
+const CONNECTION_SEARCH_ALIASES_BY_ID: Record<string, readonly string[]> = {
+  gmail: ["google", "google mail", "email", "mail"],
+};
+
+export function connectionMatchesSearch(
+  tile: ConnectionSuggestionTile,
+  query: string,
+): boolean {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return true;
+
+  return [
+    tile.name,
+    tile.id,
+    tile.description ?? "",
+    ...(CONNECTION_SEARCH_ALIASES_BY_ID[tile.id] ?? []),
+  ].some((term) => term.toLowerCase().includes(normalizedQuery));
+}
+
 export const CONNECTION_HARDCODED_DESCRIPTIONS: Record<string, string> = {
   "claude": "Search your screen & audio from Claude Desktop via MCP",
   "cursor": "Give Cursor AI access to your screen history via MCP",


### PR DESCRIPTION
## what changed

- make connection search match stable IDs, descriptions, and explicit aliases
- add Gmail aliases for `google`, `google mail`, `email`, and `mail`
- add regression coverage for the reported search terms

## why

The Connections page only searched display names. Searching `google` showed the other Google integrations but hid Gmail because its display name does not contain “Google”.

## visual

```text
search: google

before                      after
Google Calendar             Google Calendar
Google Docs                 Google Docs
Google Drive                Google Drive
Google Sheets               Google Sheets
                             Gmail
```

## validation

- `bun x vitest run --config vitest.config.ts lib/constants/__tests__/connections-suggestions.test.ts` — 12 passed
- `bun run typecheck` — passed
- focused ESLint — 0 errors (existing file warnings remain)
