### PR TITLE
fix(activity): use a single range calendar

### DIFF
--- a/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
@@ -628,6 +628,23 @@ describe("ActivityLedger", () => {
     expect(screen.getByLabelText("AI preset")).toBeVisible();
   });
 
+  it("uses one popover trigger instead of two native custom-date inputs", async () => {
+    render(<ActivityLedger />);
+
+    await screen.findByRole("button", { name: "Generate activities" });
+    fireEvent.click(screen.getByLabelText("Time range"));
+    fireEvent.click(
+      await screen.findByRole("option", { name: "Custom range" }),
+    );
+
+    expect(
+      document.querySelectorAll('input[type="datetime-local"]'),
+    ).toHaveLength(0);
+    expect(
+      screen.getByRole("button", { name: "Choose custom date range" }),
+    ).toHaveAttribute("aria-haspopup", "dialog");
+  });
+
   it("generates through click time when capture starts after Activity opens", async () => {
     let summaryCalls = 0;
     mocks.localFetch.mockImplementation((path: string) =>

--- a/apps/screenpipe-app-tauri/components/activity-ledger.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.tsx
@@ -16,11 +16,20 @@ import posthog from "posthog-js";
 import {
   AppWindow,
   AudioLines,
+  CalendarDays,
   RefreshCw,
   Users,
 } from "lucide-react";
+import { format } from "date-fns";
+import type { DateRange } from "react-day-picker";
 
 import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { Skeleton } from "@/components/ui/skeleton";
 import { faviconUrl } from "@/components/settings/capture-filters/icon-urls";
 import {
@@ -165,6 +174,28 @@ function startOfLocalDay(value: Date): Date {
 function toLocalInputValue(value: Date): string {
   const local = new Date(value.getTime() - value.getTimezoneOffset() * 60_000);
   return local.toISOString().slice(0, 16);
+}
+
+function selectedDateRange(startValue: string, endValue: string): DateRange {
+  return {
+    from: startOfLocalDay(new Date(startValue)),
+    to: startOfLocalDay(new Date(endValue)),
+  };
+}
+
+function endOfSelectedDay(value: Date, now: Date): Date {
+  if (startOfLocalDay(value).getTime() === startOfLocalDay(now).getTime()) {
+    return now;
+  }
+  const end = new Date(value);
+  end.setHours(23, 59, 59, 999);
+  return end;
+}
+
+function customRangeLabel(range: DateRange | undefined): string {
+  if (!range?.from) return "Choose dates";
+  if (!range.to) return `${format(range.from, "MMM d, yyyy")} – …`;
+  return `${format(range.from, "MMM d, yyyy")} – ${format(range.to, "MMM d, yyyy")}`;
 }
 
 export function rangeForPreset(
@@ -664,6 +695,10 @@ export function ActivityLedger({
       toLocalInputValue(initialNow),
     ),
   );
+  const [customDateRange, setCustomDateRange] = useState<
+    DateRange | undefined
+  >(() => selectedDateRange(customStart, customEnd));
+  const [customCalendarOpen, setCustomCalendarOpen] = useState(false);
   const [summary, setSummary] = useState<ActivitySummaryResponse | null>(null);
   const [meetings, setMeetings] = useState<ActivityReviewMeeting[]>([]);
   const meetingsRef = useRef(meetings);
@@ -1220,25 +1255,54 @@ Re-query Screenpipe only inside the cited time range and use the cited frames an
           </div>
 
           {preset === "custom" ? (
-            <div className="mt-4 flex flex-wrap justify-end gap-2">
-              <label className="flex items-center gap-2 text-xs text-muted-foreground">
-                From
-                <input
-                  type="datetime-local"
-                  value={customStart}
-                  onChange={(event) => setCustomStart(event.target.value)}
-                  className="h-9 border border-border bg-background px-3 font-mono text-xs text-foreground outline-none focus:border-foreground"
-                />
-              </label>
-              <label className="flex items-center gap-2 text-xs text-muted-foreground">
-                To
-                <input
-                  type="datetime-local"
-                  value={customEnd}
-                  onChange={(event) => setCustomEnd(event.target.value)}
-                  className="h-9 border border-border bg-background px-3 font-mono text-xs text-foreground outline-none focus:border-foreground"
-                />
-              </label>
+            <div className="mt-4 flex justify-end">
+              <Popover
+                open={customCalendarOpen}
+                onOpenChange={setCustomCalendarOpen}
+              >
+                <PopoverTrigger asChild>
+                  <Button
+                    variant="outline"
+                    className="h-9 justify-start rounded-none border-border bg-background px-3 font-mono text-xs font-normal normal-case tracking-normal"
+                    aria-label="Choose custom date range"
+                  >
+                    <CalendarDays className="mr-2 h-3.5 w-3.5" />
+                    {customRangeLabel(customDateRange)}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent
+                  align="end"
+                  className="w-auto rounded-none border-border p-0 shadow-lg shadow-black/5"
+                >
+                  <Calendar
+                    mode="range"
+                    selected={customDateRange}
+                    onSelect={(nextRange) => {
+                      setCustomDateRange(nextRange);
+                      if (!nextRange?.from || !nextRange.to) return;
+                      const now = new Date();
+                      setCustomStart(
+                        toLocalInputValue(startOfLocalDay(nextRange.from)),
+                      );
+                      setCustomEnd(
+                        toLocalInputValue(endOfSelectedDay(nextRange.to, now)),
+                      );
+                    }}
+                    defaultMonth={customDateRange?.from}
+                    disabled={{ after: new Date() }}
+                    numberOfMonths={1}
+                    className="p-3"
+                    classNames={{
+                      cell: "h-9 w-9 p-0 text-center text-sm relative [&:has([aria-selected])]:bg-accent focus-within:relative focus-within:z-20",
+                      day: "h-9 w-9 rounded-none p-0 font-normal aria-selected:opacity-100",
+                      day_selected:
+                        "bg-foreground text-background hover:bg-foreground hover:text-background focus:bg-foreground focus:text-background",
+                      day_range_middle:
+                        "aria-selected:bg-accent aria-selected:text-accent-foreground",
+                    }}
+                  />
+                </PopoverContent>
+              </Popover>
             </div>
           ) : null}
         </div>


### PR DESCRIPTION
## description

Replace Activity's two native custom datetime inputs with one maintained range calendar built from the Shadcn-style `Popover` + `Calendar` components already in the app.

- keeps the existing Screenpipe visual treatment
- preserves stored custom ranges and current-day end-time behavior
- disables future dates
- adds no dependency and does not hand-roll calendar selection behavior

related issue: not applicable

## AI assistance and human ownership

- AI tool(s) used (`none` if not used): Codex
- autonomy level (`none`, `autocomplete`, `chat`, or `agent`): agent
- what I personally verified: pending human review; Codex ran the checks and real web preview listed below

- [ ] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [ ] The problem statement, rationale, and replies to maintainers are my own.

## evidence type

- [x] UI or behavior change — before/after visual below
- [ ] Backend change — regression tests and relevant logs/results
- [ ] Performance change — reproducible before/after benchmarks
- [ ] Docs, CI, or pure refactor — relevant checks and an explanation; no video required

## before

```text
Custom range
[ From: 08/15/2026  🗓 ]  [ To: 08/16/2026  🗓 ]
```

Two independent native datetime controls opened separate OS calendars.

## after

```text
Custom range
[ 🗓  Aug 15, 2026 – Aug 16, 2026 ]
                    ┌─────────────────────┐
                    │     August 2026     │
                    │ Su Mo Tu We Th Fr Sa│
                    │          [15][16]   │
                    └─────────────────────┘
```

One popover owns the range interaction. React DayPicker handles range semantics; the app only maps the chosen days onto the existing stored start/end timestamps.

## how to test

1. `node node_modules/vitest/vitest.mjs run --config vitest.config.ts components/activity-ledger.test.tsx` — 28 tests passed.
2. `node node_modules/typescript/bin/tsc --noEmit` — passed.
3. Ran the mock web app, opened Activity → Custom range, selected a multi-day range, verified the single calendar remained open for boundary adjustment, future dates were disabled, and the trigger label updated.

## desktop app checklist (if applicable)

No Tauri commands or exported Rust types changed.

- [ ] `bun run bindings:generate` (not applicable)
- [ ] `bun run bindings:check` (not applicable)
- [x] `bun run typecheck`
