### PR TITLE
Remove noisy WGC capture startup log

### DIFF
--- a/crates/screenpipe-screen/src/wgc_capture.rs
+++ b/crates/screenpipe-screen/src/wgc_capture.rs
@@ -535,8 +535,6 @@ impl PersistentCapture {
             return Err(anyhow!("StartCapture failed: {}", e));
         }
 
-        tracing::info!("persistent WGC capture started for monitor {}", monitor_id);
-
         Ok(Self {
             d3d,
             item,


### PR DESCRIPTION
## Summary

- remove the unconditional info log emitted when persistent WGC capture starts
- leave capture startup, cleanup, and error reporting unchanged

## Before / after

Before:
```text
INFO screenpipe_screen::wgc_capture: persistent WGC capture started for monitor 65778
```

After:
```text
(no startup log emitted)
```

## Validation

- `cargo fmt -p screenpipe-screen -- --check`
- `cargo check -p screenpipe-screen`
- `git diff --check`