### PR TITLE
fix(meetings): avoid Intel app-name CFString crash

### DIFF
--- a/.github/workflows/macos-intel-launch-smoke.yml
+++ b/.github/workflows/macos-intel-launch-smoke.yml
@@ -56,6 +56,7 @@ on:
     paths: &paths
       - "crates/screenpipe-screen/**"
       - "crates/screenpipe-audio/src/meeting_processes.rs"
+      - "crates/screenpipe-engine/src/meeting_watcher/ui_scan/**"
       - "crates/screenpipe-engine/src/event_driven_capture.rs"
       - "crates/screenpipe-engine/src/hd_recorder.rs"
       - "crates/screenpipe-engine/src/vision_manager/**"
@@ -189,6 +190,27 @@ jobs:
           cargo test -p screenpipe-audio --lib \
             meeting_processes::platform::runtime_smoke::repeated_input_process_snapshots_do_not_crash \
             -- --exact --nocapture
+
+      - name: Smoke-test meeting UI app discovery under process churn
+        shell: bash
+        env:
+          # Reuse the artifacts produced by the Tauri build above instead of
+          # compiling screenpipe-engine's native dependency graph again.
+          CARGO_TARGET_DIR: apps/screenpipe-app-tauri/src-tauri/target
+        run: |
+          set -euo pipefail
+
+          # This API is forbidden in the meeting scanner. On Intel it can
+          # return an invalid CFString while a process exits, which crashes in
+          # CFStringGetLength before Rust can recover.
+          if rg -n 'localized_name\s*\(' crates/screenpipe-engine/src/meeting_watcher/ui_scan/macos.rs; then
+            echo "::error::Meeting UI scanner must use checked libproc names, not NSRunningApplication.localizedName"
+            exit 1
+          fi
+
+          cargo test -p screenpipe-engine --lib --no-default-features \
+            meeting_watcher::ui_scan::macos::runtime_smoke \
+            -- --nocapture
 
       - name: Wrap binary as .app bundle for tcc-grant
         id: wrap_bundle

--- a/crates/screenpipe-engine/src/meeting_watcher/ui_scan/macos.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/ui_scan/macos.rs
@@ -5,8 +5,53 @@
 //! macOS AX-tree scanning backend for meeting detection.
 
 use super::*;
+use std::ffi::c_void;
 use std::time::{Duration, Instant};
 use tracing::{debug, warn};
+
+#[link(name = "proc")]
+extern "C" {
+    fn proc_name(pid: i32, buffer: *mut c_void, buffersize: u32) -> i32;
+}
+
+const PROCESS_NAME_BUFFER_SIZE: usize = 1024;
+
+fn decode_process_name(buffer: &[u8], written: i32) -> Option<String> {
+    if written <= 0 {
+        return None;
+    }
+
+    let end = (written as usize).min(buffer.len());
+    let bytes = &buffer[..end];
+    let nul = bytes
+        .iter()
+        .position(|byte| *byte == 0)
+        .unwrap_or(bytes.len());
+    let name = String::from_utf8_lossy(&bytes[..nul]).trim().to_owned();
+    (!name.is_empty()).then_some(name)
+}
+
+/// Resolve a process name without touching nullable Foundation strings.
+///
+/// `NSRunningApplication.localizedName` has repeatedly returned an invalid
+/// CFString while an app is exiting on Intel macOS. Formatting that value
+/// segfaults in `CFStringGetLength`, so every meeting-scanner app-name lookup
+/// goes through libproc instead.
+fn process_name_for_pid(pid: i32) -> Option<String> {
+    if pid <= 0 {
+        return None;
+    }
+
+    let mut buffer = [0_u8; PROCESS_NAME_BUFFER_SIZE];
+    let written = unsafe {
+        proc_name(
+            pid,
+            buffer.as_mut_ptr().cast::<c_void>(),
+            buffer.len() as u32,
+        )
+    };
+    decode_process_name(&buffer, written)
+}
 
 /// Walk an AX element's subtree looking for call signals.
 ///
