### PR TITLE
fix(activity): restore recent activity control

### DIFF
--- a/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
@@ -92,6 +92,7 @@ import {
   buildActivityLedgerArtifactsPath,
   buildActivityMeetingsPath,
   buildActivitySummaryPath,
+  canAddRecentActivity,
   minimumHistoryEntryCount,
   rangeForPreset,
 } from "@/components/activity-ledger";
@@ -350,6 +351,27 @@ describe("activity history helpers", () => {
     expect(artifacts.pathname).toBe("/activity-ledger");
     expect(artifacts.searchParams.get("depth")).toBe("task");
     expect(artifacts.searchParams.get("include_artifacts")).toBe("true");
+  });
+
+  it("requires more than 10 uncovered minutes before appending", () => {
+    const range = {
+      start: new Date("2026-08-17T07:00:00Z"),
+      end: new Date("2026-08-17T20:10:00Z"),
+    };
+    const coverage = [
+      {
+        start: range.start.toISOString(),
+        end: "2026-08-17T20:00:00.000Z",
+      },
+    ];
+
+    expect(canAddRecentActivity(range, coverage)).toBe(false);
+    expect(
+      canAddRecentActivity(
+        { ...range, end: new Date("2026-08-17T20:10:00.001Z") },
+        coverage,
+      ),
+    ).toBe(true);
   });
 
   it("requires enough entries to account for a full day", () => {
@@ -693,7 +715,7 @@ describe("ActivityLedger", () => {
         coverage: [
           {
             start: range.start.toISOString(),
-            end: range.end.toISOString(),
+            end: new Date(range.end.getTime() - 11 * 60_000).toISOString(),
           },
         ],
       }),
@@ -720,6 +742,81 @@ describe("ActivityLedger", () => {
         }),
       ),
     );
