### PR TITLE
fix(tray): expose log upload from the native menu

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
@@ -1195,8 +1195,12 @@ fn create_dynamic_menu(
     //             .build(app)?,
     //     );
 
-    // --- Settings + Quit ---
+    // --- Support, Settings + Quit ---
     menu_builder = menu_builder.item(&PredefinedMenuItem::separator(app)?);
+    if !data.app_ui_hidden {
+        menu_builder = menu_builder
+            .item(&MenuItemBuilder::with_id("feedback", "Send logs & feedback").build(app)?);
+    }
     if !data.app_ui_hidden && !is_tray_item_hidden("tray_settings") {
         menu_builder = menu_builder.item(
             &MenuItemBuilder::with_id("settings", "Settings...")
@@ -1292,6 +1296,7 @@ fn handle_menu_event(app_handle: &AppHandle, event: tauri::menu::MenuEvent) {
                 | "show_chat"
                 | "open_app"
                 | "settings"
+                | "feedback"
                 | "upgrade"
                 | "onboarding"
         )


### PR DESCRIPTION
## Summary

Add a native tray entry that opens the existing Help screen for log upload and feedback.

This shortens the support path when the main UI, chat, capture, or AI flow is the thing being diagnosed.

## Before / after

Before:

    Settings...
    Quit

After:

    Send logs & feedback
    Settings...
    Quit

The item reuses the existing feedback handler and Help page. It does not upload anything until the user chooses the existing share-logs action.

## Validation

- rustfmt --edition 2021 --check apps/screenpipe-app-tauri/src-tauri/src/tray.rs
- git diff --check

## Manual validation still needed

- Open a packaged desktop build, select the new tray item, and confirm the Help screen opens.
