### PR TITLE
fix(activity): resolve app icons from runtime server port

### DIFF
--- a/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
@@ -17,6 +17,7 @@ Element.prototype.scrollIntoView ||= () => {};
 
 const mocks = vi.hoisted(() => ({
   emit: vi.fn(),
+  getAppServerBaseUrl: vi.fn(),
   loadPersistedActivityHistory: vi.fn(),
   localFetch: vi.fn(),
   posthogCapture: vi.fn(),
@@ -61,6 +62,9 @@ vi.mock("next/navigation", () => ({
 vi.mock("@/lib/api", () => ({ localFetch: mocks.localFetch }));
 vi.mock("@/lib/chat-utils", () => ({
   showChatWithPrefill: mocks.showChatWithPrefill,
+}));
+vi.mock("@/lib/notifications/app-server", () => ({
+  getAppServerBaseUrl: mocks.getAppServerBaseUrl,
 }));
 vi.mock("@/lib/daily-summary-pi", () => ({
   runDailySummaryWithPi: mocks.runDailySummaryWithPi,
@@ -243,6 +247,7 @@ const LEDGER_ARTIFACTS_RESPONSE = {
 beforeEach(() => {
   vi.useFakeTimers({ shouldAdvanceTime: true });
   vi.setSystemTime(new Date("2026-08-17T20:00:00Z"));
+  mocks.getAppServerBaseUrl.mockResolvedValue("http://localhost:11535");
   mocks.settings.enhancedAI = true;
   const values = new Map<string, string>();
   Object.defineProperty(window, "localStorage", {
@@ -975,9 +980,11 @@ describe("ActivityLedger", () => {
       name: /Open github.com at .* in Timeline/,
     });
     expect(appArtifact).toHaveAttribute("href", "screenpipe://frame/12345");
-    expect(appArtifact.querySelector("img")).toHaveAttribute(
-      "src",
-      "http://localhost:11435/app-icon?name=Arc",
+    await waitFor(() =>
+      expect(appArtifact.querySelector("img")).toHaveAttribute(
+        "src",
+        "http://localhost:11535/app-icon?name=Arc",
+      ),
     );
     expect(transcriptArtifact).toHaveAttribute(
       "href",

--- a/apps/screenpipe-app-tauri/components/activity-ledger.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.tsx
@@ -54,9 +54,9 @@ import {
 import { localFetch } from "@/lib/api";
 import { showChatWithPrefill } from "@/lib/chat-utils";
 import { runDailySummaryWithPi } from "@/lib/daily-summary-pi";
-import { appIconUrl } from "@/lib/first-run/recent-activity";
 import { useSettings } from "@/lib/hooks/use-settings";
 import { useTimelineStore } from "@/lib/hooks/use-timeline-store";
+import { getAppServerBaseUrl } from "@/lib/notifications/app-server";
 import { cn } from "@/lib/utils";
 import type { AIPreset } from "@/lib/utils/tauri";
 
@@ -495,7 +495,20 @@ export function artifactsForHistoryEntry(
 
 function EvidenceArtifactIcon({ evidence }: { evidence: ActivityArtifact }) {
   const [iconFailed, setIconFailed] = useState(false);
+  const [appServerBaseUrl, setAppServerBaseUrl] = useState<string | null>(null);
   const domain = siteDomain(evidence.browser_url);
+
+  useEffect(() => {
+    if (!evidence.app_name || domain) return;
+    let active = true;
+    void getAppServerBaseUrl().then((baseUrl) => {
+      if (active) setAppServerBaseUrl(baseUrl);
+    });
+    return () => {
+      active = false;
+    };
+  }, [domain, evidence.app_name]);
+
   if (evidence.kind === "meeting") {
     return <Users className="h-4 w-4" aria-hidden="true" />;
   }
@@ -509,10 +522,10 @@ function EvidenceArtifactIcon({ evidence }: { evidence: ActivityArtifact }) {
       />
     );
   }
-  if (evidence.app_name && !iconFailed) {
+  if (evidence.app_name && appServerBaseUrl && !iconFailed) {
     return (
       <img
-        src={appIconUrl(evidence.app_name)}
+        src={`${appServerBaseUrl}/app-icon?name=${encodeURIComponent(evidence.app_name)}`}
         alt=""
         className="h-full w-full object-contain"
         onError={() => setIconFailed(true)}


### PR DESCRIPTION
## Summary

- resolve Activity app icons through the existing runtime app-server configuration
- preserve the production `11435` behavior while supporting isolated dev builds on `11535`
- cover the runtime-port icon URL in the focused Activity test

## Before / after

```text
Before (isolated dev)
Activity -> localhost:11435/app-icon -> unavailable -> generic window glyph

After
Activity -> get_app_server_config -> localhost:11535/app-icon -> native app icon
```

## Validation

- `bun x vitest run --config vitest.config.ts components/activity-ledger.test.tsx` (23 passed)
- verified Passwords and Keychain Access return valid PNGs from the isolated dev icon server
- `git diff --check`