### PR TITLE
fix(timeline): keep fullscreen controls below MacBook notch

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/swift/timeline/TimelineCore.swift
+++ b/apps/screenpipe-app-tauri/src-tauri/swift/timeline/TimelineCore.swift
@@ -16,6 +16,19 @@
 import Foundation
 import CoreGraphics
 
+// MARK: - Screen-safe chrome
+
+/// Keeps top chrome below the part of a display macOS reserves for its menu
+/// bar and camera housing. `NSScreen.visibleFrame` is the same authoritative
+/// work area used by the shortcut overlay; comparing it with the actual
+/// timeline window means ordinary windows keep their existing spacing while a
+/// fullscreen child gets only the inset it needs.
+enum TimelineTopChromeLayout {
+    static func safeInset(windowMaxY: CGFloat, visibleFrameMaxY: CGFloat) -> CGFloat {
+        max(0, windowMaxY - visibleFrameMaxY)
+    }
+}
+
 // MARK: - JS number semantics
 
 /// `ToInt32` from the ECMAScript spec. The colour hashes rely on `<<` and `^`

--- a/apps/screenpipe-app-tauri/src-tauri/swift/timeline/TimelineViews.swift
+++ b/apps/screenpipe-app-tauri/src-tauri/swift/timeline/TimelineViews.swift
@@ -20,6 +20,10 @@ struct TimelineRootView: View {
     /// Embedded inside the main window rather than the fullscreen overlay: the
     /// webview varies its insets and hides window-level actions the same way.
     var embedded: Bool = false
+    /// Distance from the top of this child window to the display's visible
+    /// work area. Nonzero only when fullscreen content reaches into macOS's
+    /// menu-bar/camera-housing band.
+    var topSafeInset: CGFloat = 0
 
     @StateObject private var thumbnailLoader = ThumbnailLoader()
 
@@ -59,7 +63,7 @@ struct TimelineRootView: View {
 
             VStack(spacing: 0) {
                 TimelineControlBar(model: model, embedded: embedded)
-                    .padding(.top, embedded ? 8 : 24)
+                    .padding(.top, topSafeInset + (embedded ? 8 : 24))
                 if let url = model.displayFrame.flatMap(TimelineFrames.browserURL) {
                     TimelineURLPill(url: url)
                         .padding(.top, 6)
@@ -79,7 +83,7 @@ struct TimelineRootView: View {
 
             TimelineFilterRail(model: model)
                 .padding(.leading, 12)
-                .padding(.top, 72)
+                .padding(.top, topSafeInset + 72)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
 
             if let selection = model.selection, selection.isMultiFrame {
@@ -129,7 +133,7 @@ struct TimelineRootView: View {
             if model.showAudioTranscript {
                 TimelineTranscriptPanel(model: model)
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
-                    .padding(.top, 72)
+                    .padding(.top, topSafeInset + 72)
                     .padding(.trailing, 20)
             }
         }

--- a/apps/screenpipe-app-tauri/src-tauri/swift/timeline/TimelineWindow.swift
+++ b/apps/screenpipe-app-tauri/src-tauri/swift/timeline/TimelineWindow.swift
@@ -340,13 +340,35 @@ final class TimelineOriginChrome: ObservableObject {
     }
 }
 
+@MainActor
+final class TimelineWindowGeometry: ObservableObject {
+    @Published private(set) var topSafeInset: CGFloat = 0
+
+    func update(windowFrame: NSRect, visibleFrame: NSRect?) {
+        let inset = visibleFrame.map {
+            TimelineTopChromeLayout.safeInset(
+                windowMaxY: windowFrame.maxY,
+                visibleFrameMaxY: $0.maxY
+            )
+        } ?? 0
+        if abs(topSafeInset - inset) > 0.5 {
+            topSafeInset = inset
+        }
+    }
+}
+
 struct TimelineHostView: View {
     @ObservedObject var model: TimelineViewModel
     @ObservedObject var originChrome: TimelineOriginChrome
+    @ObservedObject var geometry: TimelineWindowGeometry
     var embedded: Bool
 
     var body: some View {
-        TimelineRootView(model: model, embedded: embedded)
+        TimelineRootView(
+            model: model,
+            embedded: embedded,
+            topSafeInset: geometry.topSafeInset
+        )
             .overlay(alignment: .topLeading) {
                 if originChrome.showsActivityReturn {
                     Button(action: originChrome.returnToActivity) {
@@ -618,6 +640,7 @@ final class TimelineWindowController: NSObject, NSWindowDelegate {
     private var window: NSWindow?
     private var model: TimelineViewModel?
     private let originChrome = TimelineOriginChrome()
+    private let geometry = TimelineWindowGeometry()
     private var keyMonitor: Any?
     private var scrollMonitor: Any?
     private var scrollHandler: TimelineScrollHandler?
@@ -667,6 +690,16 @@ final class TimelineWindowController: NSObject, NSWindowDelegate {
                   !self.attachedHierarchyHasKeyWindow() else { return }
             TimelineActionBridge.shared.emit("close_window", windowLabel: hostWindowLabel)
         }
+    }
+
+    func windowDidResize(_ notification: Notification) {
+        guard notification.object as? NSWindow === window else { return }
+        updateTopSafeInset()
+    }
+
+    func windowDidMove(_ notification: Notification) {
+        guard notification.object as? NSWindow === window else { return }
+        updateTopSafeInset()
     }
 
     /// Focus may move into a native child such as a Live Text surface or back
@@ -730,6 +763,7 @@ final class TimelineWindowController: NSObject, NSWindowDelegate {
             rootView: TimelineHostView(
                 model: model,
                 originChrome: originChrome,
+                geometry: geometry,
                 embedded: embedded
             )
         )
@@ -762,6 +796,7 @@ final class TimelineWindowController: NSObject, NSWindowDelegate {
         window.contentView = hosting
         window.delegate = self
         self.window = window
+        updateTopSafeInset()
 
         installKeyMonitor(model: model, embedded: embedded, closeOnEscape: closeOnEscape)
         installScrollMonitor(model: model)
@@ -888,6 +923,18 @@ final class TimelineWindowController: NSObject, NSWindowDelegate {
 
     private func applyAttachedFrame(host: NSWindow, rect: NSRect) {
         window?.setFrame(attachedFrame(host: host, rect: rect), display: true)
+        updateTopSafeInset()
+    }
+
+    private func updateTopSafeInset() {
+        guard let window else {
+            geometry.update(windowFrame: .zero, visibleFrame: nil)
+            return
+        }
+        let center = NSPoint(x: window.frame.midX, y: window.frame.midY)
+        let screen = window.screen
+            ?? NSScreen.screens.first { NSMouseInRect(center, $0.frame, false) }
+        geometry.update(windowFrame: window.frame, visibleFrame: screen?.visibleFrame)
     }
 
     private func observeParent(_ host: NSWindow) {

--- a/apps/screenpipe-app-tauri/src-tauri/swift/timeline_tests.swift
+++ b/apps/screenpipe-app-tauri/src-tauri/swift/timeline_tests.swift
@@ -1173,6 +1173,26 @@ private func testHoverPreviewPlacement() {
     )
 }
 
+// MARK: - Screen-safe chrome
+
+private func testTopChromeSafeInset() {
+    expectClose(
+        TimelineTopChromeLayout.safeInset(windowMaxY: 982, visibleFrameMaxY: 982),
+        0,
+        "a window inside the visible frame keeps its existing top spacing"
+    )
+    expectClose(
+        TimelineTopChromeLayout.safeInset(windowMaxY: 1_116, visibleFrameMaxY: 1_082),
+        34,
+        "fullscreen chrome clears the menu bar and camera housing"
+    )
+    expectClose(
+        TimelineTopChromeLayout.safeInset(windowMaxY: 900, visibleFrameMaxY: 982),
+        0,
+        "a lower window never receives a negative inset"
+    )
+}
+
 // MARK: - Runner
 
 private let allTests: [(String, () -> Void)] = [
@@ -1209,6 +1229,7 @@ private let allTests: [(String, () -> Void)] = [
     ("date navigation", testDateNavigation),
     ("frame accessors", testFrameAccessors),
     ("hover preview placement", testHoverPreviewPlacement),
+    ("top chrome safe inset", testTopChromeSafeInset),
 ]
 
 @main


### PR DESCRIPTION
## summary
- derive the timeline top safe inset from the active macOS screen’s `visibleFrame`
- keep captured frames edge-to-edge while moving controls and related top chrome below the menu bar/camera housing
- update the inset when standalone or attached borderless timeline windows move or resize

## verification
- visually verified standalone native fullscreen and Search → Timeline borderless fullscreen on a 16-inch MacBook Pro
- timeline core: 309 checks passed across 34 groups
- timeline render: 170 checks passed across 23 groups

## visual
Before: fullscreen controls could sit behind the MacBook camera housing.

After: the screenshot remains edge-to-edge; controls stay inside `NSScreen.visibleFrame`.