### PR TITLE
fix(pi): return empty list on zero matching installed pipes in live-views

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/assets/extensions/__tests__/live-views.test.ts
+++ b/apps/screenpipe-app-tauri/src-tauri/assets/extensions/__tests__/live-views.test.ts
@@ -387,7 +387,7 @@ describe("live view retrieval the model drives", () => {
     ]);
   });
 
-  it("falls back to the full inventory rather than reporting no tasks exist", async () => {
+  it("returns an empty list when query matches zero installed pipes rather than falling back to all pipes", async () => {
     globalThis.fetch = vi.fn(async () =>
       response({
         data: [
@@ -405,7 +405,7 @@ describe("live view retrieval the model drives", () => {
       new AbortController().signal,
     );
 
-    expect(resultJson(result).pipes).toHaveLength(1);
+    expect(resultJson(result).pipes).toHaveLength(0);
   });
 
   it("reports what a Block currently renders, not its intent", async () => {
@@ -553,5 +553,82 @@ describe("screenpipe_live_view_propose", () => {
 
     expect(guidance).toContain("renders identically");
     expect(guidance).toContain("action=values");
+  });
+});
+
+describe("screenpipe_live_view action=pipes", () => {
+  it("returns all installed pipes when query is omitted", async () => {
+    globalThis.fetch = vi.fn(async (url: string) => {
+      if (url.includes("/pipes")) {
+        return response({
+          data: [
+            { id: "pipe-1", config: { name: "daily-summary", description: "Summarize today" }, enabled: true },
+            { id: "pipe-2", config: { name: "slack-tracker", description: "Track slack" }, enabled: true },
+          ],
+        });
+      }
+      return response({});
+    }) as any;
+
+    const tool = getTool();
+    const result = await tool.execute(
+      "call-pipes-1",
+      { action: "pipes" },
+      new AbortController().signal,
+    );
+
+    const parsed = resultJson(result);
+    expect(parsed.pipes).toHaveLength(2);
+    expect(parsed.pipes[0].name).toBe("daily-summary");
+    expect(parsed.pipes[1].name).toBe("slack-tracker");
+  });
+
+  it("returns only matched pipes when query matches", async () => {
+    globalThis.fetch = vi.fn(async (url: string) => {
+      if (url.includes("/pipes")) {
+        return response({
+          data: [
+            { id: "pipe-1", config: { name: "daily-summary", description: "Summarize today" }, enabled: true },
+            { id: "pipe-2", config: { name: "slack-tracker", description: "Track slack" }, enabled: true },
+          ],
+        });
+      }
+      return response({});
+    }) as any;
+
+    const tool = getTool();
+    const result = await tool.execute(
+      "call-pipes-2",
+      { action: "pipes", query: "slack" },
+      new AbortController().signal,
+    );
+
+    const parsed = resultJson(result);
+    expect(parsed.pipes).toHaveLength(1);
+    expect(parsed.pipes[0].name).toBe("slack-tracker");
+  });
+
+  it("returns empty list when query matches zero installed pipes", async () => {
+    globalThis.fetch = vi.fn(async (url: string) => {
+      if (url.includes("/pipes")) {
+        return response({
+          data: [
+            { id: "pipe-1", config: { name: "daily-summary", description: "Summarize today" }, enabled: true },
+            { id: "pipe-2", config: { name: "slack-tracker", description: "Track slack" }, enabled: true },
+          ],
+        });
+      }
+      return response({});
+    }) as any;
+
+    const tool = getTool();
+    const result = await tool.execute(
+      "call-pipes-3",
+      { action: "pipes", query: "jira-nonexistent" },
+      new AbortController().signal,
+    );
+
+    const parsed = resultJson(result);
+    expect(parsed.pipes).toEqual([]);
   });
 });

--- a/apps/screenpipe-app-tauri/src-tauri/assets/extensions/live-views.ts
+++ b/apps/screenpipe-app-tauri/src-tauri/assets/extensions/live-views.ts
@@ -288,9 +288,7 @@ async function searchInstalledPipes(query: unknown, signal: AbortSignal) {
       return words.some((word) => haystack.includes(word));
     },
   );
-  // Never hide the inventory: an empty match set would otherwise read as "no
-  // scheduled tasks exist" and push the model into inventing one.
-  return (matched.length > 0 ? matched : pipes).slice(0, MAX_PIPE_RESULTS);
+  return matched.slice(0, MAX_PIPE_RESULTS);
 }
 
 function valuePreview(value: unknown): {


### PR DESCRIPTION
## description

Fixes `searchInstalledPipes` in `live-views.ts` so that queries producing zero matches return an empty list `[]` instead of falling back to returning all installed pipes.

Previously, `(matched.length > 0 ? matched : pipes)` returned the full inventory when a search query did not match any installed pipes. This caused agents to falsely assume unrelated installed pipes were relevant to their query.

### Changes
- Updated `searchInstalledPipes` in `live-views.ts` to return `matched.slice(0, MAX_PIPE_RESULTS)`.
- When `query` is omitted or empty, `words.length === 0` continues to return the full inventory.
- Updated and added unit tests in `live-views.test.ts`.



## AI assistance and human ownership

read the [AI-assisted contribution policy](https://github.com/screenpipe/screenpipe/blob/main/CONTRIBUTING.md#ai-assisted-contributions).

- AI tool(s) used (`none` if not used): Antigravity
- autonomy level (`none`, `autocomplete`, `chat`, or `agent`): agent
- what I personally verified:
  - Verified `searchInstalledPipes` returns empty array on non-matching query and full inventory when query is omitted.
  - Ran `cd apps/screenpipe-app-tauri && bun x vitest run src-tauri/assets/extensions/__tests__/live-views.test.ts` (all 24 tests passed).
  - Ran `bun run typecheck` (0 errors).

- [x] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [x] The problem statement, rationale, and replies to maintainers are my own.

## evidence type

check every category that applies and provide its required evidence below.

- [ ] UI or behavior change — before/after recording
- [x] Backend change — regression tests and relevant logs/results
- [ ] Performance change — reproducible before/after benchmarks
- [ ] Docs, CI, or pure refactor — relevant checks and an explanation; no video required

## before

Zero matches fell back to all installed pipes:
```typescript
return (matched.length > 0 ? matched : pipes).slice(0, MAX_PIPE_RESULTS);
```

## after

Zero matches returns empty list:
```typescript
return matched.slice(0, MAX_PIPE_RESULTS);
```

## how to test

list the exact commands or manual steps you personally ran and their results.

1. `cd apps/screenpipe-app-tauri && bun x vitest run src-tauri/assets/extensions/__tests__/live-views.test.ts` -> 24 tests passed.
2. `cd apps/screenpipe-app-tauri && bun run typecheck` -> 0 errors.

## desktop app checklist (if applicable)

If this PR adds or changes `#[tauri::command]` handlers or Rust types exported to the frontend, from `apps/screenpipe-app-tauri/`:

- [ ] `bun run bindings:generate` (if bindings changed)
- [ ] `bun run bindings:check`
- [x] `bun run typecheck`

Commands are auto-collected via the vendored `tauri-helper` crate — no manual handler list edits in `main.rs`.