### PR TITLE
feat(activity): add episode chat action

### DIFF
--- a/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
@@ -717,7 +717,7 @@ describe("ActivityLedger", () => {
     );
   });
 
-  it("keeps rows concise while exposing artifact icons and skill creation", async () => {
+  it("keeps rows concise while exposing artifact icons and episode actions", async () => {
     render(<ActivityLedger />);
     await generateActivities();
 
@@ -755,6 +755,11 @@ describe("ActivityLedger", () => {
     expect(
       screen.getByRole("button", {
         name: "Make skill from Fixed a capture reliability regression",
+      }),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", {
+        name: "Chat about Fixed a capture reliability regression",
       }),
     ).toBeVisible();
 
@@ -953,6 +958,29 @@ describe("ActivityLedger", () => {
           source: "activity-history-skill",
           context: expect.stringContaining("frame 67890"),
           prompt: expect.stringContaining("Draft a focused SKILL.md"),
+        }),
+      ),
+    );
+  });
+
+  it("can ask about every activity interval in chat", async () => {
+    render(<ActivityLedger />);
+    await generateActivities();
+    await screen.findByText("Unblocked a customer's onboarding");
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Chat about Unblocked a customer's onboarding",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.showChatWithPrefill).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: "activity-history-chat",
+          context: expect.stringContaining("frame 67890"),
+          displayLabel: "Ask about “Unblocked a customer's onboarding”",
+          prompt: "Tell me more about this activity.",
         }),
       ),
     );

--- a/apps/screenpipe-app-tauri/components/activity-ledger.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.tsx
@@ -963,6 +963,15 @@ Re-query Screenpipe only inside the cited time range and use the cited frames an
     });
   };
 
+  const askAboutActivity = (entry: ActivityHistoryEntry) => {
+    void showChatWithPrefill({
+      context: compactEntryContext(entry),
+      displayLabel: `Ask about “${entry.title}”`,
+      prompt: "Tell me more about this activity.",
+      source: "activity-history-chat",
+    });
+  };
+
   const openEvidence = useCallback(
     (evidence: ActivityArtifact) => {
       onOpenArtifact?.();
@@ -1194,6 +1203,15 @@ Re-query Screenpipe only inside the cited time range and use the cited frames an
                             aria-label={`Make skill from ${entry.title}`}
                           >
                             Make skill
+                          </button>
+                          <span aria-hidden="true">·</span>
+                          <button
+                            type="button"
+                            onClick={() => askAboutActivity(entry)}
+                            className="font-mono text-[10px] uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground"
+                            aria-label={`Chat about ${entry.title}`}
+                          >
+                            Chat
                           </button>
                         </div>
                       </div>


### PR DESCRIPTION
## Summary

- add a Chat action beside Make skill on every generated Activity episode
- prefill chat with the episode title, summary, exact interval, and cited evidence
- keep the prompt editable so the user can ask a more specific follow-up

## Visual

Before: artifacts · MAKE SKILL

After:  artifacts · MAKE SKILL · CHAT

## Test plan

- bun x vitest run components/activity-ledger.test.tsx --config vitest.config.ts
- 20 tests passed
- opened the Activity page with the browser/Tauri mock runtime