### PR TITLE
fix: limit screen capture protection to overlays

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/display-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/display-section.tsx
@@ -328,27 +328,20 @@ export function DisplaySection() {
                 <div>
                   <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
                     Show Overlay in Screen Recording
-                    <HelpTooltip text="When enabled, the screenpipe overlay can appear in OBS or Screen Studio. The broader 'Hide screenpipe from screen capture' preference in Audio & meetings takes priority." />
+                    <HelpTooltip text="When enabled, the screenpipe overlay can appear in OBS or Screen Studio. Other screenpipe windows are always capturable." />
                   </h3>
                   <p className="text-xs text-muted-foreground">
-                    {(settings?.hideAppInScreenShare ?? true)
-                      ? "Global screen-share privacy is on in Audio & meetings"
-                      : "Let OBS or Screen Studio capture the overlay"}
+                    Let OBS or Screen Studio capture the overlay
                   </p>
                 </div>
               </div>
               <Switch
-                checked={
-                  !(settings?.hideAppInScreenShare ?? true) &&
-                  (settings?.showOverlayInScreenRecording ?? false)
-                }
-                disabled={settings?.hideAppInScreenShare ?? true}
+                data-testid="show-overlay-in-screen-recording-toggle"
+                checked={settings?.showOverlayInScreenRecording ?? false}
                 onCheckedChange={async (checked) => {
                   try {
                     await updateSettings({ showOverlayInScreenRecording: checked });
-                    const result = await commands.setAppScreenCaptureProtection(
-                      settings?.hideAppInScreenShare ?? true,
-                    );
+                    const result = await commands.setAppScreenCaptureProtection(!checked);
                     if (result.status === "error") {
                       throw new Error(result.error);
                     }

--- a/apps/screenpipe-app-tauri/components/settings/recording-settings.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/recording-settings.tsx
@@ -39,7 +39,6 @@ export const audioSearchIndex: SettingsField[] = [
   { label: "Live meeting notes", keywords: ["captions", "meeting", "live"], conditional: true },
   { label: "Append typed text to note", keywords: ["note", "append"], conditional: true },
   { label: "Automatic meeting detection", keywords: ["zoom", "teams", "meet"], conditional: true },
-  { label: "Hide screenpipe from screen capture", keywords: ["screen share", "zoom", "screenshot", "privacy"] },
   { label: "Auto-select audio devices", keywords: ["devices", "bluetooth"], conditional: true },
   { label: "Languages", keywords: ["transcript language", "language"], conditional: true },
   { label: "Custom Vocabulary", keywords: ["vocabulary", "names", "jargon", "replacement"], conditional: true },
@@ -103,7 +102,6 @@ import {
   RefreshCw,
   Loader2,
   Globe,
-  Shield,
   Zap,
   FileAudio,
   FileText,
@@ -2570,23 +2568,6 @@ export function RecordingSettings({ section }: { section: RecordingSettingsSecti
     handleSettingsChange({ disableAudio: checked }, true);
   };
 
-  const handleScreenSharePrivacyChange = async (hidden: boolean) => {
-    try {
-      await updateSettings({ hideAppInScreenShare: hidden });
-      const result = await commands.setAppScreenCaptureProtection(hidden);
-      if (result.status === "error") {
-        throw new Error(result.error);
-      }
-    } catch (error) {
-      await updateSettings({ hideAppInScreenShare: !hidden });
-      toast({
-        title: "could not update screen-share privacy",
-        description: error instanceof Error ? error.message : String(error),
-        variant: "destructive",
-      });
-    }
-  };
-
   const handleAnalyticsToggle = (checked: boolean) => {
     const newValue = checked;
     handleSettingsChange({ analyticsEnabled: newValue }, true);
@@ -2788,32 +2769,6 @@ Your screen is a pipe. Everything you see, hear, and type flows through it. Scre
       {/* Audio */}
       <div className="space-y-2 pt-2">
         <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider px-1">Audio &amp; meetings</h2>
-
-        <Card className="border-border bg-card">
-          <CardContent className="px-3 py-2.5">
-            <div className="flex items-center justify-between gap-3">
-              <div className="flex min-w-0 items-center space-x-2.5">
-                <Shield className="h-4 w-4 shrink-0 text-muted-foreground" />
-                <div className="min-w-0">
-                  <h3 className="text-sm font-medium text-foreground">
-                    Hide screenpipe from screen capture
-                  </h3>
-                  <p className="text-xs text-muted-foreground">
-                    You&apos;ll still see screenpipe, but it stays hidden from screenshots and anyone watching your shared screen.
-                  </p>
-                </div>
-              </div>
-              <Switch
-                id="hideAppInScreenShare"
-                data-testid="hide-app-in-screen-share-toggle"
-                checked={settings.hideAppInScreenShare ?? true}
-                onCheckedChange={(checked) => {
-                  void handleScreenSharePrivacyChange(checked);
-                }}
-              />
-            </div>
-          </CardContent>
-        </Card>
 
         <LockedSetting settingKey="audio_recording">
         <div className="space-y-2">

--- a/apps/screenpipe-app-tauri/e2e/specs/settings-sections.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/settings-sections.spec.ts
@@ -139,7 +139,7 @@ describe('Settings sections', () => {
     expect(existsSync(filepath)).toBe(true);
   });
 
-  it('keeps audio and meeting notes separate and applies screen-share privacy live', async () => {
+  it('keeps audio and meeting notes separate from screen capture visibility', async () => {
     const navAudio = await $('[data-testid="settings-nav-audio"]');
     await navAudio.waitForExist({ timeout: 8_000 });
     expect((await navAudio.getText()).toLowerCase()).toContain('audio & meetings');
@@ -153,12 +153,19 @@ describe('Settings sections', () => {
       )) as string
     ).toLowerCase();
     expect(sectionText).toContain('audio recording');
-    expect(sectionText).toContain('hide screenpipe from screen capture');
+    expect(sectionText).not.toContain('hide screenpipe from screen capture');
     expect(sectionText).not.toContain('screen context capture');
     expect(sectionText).not.toContain('screenshot images');
+  });
 
-    const toggle = await $('[data-testid="hide-app-in-screen-share-toggle"]');
+  it('applies screen capture protection only to the overlay', async () => {
+    const navDisplay = await $('[data-testid="settings-nav-display"]');
+    await navDisplay.waitForExist({ timeout: 8_000 });
+    await navDisplay.click();
+
+    const toggle = await $('[data-testid="show-overlay-in-screen-recording-toggle"]');
     await toggle.waitForExist({ timeout: 5_000 });
+
     const initial = await invokeOrThrow<{
       requestedHidden: boolean;
       effectiveHidden: boolean;
@@ -180,7 +187,7 @@ describe('Settings sections', () => {
     // the supported platforms, and Linux cannot hide them at all.
     expect(initial.effectiveHidden).toBe(false);
     expect(initial.windowLabels).toContain('home');
-    expect(await toggle.getAttribute('data-state')).toBe('checked');
+    expect(await toggle.getAttribute('data-state')).toBe('unchecked');
 
     try {
       await toggle.click();
@@ -192,10 +199,10 @@ describe('Settings sections', () => {
         {
           timeout: t(8_000),
           interval: 100,
-          timeoutMsg: 'screen-share privacy opt-out did not persist',
+          timeoutMsg: 'overlay capture opt-in did not persist',
         },
       );
-      expect(await toggle.getAttribute('data-state')).toBe('unchecked');
+      expect(await toggle.getAttribute('data-state')).toBe('checked');
 
       await toggle.click();
       await browser.waitUntil(
@@ -206,12 +213,12 @@ describe('Settings sections', () => {
         {
           timeout: t(8_000),
           interval: 100,
-          timeoutMsg: 'screen-share privacy opt-in did not persist',
+          timeoutMsg: 'overlay capture opt-out did not persist',
         },
       );
-      expect(await toggle.getAttribute('data-state')).toBe('checked');
+      expect(await toggle.getAttribute('data-state')).toBe('unchecked');
 
-      const filepath = await saveScreenshot('settings-audio-meetings-privacy');
+      const filepath = await saveScreenshot('settings-display-overlay-capture');
       expect(existsSync(filepath)).toBe(true);
     } finally {
       const status = await invokeOrThrow<{ requestedHidden: boolean }>(

--- a/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -360,8 +360,8 @@ export type Settings = SettingsStore & {
 	powerMode?: "auto" | "performance" | "battery_saver";
 	/** Show restart notifications when audio/vision capture stalls (default: false for now) */
 	showRestartNotifications?: boolean;
-	/** Hide screenpipe windows from screenshots and screen-sharing viewers while
-	 * keeping them visible locally. Defaults on. */
+	/** @deprecated Retained for settings compatibility; overlay capture visibility
+	 * is controlled by showOverlayInScreenRecording. */
 	hideAppInScreenShare?: boolean;
 	/** Pause all screen capture when a DRM-protected streaming app (Netflix, Disney+, etc.) or a remote-desktop client (Omnissa/VMware Horizon) is focused — they blank their windows during screen recording */
 	pauseOnDrmContent?: boolean;

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -3347,7 +3347,7 @@ pub(crate) async fn show_shortcut_reminder_impl(
 
             // Clone window to pass into main thread closure
             let window_clone = window.clone();
-            let capturable = crate::window::app_windows_are_capturable(&app_handle);
+            let capturable = crate::window::native_overlay_is_capturable(&app_handle);
             let _ = app_handle.run_on_main_thread(move || {
                 use tauri_nspanel::cocoa::appkit::NSWindowCollectionBehavior;
 
@@ -3945,7 +3945,9 @@ pub(crate) async fn deliver_notification_panel(
             // steals focus. orderFront: in the main thread block handles visibility.
 
             let window_clone = window.clone();
-            let capturable = crate::window::app_windows_are_capturable(&app_handle);
+            // Notifications are ordinary user-facing app UI, not the recording
+            // overlay controlled by Settings > Display.
+            let capturable = true;
             let _ = app_handle.run_on_main_thread(move || {
                 use tauri_nspanel::cocoa::appkit::NSWindowCollectionBehavior;
 

--- a/apps/screenpipe-app-tauri/src-tauri/src/store.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/store.rs
@@ -1033,8 +1033,9 @@ pub struct SettingsStore {
     #[serde(rename = "showOverlayInScreenRecording", default)]
     pub show_overlay_in_screen_recording: bool,
 
-    /// Hide screenpipe windows from screenshots and screen-sharing viewers
-    /// while keeping them visible and interactive on the user's own display.
+    /// Legacy global capture-protection preference. Retained for settings-file
+    /// compatibility; capture protection is now controlled only by the overlay
+    /// preference above.
     #[serde(rename = "hideAppInScreenShare", default = "default_true")]
     pub hide_app_in_screen_share: bool,
 

--- a/apps/screenpipe-app-tauri/src-tauri/src/window/capture_protection.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/window/capture_protection.rs
@@ -6,7 +6,7 @@ use crate::store::SettingsStore;
 use serde::Serialize;
 use tauri::{AppHandle, Manager, WebviewWindow};
 
-const OVERLAY_WINDOW_LABELS: [&str; 3] = ["main", "main-window", "chat"];
+const OVERLAY_WINDOW_LABELS: [&str; 4] = ["main", "main-window", "chat", "shortcut-reminder"];
 
 #[derive(Debug, Clone, Serialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
@@ -27,9 +27,9 @@ fn is_overlay_window(label: &str) -> bool {
 }
 
 /// Resolve whether one screenpipe window should be excluded from screenshots
-/// and screen sharing. The global privacy preference wins over the narrower
-/// overlay preference. E2E builds stay capturable so WebDriver screenshots and
-/// visual assertions remain possible; the E2E API reports that bypass plainly.
+/// and screen sharing. Capture protection is deliberately limited to overlay
+/// windows; Home, Settings, and other regular app windows remain capturable.
+/// E2E builds stay capturable so visual assertions remain possible.
 pub(crate) fn should_protect_window(
     settings: &SettingsStore,
     label: &str,
@@ -38,24 +38,22 @@ pub(crate) fn should_protect_window(
     if e2e_mode {
         return false;
     }
-    settings.hide_app_in_screen_share
-        || (is_overlay_window(label) && !settings.show_overlay_in_screen_recording)
+    is_overlay_window(label) && !settings.show_overlay_in_screen_recording
 }
 
 pub(crate) fn overlay_is_capturable(settings: &SettingsStore) -> bool {
     !should_protect_window(settings, "main", crate::config::is_e2e_mode())
 }
 
-/// Read only by the macOS NSPanel setup in `commands.rs`, which mirrors the
-/// preference onto `NSWindowSharingType`. Other platforms apply the same
-/// preference through `set_content_protected` in `apply_to_window_with_settings`.
+/// Read by native overlay panels in `commands.rs`, which cannot use the webview
+/// label helper but must follow the same overlay-only preference.
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
-pub(crate) fn app_windows_are_capturable(app: &AppHandle) -> bool {
+pub(crate) fn native_overlay_is_capturable(app: &AppHandle) -> bool {
     let settings = SettingsStore::get(app)
         .ok()
         .flatten()
         .unwrap_or_default();
-    !settings.hide_app_in_screen_share || crate::config::is_e2e_mode()
+    overlay_is_capturable(&settings)
 }
 
 fn apply_to_window_with_settings(
@@ -114,7 +112,7 @@ pub fn set_app_screen_capture_protection(
         .ok()
         .flatten()
         .unwrap_or_default();
-    settings.hide_app_in_screen_share = hidden;
+    settings.show_overlay_in_screen_recording = !hidden;
 
     let mut errors = Vec::new();
     for window in app_handle.webview_windows().values() {
@@ -134,11 +132,11 @@ pub fn set_app_screen_capture_protection(
 pub fn get_app_screen_capture_protection(
     app_handle: AppHandle,
 ) -> ScreenCaptureProtectionStatus {
-    let requested_hidden = SettingsStore::get(&app_handle)
+    let requested_hidden = !SettingsStore::get(&app_handle)
         .ok()
         .flatten()
         .unwrap_or_default()
-        .hide_app_in_screen_share;
+        .show_overlay_in_screen_recording;
     status(&app_handle, requested_hidden)
 }
 
@@ -148,21 +146,17 @@ mod tests {
     use crate::store::SettingsStore;
 
     #[test]
-    fn new_install_hides_all_windows_from_capture() {
+    fn capture_protection_is_limited_to_overlays() {
         let settings = SettingsStore::default();
         assert!(settings.hide_app_in_screen_share);
-        assert!(should_protect_window(&settings, "home", false));
-        assert!(should_protect_window(&settings, "main", false));
-    }
-
-    #[test]
-    fn global_opt_out_preserves_the_narrow_overlay_preference() {
-        let mut settings = SettingsStore::default();
-        settings.hide_app_in_screen_share = false;
-        settings.show_overlay_in_screen_recording = false;
         assert!(!should_protect_window(&settings, "home", false));
+        assert!(!should_protect_window(&settings, "settings", false));
+        assert!(should_protect_window(&settings, "main", false));
         assert!(should_protect_window(&settings, "chat", false));
+        assert!(should_protect_window(&settings, "shortcut-reminder", false));
+        assert!(!should_protect_window(&settings, "notification-panel", false));
 
+        let mut settings = settings;
         settings.show_overlay_in_screen_recording = true;
         assert!(!should_protect_window(&settings, "main-window", false));
     }

--- a/apps/screenpipe-app-tauri/src-tauri/src/window/mod.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/window/mod.rs
@@ -473,7 +473,7 @@ pub fn enforce_enterprise_ui_visibility(app: &tauri::AppHandle) {
 // callers (commands.rs, space_monitor.rs, etc.) may also reference them.
 #[allow(unused_imports)]
 pub use util::screen_aware_size;
-pub(crate) use capture_protection::{app_windows_are_capturable, overlay_is_capturable};
+pub(crate) use capture_protection::{native_overlay_is_capturable, overlay_is_capturable};
 pub use capture_protection::{
     get_app_screen_capture_protection, set_app_screen_capture_protection,
 };


### PR DESCRIPTION
## Summary

- scope macOS screen-capture protection to the timeline, chat, and shortcut overlays
- keep Home, Settings, and the notification panel visible in recordings
- consolidate the control under Display > Show Overlay in Screen Recording and remove the global Audio & meetings toggle

## Before / after

```text
Before: capture protection -> app windows + overlays + notification panel
After:  capture protection -> overlays only
```

## Validation

- [x] `git show --check`
- [ ] focused Rust test did not complete because the cold Tauri dependency build was interrupted
- [ ] focused Vitest could not start because this worktree does not have `vitest/config` or `@vitejs/plugin-react` installed