+  });
+
+  it("restores the bottom append control without a rolling page clock", async () => {
+    mocks.loadPersistedActivityHistory.mockImplementation(
+      async (_producer: string, range: { start: Date; end: Date }) => ({
+        entries: parseActivityHistoryResponse(HISTORY_RESPONSE, range).entries,
+        coverage: [
+          {
+            start: range.start.toISOString(),
+            end: range.end.toISOString(),
+          },
+        ],
+      }),
+    );
+
+    render(<ActivityLedger />);
+
+    await screen.findByText("Fixed a capture reliability regression");
+    const addRecent = screen.getByRole("button", {
+      name: "Add recent activities",
+    });
+    expect(addRecent).toBeVisible();
+    expect(addRecent).toBeDisabled();
+    expect(
+      screen.getByText("More activity can be added every 10 minutes."),
+    ).toBeVisible();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10 * 60_000 + 1_002);
+    });
+
+    await waitFor(() => expect(addRecent).toBeEnabled());
+    fireEvent.click(addRecent);
+
+    await waitFor(() =>
+      expect(mocks.runDailySummaryWithPi).toHaveBeenCalledWith(
+        expect.objectContaining({
+          range: {
+            start: expect.stringMatching(/^2026-08-17T19:50:00\.\d{3}Z$/),
+            end: expect.stringMatching(/^2026-08-17T20:10:01\.\d{3}Z$/),
+          },
+        }),
+      ),
+    );
+  });
+
+  it("shows the append control only for Today and Last 24 hours", async () => {
+    mocks.loadPersistedActivityHistory.mockImplementation(
+      async (_producer: string, range: { start: Date; end: Date }) => ({
+        entries: parseActivityHistoryResponse(HISTORY_RESPONSE, range).entries,
+        coverage: [
+          {
+            start: range.start.toISOString(),
+            end: range.end.toISOString(),
+          },
+        ],
+      }),
+    );
+
+    for (const [preset, expected] of [
+      ["today", true],
+      ["24h", true],
+      ["7d", false],
+      ["custom", false],
+    ] as const) {
+      window.localStorage.setItem("screenpipe:activity-history:range", preset);
+      render(<ActivityLedger />);
+      await screen.findByText("Fixed a capture reliability regression");
+      const addRecent = screen.queryByRole("button", {
+        name: "Add recent activities",
+      });
+      if (expected) expect(addRecent).toBeVisible();
+      else expect(addRecent).toBeNull();
+      cleanup();
+    }
   });
 
   it("shows the exhausted AI preset instead of a generic failure", async () => {

--- a/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
@@ -11,6 +11,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 
 Element.prototype.scrollIntoView ||= () => {};
@@ -782,12 +783,12 @@ describe("ActivityLedger", () => {
 
     await screen.findByText("Fixed a capture reliability regression");
     const addRecent = screen.getByRole("button", {
-      name: "Add recent activities",
+      name: "Generate more results",
     });
     expect(addRecent).toBeVisible();
     expect(addRecent).toBeDisabled();
     expect(
-      screen.getByText("More activity can be added every 10 minutes."),
+      screen.getByText("More results can be generated every 10 minutes."),
     ).toBeVisible();
 
     await act(async () => {
@@ -832,7 +833,7 @@ describe("ActivityLedger", () => {
       render(<ActivityLedger />);
       await screen.findByText("Fixed a capture reliability regression");
       const addRecent = screen.queryByRole("button", {
-        name: "Add recent activities",
+        name: "Generate more results",
       });
       if (expected) expect(addRecent).toBeVisible();
       else expect(addRecent).toBeNull();
@@ -1063,6 +1064,7 @@ describe("ActivityLedger", () => {
       }),
     ).toBeVisible();
 
+    const activityRows = screen.getAllByRole("article");
     for (const noisyLabel of [
       "completed",
       "in progress",
@@ -1076,7 +1078,11 @@ describe("ActivityLedger", () => {
       "granularity",
       "hour by hour",
     ]) {
-      expect(screen.queryByText(noisyLabel, { exact: false })).toBeNull();
+      for (const row of activityRows) {
+        expect(
+          within(row).queryByText(noisyLabel, { exact: false }),
+        ).toBeNull();
+      }
     }
 
     await waitFor(() =>

--- a/apps/screenpipe-app-tauri/components/activity-ledger.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.tsx
@@ -1550,12 +1550,12 @@ Re-query Screenpipe only inside the cited time range and use the cited frames an
                       )}
                       aria-hidden="true"
                     />
-                    Add recent activities
+                    Generate more results
                   </Button>
                   <p className="mt-2 text-xs text-muted-foreground">
                     {recentActivityAvailable
-                      ? "Include work recorded since your last update."
-                      : "More activity can be added every 10 minutes."}
+                      ? "Include activity recorded since your last update."
+                      : "More results can be generated every 10 minutes."}
                   </p>
                 </div>
               ) : null}

--- a/apps/screenpipe-app-tauri/components/activity-ledger.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.tsx
@@ -43,9 +43,11 @@ import {
   type ActivityReviewMeeting,
 } from "@/lib/activity-review-prompt";
 import {
+  ACTIVITY_HISTORY_RECONCILE_OVERLAP_MS,
   loadPersistedActivityHistory,
   mergeActivityHistoryCoverage,
   mergeActivityHistoryDocuments,
+  nextActivityHistoryRange,
   reconcilePersistedActivityHistory,
   type ActivityHistoryCoverage,
 } from "@/lib/activity-history-persistence";
@@ -112,6 +114,7 @@ type ActivityArtifact = ActivityHistoryEvidence & {
 };
 
 const MAX_VISIBLE_ARTIFACTS = 6;
+const ACTIVITY_HISTORY_REFRESH_INTERVAL_MS = 10 * 60_000;
 const ACTIVITY_RANGE_STORAGE_KEY = "screenpipe:activity-history:range";
 const ACTIVITY_CUSTOM_START_STORAGE_KEY =
   "screenpipe:activity-history:custom-start";
@@ -276,6 +279,38 @@ export function minimumHistoryEntryCount(
   }
   const activeDays = Math.max(1, Math.ceil(wallHours / 24));
   return Math.min(activeDays * 18, Math.max(1, Math.ceil(activeMinutes / 60)));
+}
+
+export function canAddRecentActivity(
+  range: TimeRange,
+  coverage: ActivityHistoryCoverage[],
+): boolean {
+  const pending = nextActivityHistoryRange(range, coverage);
+  if (!pending) return false;
+  const overlap =
+    pending.start.getTime() > range.start.getTime()
+      ? ACTIVITY_HISTORY_RECONCILE_OVERLAP_MS
+      : 0;
+  return (
+    pending.end.getTime() - pending.start.getTime() - overlap >
+    ACTIVITY_HISTORY_REFRESH_INTERVAL_MS
+  );
+}
+
+function recentActivityUnlockDelay(
+  range: TimeRange,
+  coverage: ActivityHistoryCoverage[],
+): number | null {
+  const pending = nextActivityHistoryRange(range, coverage);
+  if (!pending) return ACTIVITY_HISTORY_REFRESH_INTERVAL_MS + 1_001;
+  const overlap =
+    pending.start.getTime() > range.start.getTime()
+      ? ACTIVITY_HISTORY_RECONCILE_OVERLAP_MS
+      : 0;
+  const uncoveredMs =
+    pending.end.getTime() - pending.start.getTime() - overlap;
+  if (uncoveredMs > ACTIVITY_HISTORY_REFRESH_INTERVAL_MS) return null;
+  return ACTIVITY_HISTORY_REFRESH_INTERVAL_MS - uncoveredMs + 1;
 }
 
 function formatEntryTime(entry: ActivityHistoryEntry): string {
@@ -630,6 +665,7 @@ export function ActivityLedger({
   const [historyLoading, setHistoryLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [historyError, setHistoryError] = useState("");
+  const [recentEligibilityTick, setRecentEligibilityTick] = useState(0);
   const historyAbortRef = useRef<AbortController | null>(null);
   const historyLoadingRef = useRef(false);
   const [selectedReviewPresetId, setSelectedReviewPresetId] = useState<
@@ -665,6 +701,35 @@ export function ActivityLedger({
       selectableReviewPresets[0],
     [selectableReviewPresets, selectedReviewPresetId],
   );
+  const supportsRecentActivity = preset === "today" || preset === "24h";
+  const recentRange = useMemo(
+    () =>
+      supportsRecentActivity
+        ? rangeForPreset(preset, new Date(), customStart, customEnd)
+        : null,
+    [
+      customEnd,
+      customStart,
+      preset,
+      recentEligibilityTick,
+      supportsRecentActivity,
+    ],
+  );
+  const recentActivityAvailable = Boolean(
+    recentRange && canAddRecentActivity(recentRange, historyCoverage),
+  );
+
+  useEffect(() => {
+    if (!recentRange || recentActivityAvailable || !cacheReady) return;
+    const delay = recentActivityUnlockDelay(recentRange, historyCoverage);
+    if (delay === null) return;
+    const timeout = window.setTimeout(
+      () => setRecentEligibilityTick((value) => value + 1),
+      delay,
+    );
+    return () => window.clearTimeout(timeout);
+  }, [cacheReady, historyCoverage, recentActivityAvailable, recentRange]);
+
   useEffect(() => {
     posthog.capture("activity_viewed", { range: initialPresetRef.current });
   }, []);
@@ -1040,6 +1105,49 @@ export function ActivityLedger({
     void generateHistory(clickedRange, source, clickedRange);
   }, [customEnd, customStart, generateHistory, preset]);
 
+  const addRecentActivity = useCallback(() => {
+    const clickedRange = rangeForPreset(
+      preset,
+      new Date(),
+      customStart,
+      customEnd,
+    );
+    const clickedHistoryRange = clickedRange
+      ? nextActivityHistoryRange(clickedRange, historyCoverage)
+      : null;
+    if (
+      !clickedRange ||
+      !clickedHistoryRange ||
+      !supportsRecentActivity ||
+      !canAddRecentActivity(clickedRange, historyCoverage) ||
+      loading ||
+      historyLoading ||
+      !cacheReady ||
+      invalidRange
+    ) {
+      return;
+    }
+    void generateHistory(clickedHistoryRange, "refresh", clickedRange);
+  }, [
+    cacheReady,
+    customEnd,
+    customStart,
+    generateHistory,
+    historyCoverage,
+    historyLoading,
+    invalidRange,
+    loading,
+    preset,
+    supportsRecentActivity,
+  ]);
+
+  const recentActivityDisabled =
+    loading ||
+    historyLoading ||
+    !cacheReady ||
+    invalidRange ||
+    !recentActivityAvailable;
+
   const makeSkill = (entry: ActivityHistoryEntry) => {
     posthog.capture("activity_skill_clicked");
     void showChatWithPrefill({
@@ -1159,9 +1267,15 @@ Re-query Screenpipe only inside the cited time range and use the cited frames an
               <Button
                 variant="ghost"
                 size="icon"
-                onClick={() => regenerateSelectedRange("refresh")}
+                onClick={() =>
+                  history && supportsRecentActivity
+                    ? addRecentActivity()
+                    : regenerateSelectedRange("refresh")
+                }
                 disabled={
-                  loading || historyLoading || !cacheReady || invalidRange
+                  history && supportsRecentActivity
+                    ? recentActivityDisabled
+                    : loading || historyLoading || !cacheReady || invalidRange
                 }
                 aria-label="Refresh history"
               >
@@ -1312,6 +1426,31 @@ Re-query Screenpipe only inside the cited time range and use the cited frames an
                   ))}
                 </div>
               ))}
+              {supportsRecentActivity ? (
+                <div className="flex flex-col items-center border-t border-border py-10 text-center">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="h-10 rounded-none px-5 uppercase tracking-wide"
+                    onClick={addRecentActivity}
+                    disabled={recentActivityDisabled}
+                  >
+                    <RefreshCw
+                      className={cn(
+                        "mr-2 h-3.5 w-3.5",
+                        historyLoading && "animate-spin",
+                      )}
+                      aria-hidden="true"
+                    />
+                    Add recent activities
+                  </Button>
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    {recentActivityAvailable
+                      ? "Include work recorded since your last update."
+                      : "More activity can be added every 10 minutes."}
+                  </p>
+                </div>
+              ) : null}
             </section>
           ) : loading && !summary ? (
             <div className="flex h-48 items-center justify-center gap-2 text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
- restore the bottom Add recent activities control for Today and Last 24 hours
- append only uncovered activity using the existing reconciliation overlap
- unlock the control after 10 minutes with a one-shot timer, without restoring the rolling page clock
- preserve full-range regeneration for custom and 7-day ranges

## Visual
Before: generated ledgers ended with no continuation action.
After: the ledger ends with a visible Add recent activities button and cooldown explanation.

## Validation
- `bun x vitest run --config vitest.config.ts components/activity-ledger.test.tsx --reporter=dot` (27 passed)
- `bun run typecheck`
- focused effects lint: 0 errors (10 pre-existing set-state-in-effect warnings)