@@ -254,10 +299,7 @@ pub(crate) fn get_ax_identifier(elem: &cidre::ax::UiElement) -> Option<String> {
 
 /// Get the app name for a PID on macOS.
 pub(crate) fn get_app_name_for_pid(pid: i32) -> Option<String> {
-    cidre::objc::ar_pool(|| -> Option<String> {
-        let app = cidre::ns::RunningApp::with_pid(pid)?;
-        app.localized_name().map(|s| s.to_string())
-    })
+    process_name_for_pid(pid)
 }
 
 /// Find running processes that match any meeting detection profile.
@@ -285,9 +327,8 @@ pub fn find_running_meeting_apps(
         for i in 0..apps.len() {
             let app = &apps[i];
             let pid = app.pid();
-            let name = match app.localized_name() {
-                Some(n) => n.to_string(),
-                None => continue,
+            let Some(name) = process_name_for_pid(pid) else {
+                continue;
             };
             let name_lower = name.to_lowercase();
 
@@ -568,10 +609,8 @@ pub(crate) fn resolve_browser_pid(app: &str) -> i32 {
         let apps = ws.running_apps();
         for i in 0..apps.len() {
             let a = &apps[i];
-            if let Some(n) = a.localized_name() {
-                if n.to_string().to_lowercase() == app_lower {
-                    return a.pid();
-                }
+            if process_name_for_pid(a.pid()).is_some_and(|name| name.to_lowercase() == app_lower) {
+                return a.pid();
             }
         }
         -1
@@ -611,10 +650,7 @@ mod live_tests {
                 let running = workspace.running_apps();
                 for i in 0..running.len() {
                     let app = &running[i];
-                    let name = app
-                        .localized_name()
-                        .map(|s| s.to_string())
-                        .unwrap_or_default();
+                    let name = process_name_for_pid(app.pid()).unwrap_or_default();
                     let name_lower = name.to_lowercase();
                     if BROWSER_NAMES.iter().any(|b| name_lower.contains(b)) {
                         println!("\nBROWSER: {} (pid={})", name, app.pid());
@@ -688,10 +724,7 @@ mod live_tests2 {
             let running = workspace.running_apps();
             for i in 0..running.len() {
                 let app = &running[i];
-                let name = app
-                    .localized_name()
-                    .map(|s| s.to_string())
-                    .unwrap_or_default();
+                let name = process_name_for_pid(app.pid()).unwrap_or_default();
                 if name != "Arc" {
                     continue;
                 }
@@ -750,5 +783,46 @@ mod live_tests2 {
                 }
             }
         });
+    }
+}
+
+#[cfg(test)]
+mod runtime_smoke {
+    use super::*;
+    use std::process::Command;
+
+    #[test]
+    fn process_name_decoder_handles_bounds_nul_and_invalid_utf8() {
+        assert_eq!(
+            decode_process_name(b"screenpipe\0ignored", 18),
+            Some("screenpipe".into())
+        );
+        assert_eq!(decode_process_name(b" app ", 5), Some("app".into()));
+        assert_eq!(
+            decode_process_name(b"app-\xff", 5),
+            Some("app-\u{fffd}".into())
+        );
+        assert_eq!(decode_process_name(b"screenpipe", 0), None);
+        assert_eq!(decode_process_name(b"\0ignored", 8), None);
+    }
+
+    #[test]
+    fn repeated_app_discovery_and_process_exit_do_not_crash() {
+        let current_pid = std::process::id() as i32;
+        assert!(process_name_for_pid(current_pid).is_some());
+
+        for _ in 0..250 {
+            let mut child = Command::new("/usr/bin/true")
+                .spawn()
+                .expect("spawn short-lived process");
+            let pid = child.id() as i32;
+            let _ = process_name_for_pid(pid);
+            child.wait().expect("wait for short-lived process");
+            let _ = process_name_for_pid(pid);
+
+            // Exercise the production NSWorkspace enumeration plus libproc
+            // naming while the system process table is actively changing.
+            let _ = find_running_meeting_apps(&[], None);
+        }
     }
 }


### PR DESCRIPTION
## description

Fix an Intel macOS meeting-detection crash caused by formatting nullable `NSRunningApplication.localizedName` values while processes are exiting.

- route every meeting-scanner app-name lookup through checked `libproc::proc_name` bytes
- preserve `NSWorkspace` only for running-app PID enumeration
- degrade disappeared processes to `None` instead of reaching `CFStringGetLength`
- trigger the native Intel workflow for meeting UI scanner changes
- add a deterministic CI ban on `localized_name()` in this scanner
- add native process-churn and repeated production app-discovery coverage

The source-backed production signature was `EXC_BAD_ACCESS` at null in `CFStringGetLength`, called through `cidre::objc::ar_pool` on a `screenpipe-worker` thread in signed v2.6.56. Earlier CoreAudio and accessibility fixes were present in that build; this remaining UI-scanner path was not covered by the existing Intel CoreAudio snapshot smoke.

related issue: none

## AI assistance and human ownership

- AI tool(s) used: Codex
- autonomy level: agent
- what I personally verified: Agent validation is listed below; Louis's personal review is pending.

- [ ] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [ ] The problem statement, rationale, and replies to maintainers are my own.

## evidence type

- [ ] UI or behavior change — before/after recording
- [x] Backend change — regression tests and relevant logs/results
- [ ] Performance change — reproducible before/after benchmarks
- [x] Docs, CI, or pure refactor — relevant checks and an explanation; no video required

## before

Not applicable for UI. During meeting detection, five runtime/debug paths formatted `NSRunningApplication.localizedName`. A transient invalid Foundation string could terminate the process before Rust could recover.

## after

All meeting-scanner app names come from `proc_name(pid)` into a bounded byte buffer. Empty, invalid, and disappeared processes degrade safely. CI statically rejects reintroducing `localized_name()` and exercises 250 iterations of real app discovery while short-lived processes exit.

## how to test

1. `CARGO_TARGET_DIR=/Users/louisbeaumont/Documents/screenpipe/target cargo test -p screenpipe-engine --lib --no-default-features meeting_watcher::ui_scan -- --nocapture` — 135 passed, 2 ignored.
2. `cargo fmt --all -- --check` — passed.
3. `git diff --check origin/main...HEAD` — passed.
4. `cargo clippy -p screenpipe-engine --lib --no-default-features --no-deps` — passed with nine existing warnings outside the changed file. `-D warnings` remains baseline-blocked by those same warnings.
5. Native `macos-15-intel` PR check: pending.

## desktop app checklist (if applicable)

No Tauri commands, frontend bindings, or exported Rust types changed.

- [ ] `bun run bindings:generate` (if bindings changed)
- [ ] `bun run bindings:check`
- [ ] `bun run typecheck`
