### PR TITLE
fix(activity): recover empty history generations

### DIFF
--- a/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
@@ -953,6 +953,36 @@ describe("ActivityLedger", () => {
     );
   });
 
+  it("keeps a valid first pass when the coverage repair fails", async () => {
+    mocks.localFetch.mockImplementation((path: string) =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () =>
+          path.startsWith("/meetings?")
+            ? []
+            : { data_status: "ok", total_active_minutes: 300 },
+      }),
+    );
+    mocks.runDailySummaryWithPi
+      .mockResolvedValueOnce(HISTORY_RESPONSE)
+      .mockRejectedValueOnce(new Error("repair failed"));
+
+    render(<ActivityLedger />);
+    await generateActivities();
+
+    expect(
+      await screen.findByRole("heading", {
+        name: "Fixed a capture reliability regression",
+      }),
+    ).toBeVisible();
+    expect(mocks.runDailySummaryWithPi).toHaveBeenCalledTimes(2);
+    expect(mocks.reconcilePersistedActivityHistory).toHaveBeenCalled();
+    expect(
+      screen.queryByText("History could not be updated. Try again."),
+    ).toBeNull();
+  });
+
   it("does not offer a header chat action", async () => {
     render(<ActivityLedger />);
     await generateActivities();

--- a/apps/screenpipe-app-tauri/components/activity-ledger.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.tsx
@@ -804,8 +804,6 @@ export function ActivityLedger({
     historyLoadingRef.current = false;
     setHistoryLoading(false);
     setHistoryError("");
-    setHistory(null);
-    setHistoryCoverage([]);
     setCacheReady(false);
     if (!range) return;
     let cancelled = false;
@@ -942,36 +940,40 @@ export function ActivityLedger({
       );
       let missingMeetings = missingRequiredMeetingIds(next, generationMeetings);
       if (next.entries.length < minimumEntries || missingMeetings.length > 0) {
-        const repairedRaw = await runDailySummaryWithPi({
-          date: generationRange.start,
-          range: {
-            start: generationRange.start.toISOString(),
-            end: generationRange.end.toISOString(),
-          },
-          preset: reviewPreset,
-          userToken: settings.user?.token ?? null,
-          signal: controller.signal,
-          sessionPrefix: "activity-history-repair",
-          systemPrompt: ACTIVITY_REVIEW_AGENT_SYSTEM_PROMPT,
-          prompt: buildActivityReviewRepairPrompt(
-            reviewRange,
+        try {
+          const repairedRaw = await runDailySummaryWithPi({
+            date: generationRange.start,
+            range: {
+              start: generationRange.start.toISOString(),
+              end: generationRange.end.toISOString(),
+            },
+            preset: reviewPreset,
+            userToken: settings.user?.token ?? null,
+            signal: controller.signal,
+            sessionPrefix: "activity-history-repair",
+            systemPrompt: ACTIVITY_REVIEW_AGENT_SYSTEM_PROMPT,
+            prompt: buildActivityReviewRepairPrompt(
+              reviewRange,
+              generationMeetings,
+              next,
+              minimumEntries,
+              missingMeetings,
+            ),
+          });
+          const repaired = parseActivityHistoryResponse(
+            repairedRaw,
+            generationRange,
             generationMeetings,
-            next,
-            minimumEntries,
-            missingMeetings,
-          ),
-        });
-        next = parseActivityHistoryResponse(
-          repairedRaw,
-          generationRange,
-          generationMeetings,
-        );
-        missingMeetings = missingRequiredMeetingIds(next, generationMeetings);
-      }
-      if (next.entries.length < minimumEntries) {
-        throw new Error(
-          "History is still resolving this range. Try again in a moment.",
-        );
+          );
+          // Never discard a valid, source-backed first pass merely because a
+          // best-effort repair returned fewer usable rows.
+          if (repaired.entries.length >= next.entries.length) next = repaired;
+          missingMeetings = missingRequiredMeetingIds(next, generationMeetings);
+        } catch (reason) {
+          if (controller.signal.aborted) throw reason;
+          // The first pass is already structurally validated and cited. Keep
+          // it instead of turning a coverage-quality miss into a blank page.
+        }
       }
       if (missingMeetings.length > 0) {
         throw new Error(

--- a/apps/screenpipe-app-tauri/lib/daily-summary-pi.test.ts
+++ b/apps/screenpipe-app-tauri/lib/daily-summary-pi.test.ts
@@ -176,6 +176,84 @@ describe("runDailySummaryWithPi", () => {
     );
   });
 
+  it("continues once when tools finish without a final assistant response", async () => {
+    let handler: ((envelope: any) => void) | null = null;
+    mocks.registerForeground.mockImplementation((_sessionId, nextHandler) => {
+      handler = nextHandler;
+      return vi.fn();
+    });
+    mocks.piPrompt
+      .mockImplementationOnce(async () => {
+        queueMicrotask(() => {
+          handler?.({
+            event: {
+              type: "agent_end",
+              messages: [
+                { role: "assistant", content: [{ type: "toolCall" }] },
+                { role: "toolResult", content: "source evidence" },
+              ],
+            },
+          });
+        });
+        return { status: "ok", data: null };
+      })
+      .mockImplementationOnce(async () => {
+        queueMicrotask(() => {
+          handler?.({
+            event: {
+              type: "agent_end",
+              messages: [
+                {
+                  role: "assistant",
+                  content: [{ type: "text", text: "Recovered summary" }],
+                },
+              ],
+            },
+          });
+        });
+        return { status: "ok", data: null };
+      });
+
+    await expect(
+      runDailySummaryWithPi({
+        date: new Date(2026, 7, 18),
+        range: { start: "start", end: "end" },
+        preset: PRESET,
+        userToken: "user-token",
+      }),
+    ).resolves.toBe("Recovered summary");
+
+    expect(mocks.piPrompt).toHaveBeenCalledTimes(2);
+    expect(mocks.piPrompt).toHaveBeenLastCalledWith(
+      expect.stringContaining("daily-summary"),
+      expect.stringContaining("without a final response"),
+      null,
+      null,
+    );
+  });
+
+  it("fails after a second empty terminal response", async () => {
+    let handler: ((envelope: any) => void) | null = null;
+    mocks.registerForeground.mockImplementation((_sessionId, nextHandler) => {
+      handler = nextHandler;
+      return vi.fn();
+    });
+    mocks.piPrompt.mockImplementation(async () => {
+      queueMicrotask(() => handler?.({ event: { type: "agent_end" } }));
+      return { status: "ok", data: null };
+    });
+
+    await expect(
+      runDailySummaryWithPi({
+        date: new Date(2026, 7, 18),
+        range: { start: "start", end: "end" },
+        preset: PRESET,
+        userToken: "user-token",
+      }),
+    ).rejects.toThrow("AI returned an empty daily summary");
+    expect(mocks.piPrompt).toHaveBeenCalledTimes(2);
+  });
+
   it("stops the Pi session when the request is aborted", async () => {
     mocks.registerForeground.mockReturnValue(vi.fn());
     mocks.piPrompt.mockResolvedValue({ status: "ok", data: null });

--- a/apps/screenpipe-app-tauri/lib/daily-summary-pi.ts
+++ b/apps/screenpipe-app-tauri/lib/daily-summary-pi.ts
@@ -21,6 +21,8 @@ import { INTERNAL_TITLE_PREFIX } from "@/lib/utils/internal-session";
 import { applyResolvedModelLimits } from "@/lib/model-metadata";
 
 const DAILY_SUMMARY_PROJECT_DIR = "pi-daily-summary";
+const EMPTY_COMPLETION_PROMPT =
+  "Your previous turn ended after tool execution without a final response. Using the tool results already in this session, return the requested final response now. Do not call tools again.";
 
 export type RunDailySummaryOptions = {
   date: Date;
@@ -103,6 +105,7 @@ export async function runDailySummaryWithPi(
 
   let settled = false;
   let lastAssistant = "";
+  let emptyCompletionRetries = 0;
   let resolveResponse!: (value: string) => void;
   let rejectResponse!: (error: Error) => void;
   const response = new Promise<string>((resolve, reject) => {
@@ -130,7 +133,22 @@ export async function runDailySummaryWithPi(
       if (candidate) lastAssistant = candidate;
     }
     if (event.type === "agent_end") {
-      settle(finalAssistantText(envelope) || lastAssistant);
+      const finalText = finalAssistantText(envelope) || lastAssistant;
+      if (finalText) {
+        settle(finalText);
+      } else if (emptyCompletionRetries === 0) {
+        emptyCompletionRetries += 1;
+        void commands
+          .piPrompt(sessionId, EMPTY_COMPLETION_PROMPT, null, null)
+          .then((result) => {
+            if (result.status === "error") fail(new Error(result.error));
+          })
+          .catch((reason: unknown) => {
+            fail(reason instanceof Error ? reason : new Error(String(reason)));
+          });
+      } else {
+        settle("");
+      }
     } else if (event.type === "error") {
       // Keep the provider error intact — the UI classifies quota/rate-limit
       // codes out of it to offer the right recovery (upgrade vs retry).

--- a/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
@@ -108,6 +108,27 @@ fn assistant_text_delta(event: &Value) -> Option<&str> {
     assistant_event.get("delta").and_then(|d| d.as_str())
 }
 
+fn agent_end_has_assistant_text(event: &Value) -> bool {
+    event
+        .get("messages")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter(|message| message.get("role").and_then(Value::as_str) == Some("assistant"))
+        .filter_map(|message| message.get("content"))
+        .any(|content| match content {
+            Value::String(text) => !text.trim().is_empty(),
+            Value::Array(parts) => parts.iter().any(|part| {
+                part.get("type").and_then(Value::as_str) == Some("text")
+                    && part
+                        .get("text")
+                        .and_then(Value::as_str)
+                        .is_some_and(|text| !text.trim().is_empty())
+            }),
+            _ => false,
+        })
+}
+
 fn set_assistant_text_delta(event: &mut Value, delta: String) {
     if let Some(assistant_event) = event
         .get_mut("assistantMessageEvent")
@@ -3359,6 +3380,30 @@ pub async fn pi_start_inner(
                 sync_queue_state_from_event(qs, event);
             }
 
+            if let Some(event) = parsed.as_ref() {
+                if event_type.as_deref() == Some("error")
+                    && sid_clone.contains("activity-history")
+                {
+                    error!(
+                        "Pi provider error (session {}): {}",
+                        sid_clone,
+                        event
+                            .get("errorMessage")
+                            .or_else(|| event.get("finalError"))
+                            .or_else(|| event.get("message"))
+                            .unwrap_or(event)
+                    );
+                } else if event_type.as_deref() == Some("agent_end")
+                    && sid_clone.contains("activity-history")
+                    && !agent_end_has_assistant_text(event)
+                {
+                    error!(
+                        "Activity generation ended without a final assistant response (session {})",
+                        sid_clone
+                    );
+                }
+            }
+
             match parsed {
                 Some(event) => {
                     // Route RPC responses to waiting callers (legacy path, kept for compat)
@@ -5664,6 +5709,26 @@ mod tests {
             super::event_tool_call_ids(&tool_end),
             vec!["tool-1".to_string()]
         );
+    }
+
+    #[test]
+    fn detects_agent_end_without_final_assistant_text() {
+        let tool_only = json!({
+            "type": "agent_end",
+            "messages": [
+                { "role": "assistant", "content": [{ "type": "toolCall", "name": "bash" }] },
+                { "role": "toolResult", "content": [{ "type": "text", "text": "done" }] }
+            ]
+        });
+        assert!(!super::agent_end_has_assistant_text(&tool_only));
+
+        let completed = json!({
+            "type": "agent_end",
+            "messages": [
+                { "role": "assistant", "content": [{ "type": "text", "text": "final json" }] }
+            ]
+        });
+        assert!(super::agent_end_has_assistant_text(&completed));
     }
 
     #[test]

--- a/apps/screenpipe-app-tauri/src-tauri/src/server.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/server.rs
@@ -584,7 +584,7 @@ async fn get_app_icon_handler(
                         HeaderValue::from_static("public, max-age=60"),
                     ),
                 ];
-                return (StatusCode::NOT_FOUND, headers, Bytes::new());
+                return (StatusCode::NO_CONTENT, headers, Bytes::new());
             }
         }
     }
@@ -618,7 +618,7 @@ async fn get_app_icon_handler(
                         HeaderValue::from_static("public, max-age=60"),
                     ),
                 ];
-                (StatusCode::NOT_FOUND, headers, Bytes::new())
+                (StatusCode::NO_CONTENT, headers, Bytes::new())
             }
         }
     }
@@ -632,7 +632,7 @@ async fn get_app_icon_handler(
                 HeaderValue::from_static("public, max-age=60"),
             ),
         ];
-        (StatusCode::NOT_FOUND, headers, Bytes::new())
+        (StatusCode::NO_CONTENT, headers, Bytes::new())
     }
 }
 


### PR DESCRIPTION
## Summary

- continue an Activity generation once in the same Pi session when an agent turn ends after tool execution without a final assistant response
- preserve cached and valid first-pass history when refresh or best-effort coverage repair fails
- log exact Activity provider and empty-terminal failures in the native backend while keeping the user-facing error generic
- return `204 No Content` for unresolved app icons so expected fallbacks do not flood the console with `404` failures

## Root cause

A reproduced Activity Pi session successfully completed its local data tool calls, then emitted terminal `agent_end` without any final assistant JSON. `runDailySummaryWithPi` immediately interpreted that empty terminal event as a failed summary. There was no continuation, while Activity also cleared visible cached state before its asynchronous cache read completed.

## Before / after

```text
before: tools complete -> agent_end(empty) -> generation failure -> blank/error state

after:  tools complete -> agent_end(empty) -> same-session continuation -> final JSON
                                      \-> if still empty: generic UI error + exact native log
        cached/valid history remains visible throughout refresh failures
```

## Validation

- `bun x vitest run --config vitest.config.ts lib/daily-summary-pi.test.ts components/activity-ledger.test.tsx lib/activity-history-persistence.test.ts` — 34 tests passed
- `bun x eslint lib/daily-summary-pi.ts lib/daily-summary-pi.test.ts components/activity-ledger.tsx components/activity-ledger.test.tsx` — no errors (2 pre-existing `no-img-element` warnings)
- `git diff --check` — passed
- full Tauri build not run; it began rebuilding the entire native dependency graph and was intentionally stopped to keep validation focused
