### PR TITLE
fix(chat): explain opaque custom provider errors

### DIFF
--- a/apps/screenpipe-app-tauri/lib/chat/__tests__/provider-errors.test.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/__tests__/provider-errors.test.ts
@@ -169,6 +169,23 @@ describe("provider error copy", () => {
     expect(msg).toContain("Test Connection");
   });
 
+  it("maps the opaque custom-provider 400 to safe preset guidance", () => {
+    expect(
+      buildProviderErrorMessage("400 status code (no body)", {
+        provider: "custom",
+        model: "gemini-2.5-flash",
+      }),
+    ).toBe(
+      "The custom AI provider rejected the request. Verify the endpoint, model, and API key in Settings → AI.",
+    );
+    expect(
+      buildProviderErrorMessage("400 status code (no body)", {
+        provider: "screenpipe-cloud",
+        model: "auto",
+      }),
+    ).toBeNull();
+  });
+
   it("maps the ChatGPT missing-account-id error to reconnect guidance", () => {
     // exact string thrown by pi's openai-codex-responses provider when the
     // OAuth access token lacks the chatgpt_account_id claim (Enterprise/

--- a/apps/screenpipe-app-tauri/lib/chat/provider-errors.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/provider-errors.ts
@@ -315,6 +315,10 @@ function buildGenericProviderErrorMessage(
     return "The AI provider usage limit has been reached. Wait for it to reset, or switch your AI preset or provider.";
   }
 
+  if (provider === "custom" && errorStr === "400 status code (no body)") {
+    return "The custom AI provider rejected the request. Verify the endpoint, model, and API key in Settings → AI.";
+  }
+
   if (
     provider === "custom" &&
     (normalized.includes("401") ||


### PR DESCRIPTION
## Source feedback

- Trusted workflow source: Discord intake task `t_73d79265` (reported on macOS 26.5.1, app 2.6.39)
- Reconciliation review: `t_0b543f85`
- Exact reviewed head: `3a48582fec7ef13e3b594ed61e48997a069fe923`

## Root cause

The chat error classifier had no safe, actionable mapping for the exact opaque custom-provider response `400 status code (no body)`. Because the upstream response contains no body, users could not tell whether the endpoint, model name, or API key configuration was responsible.

## Fix

For provider `custom` only, map that exact opaque signature to fixed guidance that asks the user to verify the endpoint, model name, and API key. The mapping uses strict provider and message equality, so hosted providers and all other errors keep their existing behavior.

This covers the whole affected surface because custom-provider runtime errors flow through the shared provider-error classifier, and the regression suite exercises both chat call paths plus a hosted-provider negative case.

Changed files:

- `apps/screenpipe-app-tauri/lib/chat/provider-errors.ts`
- `apps/screenpipe-app-tauri/lib/chat/__tests__/provider-errors.test.ts`

Security/privacy: the displayed copy is fixed. It does not interpolate or expose the raw provider response, API key, or any other credential value.

## Visual evidence

Deterministic text-only presentation change:

```text
Before
custom + "400 status code (no body)" -> no actionable safe mapping

After
custom + "400 status code (no body)" ->
"The custom AI provider rejected the request. Verify the endpoint, model,
and API key in Settings → AI."

Hosted provider + same text -> unchanged
```

No packaged-app screenshot was captured because this is a pure classifier change with fixed text and no layout or interaction change.

## Verification

RED:

- New focused assertion failed as expected: 1 failed, 42 passed; received `null`.

GREEN and broad checks on the exact reviewed commit:

- Focused provider-error Vitest: 43/43 passed
- Related provider/agent-refusal/pipe Vitest: 65/65 passed
- Full Vitest: 3,809/3,809 passed across 365 files
- Bun tests: 236/236 passed
- `bun run typecheck`: passed
- Changed-file ESLint: passed
- `git diff --check`: passed

Independent reviewer `t_0b543f85` recorded unconditional `REVIEW APPROVED` for the exact head SHA and current-main base.

## Platform scope and risk

The originating report was on macOS, but the classifier is shared TypeScript logic and is platform-independent. Risk is low: the change is gated to one provider value and one exact error string, with negative coverage proving hosted-provider behavior remains unchanged.