### PR TITLE
fix(semantic): resolve clippy redundant closure in tree_any

### DIFF
--- a/crates/screenpipe-semantic/src/parsers/families.rs
+++ b/crates/screenpipe-semantic/src/parsers/families.rs
@@ -1079,7 +1079,7 @@ fn is_simple_slash_date(token: &str) -> bool {
 
 fn tree_any(tree: &SemanticTree, predicate: impl Fn(NodeId) -> bool) -> bool {
     tree.roots()
-        .any(|root| tree.descendants(root).any(|node| predicate(node)))
+        .any(|root| tree.descendants(root).any(&predicate))
 }
 
 /// `collect_text` starting below `root`. A Fluent message container is itself a


### PR DESCRIPTION
## description

Passes `&predicate` directly to `.any()` instead of wrapping it in a redundant closure in `tree_any` (`crates/screenpipe-semantic/src/parsers/families.rs`).

This is a pure refactor with no behavioral change. It removes the unnecessary closure and fixes the `clippy::redundant_closure` warning when compiling with `-D warnings`.

related issue: none

## AI assistance and human ownership

Read the [[AI-assisted contribution policy](https://github.com/screenpipe/screenpipe/blob/main/CONTRIBUTING.md#ai-assisted-contributions)](https://github.com/screenpipe/screenpipe/blob/main/CONTRIBUTING.md#ai-assisted-contributions).

- AI tool(s) used: `Gemini` (Antigravity IDE)
- autonomy level: `agent`
- what I personally verified: Reviewed the resulting one-line change and verified that passing `&predicate` directly to `.any()` matches the expected predicate signature. I also ran the relevant Clippy and test checks locally.

- [x] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [x] The problem statement, rationale, and replies to maintainers are my own.

## evidence type

Check every category that applies and provide the required evidence below.

- [ ] UI or behavior change — before/after recording
- [ ] Backend change — regression tests and relevant logs/results
- [ ] Performance change — reproducible before/after benchmarks
- [x] Docs, CI, or pure refactor — relevant checks and an explanation; no video required

## before

The code passed a closure wrapping `predicate` into `.any()`, which triggered the `clippy::redundant_closure` lint under `-D warnings`.

No user-facing behavior was changed.

## after

The closure is replaced with `&predicate` passed directly to `.any()`.

This removes the redundant closure and allows the crate to compile cleanly with `clippy::redundant_closure` enabled as an error.

## how to test

Commands personally run:

1. `cargo clippy -p screenpipe-semantic --all-targets -- -D warnings`
   - Passed with 0 warnings/errors.

2. `cargo test -p screenpipe-semantic`
   - Passed successfully.

3. `cargo fmt --check`
   - Passed successfully.

## desktop app checklist (if applicable)

This PR does not add or modify `#[tauri::command]` handlers or Rust types exported to the frontend, so the desktop app checks are not applicable.

- [ ] `bun run bindings:generate` (if bindings changed)
- [ ] `bun run bindings:check`
- [ ] `bun run typecheck`