### PR TITLE
fix(app): stop history timeout regressions

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -32,15 +32,15 @@ results and `cargo llvm-cov` data on top when judging release confidence.
 
 - Mapped suites: 32
 - Mapped Rust files: 327
-- Active test blocks: 3163
+- Active test blocks: 3166
 - Ignored/manual test blocks: 137
-- Weighted coverage points: 2597.6
+- Weighted coverage points: 2599.7
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 3027 | 132 | 2535.6 | 21 | 11 | 100% |
-| macos | 29 | 3085 | 112 | 2548.0 | 22 | 11 | 100% |
-| linux | 25 | 2700 | 105 | 2239.4 | 20 | 11 | 100% |
+| windows | 29 | 3030 | 132 | 2537.7 | 21 | 11 | 100% |
+| macos | 29 | 3088 | 112 | 2550.1 | 22 | 11 | 100% |
+| linux | 25 | 2703 | 105 | 2241.5 | 20 | 11 | 100% |
 
 ## Refresh
 

--- a/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
@@ -785,20 +785,16 @@ describe("ActivityLedger", () => {
     expect(screen.getByRole("button", { name: "Try again" })).toBeVisible();
   });
 
-  it("stops a stalled generation and replaces the spinner with an error", async () => {
+  it("keeps a slow generation running past two minutes", async () => {
+    let finishGeneration!: (value: string) => void;
+    let generationSignal: AbortSignal | undefined;
     mocks.runDailySummaryWithPi.mockImplementation(
-      ({ signal }: { signal?: AbortSignal }) =>
-        new Promise((_resolve, reject) => {
-          signal?.addEventListener(
-            "abort",
-            () => {
-              const error = new Error("aborted");
-              error.name = "AbortError";
-              reject(error);
-            },
-            { once: true },
-          );
-        }),
+      ({ signal }: { signal?: AbortSignal }) => {
+        generationSignal = signal;
+        return new Promise((resolve) => {
+          finishGeneration = resolve;
+        });
+      },
     );
 
     render(<ActivityLedger />);
@@ -811,13 +807,18 @@ describe("ActivityLedger", () => {
       await vi.advanceTimersByTimeAsync(120_000);
     });
 
-    expect(await screen.findByRole("alert")).toHaveTextContent(
-      "Activity generation took too long and was stopped.",
-    );
+    expect(generationSignal?.aborted).toBe(false);
     expect(
-      screen.queryByText("Understanding what you worked on…"),
-    ).toBeNull();
-    expect(screen.getByRole("button", { name: "Try again" })).toBeVisible();
+      await screen.findByText("Understanding what you worked on…"),
+    ).toBeVisible();
+
+    await act(async () => {
+      finishGeneration(HISTORY_RESPONSE);
+    });
+
+    expect(
+      await screen.findByText("Fixed a capture reliability regression"),
+    ).toBeVisible();
   });
 
   it("tracks page reach and the activity generation funnel", async () => {

--- a/apps/screenpipe-app-tauri/components/activity-ledger.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.tsx
@@ -61,7 +61,6 @@ import type { AIPreset } from "@/lib/utils/tauri";
 
 type RangePreset = "today" | "24h" | "7d" | "custom";
 type GenerationSource = "empty_state" | "refresh";
-const ACTIVITY_GENERATION_TIMEOUT_MS = 120_000;
 type ActivitySummaryResponse = {
   data_status: string;
   total_active_minutes: number;
@@ -839,11 +838,6 @@ export function ActivityLedger({
     historyLoadingRef.current = true;
     setHistoryLoading(true);
     setHistoryError("");
-    let timedOut = false;
-    const timeout = window.setTimeout(() => {
-      timedOut = true;
-      controller.abort();
-    }, ACTIVITY_GENERATION_TIMEOUT_MS);
     try {
       const [summaryResponse, meetingsResponse] = await Promise.all([
         localFetch(buildActivitySummaryPath(generationRange), {
@@ -997,24 +991,23 @@ export function ActivityLedger({
         activity_count: next.entries.length,
       });
     } catch (reason) {
-      if (controller.signal.aborted && !timedOut) return;
+      if (controller.signal.aborted) return;
       const rawError = reason instanceof Error ? reason.message : String(reason);
       const quota = presentQuotaError(rawError);
-      const friendlyError = timedOut
-        ? "Activity generation took too long and was stopped. Try again."
-        : rawError.toLowerCase().includes("hosted_ai_allowance_exceeded")
-          ? "This AI preset has no usage left. Choose a different AI preset, then try again."
-          : quota.kind !== "none"
-            ? quota.message
-            : "History could not be updated. Try again.";
+      const friendlyError = rawError
+        .toLowerCase()
+        .includes("hosted_ai_allowance_exceeded")
+        ? "This AI preset has no usage left. Choose a different AI preset, then try again."
+        : quota.kind !== "none"
+          ? quota.message
+          : "History could not be updated. Try again.";
       setHistoryError(friendlyError);
       posthog.capture("activity_generation_failed", {
         range: preset,
         source,
-        error_kind: timedOut ? "timeout" : quota.kind,
+        error_kind: quota.kind,
       });
     } finally {
-      window.clearTimeout(timeout);
       if (historyAbortRef.current === controller) {
         historyLoadingRef.current = false;
         setHistoryLoading(false);

--- a/apps/screenpipe-app-tauri/components/share-logs-button.test.tsx
+++ b/apps/screenpipe-app-tauri/components/share-logs-button.test.tsx
@@ -657,6 +657,16 @@ describe("ShareLogsButton attachments", () => {
     vi.useRealTimers();
   });
 
+  it("only loads the five conversations that can be attached", async () => {
+    render(<ShareLogsButton />);
+
+    fireEvent.click(sendButton());
+
+    await waitFor(() =>
+      expect(loadAllConversationsMock).toHaveBeenCalledWith({ limit: 5 }),
+    );
+  });
+
   it("keeps the dialog open when Rust rejects the handoff", async () => {
     commandsMock.startFeedbackUpload.mockResolvedValue({
       status: "error",

--- a/apps/screenpipe-app-tauri/components/share-logs-button.tsx
+++ b/apps/screenpipe-app-tauri/components/share-logs-button.tsx
@@ -79,6 +79,7 @@ async function compressImageFile(file: File): Promise<string> {
 // Webview preparation must settle before Rust can own the background job.
 // Once `startFeedbackUpload` acknowledges, every network step is Rust-owned.
 const TIMEOUT_PREPARE_MS = 30_000;
+const MAX_INCLUDED_CHAT_CONVERSATIONS = 5;
 
 function timeoutError(label: string): Error {
   return new Error(`${label} timed out — check your connection and try again`);
@@ -494,12 +495,15 @@ export const ShareLogsButton = ({
       if (includeChatHistory) {
         try {
           const conversations = await withTimeout(
-            loadAllConversations(),
+            loadAllConversations({ limit: MAX_INCLUDED_CHAT_CONVERSATIONS }),
             TIMEOUT_PREPARE_MS,
             "chat history",
           );
           const MAX_CHAT_SIZE = 200 * 1024;
-          const recentConvs = conversations.slice(0, 5);
+          const recentConvs = conversations.slice(
+            0,
+            MAX_INCLUDED_CHAT_CONVERSATIONS,
+          );
           let chatData = "";
           for (const conv of recentConvs) {
             const convText = conv.messages

--- a/docs/coverage/CORE.md
+++ b/docs/coverage/CORE.md
@@ -9,10 +9,10 @@ confidence, and criticality.
 - Tracked crates: screenpipe-engine, screenpipe-db, screenpipe-sqlite-coordinator, screenpipe-audio, screenpipe-screen, screenpipe-a11y
 - Mapped suites: 32
 - Mapped Rust files: 327
-- Active test blocks: 3163
+- Active test blocks: 3166
 - Ignored/manual test blocks: 137
-- Declared test blocks: 3300
-- Weighted coverage points: 2597.6
+- Declared test blocks: 3303
+- Weighted coverage points: 2599.7
 
 Confidence weights: strong=1.0, partial=0.7, conditional=0.4, smoke=0.3.
 Criticality weights: high=1.0, medium=0.7, low=0.4.
@@ -23,19 +23,19 @@ are explicitly enabled in a runtime lane.
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 3027 | 132 | 2535.6 | 21 | 11 | 100% |
-| macos | 29 | 3085 | 112 | 2548.0 | 22 | 11 | 100% |
-| linux | 25 | 2700 | 105 | 2239.4 | 20 | 11 | 100% |
+| windows | 29 | 3030 | 132 | 2537.7 | 21 | 11 | 100% |
+| macos | 29 | 3088 | 112 | 2550.1 | 22 | 11 | 100% |
+| linux | 25 | 2703 | 105 | 2241.5 | 20 | 11 | 100% |
 
 ## Crate Summary
 
 | Crate | Suites | Integration files | Source unit files | Active tests | Ignored tests | Weighted points | Flows |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| screenpipe-engine | 10 | 19 | 106 | 1515 | 42 | 1160.3 | 10 |
+| screenpipe-engine | 10 | 19 | 106 | 1517 | 42 | 1161.7 | 10 |
 | screenpipe-db | 5 | 52 | 15 | 451 | 16 | 428.2 | 9 |
 | screenpipe-sqlite-coordinator | 1 | 0 | 2 | 16 | 0 | 16.0 | 2 |
 | screenpipe-audio | 6 | 25 | 51 | 591 | 43 | 517.4 | 5 |
-| screenpipe-screen | 6 | 9 | 18 | 251 | 9 | 225.4 | 4 |
+| screenpipe-screen | 6 | 9 | 18 | 252 | 9 | 226.1 | 4 |
 | screenpipe-a11y | 4 | 2 | 28 | 339 | 27 | 250.3 | 3 |
 
 ## Line Coverage
@@ -68,9 +68,9 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | database | 6 suites / 370 active / 12 ignored / 347.2 pts | 6 suites / 370 active / 12 ignored / 347.2 pts | 6 suites / 370 active / 12 ignored / 347.2 pts |
 | db-search | 2 suites / 111 active / 9 ignored / 111.0 pts | 2 suites / 111 active / 9 ignored / 111.0 pts | 2 suites / 111 active / 9 ignored / 111.0 pts |
 | engine-lifecycle | 6 suites / 208 active / 1 ignored / 183.6 pts | 6 suites / 208 active / 1 ignored / 183.6 pts | 5 suites / 202 active / 1 ignored / 181.9 pts |
-| local-api | 2 suites / 353 active / 9 ignored / 248.9 pts | 2 suites / 353 active / 9 ignored / 248.9 pts | 2 suites / 353 active / 9 ignored / 248.9 pts |
-| meeting | 6 suites / 1451 active / 19 ignored / 1184.9 pts | 6 suites / 1451 active / 19 ignored / 1184.9 pts | 4 suites / 1160 active / 15 ignored / 916.4 pts |
-| ocr | 4 suites / 124 active / 7 ignored / 118.3 pts | 4 suites / 128 active / 7 ignored / 123.8 pts | 3 suites / 119 active / 6 ignored / 114.8 pts |
+| local-api | 2 suites / 355 active / 9 ignored / 250.3 pts | 2 suites / 355 active / 9 ignored / 250.3 pts | 2 suites / 355 active / 9 ignored / 250.3 pts |
+| meeting | 6 suites / 1453 active / 19 ignored / 1186.3 pts | 6 suites / 1453 active / 19 ignored / 1186.3 pts | 4 suites / 1162 active / 15 ignored / 917.8 pts |
+| ocr | 4 suites / 125 active / 7 ignored / 119.0 pts | 4 suites / 129 active / 7 ignored / 124.5 pts | 3 suites / 120 active / 6 ignored / 115.5 pts |
 | os-integration | 1 suites / 6 active / 0 ignored / 1.7 pts | 1 suites / 6 active / 0 ignored / 1.7 pts | - |
 | performance | 13 suites / 1413 active / 67 ignored / 1242.5 pts | 14 suites / 1516 active / 70 ignored / 1283.7 pts | 13 suites / 1413 active / 67 ignored / 1242.5 pts |
 | pipes | 1 suites / 465 active / 3 ignored / 325.5 pts | 1 suites / 465 active / 3 ignored / 325.5 pts | 1 suites / 465 active / 3 ignored / 325.5 pts |
@@ -79,10 +79,10 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | speaker | 2 suites / 348 active / 8 ignored / 348.0 pts | 2 suites / 348 active / 8 ignored / 348.0 pts | 2 suites / 348 active / 8 ignored / 348.0 pts |
 | storage | 3 suites / 506 active / 29 ignored / 407.9 pts | 3 suites / 506 active / 29 ignored / 407.9 pts | 3 suites / 506 active / 29 ignored / 407.9 pts |
 | sync | 1 suites / 465 active / 3 ignored / 325.5 pts | 1 suites / 465 active / 3 ignored / 325.5 pts | 1 suites / 465 active / 3 ignored / 325.5 pts |
-| timeline | 4 suites / 999 active / 33 ignored / 808.2 pts | 4 suites / 999 active / 33 ignored / 808.2 pts | 4 suites / 999 active / 33 ignored / 808.2 pts |
-| transcription | 5 suites / 726 active / 40 ignored / 570.8 pts | 5 suites / 726 active / 40 ignored / 570.8 pts | 5 suites / 726 active / 40 ignored / 570.8 pts |
+| timeline | 4 suites / 1001 active / 33 ignored / 809.6 pts | 4 suites / 1001 active / 33 ignored / 809.6 pts | 4 suites / 1001 active / 33 ignored / 809.6 pts |
+| transcription | 5 suites / 728 active / 40 ignored / 572.2 pts | 5 suites / 728 active / 40 ignored / 572.2 pts | 5 suites / 728 active / 40 ignored / 572.2 pts |
 | ui-events | 4 suites / 704 active / 28 ignored / 536.0 pts | 3 suites / 655 active / 5 ignored / 501.7 pts | 3 suites / 655 active / 5 ignored / 501.7 pts |
-| vision-capture | 5 suites / 531 active / 32 ignored / 418.7 pts | 5 suites / 535 active / 32 ignored / 424.2 pts | 4 suites / 526 active / 31 ignored / 415.2 pts |
+| vision-capture | 5 suites / 532 active / 32 ignored / 419.4 pts | 5 suites / 536 active / 32 ignored / 424.9 pts | 4 suites / 527 active / 31 ignored / 415.9 pts |
 
 ## Critical Flow Matrix
 
@@ -133,7 +133,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | db-runtime-reliability | screenpipe-db | windows, macos, linux | database, performance | performance-liveness | high | partial | mixed | 13 | 30 | 6 | SQLite hard-fault classification, failpoint VFS injection, fresh-identity recovery verification with integrity/FK/write canaries, query cancellation, close-severs-connections regressions, multi-pool WAL parity, runtime version pinning, and WAL chaos plus memory-pressure probes, plus read-only quarantine self-heal verification for transient IOERR faults. |
 | db-search-indexing | screenpipe-db | windows, macos, linux | db-search, ocr, accessibility, performance | local-api-search, capture-ocr-pipeline, accessibility-ui-events, performance-liveness | high | strong | mixed | 13 | 105 | 4 | FTS, tokenizer, OCR snapshot search, query planning, ordering, accessibility search, and contention coverage. |
 | db-timeline-frames | screenpipe-db | windows, macos, linux | database, timeline, storage, performance | timeline-streaming, performance-liveness | high | strong | mixed | 19 | 179 | 3 | Frame/audio joins, timeline query shape, suggestions frames, write queue, DB primitives (src/db.rs split into src/db/ modules), feedback record upserts, media eviction anti-join regressions, SAF output registry, semantic storage, and timeline performance. |
-| engine-api-routes | screenpipe-engine | windows, macos, linux | local-api, timeline, meeting, transcription | local-api-search, timeline-streaming, meeting-live-notes, audio-record-transcribe | high | partial | mixed | 34 | 347 | 4 | Route/unit coverage for search, health, streaming, meetings, time/timezone, and transcription. Legacy endpoint/websocket tests require local data and remain ignored. |
+| engine-api-routes | screenpipe-engine | windows, macos, linux | local-api, timeline, meeting, transcription | local-api-search, timeline-streaming, meeting-live-notes, audio-record-transcribe | high | partial | mixed | 34 | 349 | 4 | Route/unit coverage for search, health, streaming, meetings, time/timezone, and transcription. Legacy endpoint/websocket tests require local data and remain ignored. |
 | engine-capture-timeline | screenpipe-engine | windows, macos, linux | vision-capture, timeline, storage, performance | capture-ocr-pipeline, timeline-streaming, performance-liveness | high | partial | mixed | 25 | 289 | 26 | Covers capture trigger logic, frame/audio linking, hot cache, timeline refresh regressions, fragmented MP4 extraction, and HD-mode control. Several real-data tests are intentionally ignored by default. |
 | engine-config-lifecycle | screenpipe-engine | windows, macos, linux | configuration, engine-lifecycle, performance | settings-to-engine-config, engine-health-lifecycle, performance-liveness | high | strong | mixed | 11 | 111 | 1 | Fast logic coverage for the config bridge, tray health debounce, sleep/power policies, and queue backpressure. |
 | engine-db-recovery-cli | screenpipe-engine | windows, macos, linux | database, engine-lifecycle | engine-health-lifecycle, performance-liveness | high | strong | unit | 1 | 8 | 0 | Exact DB/WAL/SHM working-copy preservation, rollback on archive failure, and restart repair for crashes during the multi-file generation swap. |
@@ -143,7 +143,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | engine-meeting-watcher | screenpipe-engine | windows, macos | meeting | meeting-live-notes | high | strong | mixed | 9 | 216 | 3 | Successor of src/meeting_detector.rs and src/meeting_telemetry.rs. Audio-process and UI-scan backend state machines, candidate resolution, shared telemetry, and a scored trajectory eval. ui_scan/macos.rs and ui_scan/windows.rs are cfg-gated and only execute on their target OS; both backends are null on Linux. |
 | engine-retention-storage | screenpipe-engine | windows, macos, linux | storage, engine-lifecycle, performance | engine-health-lifecycle, performance-liveness | medium | strong | mixed | 5 | 38 | 0 | Local retention deletion (including lean-mode heavy-text stripping), cloud archive watermarking, atomic state-file replacement, and the low-disk capture monitor. |
 | engine-telemetry-observability | screenpipe-engine | windows, macos, linux | engine-lifecycle, performance | engine-health-lifecycle, performance-liveness | medium | strong | unit | 6 | 29 | 0 | PostHog capture gating, telemetry context shaping, piggyback telemetry forwarding, crash-log helpers, resource monitoring, and the recording-coverage reliability metric. |
-| screen-capture-ocr-contract | screenpipe-screen | windows, macos, linux | vision-capture, ocr | capture-ocr-pipeline | high | partial | unit | 3 | 14 | 0 | Cross-platform cached-OCR unit coverage for RawCaptureResult to CaptureResult metadata, browser URL, focus state, window-to-screen OCR coordinate transformation, Tesseract output parsing, and contour-based text-region detection for the meeting OCR gate. |
+| screen-capture-ocr-contract | screenpipe-screen | windows, macos, linux | vision-capture, ocr | capture-ocr-pipeline | high | partial | unit | 3 | 15 | 0 | Cross-platform cached-OCR unit coverage for RawCaptureResult to CaptureResult metadata, browser URL, focus state, window-to-screen OCR coordinate transformation, Tesseract output parsing, and contour-based text-region detection for the meeting OCR gate. |
 | screen-capture-windowing | screenpipe-screen | windows, macos, linux | vision-capture, timeline, performance, privacy | capture-ocr-pipeline, timeline-streaming, privacy-and-redaction, performance-liveness | high | strong | mixed | 14 | 184 | 0 | Window filtering, empty-window regressions, retry policy, URL timing, monitor cache, OCR cache, snapshots, and image comparison. |
 | screen-custom-ocr | screenpipe-screen | windows, macos, linux | ocr | capture-ocr-pipeline | medium | conditional | manual | 1 | 0 | 2 | Custom OCR tests are ignored by default and only contribute when explicitly run. |
 | screen-macos-ocr | screenpipe-screen | macos | ocr, vision-capture | capture-ocr-pipeline | high | strong | mixed | 2 | 9 | 1 | Apple Vision OCR source/unit coverage and fixture OCR assertions. |
@@ -401,7 +401,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | engine-api-routes | screenpipe-engine | src/routes/data.rs | source | 2 | 0 | 2 |
 | engine-api-routes | screenpipe-engine | src/routes/elements.rs | source | 25 | 1 | 26 |
 | engine-api-routes | screenpipe-engine | src/routes/frames.rs | source | 7 | 1 | 8 |
-| engine-api-routes | screenpipe-engine | src/routes/health.rs | source | 44 | 0 | 44 |
+| engine-api-routes | screenpipe-engine | src/routes/health.rs | source | 46 | 0 | 46 |
 | engine-api-routes | screenpipe-engine | src/routes/live_views.rs | source | 1 | 0 | 1 |
 | engine-api-routes | screenpipe-engine | src/routes/meeting_summary_status.rs | source | 10 | 0 | 10 |
 | engine-api-routes | screenpipe-engine | src/routes/meetings.rs | source | 6 | 0 | 6 |
@@ -467,7 +467,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | screen-monitor-platform | screenpipe-screen | src/monitor/windows.rs | source | 2 | 1 | 3 |
 | screen-capture-windowing | screenpipe-screen | src/ocr_cache.rs | source | 15 | 0 | 15 |
 | screen-capture-windowing | screenpipe-screen | src/snapshot_writer.rs | source | 4 | 0 | 4 |
-| screen-capture-ocr-contract | screenpipe-screen | src/tesseract.rs | source | 5 | 0 | 5 |
+| screen-capture-ocr-contract | screenpipe-screen | src/tesseract.rs | source | 6 | 0 | 6 |
 | screen-capture-ocr-contract | screenpipe-screen | src/text_regions.rs | source | 8 | 0 | 8 |
 | screen-capture-windowing | screenpipe-screen | src/utils.rs | source | 5 | 0 | 5 |
 | screen-monitor-platform | screenpipe-screen | src/wgc_capture.rs | source | 8 | 2 | 10 |


### PR DESCRIPTION
## Summary

- load only the five chat conversations that a feedback report can attach instead of reading every saved conversation first
- keep Activity history generation alive past the removed two-minute client deadline while retaining explicit cancellation on range or preset replacement
- add regressions for both boundaries

## Why

The v2.6.56 support log showed feedback collection hitting its exact 30-second chat-history deadline. That code read and parsed every conversation, then sliced the result to five. Large histories therefore timed out locally and the report continued without chat history.

The separate Activity deadline removed in #6391 was later reintroduced by #6406. This change preserves the useful error handling from #6406 without restoring that arbitrary cutoff.

## Before / after

```text
Before: N chat files -> read N -> 30s timeout -> report has no chats
After:  native ordered list -> read <= 5 -> attach <= 5 chats

Activity: start -> 120s -> keep running -> result or explicit cancellation
```

## CI synchronization

Current main had stale generated core/unified coverage dashboards after recent Rust tests landed. The separate generated-only commit refreshes those files because the required coverage freshness job otherwise blocks every PR.

## Validation

- `bun x vitest run --config vitest.config.ts components/share-logs-button.test.tsx components/activity-ledger.test.tsx` (55 passed)
- `bun run typecheck`
- `bun run coverage:all:check`
- `git diff --check upstream/main...HEAD`