### PR TITLE
feat(app): add activity loading skeleton

### DIFF
--- a/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
@@ -580,6 +580,10 @@ describe("ActivityLedger", () => {
     expect(
       await screen.findByText("Loading generated activities…"),
     ).toBeVisible();
+    expect(screen.getByTestId("activity-ledger-skeleton")).toBeVisible();
+    expect(screen.getAllByTestId("activity-ledger-skeleton-row")).toHaveLength(
+      3,
+    );
     expect(
       screen.queryByRole("button", { name: "Generate activities" }),
     ).toBeNull();

--- a/apps/screenpipe-app-tauri/components/activity-ledger.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.tsx
@@ -16,12 +16,12 @@ import posthog from "posthog-js";
 import {
   AppWindow,
   AudioLines,
-  Loader2,
   RefreshCw,
   Users,
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import { faviconUrl } from "@/components/settings/capture-filters/icon-urls";
 import {
   Select,
@@ -569,6 +569,57 @@ function groupByDay(entries: ActivityHistoryEntry[]) {
     groups.set(key, [...(groups.get(key) ?? []), entry]);
   }
   return [...groups.entries()];
+}
+
+function ActivityLedgerSkeleton({ label }: { label: string }) {
+  return (
+    <section
+      aria-label={label}
+      aria-live="polite"
+      data-testid="activity-ledger-skeleton"
+    >
+      <span className="sr-only">{label}</span>
+      <div className="border-b border-foreground/20 pb-3">
+        <Skeleton className="h-7 w-40 rounded-none" />
+      </div>
+
+      {["first", "second", "third"].map((row, index) => (
+        <div
+          key={row}
+          className="grid gap-3 border-b border-border py-6 last:border-b-0 sm:grid-cols-[112px_1fr]"
+          data-testid="activity-ledger-skeleton-row"
+        >
+          <Skeleton className="h-3 w-16 rounded-none" />
+          <div className="min-w-0">
+            <Skeleton
+              className={cn(
+                "h-5 rounded-none",
+                index === 1 ? "w-1/2" : "w-2/3",
+              )}
+            />
+            <div className="mt-2 space-y-2">
+              <Skeleton className="h-3.5 w-full max-w-2xl rounded-none" />
+              <Skeleton
+                className={cn(
+                  "h-3.5 max-w-2xl rounded-none",
+                  index === 2 ? "w-3/5" : "w-4/5",
+                )}
+              />
+            </div>
+            <div className="mt-4 flex items-center gap-3">
+              <div className="flex items-center gap-1.5">
+                {[0, 1, 2].map((artifact) => (
+                  <Skeleton key={artifact} className="h-7 w-7 rounded-none" />
+                ))}
+              </div>
+              <Skeleton className="h-2.5 w-14 rounded-none" />
+              <Skeleton className="h-2.5 w-9 rounded-none" />
+            </div>
+          </div>
+        </div>
+      ))}
+    </section>
+  );
 }
 
 function compactEntryContext(entry: ActivityHistoryEntry): string {
@@ -1307,22 +1358,13 @@ Re-query Screenpipe only inside the cited time range and use the cited frames an
               ))}
             </section>
           ) : loading && !summary ? (
-            <div className="flex h-48 items-center justify-center gap-2 text-sm text-muted-foreground">
-              <Loader2 className="h-4 w-4 animate-spin" />
-              Reading your day…
-            </div>
+            <ActivityLedgerSkeleton label="Reading your day…" />
           ) : error ? (
             <p className="text-sm text-muted-foreground">{error}</p>
           ) : !cacheReady ? (
-            <div className="flex h-48 items-center justify-center gap-2 text-sm text-muted-foreground">
-              <Loader2 className="h-4 w-4 animate-spin" />
-              Loading generated activities…
-            </div>
+            <ActivityLedgerSkeleton label="Loading generated activities…" />
           ) : historyLoading && !history ? (
-            <div className="flex h-48 items-center justify-center gap-2 text-sm text-muted-foreground">
-              <Loader2 className="h-4 w-4 animate-spin" />
-              Understanding what you worked on…
-            </div>
+            <ActivityLedgerSkeleton label="Understanding what you worked on…" />
           ) : (
             <div className="flex min-h-[320px] items-center justify-center py-12 text-center">
               <div className="max-w-sm">


### PR DESCRIPTION
## description\n\nreplace the Activity loading spinners with a shared skeleton that mirrors the loaded history layout: day heading, time column, activity copy, source artifacts, and row actions.\n\nthe same skeleton now covers initial summary loading, encrypted cache loading, and AI activity generation. loading labels remain available to assistive technology.\n\nrelated issue: not linked\n\n## AI assistance and human ownership\n\nread the [AI-assisted contribution policy](https://github.com/screenpipe/screenpipe/blob/main/CONTRIBUTING.md#ai-assisted-contributions).\n\n- AI tool(s) used (none if not used): Codex\n- autonomy level (none, autocomplete, chat, or agent): agent\n- what I personally verified: Codex ran the focused Activity component suite and previewed the loading skeleton in the local app with web mocks.\n\n- [ ] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.\n- [ ] The problem statement, rationale, and replies to maintainers are my own.\n\n## evidence type\n\n- [x] UI or behavior change — before/after visual below and focused component coverage\n- [ ] Backend change — regression tests and relevant logs/results\n- [ ] Performance change — reproducible before/after benchmarks\n- [ ] Docs, CI, or pure refactor — relevant checks and an explanation; no video required\n\n## before\n\nActivity loading used a centered spinner and status copy:\n\n    ┌──────────────────────────────────────┐\n    │                                      │\n    │        ◌  Reading your day…          │\n    │                                      │\n    └──────────────────────────────────────┘\n\n## after\n\nActivity loading preserves the shape of the destination UI:\n\n    ███████████\n    ────────────────────────────────────────\n    ████    ███████████████████\n            ████████████████████████████████\n            ███████████████████████\n            ██ ██ ██   █████   ███\n    ────────────────────────────────────────\n    ████    ███████████████\n            ████████████████████████████████\n            ███████████████████████\n            ██ ██ ██   █████   ███\n\nmanually previewed in the local Activity screen using the supported web-mock development mode.\n\n## how to test\n\n1. cd apps/screenpipe-app-tauri\n2. bun run test:vitest -- components/activity-ledger.test.tsx\n3. result: 27 tests passed\n4. run bun run dev:web, open /home?section=activity, and observe the layout-shaped skeleton while Activity data loads\n\n## desktop app checklist (if applicable)\n\nnot applicable: no Tauri commands or exported Rust types changed.\n