### PR TITLE
fix(ai): keep GPT-5.6 cache markers off media content

### DIFF
--- a/packages/ai-gateway/src/providers/openai.ts
+++ b/packages/ai-gateway/src/providers/openai.ts
@@ -25,9 +25,6 @@ const GPT56_MAX_READ_BREAKPOINTS = 50;
 const GPT56_HISTORY_BREAKPOINTS = GPT56_MAX_READ_BREAKPOINTS - 1;
 const CACHEABLE_CONTENT_TYPES = new Set([
 	'text',
-	'image_url',
-	'input_audio',
-	'file',
 	'refusal',
 ]);
 
@@ -50,14 +47,6 @@ function isCacheableContentPart(part: any): boolean {
 			return typeof part.text === 'string' && part.text.length > 0;
 		case 'refusal':
 			return typeof part.refusal === 'string' && part.refusal.length > 0;
-		case 'image_url':
-			return typeof part.image_url === 'string'
-				? part.image_url.length > 0
-				: Boolean(part.image_url?.url);
-		case 'input_audio':
-			return Boolean(part.input_audio?.data);
-		case 'file':
-			return Boolean(part.file?.file_id || part.file?.filename || part.file?.file_data);
 		default:
 			return false;
 	}

--- a/packages/ai-gateway/src/test/openai-models.unit.test.ts
+++ b/packages/ai-gateway/src/test/openai-models.unit.test.ts
@@ -412,32 +412,33 @@ describe('OpenAI API accounting and routing', () => {
 		expect(marked).toEqual([true, false, true, false, false, true, false, true, false, false, true]);
 	});
 
-	it('marks the last supported multipart image or file block without changing it', async () => {
+	it('marks preceding multipart text without adding cache fields to media blocks', async () => {
 		const imagePart = {
 			type: 'image_url',
 			image_url: { url: 'data:image/png;base64,AA', detail: 'high' },
 		};
 		const filePart = { type: 'file', file: { file_id: 'file_123' } };
+		const audioPart = { type: 'input_audio', input_audio: { data: 'AA', format: 'wav' } };
 		const params: any = {
 			model: 'gpt-5.6-luna',
 			messages: [
 				{ role: 'system', content: 'stable' },
 				{ role: 'user', content: [{ type: 'text', text: 'look' }, imagePart, { type: 'text', text: '' }] },
 				{ role: 'assistant', content: 'seen' },
-				{ role: 'user', content: [filePart, { type: 'text', text: '' }] },
+				{ role: 'user', content: [{ type: 'text', text: 'read' }, filePart, { type: 'text', text: '' }] },
+				{ role: 'assistant', content: 'read' },
+				{ role: 'user', content: [{ type: 'text', text: 'listen' }, audioPart, { type: 'text', text: '' }] },
 			],
 		};
 
 		await applyGpt56PromptCaching(params, true);
 
-		expect(params.messages[1].content[1]).toEqual({
-			...imagePart,
-			prompt_cache_breakpoint: { mode: 'explicit' },
-		});
-		expect(params.messages[3].content[0]).toEqual({
-			...filePart,
-			prompt_cache_breakpoint: { mode: 'explicit' },
-		});
+		expect(params.messages[1].content[0].prompt_cache_breakpoint).toEqual({ mode: 'explicit' });
+		expect(params.messages[1].content[1]).toEqual(imagePart);
+		expect(params.messages[3].content[0].prompt_cache_breakpoint).toEqual({ mode: 'explicit' });
+		expect(params.messages[3].content[1]).toEqual(filePart);
+		expect(params.messages[5].content[0].prompt_cache_breakpoint).toEqual({ mode: 'explicit' });
+		expect(params.messages[5].content[1]).toEqual(audioPart);
 	});
 
 	it('recomputes GPT-5.6 breakpoints idempotently after rewritten history', async () => {


### PR DESCRIPTION
## Summary
- Prevents GPT-5.6 history caching from appending `prompt_cache_breakpoint` to strict `image_url`, `file`, and `input_audio` content dictionaries.
- Places the explicit cache marker on the preceding non-empty `text` or `refusal` block instead.
- Preserves existing text-only, system-message, marker-budget, run-boundary, idempotence, and cache-key behavior.

## Source feedback
- Discord feedback identity: message `1539224512107782146` in channel `1339037549926289500`.
- Internal implementation task: `t_9a7d9701`.
- Reported environment: Windows 10.0.26200, app 2.6.39.
- Reported symptom: OpenAI-compatible chat returned HTTP 400 because an image content dictionary contained an unexpected key.

## Root cause and coverage
GPT-5.6 prompt caching reverse-scans message content to choose explicit cache breakpoints. The shared cacheability predicate incorrectly classified `image_url`, `file`, and `input_audio` dictionaries as valid marker targets, so the gateway mutated otherwise valid provider payloads by adding an outer `prompt_cache_breakpoint` key.

The fix removes all three strict media shapes from the central cacheability predicate. Because every GPT-5.6 history turn passes through this shared transform, the correction covers image, file, and audio content across the full gateway surface rather than special-casing the reported image path. Existing cleanup still strips stale media markers before recomputation.

## RED / GREEN evidence
- RED on untouched `origin/main`: focused regression failed because the preceding text marker was missing (0 passed, 1 failed).
- GREEN on this commit: focused regression passed 1/1 with 6 assertions covering image, file, audio, and their preceding text blocks.

## Verification
- `openai-models.unit.test.ts`: 40 passed, 0 failed, 244 assertions.
- Local gateway integration harness: 3 passed, 0 failed, 22 assertions.
- Full `packages/ai-gateway` suite: 997 passed, 0 failed, 3875 assertions.
- `bun x tsc --noEmit`: passed.
- Independent runtime schema checks for image/file/audio, including media-only input: passed.
- `git diff --check`: passed.
- Independent review: unconditional approval for exact commit `cf3d0ba69935506f2cdc43f563afed8a41b9985c`.

## Platform scope
The report came from Windows, but this fix is in the platform-independent AI gateway payload transformation and applies equally on Windows, macOS, and Linux. No native UI, capture, audio-device, or OS-specific code changes.

## Visual evidence
Backend payload-shape change; no user interface changed.

```text
Before: [text] [image_url + prompt_cache_breakpoint] -> provider HTTP 400
After:  [text + prompt_cache_breakpoint] [image_url] -> schema-clean payload
        [text + prompt_cache_breakpoint] [file]      -> schema-clean payload
        [text + prompt_cache_breakpoint] [audio]     -> schema-clean payload
```