### PR TITLE
fix(activity): generate current selected range

### DIFF
--- a/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
@@ -92,7 +92,6 @@ import {
   buildActivityLedgerArtifactsPath,
   buildActivityMeetingsPath,
   buildActivitySummaryPath,
-  canAddRecentActivity,
   minimumHistoryEntryCount,
   rangeForPreset,
 } from "@/components/activity-ledger";
@@ -361,29 +360,6 @@ describe("activity history helpers", () => {
     expect(minimumHistoryEntryCount(480, { start, end })).toBe(7);
   });
 
-  it("offers recent activity only after more than ten uncovered minutes", () => {
-    const start = new Date("2026-08-17T07:00:00Z");
-    const coverage = [
-      {
-        start: start.toISOString(),
-        end: "2026-08-17T20:00:00.000Z",
-      },
-    ];
-
-    expect(
-      canAddRecentActivity(
-        { start, end: new Date("2026-08-17T20:10:00.000Z") },
-        coverage,
-      ),
-    ).toBe(false);
-    expect(
-      canAddRecentActivity(
-        { start, end: new Date("2026-08-17T20:10:00.001Z") },
-        coverage,
-      ),
-    ).toBe(true);
-  });
-
   it("ranks a compact artifact set while preserving a real website", () => {
     const entry = parseActivityHistoryResponse(HISTORY_RESPONSE, {
       start: new Date("2026-08-17T16:00:00Z"),
@@ -639,6 +615,68 @@ describe("ActivityLedger", () => {
     );
   });
 
+  it("generates through click time when capture starts after Activity opens", async () => {
+    let summaryCalls = 0;
+    mocks.localFetch.mockImplementation((path: string) =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => {
+          if (path.startsWith("/meetings?")) return [];
+          if (path.startsWith("/activity-ledger?")) {
+            return LEDGER_ARTIFACTS_RESPONSE;
+          }
+          summaryCalls += 1;
+          return summaryCalls === 1
+            ? { data_status: "unknown", total_active_minutes: 0 }
+            : { data_status: "ok", total_active_minutes: 8 };
+        },
+      }),
+    );
+
+    render(<ActivityLedger />);
+
+    const generate = await screen.findByRole("button", {
+      name: "Generate activities",
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+    fireEvent.click(generate);
+
+    await waitFor(() =>
+      expect(mocks.runDailySummaryWithPi).toHaveBeenCalledWith(
+        expect.objectContaining({
+          range: expect.objectContaining({
+            end: expect.stringMatching(
+              /^2026-08-17T20:00:30\.\d{3}Z$/,
+            ),
+          }),
+        }),
+      ),
+    );
+  });
+
+  it("keeps the generate action after a previously empty covered range", async () => {
+    mocks.loadPersistedActivityHistory.mockImplementation(
+      async (_producer: string, range: { start: Date; end: Date }) => ({
+        entries: [],
+        coverage: [
+          {
+            start: range.start.toISOString(),
+            end: range.end.toISOString(),
+          },
+        ],
+      }),
+    );
+
+    render(<ActivityLedger />);
+
+    expect(
+      await screen.findByRole("button", { name: "Generate activities" }),
+    ).toBeVisible();
+  });
+
   it("uses the selected preset for an explicit refresh", async () => {
     mocks.loadPersistedActivityHistory.mockImplementation(
       async (_producer: string, range: { start: Date; end: Date }) => ({
@@ -662,10 +700,6 @@ describe("ActivityLedger", () => {
       }),
     );
     const refresh = screen.getByRole("button", { name: "Refresh history" });
-    expect(refresh).toBeDisabled();
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(10 * 60_000 + 30_000);
-    });
     await waitFor(() => expect(refresh).toBeEnabled());
     fireEvent.click(refresh);
 
@@ -674,61 +708,6 @@ describe("ActivityLedger", () => {
         expect.objectContaining({
           preset: expect.objectContaining({ id: "pipes" }),
           sessionPrefix: "activity-history",
-        }),
-      ),
-    );
-  });
-
-  it("shows a bottom action that unlocks with the header refresh", async () => {
-    mocks.loadPersistedActivityHistory.mockImplementation(
-      async (_producer: string, range: { start: Date; end: Date }) => ({
-        entries: parseActivityHistoryResponse(HISTORY_RESPONSE, range).entries,
-        coverage: [
-          {
-            start: range.start.toISOString(),
-            end: range.end.toISOString(),
-          },
-        ],
-      }),
-    );
-
-    render(<ActivityLedger />);
-
-    await screen.findByText("Fixed a capture reliability regression");
-    const addRecent = screen.getByRole("button", {
-      name: "Add recent activities",
-    });
-    const refresh = screen.getByRole("button", { name: "Refresh history" });
-    expect(addRecent).toBeVisible();
-    expect(addRecent).toBeDisabled();
-    expect(refresh).toBeDisabled();
-    expect(
-      screen.getByText("More activity can be added every 10 minutes."),
-    ).toBeVisible();
-
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(10 * 60_000 + 30_000);
-    });
-
-    await waitFor(() => {
-      expect(addRecent).toBeEnabled();
-      expect(refresh).toBeEnabled();
-    });
-    expect(
-      screen.getByText("Include work recorded since your last update."),
-    ).toBeVisible();
-
-    fireEvent.click(addRecent);
-
-    await waitFor(() =>
-      expect(mocks.runDailySummaryWithPi).toHaveBeenCalledWith(
-        expect.objectContaining({
-          range: expect.objectContaining({
-            start: "2026-08-17T19:50:00.000Z",
-            end: expect.stringMatching(
-              /^2026-08-17T20:10:30\.\d{3}Z$/,
-            ),
-          }),
         }),
       ),
     );
@@ -825,7 +804,9 @@ describe("ActivityLedger", () => {
     const view = render(<ActivityLedger />);
 
     await generateActivities();
-    expect(mocks.runDailySummaryWithPi).toHaveBeenCalledOnce();
+    await waitFor(() =>
+      expect(mocks.runDailySummaryWithPi).toHaveBeenCalledOnce(),
+    );
     const generationSignal = mocks.runDailySummaryWithPi.mock.calls[0][0]
       .signal as AbortSignal;
 

--- a/apps/screenpipe-app-tauri/components/activity-ledger.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.tsx
@@ -43,11 +43,9 @@ import {
   type ActivityReviewMeeting,
 } from "@/lib/activity-review-prompt";
 import {
-  ACTIVITY_HISTORY_RECONCILE_OVERLAP_MS,
   loadPersistedActivityHistory,
   mergeActivityHistoryCoverage,
   mergeActivityHistoryDocuments,
-  nextActivityHistoryRange,
   reconcilePersistedActivityHistory,
   type ActivityHistoryCoverage,
 } from "@/lib/activity-history-persistence";
@@ -97,7 +95,6 @@ type ActivityArtifact = ActivityHistoryEvidence & {
 };
 
 const MAX_VISIBLE_ARTIFACTS = 6;
-const ACTIVITY_HISTORY_REFRESH_INTERVAL_MS = 10 * 60_000;
 const ACTIVITY_RANGE_STORAGE_KEY = "screenpipe:activity-history:range";
 const ACTIVITY_CUSTOM_START_STORAGE_KEY =
   "screenpipe:activity-history:custom-start";
@@ -262,22 +259,6 @@ export function minimumHistoryEntryCount(
   }
   const activeDays = Math.max(1, Math.ceil(wallHours / 24));
   return Math.min(activeDays * 18, Math.max(1, Math.ceil(activeMinutes / 60)));
-}
-
-export function canAddRecentActivity(
-  range: TimeRange,
-  coverage: ActivityHistoryCoverage[],
-): boolean {
-  const pending = nextActivityHistoryRange(range, coverage);
-  if (!pending) return false;
-  const overlap =
-    pending.start.getTime() > range.start.getTime()
-      ? ACTIVITY_HISTORY_RECONCILE_OVERLAP_MS
-      : 0;
-  return (
-    pending.end.getTime() - pending.start.getTime() - overlap >
-    ACTIVITY_HISTORY_REFRESH_INTERVAL_MS
-  );
 }
 
 function formatEntryTime(entry: ActivityHistoryEntry): string {
@@ -602,7 +583,6 @@ export function ActivityLedger({
   );
   const initialNow = useMemo(() => new Date(), []);
   const anchor = initialNow;
-  const [currentTimeMs, setCurrentTimeMs] = useState(initialNow.getTime());
   const [preset, setPreset] = useState<RangePreset>(readStoredRangePreset);
   const initialPresetRef = useRef(preset);
   const [customStart, setCustomStart] = useState(() =>
@@ -668,32 +648,6 @@ export function ActivityLedger({
       selectableReviewPresets[0],
     [selectableReviewPresets, selectedReviewPresetId],
   );
-  const pendingHistoryRange = useMemo(
-    () => (range ? nextActivityHistoryRange(range, historyCoverage) : null),
-    [historyCoverage, range],
-  );
-  const recentRange = useMemo(
-    () =>
-      rangeForPreset(
-        preset,
-        new Date(currentTimeMs),
-        customStart,
-        customEnd,
-      ),
-    [currentTimeMs, customEnd, customStart, preset],
-  );
-  const recentActivityAvailable = Boolean(
-    recentRange && canAddRecentActivity(recentRange, historyCoverage),
-  );
-
-  useEffect(() => {
-    const interval = window.setInterval(
-      () => setCurrentTimeMs(Date.now()),
-      30_000,
-    );
-    return () => window.clearInterval(interval);
-  }, []);
-
   useEffect(() => {
     posthog.capture("activity_viewed", { range: initialPresetRef.current });
   }, []);
@@ -869,26 +823,28 @@ export function ActivityLedger({
     setHistoryLoading(true);
     setHistoryError("");
     try {
-      const generationMeetings = meetings.filter(
-        (meeting) =>
-          new Date(meeting.end_at).getTime() >
-            generationRange.start.getTime() &&
-          new Date(meeting.start_at).getTime() < generationRange.end.getTime(),
-      );
-      let generationSummary = summary;
-      if (
-        generationRange.start.getTime() !== range.start.getTime() ||
-        generationRange.end.getTime() !== range.end.getTime()
-      ) {
-        const response = await localFetch(
-          buildActivitySummaryPath(generationRange),
-          { signal: controller.signal },
-        );
-        if (!response.ok) {
-          throw new Error(`Activity request failed (${response.status}).`);
-        }
-        generationSummary = (await response.json()) as ActivitySummaryResponse;
+      const [summaryResponse, meetingsResponse] = await Promise.all([
+        localFetch(buildActivitySummaryPath(generationRange), {
+          signal: controller.signal,
+        }),
+        localFetch(buildActivityMeetingsPath(generationRange), {
+          signal: controller.signal,
+        }),
+      ]);
+      if (!summaryResponse.ok) {
+        throw new Error(`Activity request failed (${summaryResponse.status}).`);
       }
+      if (!meetingsResponse.ok) {
+        throw new Error(`Meeting request failed (${meetingsResponse.status}).`);
+      }
+      const [generationSummary, meetingRecords] = await Promise.all([
+        summaryResponse.json() as Promise<ActivitySummaryResponse>,
+        meetingsResponse.json() as Promise<MeetingResponse[]>,
+      ]);
+      const generationMeetings = meetingAnchors(
+        meetingRecords,
+        generationRange,
+      );
       const reviewRange = {
         start: generationRange.start.toISOString(),
         end: generationRange.end.toISOString(),
@@ -1028,56 +984,24 @@ export function ActivityLedger({
       }
     }
   }, [
-    meetings,
     preset,
     range,
     reviewPreset,
     settings,
-    summary,
     history,
     historyCoverage,
   ]);
 
-  const addRecentActivity = useCallback(() => {
+  const regenerateSelectedRange = useCallback((source: GenerationSource) => {
     const clickedRange = rangeForPreset(
       preset,
       new Date(),
       customStart,
       customEnd,
     );
-    const clickedHistoryRange = clickedRange
-      ? nextActivityHistoryRange(clickedRange, historyCoverage)
-      : null;
-    if (
-      !clickedRange ||
-      !clickedHistoryRange ||
-      !canAddRecentActivity(clickedRange, historyCoverage) ||
-      loading ||
-      historyLoading ||
-      !cacheReady ||
-      invalidRange
-    ) {
-      return;
-    }
-    void generateHistory(clickedHistoryRange, "refresh", clickedRange);
-  }, [
-    cacheReady,
-    customEnd,
-    customStart,
-    generateHistory,
-    historyCoverage,
-    historyLoading,
-    invalidRange,
-    loading,
-    preset,
-  ]);
-
-  const recentActivityDisabled =
-    loading ||
-    historyLoading ||
-    !cacheReady ||
-    invalidRange ||
-    !recentActivityAvailable;
+    if (!clickedRange) return;
+    void generateHistory(clickedRange, source, clickedRange);
+  }, [customEnd, customStart, generateHistory, preset]);
 
   const makeSkill = (entry: ActivityHistoryEntry) => {
     posthog.capture("activity_skill_clicked");
@@ -1206,8 +1130,10 @@ Re-query Screenpipe only inside the cited time range and use the cited frames an
               <Button
                 variant="ghost"
                 size="icon"
-                onClick={addRecentActivity}
-                disabled={recentActivityDisabled}
+                onClick={() => regenerateSelectedRange("refresh")}
+                disabled={
+                  loading || historyLoading || !cacheReady || invalidRange
+                }
                 aria-label="Refresh history"
               >
                 <RefreshCw
@@ -1357,29 +1283,6 @@ Re-query Screenpipe only inside the cited time range and use the cited frames an
                   ))}
                 </div>
               ))}
-              <div className="flex flex-col items-center border-t border-border py-10 text-center">
-                <Button
-                  type="button"
-                  variant="outline"
-                  className="h-10 rounded-none px-5 uppercase tracking-wide"
-                  onClick={addRecentActivity}
-                  disabled={recentActivityDisabled}
-                >
-                  <RefreshCw
-                    className={cn(
-                      "mr-2 h-3.5 w-3.5",
-                      historyLoading && "animate-spin",
-                    )}
-                    aria-hidden="true"
-                  />
-                  Add recent activities
-                </Button>
-                <p className="mt-2 text-xs text-muted-foreground">
-                  {recentActivityAvailable
-                    ? "Include work recorded since your last update."
-                    : "More activity can be added every 10 minutes."}
-                </p>
-              </div>
             </section>
           ) : loading && !summary ? (
             <div className="flex h-48 items-center justify-center gap-2 text-sm text-muted-foreground">
@@ -1388,10 +1291,6 @@ Re-query Screenpipe only inside the cited time range and use the cited frames an
             </div>
           ) : error ? (
             <p className="text-sm text-muted-foreground">{error}</p>
-          ) : summary?.data_status !== "ok" ? (
-            <p className="text-sm text-muted-foreground">
-              There is not enough captured activity in this range yet.
-            </p>
           ) : !cacheReady ? (
             <div className="flex h-48 items-center justify-center gap-2 text-sm text-muted-foreground">
               <Loader2 className="h-4 w-4 animate-spin" />
@@ -1401,12 +1300,6 @@ Re-query Screenpipe only inside the cited time range and use the cited frames an
             <div className="flex h-48 items-center justify-center gap-2 text-sm text-muted-foreground">
               <Loader2 className="h-4 w-4 animate-spin" />
               Understanding what you worked on…
-            </div>
-          ) : cacheReady && !pendingHistoryRange ? (
-            <div className="py-12 text-center">
-              <p className="text-sm text-muted-foreground">
-                No generated activities in this range.
-              </p>
             </div>
           ) : (
             <div className="flex min-h-[320px] items-center justify-center py-12 text-center">
@@ -1421,9 +1314,7 @@ Re-query Screenpipe only inside the cited time range and use the cited frames an
                 <Button
                   size="sm"
                   className="mt-5 h-10 px-5 uppercase tracking-wide"
-                  onClick={() => {
-                    if (range) void generateHistory(range, "empty_state");
-                  }}
+                  onClick={() => regenerateSelectedRange("empty_state")}
                 >
                   Generate activities
                 </Button>


### PR DESCRIPTION
## Summary
- resolve Today and rolling ranges at generation time instead of freezing them at page mount
- always re-fetch current activity and meetings before generation
- remove the stale no-activity gate, ten-minute refresh clock, and covered-empty dead end

## Before / after

```text
Before: Activity opened at T0 -> later Generate still queried through T0 -> misleading no-activity state
After:  Generate clicked at T1 -> selected range resolves through T1 -> current data is generated
```

## Validation
- `bun run test:vitest -- components/activity-ledger.test.tsx` (24 passed)
- `bun run typecheck`