### PR TITLE
feat(activity): require explicit history generation

### DIFF
--- a/apps/screenpipe-app-tauri/app/(main)/home/page.tsx
+++ b/apps/screenpipe-app-tauri/app/(main)/home/page.tsx
@@ -108,10 +108,7 @@ import {
 import { PlanExpirationNotice } from "@/components/plan-expiration-notice";
 import type { AppUser } from "@/lib/app-entitlement";
 import { ONBOARDING_BRAIN_HANDOFF_EVENT } from "@/lib/live-views/onboarding-activation";
-import {
-  ActivityLedger,
-  preloadActivityHistory,
-} from "@/components/activity-ledger";
+import { ActivityLedger } from "@/components/activity-ledger";
 
 type MainSection = "home" | "timeline" | "activity" | "brain" | "pipes" | "connections" | "meetings" | "help";
 type ConnectionFocusRequest = {
@@ -1356,14 +1353,6 @@ function HomeContent() {
                   // The "home" slot is the New Chat affordance — clicking it
                   // (from any view) always spawns a new chat session.
                   if (id === "home") startNewChat();
-                }}
-                onIntent={(id) => {
-                  if (id === "activity") {
-                    void preloadActivityHistory().catch(() => {
-                      // Activity performs the same read and surfaces its own
-                      // fallback if the encrypted store is unavailable.
-                    });
-                  }
                 }}
                 onMove={(id, toIndex) =>
                   persistSidebarLayout(

--- a/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
@@ -12,9 +12,10 @@ import {
   waitFor,
 } from "@testing-library/react";
 
+Element.prototype.scrollIntoView ||= () => {};
+
 const mocks = vi.hoisted(() => ({
   emit: vi.fn(),
-  clearPersistedActivityHistory: vi.fn(),
   loadPersistedActivityHistory: vi.fn(),
   localFetch: vi.fn(),
   reconcilePersistedActivityHistory: vi.fn(),
@@ -27,9 +28,18 @@ const mocks = vi.hoisted(() => ({
     user: { token: "test-token" },
     aiPresets: [
       {
+        id: "chat",
+        provider: "screenpipe-cloud" as const,
+        model: "gpt-5.6-terra",
+        url: "",
+        maxContextChars: 200_000,
+        defaultPreset: true,
+        prompt: "",
+      },
+      {
         id: "pipes",
         provider: "screenpipe-cloud" as const,
-        model: "auto",
+        model: "claude-sonnet-5",
         url: "",
         maxContextChars: 200_000,
         defaultPreset: false,
@@ -55,7 +65,6 @@ vi.mock("@/lib/activity-history-persistence", async (importOriginal) => {
     await importOriginal<typeof import("@/lib/activity-history-persistence")>();
   return {
     ...actual,
-    clearPersistedActivityHistory: mocks.clearPersistedActivityHistory,
     loadPersistedActivityHistory: mocks.loadPersistedActivityHistory,
     reconcilePersistedActivityHistory: mocks.reconcilePersistedActivityHistory,
   };
@@ -272,7 +281,6 @@ beforeEach(() => {
       ],
     }),
   );
-  mocks.clearPersistedActivityHistory.mockResolvedValue(undefined);
   mocks.showChatWithPrefill.mockResolvedValue(undefined);
 });
 
@@ -281,6 +289,12 @@ afterEach(() => {
   vi.useRealTimers();
   vi.clearAllMocks();
 });
+
+async function generateActivities(): Promise<void> {
+  fireEvent.click(
+    await screen.findByRole("button", { name: "Generate activities" }),
+  );
+}
 
 describe("activity history helpers", () => {
   it("keeps the last 24 hours rolling across midnight", () => {
@@ -542,6 +556,91 @@ describe("activity history helpers", () => {
 });
 
 describe("ActivityLedger", () => {
+  it("waits for the encrypted cache lookup before offering generation", async () => {
+    let resolveCache!: (value: { entries: []; coverage: [] }) => void;
+    mocks.loadPersistedActivityHistory.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveCache = resolve;
+        }),
+    );
+
+    render(<ActivityLedger />);
+
+    expect(
+      await screen.findByText("Loading generated activities…"),
+    ).toBeVisible();
+    expect(
+      screen.queryByRole("button", { name: "Generate activities" }),
+    ).toBeNull();
+    expect(mocks.runDailySummaryWithPi).not.toHaveBeenCalled();
+
+    resolveCache({ entries: [], coverage: [] });
+
+    expect(
+      await screen.findByRole("button", { name: "Generate activities" }),
+    ).toBeVisible();
+  });
+
+  it("waits for explicit generation and starts with the default preset", async () => {
+    render(<ActivityLedger />);
+
+    const generate = await screen.findByRole("button", {
+      name: "Generate activities",
+    });
+    expect(screen.getByLabelText("AI preset")).toHaveTextContent(
+      "chat · gpt-5.6-terra",
+    );
+    expect(mocks.runDailySummaryWithPi).not.toHaveBeenCalled();
+
+    fireEvent.click(generate);
+
+    await waitFor(() =>
+      expect(mocks.runDailySummaryWithPi).toHaveBeenCalledWith(
+        expect.objectContaining({
+          preset: expect.objectContaining({ id: "chat" }),
+          sessionPrefix: "activity-history",
+        }),
+      ),
+    );
+  });
+
+  it("uses the selected preset for an explicit refresh", async () => {
+    mocks.loadPersistedActivityHistory.mockImplementation(
+      async (_producer: string, range: { start: Date; end: Date }) => ({
+        entries: parseActivityHistoryResponse(HISTORY_RESPONSE, range).entries,
+        coverage: [
+          {
+            start: range.start.toISOString(),
+            end: range.end.toISOString(),
+          },
+        ],
+      }),
+    );
+
+    render(<ActivityLedger />);
+
+    await screen.findByText("Fixed a capture reliability regression");
+    fireEvent.click(screen.getByLabelText("AI preset"));
+    fireEvent.click(
+      await screen.findByRole("option", {
+        name: "pipes · claude-sonnet-5",
+      }),
+    );
+    const refresh = screen.getByRole("button", { name: "Refresh history" });
+    await waitFor(() => expect(refresh).toBeEnabled());
+    fireEvent.click(refresh);
+
+    await waitFor(() =>
+      expect(mocks.runDailySummaryWithPi).toHaveBeenCalledWith(
+        expect.objectContaining({
+          preset: expect.objectContaining({ id: "pipes" }),
+          sessionPrefix: "activity-history",
+        }),
+      ),
+    );
+  });
+
   it("bypasses Enhanced AI without exposing ledger rows on AI failure", async () => {
     mocks.settings.enhancedAI = false;
     mocks.runDailySummaryWithPi.mockRejectedValue(
@@ -549,6 +648,8 @@ describe("ActivityLedger", () => {
     );
 
     render(<ActivityLedger />);
+
+    await generateActivities();
 
     expect(
       await screen.findByText("History could not be updated. Try again."),
@@ -602,9 +703,8 @@ describe("ActivityLedger", () => {
 
     const view = render(<ActivityLedger />);
 
-    await waitFor(() =>
-      expect(mocks.runDailySummaryWithPi).toHaveBeenCalledOnce(),
-    );
+    await generateActivities();
+    expect(mocks.runDailySummaryWithPi).toHaveBeenCalledOnce();
     const generationSignal = mocks.runDailySummaryWithPi.mock.calls[0][0]
       .signal as AbortSignal;
 
@@ -619,6 +719,7 @@ describe("ActivityLedger", () => {
 
   it("keeps rows concise while exposing artifact icons and skill creation", async () => {
     render(<ActivityLedger />);
+    await generateActivities();
 
     expect(
       await screen.findByRole("heading", {
@@ -712,6 +813,7 @@ describe("ActivityLedger", () => {
       .mockResolvedValueOnce(REPAIRED_HISTORY_RESPONSE);
 
     render(<ActivityLedger />);
+    await generateActivities();
 
     expect(
       await screen.findByRole("heading", { name: "Recovered task 1" }),
@@ -727,6 +829,7 @@ describe("ActivityLedger", () => {
 
   it("does not offer a header chat action", async () => {
     render(<ActivityLedger />);
+    await generateActivities();
     await screen.findByText("Fixed a capture reliability regression");
 
     expect(screen.queryByRole("button", { name: "Ask" })).toBeNull();
@@ -738,6 +841,7 @@ describe("ActivityLedger", () => {
 
   it("opens app and transcript artifacts at their exact timeline moments", async () => {
     render(<ActivityLedger />);
+    await generateActivities();
     await screen.findByText("Fixed a capture reliability regression");
 
     const appArtifact = screen.getByRole("link", {
@@ -812,6 +916,7 @@ describe("ActivityLedger", () => {
     mocks.runDailySummaryWithPi.mockResolvedValue(MEETING_HISTORY_RESPONSE);
 
     render(<ActivityLedger />);
+    await generateActivities();
     await screen.findByText("Aligned on Workflow Studio");
 
     const meetingArtifact = screen.getByRole("link", {
@@ -833,6 +938,7 @@ describe("ActivityLedger", () => {
 
   it("can draft a skill from every activity interval", async () => {
     render(<ActivityLedger />);
+    await generateActivities();
     await screen.findByText("Unblocked a customer's onboarding");
 
     fireEvent.click(

--- a/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
@@ -699,22 +699,15 @@ describe("ActivityLedger", () => {
     );
   });
 
-  it("opens chat over the interpreted history", async () => {
+  it("does not offer a header chat action", async () => {
     render(<ActivityLedger />);
     await screen.findByText("Fixed a capture reliability regression");
 
-    fireEvent.click(screen.getByRole("button", { name: "Ask" }));
-
-    await waitFor(() =>
-      expect(mocks.showChatWithPrefill).toHaveBeenCalledWith(
-        expect.objectContaining({
-          source: "activity-history",
-          context: expect.stringContaining(
-            "Fixed a capture reliability regression",
-          ),
-        }),
-      ),
-    );
+    expect(screen.queryByRole("button", { name: "Ask" })).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Refresh history" }),
+    ).toBeVisible();
+    expect(screen.getByLabelText("Time range")).toBeVisible();
   });
 
   it("opens app and transcript artifacts at their exact timeline moments", async () => {

--- a/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
@@ -591,6 +591,32 @@ describe("ActivityLedger", () => {
     expect(mocks.runDailySummaryWithPi).not.toHaveBeenCalled();
   });
 
+  it("finishes and persists history generation after leaving the page", async () => {
+    let resolveHistory!: (value: string) => void;
+    mocks.runDailySummaryWithPi.mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveHistory = resolve;
+        }),
+    );
+
+    const view = render(<ActivityLedger />);
+
+    await waitFor(() =>
+      expect(mocks.runDailySummaryWithPi).toHaveBeenCalledOnce(),
+    );
+    const generationSignal = mocks.runDailySummaryWithPi.mock.calls[0][0]
+      .signal as AbortSignal;
+
+    view.unmount();
+
+    expect(generationSignal.aborted).toBe(false);
+    resolveHistory(HISTORY_RESPONSE);
+    await waitFor(() =>
+      expect(mocks.reconcilePersistedActivityHistory).toHaveBeenCalled(),
+    );
+  });
+
   it("keeps rows concise while exposing artifact icons and skill creation", async () => {
     render(<ActivityLedger />);
 

--- a/apps/screenpipe-app-tauri/components/activity-ledger.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.tsx
@@ -42,12 +42,10 @@ import {
   type ActivityReviewMeeting,
 } from "@/lib/activity-review-prompt";
 import {
-  clearPersistedActivityHistory,
   loadPersistedActivityHistory,
   mergeActivityHistoryCoverage,
   mergeActivityHistoryDocuments,
   nextActivityHistoryRange,
-  preloadPersistedActivityHistory,
   reconcilePersistedActivityHistory,
   type ActivityHistoryCoverage,
 } from "@/lib/activity-history-persistence";
@@ -58,7 +56,6 @@ import { appIconUrl } from "@/lib/first-run/recent-activity";
 import { useSettings } from "@/lib/hooks/use-settings";
 import { useTimelineStore } from "@/lib/hooks/use-timeline-store";
 import { cn } from "@/lib/utils";
-import { pickPipePreset } from "@/lib/utils/pick-pipe-preset";
 import type { AIPreset } from "@/lib/utils/tauri";
 
 type RangePreset = "today" | "24h" | "7d" | "custom";
@@ -140,10 +137,6 @@ function readStoredDateInput(key: string, fallback: string): string {
   return stored && Number.isFinite(new Date(stored).getTime())
     ? stored
     : fallback;
-}
-
-export function preloadActivityHistory(): Promise<unknown> {
-  return preloadPersistedActivityHistory(ACTIVITY_REVIEW_PROMPT_VERSION);
 }
 
 function startOfLocalDay(value: Date): Date {
@@ -575,7 +568,7 @@ export function ActivityLedger({
     (state) => state.setPendingNavigation,
   );
   const initialNow = useMemo(() => new Date(), []);
-  const [anchor, setAnchor] = useState(initialNow);
+  const anchor = initialNow;
   const [preset, setPreset] = useState<RangePreset>(readStoredRangePreset);
   const [customStart, setCustomStart] = useState(() =>
     readStoredDateInput(
@@ -607,6 +600,9 @@ export function ActivityLedger({
   const [historyError, setHistoryError] = useState("");
   const historyAbortRef = useRef<AbortController | null>(null);
   const historyLoadingRef = useRef(false);
+  const [selectedReviewPresetId, setSelectedReviewPresetId] = useState<
+    string | null
+  >(null);
   const { settings } = useSettings();
 
   const range = useMemo(
@@ -614,11 +610,28 @@ export function ActivityLedger({
     [anchor, customEnd, customStart, preset],
   );
   const invalidRange = !range || range.start >= range.end;
+  const reviewPresets = useMemo(
+    () =>
+      ((settings?.aiPresets ?? []) as AIPreset[]).filter(
+        (candidate) => candidate.provider !== "acp",
+      ),
+    [settings?.aiPresets],
+  );
+  const selectableReviewPresets = useMemo(
+    () =>
+      reviewPresets.length > 0
+        ? reviewPresets
+        : [DEFAULT_ACTIVITY_REVIEW_PRESET],
+    [reviewPresets],
+  );
   const reviewPreset = useMemo(
     () =>
-      pickPipePreset((settings?.aiPresets ?? []) as AIPreset[]) ??
-      DEFAULT_ACTIVITY_REVIEW_PRESET,
-    [settings?.aiPresets],
+      selectableReviewPresets.find(
+        (candidate) => candidate.id === selectedReviewPresetId,
+      ) ??
+      selectableReviewPresets.find((candidate) => candidate.defaultPreset) ??
+      selectableReviewPresets[0],
+    [selectableReviewPresets, selectedReviewPresetId],
   );
   const pendingHistoryRange = useMemo(
     () => (range ? nextActivityHistoryRange(range, historyCoverage) : null),
@@ -781,10 +794,8 @@ export function ActivityLedger({
     };
   }, [preset, range]);
 
-  const generateHistory = useCallback(async () => {
+  const generateHistory = useCallback(async (generationRange: TimeRange) => {
     if (!range || historyLoadingRef.current) return;
-    const generationRange = nextActivityHistoryRange(range, historyCoverage);
-    if (!generationRange) return;
     historyAbortRef.current?.abort();
     const controller = new AbortController();
     historyAbortRef.current = controller;
@@ -941,49 +952,6 @@ export function ActivityLedger({
     historyCoverage,
   ]);
 
-  useEffect(() => {
-    if (
-      !cacheReady ||
-      loading ||
-      error ||
-      summary?.data_status !== "ok" ||
-      !pendingHistoryRange ||
-      historyError
-    ) {
-      return;
-    }
-    void generateHistory();
-  }, [
-    cacheReady,
-    error,
-    generateHistory,
-    history,
-    historyError,
-    loading,
-    summary?.data_status,
-    pendingHistoryRange,
-  ]);
-
-  const refresh = async () => {
-    historyAbortRef.current?.abort();
-    if (range) {
-      try {
-        await clearPersistedActivityHistory(
-          ACTIVITY_REVIEW_PROMPT_VERSION,
-          range,
-        );
-        window.localStorage.removeItem(historyCacheKey(range, preset));
-      } catch {
-        // Regeneration still works in memory without store access.
-      }
-    }
-    setHistory(null);
-    setHistoryCoverage([]);
-    setHistoryError("");
-    setAnchor(new Date());
-    if (preset === "custom") setCustomEnd(toLocalInputValue(new Date()));
-  };
-
   const makeSkill = (entry: ActivityHistoryEntry) => {
     void showChatWithPrefill({
       context: compactEntryContext(entry),
@@ -1041,7 +1009,7 @@ Re-query Screenpipe only inside the cited time range and use the cited frames an
                 Activity
               </h1>
               <p className="mt-1 text-sm text-muted-foreground">
-                A clear record of what you worked on.
+            An encrypted record of what you worked on.
               </p>
             </div>
             <div className="flex items-center gap-2">
@@ -1066,11 +1034,33 @@ Re-query Screenpipe only inside the cited time range and use the cited frames an
                   ))}
                 </SelectContent>
               </Select>
+              <Select
+                value={reviewPreset.id}
+                onValueChange={setSelectedReviewPresetId}
+              >
+                <SelectTrigger
+                  className="h-9 w-[190px] max-w-[36vw] text-xs"
+                  aria-label="AI preset"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent align="end">
+                  {selectableReviewPresets.map((candidate) => (
+                    <SelectItem key={candidate.id} value={candidate.id}>
+                      {candidate.id} · {candidate.model || "default"}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
               <Button
                 variant="ghost"
                 size="icon"
-                onClick={() => void refresh()}
-                disabled={loading || historyLoading}
+                onClick={() => {
+                  if (range) void generateHistory(range);
+                }}
+                disabled={
+                  loading || historyLoading || !cacheReady || invalidRange
+                }
                 aria-label="Refresh history"
               >
                 <RefreshCw
@@ -1223,24 +1213,42 @@ Re-query Screenpipe only inside the cited time range and use the cited frames an
             <p className="text-sm text-muted-foreground">
               There is not enough captured activity in this range yet.
             </p>
+          ) : !cacheReady ? (
+            <div className="flex h-48 items-center justify-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Loading generated activities…
+            </div>
           ) : historyLoading && !history ? (
             <div className="flex h-48 items-center justify-center gap-2 text-sm text-muted-foreground">
               <Loader2 className="h-4 w-4 animate-spin" />
               Understanding what you worked on…
             </div>
-          ) : (
+          ) : cacheReady && !pendingHistoryRange ? (
             <div className="py-12 text-center">
               <p className="text-sm text-muted-foreground">
-                {historyError || "Your history is ready to be understood."}
+                No generated activities in this range.
               </p>
-              <Button
-                variant="outline"
-                size="sm"
-                className="mt-4"
-                onClick={() => void generateHistory()}
-              >
-                Build history
-              </Button>
+            </div>
+          ) : (
+            <div className="flex min-h-[320px] items-center justify-center py-12 text-center">
+              <div className="max-w-sm">
+                <h2 className="font-sans text-xl font-medium tracking-tight">
+                  Generate activities
+                </h2>
+                <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                  {historyError ||
+                    "Turn this range into a private activity history when you’re ready."}
+                </p>
+                <Button
+                  size="sm"
+                  className="mt-5 h-10 px-5 uppercase tracking-wide"
+                  onClick={() => {
+                    if (range) void generateHistory(range);
+                  }}
+                >
+                  Generate activities
+                </Button>
+              </div>
             </div>
           )}
         </div>

--- a/apps/screenpipe-app-tauri/components/activity-ledger.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.tsx
@@ -776,7 +776,8 @@ export function ActivityLedger({
       });
     return () => {
       cancelled = true;
-      historyAbortRef.current?.abort();
+      // History generation must outlive this page so its result is persisted
+      // even when the user navigates elsewhere while Pi is still working.
     };
   }, [preset, range]);
 

--- a/apps/screenpipe-app-tauri/components/activity-ledger.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.tsx
@@ -16,7 +16,6 @@ import {
   AppWindow,
   AudioLines,
   Loader2,
-  MessageCircleMore,
   RefreshCw,
   Users,
 } from "lucide-react";
@@ -984,23 +983,6 @@ export function ActivityLedger({
     if (preset === "custom") setCustomEnd(toLocalInputValue(new Date()));
   };
 
-  const askAboutHistory = () => {
-    if (!range) return;
-    const context = [
-      `Computer history range: ${range.start.toISOString()} to ${range.end.toISOString()}`,
-      history
-        ? `Activities:\n${history.entries.map(compactEntryContext).join("\n\n")}`
-        : "",
-    ]
-      .filter(Boolean)
-      .join("\n\n");
-    void showChatWithPrefill({
-      context,
-      prompt: "What was I working on, and what should I pick up next?",
-      source: "activity-history",
-    });
-  };
-
   const makeSkill = (entry: ActivityHistoryEntry) => {
     void showChatWithPrefill({
       context: compactEntryContext(entry),
@@ -1054,8 +1036,8 @@ Re-query Screenpipe only inside the cited time range and use the cited frames an
         <div className="mx-auto max-w-4xl">
           <div className="flex flex-wrap items-end justify-between gap-4">
             <div>
-              <h1 className="font-sans text-3xl font-medium tracking-tight">
-                history
+              <h1 className="font-sans text-2xl font-medium tracking-tight">
+                Activity
               </h1>
               <p className="mt-1 text-sm text-muted-foreground">
                 A clear record of what you worked on.
@@ -1083,10 +1065,6 @@ Re-query Screenpipe only inside the cited time range and use the cited frames an
                   ))}
                 </SelectContent>
               </Select>
-              <Button variant="outline" size="sm" onClick={askAboutHistory}>
-                <MessageCircleMore className="mr-2 h-3.5 w-3.5" />
-                Ask
-              </Button>
               <Button
                 variant="ghost"
                 size="icon"

--- a/apps/screenpipe-app-tauri/lib/daily-summary-pi.ts
+++ b/apps/screenpipe-app-tauri/lib/daily-summary-pi.ts
@@ -20,7 +20,6 @@ import {
 import { INTERNAL_TITLE_PREFIX } from "@/lib/utils/internal-session";
 import { applyResolvedModelLimits } from "@/lib/model-metadata";
 
-const DAILY_SUMMARY_TIMEOUT_MS = 120_000;
 const DAILY_SUMMARY_PROJECT_DIR = "pi-daily-summary";
 
 export type RunDailySummaryOptions = {
@@ -104,7 +103,6 @@ export async function runDailySummaryWithPi(
 
   let settled = false;
   let lastAssistant = "";
-  let timeoutId: ReturnType<typeof setTimeout> | null = null;
   let resolveResponse!: (value: string) => void;
   let rejectResponse!: (error: Error) => void;
   const response = new Promise<string>((resolve, reject) => {
@@ -115,7 +113,6 @@ export async function runDailySummaryWithPi(
   const settle = (value: string) => {
     if (settled) return;
     settled = true;
-    if (timeoutId) clearTimeout(timeoutId);
     const summary = value.trim();
     if (summary) resolveResponse(summary);
     else rejectResponse(new Error("AI returned an empty daily summary"));
@@ -123,7 +120,6 @@ export async function runDailySummaryWithPi(
   const fail = (error: Error) => {
     if (settled) return;
     settled = true;
-    if (timeoutId) clearTimeout(timeoutId);
     rejectResponse(error);
   };
 
@@ -179,13 +175,8 @@ export async function runDailySummaryWithPi(
     );
     if (prompted.status !== "ok") throw new Error(prompted.error);
 
-    timeoutId = setTimeout(
-      () => fail(new Error("Daily summary generation timed out")),
-      DAILY_SUMMARY_TIMEOUT_MS,
-    );
     return await response;
   } finally {
-    if (timeoutId) clearTimeout(timeoutId);
     options.signal?.removeEventListener("abort", handleAbort);
     unregister();
     void commands.piStop(sessionId);

--- a/apps/screenpipe-app-tauri/lib/dev/browser-engine-mock.ts
+++ b/apps/screenpipe-app-tauri/lib/dev/browser-engine-mock.ts
@@ -252,6 +252,8 @@ function mockActivitySummary() {
   const { start, end } = mockMeetingWindow();
   const span = end.getTime() - start.getTime();
   return {
+    data_status: "ok",
+    total_active_minutes: 20,
     apps: [
       {
         name: "Google Chrome",


### PR DESCRIPTION
## Summary

- remove Activity history preloading from sidebar hover
- show already-computed encrypted history immediately while requiring an explicit CTA or refresh for new generation
- add a preset selector beside refresh, initialized from the default non-agent preset
- remove the generation timeout and let active generation finish and persist after navigation
- describe Activity as an encrypted record

## Before / after

```text
Before
Activity hover/open -> preload -> missing coverage can begin AI generation

After
Activity open -> encrypted cache lookup -> cached range? show it
                                      -> uncached range? wait for Generate activities or Refresh
                                         using [preset selector]
```

## Validation

- `bun x vitest run --config vitest.config.ts components/activity-ledger.test.tsx components/__tests__/sidebar-nav-list.test.tsx lib/daily-summary-pi.test.ts` (37 passed)
- `bun run typecheck`
- browser-verified the consent CTA and preset dropdown with no console errors
- built the unsigned macOS development app with `CARGO_INCREMENTAL=0` and the `dev-debug` profile
