### PR TITLE
fix(activity): append recent ledger work

### DIFF
--- a/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
@@ -5,6 +5,7 @@
 import React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -87,6 +88,7 @@ import {
   buildActivityLedgerArtifactsPath,
   buildActivityMeetingsPath,
   buildActivitySummaryPath,
+  canAddRecentActivity,
   minimumHistoryEntryCount,
   rangeForPreset,
 } from "@/components/activity-ledger";
@@ -352,6 +354,29 @@ describe("activity history helpers", () => {
     expect(minimumHistoryEntryCount(45, { start, end })).toBe(2);
     expect(minimumHistoryEntryCount(180, { start, end })).toBe(5);
     expect(minimumHistoryEntryCount(480, { start, end })).toBe(7);
+  });
+
+  it("offers recent activity only after more than ten uncovered minutes", () => {
+    const start = new Date("2026-08-17T07:00:00Z");
+    const coverage = [
+      {
+        start: start.toISOString(),
+        end: "2026-08-17T20:00:00.000Z",
+      },
+    ];
+
+    expect(
+      canAddRecentActivity(
+        { start, end: new Date("2026-08-17T20:10:00.000Z") },
+        coverage,
+      ),
+    ).toBe(false);
+    expect(
+      canAddRecentActivity(
+        { start, end: new Date("2026-08-17T20:10:00.001Z") },
+        coverage,
+      ),
+    ).toBe(true);
   });
 
   it("ranks a compact artifact set while preserving a real website", () => {
@@ -632,6 +657,10 @@ describe("ActivityLedger", () => {
       }),
     );
     const refresh = screen.getByRole("button", { name: "Refresh history" });
+    expect(refresh).toBeDisabled();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10 * 60_000 + 30_000);
+    });
     await waitFor(() => expect(refresh).toBeEnabled());
     fireEvent.click(refresh);
 
@@ -640,6 +669,61 @@ describe("ActivityLedger", () => {
         expect.objectContaining({
           preset: expect.objectContaining({ id: "pipes" }),
           sessionPrefix: "activity-history",
+        }),
+      ),
+    );
+  });
+
+  it("shows a bottom action that unlocks with the header refresh", async () => {
+    mocks.loadPersistedActivityHistory.mockImplementation(
+      async (_producer: string, range: { start: Date; end: Date }) => ({
+        entries: parseActivityHistoryResponse(HISTORY_RESPONSE, range).entries,
+        coverage: [
+          {
+            start: range.start.toISOString(),
+            end: range.end.toISOString(),
+          },
+        ],
+      }),
+    );
+
+    render(<ActivityLedger />);
+
+    await screen.findByText("Fixed a capture reliability regression");
+    const addRecent = screen.getByRole("button", {
+      name: "Add recent activities",
+    });
+    const refresh = screen.getByRole("button", { name: "Refresh history" });
+    expect(addRecent).toBeVisible();
+    expect(addRecent).toBeDisabled();
+    expect(refresh).toBeDisabled();
+    expect(
+      screen.getByText("More activity can be added every 10 minutes."),
+    ).toBeVisible();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10 * 60_000 + 30_000);
+    });
+
+    await waitFor(() => {
+      expect(addRecent).toBeEnabled();
+      expect(refresh).toBeEnabled();
+    });
+    expect(
+      screen.getByText("Include work recorded since your last update."),
+    ).toBeVisible();
+
+    fireEvent.click(addRecent);
+
+    await waitFor(() =>
+      expect(mocks.runDailySummaryWithPi).toHaveBeenCalledWith(
+        expect.objectContaining({
+          range: expect.objectContaining({
+            start: "2026-08-17T19:50:00.000Z",
+            end: expect.stringMatching(
+              /^2026-08-17T20:10:30\.\d{3}Z$/,
+            ),
+          }),
         }),
       ),
     );

