### PR TITLE
Fix/chat ordinal selection prompt

### DIFF
--- a/apps/screenpipe-app-tauri/lib/chat/system-prompt.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/system-prompt.ts
@@ -42,6 +42,12 @@ If the user sends "hi", "gih", "d", a single word, or an obvious typo, ask one s
 
 When summarizing what the user did, write like a friend recapping their day. Connect windows, content, and audio into a short narrative. Name specific projects, people, files, URLs from the data. "You spent the morning debugging a Windows crash, then took a call with Pat about pricing" — not "WezTerm 39m, Arc 8m, Zoom 12m". Pull the specifics from window titles and key_texts in activity-summary. Cap at ~150 words unless the user asked for depth.
 
+# Presenting Choices & Handling User Selection
+
+- When offering multiple actions, options, or next steps to the user, always format them as a numbered list (1., 2., 3.) rather than bullet points.
+- When the user responds with an ordinal or indexed shorthand (e.g., "1st", "first", "2", "option 3", "last one"), immediately map it to the corresponding numbered choice from your previous message and proceed with that action.
+- Do not ask the user to re-select or re-confirm their choice if they have already provided a valid index or shorthand.
+
 # Acting on requests
 
 - Act immediately on clear intent. Don't ask to confirm what's obvious.

--- a/crates/screenpipe-semantic/src/parsers/families.rs
+++ b/crates/screenpipe-semantic/src/parsers/families.rs
@@ -1079,7 +1079,7 @@ fn is_simple_slash_date(token: &str) -> bool {
 
 fn tree_any(tree: &SemanticTree, predicate: impl Fn(NodeId) -> bool) -> bool {
     tree.roots()
-        .any(|root| tree.descendants(root).any(|node| predicate(node)))
+        .any(|root| tree.descendants(root).any(&predicate))
 }
 
 /// `collect_text` starting below `root`. A Fluent message container is itself a

--- a/crates/screenpipe-semantic/src/parsers/families.rs
+++ b/crates/screenpipe-semantic/src/parsers/families.rs
@@ -1079,7 +1079,7 @@ fn is_simple_slash_date(token: &str) -> bool {
 
 fn tree_any(tree: &SemanticTree, predicate: impl Fn(NodeId) -> bool) -> bool {
     tree.roots()
-        .any(|root| tree.descendants(root).any(&predicate))
+        .any(|root| tree.descendants(root).any(|node| predicate(node)))
 }
 
 /// `collect_text` starting below `root`. A Fluent message container is itself a


### PR DESCRIPTION
## description

Fixes a conversational UX issue where the chat assistant failed to resolve ordinal shorthand such as `1st`, `2nd`, or `the first one` when responding to a list of choices presented in the previous message.

Previously, the assistant presented actionable choices as unnumbered bullet points. When the user replied with an ordinal reference such as `1st`, the assistant did not reliably map the response to the corresponding choice and could enter a redundant confirmation loop instead of proceeding with the selected action.

### Key Changes

- Updated `system-prompt.ts` to instruct the assistant to format actionable choices and next steps as explicitly numbered lists (`1.`, `2.`, `3.`, etc.).
- Added explicit instructions for resolving ordinal and conversational index references such as `1st`, `2nd`, `option 1`, and `the first one` against the immediately preceding choices.
- Instructed the assistant to proceed directly when the user's response clearly identifies a previously presented option, avoiding unnecessary confirmation prompts.

related issue: none

## AI assistance and human ownership

- AI tool(s) used: none
- autonomy level: none
- what I personally verified: Manually tested the conversational flow using numbered choices and ordinal responses such as `1st` and `2nd`, and verified that the selected option is resolved without triggering a redundant confirmation prompt. Also verified that TypeScript type checking passes without regressions.

- [x] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [x] The problem statement, rationale, and replies to maintainers are my own.

## evidence type

- [x] UI or behavior change — before/after recording
- [ ] Backend change — regression tests and relevant logs/results
- [ ] Performance change — reproducible before/after benchmarks
- [ ] Docs, CI, or pure refactor — relevant checks and an explanation; no video required

## before

The assistant presented actionable choices as unnumbered bullet points:

- Create a reminder
- Make a preparation checklist
- Plan the remaining work

When the user replied `1st`, the assistant failed to reliably associate the response with the first option and instead asked a redundant follow-up:

> "What would you like to do first: set a reminder, create a preparation checklist, or make a work plan?"

This required the user to repeat a choice that had already been made.

**Before:**  
*(Drag and drop the before screenshot/recording here.)*

## after

The assistant now presents actionable choices as explicitly numbered options:

1. Create a reminder
2. Make a preparation checklist
3. Plan the remaining work

Responses such as `1st`, `2nd`, `option 1`, or `the first one` are resolved against the corresponding preceding option, allowing the assistant to proceed without an unnecessary confirmation loop.

**After:**  
*(Drag and drop the after screenshot/recording here.)*

## how to test

1. From `apps/screenpipe-app-tauri/`, run:
   `bun run typecheck`
2. Open the desktop chat interface.
3. Start a conversation that causes the assistant to present multiple actionable choices. For example:
   `I have a project submission on 23rd August.`
4. Verify that the assistant presents the available choices as a numbered list.
5. Reply with `1st` and verify that the assistant resolves it to the first option and proceeds without asking the user to select again.
6. Repeat with `2nd`, `option 1`, and `the first one` to verify that common ordinal/index references are handled correctly.

## desktop app checklist (if applicable)

- [ ] `bun run bindings:generate`
- [ ] `bun run bindings:check`
- [x] `bun run typecheck`
<img width="4032" height="3024" alt="IMG_4116" src="https://github.com/user-attachments/assets/4e6a8cb6-48c7-40d3-8dd2-2e6f85bc4853" />