--- a/apps/screenpipe-app-tauri/components/activity-ledger.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.tsx
@@ -43,6 +43,7 @@ import {
   type ActivityReviewMeeting,
 } from "@/lib/activity-review-prompt";
 import {
+  ACTIVITY_HISTORY_RECONCILE_OVERLAP_MS,
   loadPersistedActivityHistory,
   mergeActivityHistoryCoverage,
   mergeActivityHistoryDocuments,
@@ -96,6 +97,7 @@ type ActivityArtifact = ActivityHistoryEvidence & {
 };
 
 const MAX_VISIBLE_ARTIFACTS = 6;
+const ACTIVITY_HISTORY_REFRESH_INTERVAL_MS = 10 * 60_000;
 const ACTIVITY_RANGE_STORAGE_KEY = "screenpipe:activity-history:range";
 const ACTIVITY_CUSTOM_START_STORAGE_KEY =
   "screenpipe:activity-history:custom-start";
@@ -260,6 +262,22 @@ export function minimumHistoryEntryCount(
   }
   const activeDays = Math.max(1, Math.ceil(wallHours / 24));
   return Math.min(activeDays * 18, Math.max(1, Math.ceil(activeMinutes / 60)));
+}
+
+export function canAddRecentActivity(
+  range: TimeRange,
+  coverage: ActivityHistoryCoverage[],
+): boolean {
+  const pending = nextActivityHistoryRange(range, coverage);
+  if (!pending) return false;
+  const overlap =
+    pending.start.getTime() > range.start.getTime()
+      ? ACTIVITY_HISTORY_RECONCILE_OVERLAP_MS
+      : 0;
+  return (
+    pending.end.getTime() - pending.start.getTime() - overlap >
+    ACTIVITY_HISTORY_REFRESH_INTERVAL_MS
+  );
 }
 
 function formatEntryTime(entry: ActivityHistoryEntry): string {
@@ -571,6 +589,7 @@ export function ActivityLedger({
   );
   const initialNow = useMemo(() => new Date(), []);
   const anchor = initialNow;
+  const [currentTimeMs, setCurrentTimeMs] = useState(initialNow.getTime());
   const [preset, setPreset] = useState<RangePreset>(readStoredRangePreset);
   const initialPresetRef = useRef(preset);
   const [customStart, setCustomStart] = useState(() =>
@@ -640,6 +659,27 @@ export function ActivityLedger({
     () => (range ? nextActivityHistoryRange(range, historyCoverage) : null),
     [historyCoverage, range],
   );
+  const recentRange = useMemo(
+    () =>
+      rangeForPreset(
+        preset,
+        new Date(currentTimeMs),
+        customStart,
+        customEnd,
+      ),
+    [currentTimeMs, customEnd, customStart, preset],
+  );
+  const recentActivityAvailable = Boolean(
+    recentRange && canAddRecentActivity(recentRange, historyCoverage),
+  );
+
+  useEffect(() => {
+    const interval = window.setInterval(
+      () => setCurrentTimeMs(Date.now()),
+      30_000,
+    );
+    return () => window.clearInterval(interval);
+  }, []);
 
   useEffect(() => {
     posthog.capture("activity_viewed", { range: initialPresetRef.current });
@@ -804,6 +844,7 @@ export function ActivityLedger({
   const generateHistory = useCallback(async (
     generationRange: TimeRange,
     source: GenerationSource,
+    viewRange: TimeRange = range!,
   ) => {
     if (!range || historyLoadingRef.current) return;
     posthog.capture("activity_generation_started", {
@@ -850,7 +891,7 @@ export function ActivityLedger({
           ACTIVITY_REVIEW_PROMPT_VERSION,
           generationRange,
           { entries: [] },
-          range,
+          viewRange,
         );
         setHistory(
           persisted.entries.length > 0 ? { entries: persisted.entries } : null,
@@ -930,7 +971,7 @@ export function ActivityLedger({
           ACTIVITY_REVIEW_PROMPT_VERSION,
           generationRange,
           next,
-          range,
+          viewRange,
         );
       } catch {
         persisted = {
@@ -981,6 +1022,47 @@ export function ActivityLedger({
     history,
     historyCoverage,
   ]);
+
+  const addRecentActivity = useCallback(() => {
+    const clickedRange = rangeForPreset(
+      preset,
+      new Date(),
+      customStart,
+      customEnd,
+    );
+    const clickedHistoryRange = clickedRange
+      ? nextActivityHistoryRange(clickedRange, historyCoverage)
+      : null;
+    if (
+      !clickedRange ||
+      !clickedHistoryRange ||
+      !canAddRecentActivity(clickedRange, historyCoverage) ||
+      loading ||
+      historyLoading ||
+      !cacheReady ||
+      invalidRange
+    ) {
+      return;
+    }
+    void generateHistory(clickedHistoryRange, "refresh", clickedRange);
+  }, [
+    cacheReady,
+    customEnd,
+    customStart,
+    generateHistory,
+    historyCoverage,
+    historyLoading,
+    invalidRange,
+    loading,
+    preset,
+  ]);
+
+  const recentActivityDisabled =
+    loading ||
+    historyLoading ||
+    !cacheReady ||
+    invalidRange ||
+    !recentActivityAvailable;
 
   const makeSkill = (entry: ActivityHistoryEntry) => {
     posthog.capture("activity_skill_clicked");
@@ -1109,12 +1191,8 @@ Re-query Screenpipe only inside the cited time range and use the cited frames an
               <Button
                 variant="ghost"
                 size="icon"
-                onClick={() => {
-                  if (range) void generateHistory(range, "refresh");
-                }}
-                disabled={
-                  loading || historyLoading || !cacheReady || invalidRange
-                }
+                onClick={addRecentActivity}
+                disabled={recentActivityDisabled}
                 aria-label="Refresh history"
               >
                 <RefreshCw
@@ -1264,6 +1342,29 @@ Re-query Screenpipe only inside the cited time range and use the cited frames an
                   ))}
                 </div>
               ))}
+              <div className="flex flex-col items-center border-t border-border py-10 text-center">
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="h-10 rounded-none px-5 uppercase tracking-wide"
+                  onClick={addRecentActivity}
+                  disabled={recentActivityDisabled}
+                >
+                  <RefreshCw
+                    className={cn(
+                      "mr-2 h-3.5 w-3.5",
+                      historyLoading && "animate-spin",
+                    )}
+                    aria-hidden="true"
+                  />
+                  Add recent activities
+                </Button>
+                <p className="mt-2 text-xs text-muted-foreground">
+                  {recentActivityAvailable
+                    ? "Include work recorded since your last update."
+                    : "More activity can be added every 10 minutes."}
+                </p>
+              </div>
             </section>
           ) : loading && !summary ? (
             <div className="flex h-48 items-center justify-center gap-2 text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary

- add a bottom-of-ledger **Add recent activities** control paired with the header refresh
- keep both controls visible but disabled until more than 10 minutes of uncovered activity is available
- fix refresh to extend through the actual click time instead of reusing the page-open timestamp
- reconcile only the new tail with the existing 10-minute overlap, preserving prior activities

## Root cause

The Activity range end was anchored when the page mounted. Refresh reused that frozen range, so work performed after opening the page was outside the generation request and could not be appended. This was unrelated to a 30-minute reconciliation timer; the reconciliation overlap is 10 minutes.

## Before / after

```text
BEFORE
[ledger rows]
(end)

Header refresh -> original page-open range -> recent work omitted

AFTER
[ledger rows]
────────────────────────────────────────
        ↻  ADD RECENT ACTIVITIES
   More activity can be added every 10 minutes.

Header refresh ─┐
Footer action ──┴─> uncovered tail through click time + 10m overlap
```

When eligible, the helper changes to: `Include work recorded since your last update.`

## Validation

- `bun x vitest run --config vitest.config.ts components/activity-ledger.test.tsx` — 23 passed
- `bun x tsc --noEmit --pretty false`
- `bunx --bun @biomejs/biome check components/activity-ledger.tsx components/activity-ledger.test.tsx`
- `git diff --check upstream/main...HEAD`
