### PR TITLE
feat(connect): wire OpenCode into MCP and skills setup

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -32,15 +32,15 @@ results and `cargo llvm-cov` data on top when judging release confidence.
 
 - Mapped suites: 32
 - Mapped Rust files: 330
-- Active test blocks: 3205
+- Active test blocks: 3213
 - Ignored/manual test blocks: 137
-- Weighted coverage points: 2628.4
+- Weighted coverage points: 2634.0
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 3066 | 132 | 2565.0 | 21 | 11 | 100% |
-| macos | 29 | 3124 | 112 | 2577.4 | 22 | 11 | 100% |
-| linux | 25 | 2740 | 105 | 2268.3 | 20 | 11 | 100% |
+| windows | 29 | 3074 | 132 | 2570.6 | 21 | 11 | 100% |
+| macos | 29 | 3132 | 112 | 2583.0 | 22 | 11 | 100% |
+| linux | 25 | 2748 | 105 | 2273.9 | 20 | 11 | 100% |
 
 ## Refresh
 

--- a/apps/screenpipe-app-tauri/components/settings/ai-tools-card.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/ai-tools-card.tsx
@@ -33,6 +33,7 @@ import {
   isGeminiMcpInstalled,
   isRunnerMcpInstalled,
   isWindsurfMcpInstalled,
+  isOpencodeMcpInstalled,
 } from "@/lib/ai-tools-mcp";
 import { areExternalAgentSkillsInstalled } from "@/lib/external-agent-skills";
 import {
@@ -108,6 +109,8 @@ async function isToolConnected(id: ConnectAllToolId): Promise<boolean> {
       return isRunnerMcpInstalled();
     case "windsurf":
       return isWindsurfMcpInstalled();
+    case "opencode":
+      return (await isOpencodeMcpInstalled()) && (await areExternalAgentSkillsInstalled("opencode"));
   }
 }
 
@@ -135,6 +138,8 @@ function ToolIcon({ id }: { id: ConnectAllToolId }) {
     case "windsurf":
       // Devin mark (black vector) — Windsurf was rebranded to Devin Desktop.
       return <img src="/images/devin.svg" alt="" className={`${img} dark:invert`} />;
+    case "opencode":
+      return <img src="/images/opencode.svg" alt="" className={`${img} dark:invert`} />;
   }
 }
 

--- a/apps/screenpipe-app-tauri/lib/__tests__/ai-tools-mcp.test.ts
+++ b/apps/screenpipe-app-tauri/lib/__tests__/ai-tools-mcp.test.ts
@@ -90,6 +90,9 @@ import {
   uninstallRunnerMcp,
   installGeminiMcp,
   uninstallGeminiMcp,
+  installOpencodeMcp,
+  uninstallOpencodeMcp,
+  isOpencodeMcpInstalled,
   detectAiTools,
   connectAiTool,
   connectAiToolTargets,
@@ -104,6 +107,7 @@ const CLAUDE_CODE = "/Users/test/.claude.json";
 const HERMES = "/Users/test/.hermes/config.yaml";
 const RUNNER = "/Users/test/.runner/mcp.json";
 const GEMINI = "/Users/test/.gemini/settings.json";
+const OPENCODE = "/Users/test/.config/opencode/opencode.json";
 
 const backupsOf = (path: string) =>
   Array.from(fsMock.files.keys()).filter((p) => p.startsWith(`${path}.screenpipe-backup-`));
@@ -334,6 +338,86 @@ describe("gemini CLI MCP", () => {
   });
 });
 
+describe("opencode MCP", () => {
+  it("detects OpenCode from its XDG config directory, not a home dot-dir", async () => {
+    fsMock.files.set("/Users/test/.config/opencode", "directory marker");
+
+    await expect(detectAiTools()).resolves.toContain("opencode");
+  });
+
+  // OpenCode's config is the one shape in this file that does not follow the
+  // `mcpServers` convention: servers nest under a top-level `mcp` key,
+  // `command` is a single array rather than split command+args, `enabled` is
+  // explicit, and the environment block is `environment` rather than `env`.
+  // https://opencode.ai/docs/mcp-servers/#local-server
+  //
+  // Every one of those is silently wrong-but-valid JSON if it regresses:
+  // OpenCode would simply not see the server, with no error anywhere.
+  it("writes OpenCode's bespoke schema rather than the mcpServers convention", async () => {
+    await installOpencodeMcp();
+
+    const config = JSON.parse(fsMock.files.get(OPENCODE)!);
+    expect(config.mcpServers).toBeUndefined();
+
+    const entry = config.mcp.screenpipe;
+    expect(entry.type).toBe("local");
+    expect(entry.enabled).toBe(true);
+    // command+args flattened into one array, not split fields
+    expect(entry.command).toEqual(["/app/bun", "x", "screenpipe-mcp@latest"]);
+    expect(entry.args).toBeUndefined();
+    // `environment`, not `env`
+    expect(entry.env).toBeUndefined();
+    expect(entry.environment.SCREENPIPE_LOCAL_API_KEY).toBe("sp-test");
+    expect(entry.environment.SCREENPIPE_MCP_CLIENT).toBe("opencode");
+  });
+
+  it("preserves unrelated OpenCode settings and servers across install and remove", async () => {
+    const seeded = JSON.stringify({
+      mcp: { other: { type: "local", command: ["other-server"], enabled: true } },
+      theme: "opencode-dark",
+      model: "anthropic/claude-sonnet-4",
+    });
+    fsMock.files.set(OPENCODE, seeded);
+
+    await installOpencodeMcp();
+
+    const config = JSON.parse(fsMock.files.get(OPENCODE)!);
+    expect(config.theme).toBe("opencode-dark");
+    expect(config.model).toBe("anthropic/claude-sonnet-4");
+    expect(config.mcp.other.command).toEqual(["other-server"]);
+    expect(config.mcp.screenpipe).toBeTruthy();
+    expect(backupsOf(OPENCODE)).toHaveLength(1);
+    expect(fsMock.files.get(backupsOf(OPENCODE)[0])).toBe(seeded);
+
+    await uninstallOpencodeMcp();
+    const removed = JSON.parse(fsMock.files.get(OPENCODE)!);
+    expect(removed.mcp.screenpipe).toBeUndefined();
+    expect(removed.mcp.other.command).toEqual(["other-server"]);
+    expect(removed.theme).toBe("opencode-dark");
+  });
+
+  it("reports installed state from the mcp key, and uninstall stays idempotent", async () => {
+    await expect(isOpencodeMcpInstalled()).resolves.toBe(false);
+    await expect(uninstallOpencodeMcp()).resolves.toBeUndefined(); // missing → no-op
+
+    await installOpencodeMcp();
+    await expect(isOpencodeMcpInstalled()).resolves.toBe(true);
+
+    await uninstallOpencodeMcp();
+    await expect(isOpencodeMcpInstalled()).resolves.toBe(false);
+    await expect(uninstallOpencodeMcp()).resolves.toBeUndefined(); // no entry → no-op
+  });
+
+  it("refuses to overwrite an invalid config and leaves it untouched", async () => {
+    fsMock.files.set(OPENCODE, "{ definitely not json");
+
+    await expect(installOpencodeMcp()).rejects.toThrow(/not valid JSON/);
+
+    expect(fsMock.files.get(OPENCODE)).toBe("{ definitely not json");
+    expect(backupsOf(OPENCODE)).toHaveLength(0);
+  });
+});
+
 describe("friendlyToolError", () => {
   it("keeps the absolute path for the open-file action but displays it tildified", () => {
     const err = friendlyToolError(
@@ -387,6 +471,16 @@ describe("transactional connect / disconnect", () => {
     await disconnectAiTool("gemini");
     expect(skillsMock.removeExternalAgentSkills).toHaveBeenCalledWith("gemini");
     expect(tauriMock.setAiToolAutoConnectOptOut).toHaveBeenCalledWith("gemini", true);
+  });
+
+  it("installs and removes OpenCode's skills with its MCP entry", async () => {
+    await connectAiTool("opencode");
+    expect(skillsMock.installExternalAgentSkills).toHaveBeenCalledWith("opencode");
+    expect(JSON.parse(fsMock.files.get(OPENCODE)!).mcp.screenpipe).toBeTruthy();
+
+    await disconnectAiTool("opencode");
+    expect(skillsMock.removeExternalAgentSkills).toHaveBeenCalledWith("opencode");
+    expect(JSON.parse(fsMock.files.get(OPENCODE)!).mcp.screenpipe).toBeUndefined();
   });
 
   it("disconnect removes skills even when the MCP step fails, then rethrows", async () => {

--- a/apps/screenpipe-app-tauri/lib/ai-tools-mcp.ts
+++ b/apps/screenpipe-app-tauri/lib/ai-tools-mcp.ts
@@ -621,7 +621,7 @@ export async function isOpencodeMcpInstalled(): Promise<boolean> {
 export async function installOpencodeMcp(): Promise<McpCommand> {
   const configPath = await getOpencodeConfigPath();
   const config = await readJsonConfigStrict(configPath);
-  const mcp = await buildMcpConfig();
+  const mcp = await buildMcpConfig({ client: "opencode" });
   if (!config.mcp || typeof config.mcp !== "object") config.mcp = {};
   (config.mcp as Record<string, unknown>).screenpipe = {
     type: "local",

--- a/apps/screenpipe-app-tauri/lib/ai-tools-mcp.ts
+++ b/apps/screenpipe-app-tauri/lib/ai-tools-mcp.ts
@@ -43,6 +43,7 @@ const CONNECT_ALL_TOOL_IDS = [
   "hermes",
   "runner",
   "windsurf",
+  "opencode",
 ] as const;
 export type ConnectAllToolId = (typeof CONNECT_ALL_TOOL_IDS)[number];
 
@@ -59,13 +60,14 @@ export const CONNECT_ALL_TOOL_NAMES: Record<ConnectAllToolId, string> = {
   // config stayed at ~/.codeium/windsurf — show both names so users on either
   // side of the OTA update recognize it.
   windsurf: "Windsurf (Devin Desktop)",
+  opencode: "OpenCode",
 };
 
 // Skills support per tool lives in the disconnect-all component's
-// SKILLS_TARGET map: claude/codex/cursor/gemini/openclaw/hermes read
-// SKILL.md skills; runner and windsurf are MCP-only. Grok is intentionally
-// not in this matrix: it isn't part of connect-all and its settings panel has
-// its own disconnect.
+// SKILLS_TARGET map: claude/codex/cursor/gemini/openclaw/hermes/opencode read
+// SKILL.md skills, windsurf and runner areMCP-only. Grok is intentionally not
+// in this matrix: it isn't part of connect-all and its settings panel has its
+// own disconnect.
 
 export async function detectAiTools(): Promise<ConnectAllToolId[]> {
   const home = await homeDir();
@@ -88,6 +90,9 @@ export async function detectAiTools(): Promise<ConnectAllToolId[]> {
     ["hermes", async () => exists(await join(home, ".hermes"))],
     ["runner", async () => exists(await join(home, ".runner"))],
     ["windsurf", async () => exists(await join(home, ".codeium", "windsurf"))],
+    // Does not account for a custom $XDG_CONFIG_HOME — same simplification
+    // every other check here already makes (no per-tool env overrides).
+    ["opencode", async () => exists(await join(home, ".config", "opencode"))],
   ];
 
   const detected: ConnectAllToolId[] = [];
@@ -587,6 +592,46 @@ export async function installRunnerMcp(): Promise<McpCommand> {
   await writeJsonConfig(configPath, config);
   return mcp;
 }
+  
+// ─── OpenCode ────────────────────────────────────────────────────────────────
+// Skills at ~/.config/opencode/skills (also falls back to ~/.claude/skills
+// for Claude Code compatibility — see https://opencode.ai/docs/skills/).
+// MCP servers use a schema that doesn't match every other JSON-format tool
+// above: a top-level `mcp` key (not `mcpServers`), `command` as an array (not
+// split command+args), an explicit `enabled` flag, and `environment` instead
+// of `env` — see https://opencode.ai/docs/mcp-servers/#local-server. Mirrors
+// crates/screenpipe-engine/src/cli/agent.rs's merge_mcp_opencode_json /
+// remove_mcp_opencode_json, which needed the same bespoke treatment.
+// Does not account for a custom $XDG_CONFIG_HOME — same simplification every
+// other path in this file already makes (no per-tool env overrides).
+
+export async function getOpencodeConfigPath(): Promise<string> {
+  const home = await homeDir();
+  return join(home, ".config", "opencode", "opencode.json");
+}
+
+export async function isOpencodeMcpInstalled(): Promise<boolean> {
+  try {
+    const content = await readTextFile(await getOpencodeConfigPath());
+    const entry = JSON.parse(content)?.mcp?.screenpipe;
+    return !!entry && entry !== null;
+  } catch { return false; }
+}
+
+export async function installOpencodeMcp(): Promise<McpCommand> {
+  const configPath = await getOpencodeConfigPath();
+  const config = await readJsonConfigStrict(configPath);
+  const mcp = await buildMcpConfig();
+  if (!config.mcp || typeof config.mcp !== "object") config.mcp = {};
+  (config.mcp as Record<string, unknown>).screenpipe = {
+    type: "local",
+    command: [mcp.command, ...mcp.args],
+    enabled: true,
+    ...(mcp.env ? { environment: mcp.env } : {}),
+  };
+  await writeJsonConfig(configPath, config);
+  return mcp;
+}
 
 export async function uninstallRunnerMcp(): Promise<void> {
   await removeScreenpipeFromJsonConfig(await getRunnerMcpConfigPath());
@@ -621,6 +666,15 @@ export async function uninstallGeminiMcp(): Promise<void> {
   await removeScreenpipeFromJsonConfig(await getGeminiMcpConfigPath());
 }
 
+export async function uninstallOpencodeMcp(): Promise<void> {
+  const configPath = await getOpencodeConfigPath();
+  const config = await readJsonConfigStrict(configPath);
+  const servers = config.mcp as Record<string, unknown> | undefined;
+  if (!servers?.screenpipe) return;
+  delete servers.screenpipe;
+  await writeJsonConfig(configPath, config);
+}
+
 // ─── Transactional Settings connect / disconnect orchestrators (#5291) ──────
 
 // Tools whose agent reads global SKILL.md skills. Runner has no global skills
@@ -636,6 +690,7 @@ export const SKILLS_TARGET: Partial<Record<ConnectAllToolId, ExternalAgentWithSk
   gemini: "gemini",
   openclaw: "openclaw",
   hermes: "hermes",
+  opencode: "opencode",
 };
 
 const INSTALL_MCP: Record<ConnectAllToolId, () => Promise<McpCommand>> = {
@@ -648,6 +703,7 @@ const INSTALL_MCP: Record<ConnectAllToolId, () => Promise<McpCommand>> = {
   hermes: installHermesMcp,
   runner: installRunnerMcp,
   windsurf: installWindsurfMcp,
+  opencode: installOpencodeMcp,
 };
 
 const UNINSTALL_MCP: Record<ConnectAllToolId, () => Promise<void>> = {
@@ -660,6 +716,7 @@ const UNINSTALL_MCP: Record<ConnectAllToolId, () => Promise<void>> = {
   hermes: uninstallHermesMcp,
   runner: uninstallRunnerMcp,
   windsurf: uninstallWindsurfMcp,
+  opencode: uninstallOpencodeMcp,
 };
 
 async function setAutoConnectOptOut(id: ConnectAllToolId, optOut: boolean): Promise<void> {
@@ -874,6 +931,9 @@ export async function isToolConfigHealthy(id: ConnectAllToolId): Promise<boolean
         // Our one refusal: a hand-authored mcp_servers block without screenpipe.
         return hermesHasScreenpipe(text) || !HERMES_MCP_BLOCK.test(text);
       }
+      case "opencode":
+        await readJsonConfigStrict(await getOpencodeConfigPath());
+        return true;
     }
   } catch {
     return false;

--- a/apps/screenpipe-app-tauri/lib/external-agent-skills.ts
+++ b/apps/screenpipe-app-tauri/lib/external-agent-skills.ts
@@ -12,17 +12,27 @@ export type ExternalAgentWithSkills =
   | "cursor"
   | "gemini"
   | "openclaw"
+  | "opencode"
   | "hermes";
 
-// Paths mirror the CLI's layout() in crates/screenpipe-engine/src/cli/agent.rs.
-function skillsDirectoryName(target: ExternalAgentWithSkills): string {
+// Path segments relative to $HOME, mirroring the CLI's layout_in() in
+// crates/screenpipe-engine/src/cli/agent.rs. Most agents are a single dot-dir
+// directly under home; OpenCode's skills live two segments down
+// (~/.config/opencode/skills), hence an array rather than one string — kept
+// as separate join() arguments rather than a single "a/b" string to match
+// how every other multi-segment path in this codebase is built (see
+// ai-tools-mcp.ts's getWindsurfMcpConfigPath, ~/.codeium/windsurf/...).
+function skillsDirectorySegments(target: ExternalAgentWithSkills): string[] {
   switch (target) {
-    case "claude": return ".claude";
-    case "codex": return ".codex";
-    case "cursor": return ".cursor";
-    case "gemini": return ".gemini";
-    case "openclaw": return ".openclaw";
-    case "hermes": return ".hermes";
+    case "claude": return [".claude"];
+    case "codex": return [".codex"];
+    case "cursor": return [".cursor"];
+    case "gemini": return [".gemini"];
+    case "openclaw": return [".openclaw"];
+    case "hermes": return [".hermes"];
+    // Does not account for a custom $XDG_CONFIG_HOME — same simplification
+    // every other entry here already makes (no per-tool env overrides).
+    case "opencode": return [".config", "opencode"];
   }
 }
 
@@ -46,7 +56,7 @@ export async function areExternalAgentSkillsInstalled(
   target: ExternalAgentWithSkills,
 ): Promise<boolean> {
   const home = await homeDir();
-  const skillsRoot = await join(home, skillsDirectoryName(target), "skills");
+  const skillsRoot = await join(home, ...skillsDirectorySegments(target), "skills");
 
   try {
     await Promise.all([

--- a/apps/screenpipe-app-tauri/src-tauri/src/skills.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/skills.rs
@@ -781,6 +781,7 @@ pub fn install_external_agent_skills(target: String) -> Result<Vec<String>, Stri
         "gemini" => "gemini",
         "openclaw" => "openclaw",
         "hermes" => "hermes",
+        "opencode" => "opencode",
         _ => return Err(format!("unsupported external agent: {target}")),
     };
 
@@ -807,6 +808,7 @@ pub fn remove_external_agent_skills(target: String) -> Result<Vec<String>, Strin
         "gemini" => "gemini",
         "openclaw" => "openclaw",
         "hermes" => "hermes",
+        "opencode" => "opencode",
         _ => return Err(format!("unsupported external agent: {target}")),
     };
 

--- a/crates/screenpipe-engine/src/cli/agent.rs
+++ b/crates/screenpipe-engine/src/cli/agent.rs
@@ -34,7 +34,7 @@ pub enum AgentCommand {
     Setup {
         /// Which agent to wire up. Omit when using --all.
         #[arg(
-            value_parser = ["openclaw", "hermes", "claude-code", "claude-desktop", "codex", "cursor", "gemini", "runner", "windsurf"],
+            value_parser = ["openclaw", "hermes", "claude-code", "claude-desktop", "codex", "cursor", "gemini", "runner", "windsurf", "opencode"],
             required_unless_present = "all",
             conflicts_with = "all"
         )]
@@ -54,7 +54,7 @@ pub enum AgentCommand {
     /// agent's own config or other skills.
     Remove {
         /// Which agent to unwire.
-        #[arg(value_parser = ["openclaw", "hermes", "claude-code", "claude-desktop", "codex", "cursor", "gemini", "runner", "windsurf"])]
+        #[arg(value_parser = ["openclaw", "hermes", "claude-code", "claude-desktop", "codex", "cursor", "gemini", "runner", "windsurf", "opencode"])]
         target: String,
     },
 }
@@ -230,6 +230,13 @@ fn detected_agents_in(home: &Path) -> Vec<DetectedAgent> {
             detected.push(DetectedAgent { target, name });
         }
     }
+    // Respects $XDG_CONFIG_HOME, unlike the dot-dir checks above.
+    if opencode_config_home(home).exists() {
+        detected.push(DetectedAgent {
+            target: "opencode",
+            name: "OpenCode",
+        });
+    }
     detected
 }
 
@@ -287,6 +294,12 @@ fn has_screenpipe_mcp(layout: &AgentLayout) -> bool {
                     && (layout.name != "Runner"
                         || entry.get("type").and_then(|value| value.as_str()) == Some("stdio"))
             }),
+        // OpenCode nests servers under a top-level `mcp` key rather than
+        // `mcpServers`, so it cannot reuse the Json arm above.
+        McpFormat::OpenCodeJson => serde_json::from_str::<serde_json::Value>(&existing)
+            .ok()
+            .and_then(|root| root.get("mcp")?.get("screenpipe").cloned())
+            .is_some_and(|entry| !entry.is_null()),
         McpFormat::Toml => existing.lines().any(is_screenpipe_toml_table),
         McpFormat::Yaml => existing.lines().any(|line| {
             let line = line.trim_start();
@@ -377,6 +390,36 @@ enum McpFormat {
     Json,
     Yaml,
     Toml,
+    /// OpenCode's `opencode.json` — a JSON config, but with a schema that
+    /// doesn't match every other JSON-format agent here (`mcpServers.name =
+    /// {command, args, env}`). OpenCode instead uses a top-level `mcp` key,
+    /// an array-form `command`, an `enabled` flag, and `environment` instead
+    /// of `env` — see https://opencode.ai/docs/mcp-servers/. Needs its own
+    /// merge/remove pair, same treatment as Codex's TOML format.
+    OpenCodeJson,
+}
+
+/// OpenCode's config directory. Precedence: `$OPENCODE_CONFIG_DIR` →
+/// `$XDG_CONFIG_HOME/opencode` → `~/.config/opencode`. Mirrors OpenCode's own
+/// resolution exactly — `packages/core/src/global.ts`'s `make()` sets
+/// `config: Flag.OPENCODE_CONFIG_DIR ?? Path.config` where `Path.config` is
+/// `xdgConfig/opencode` (via the `xdg-basedir` package — no OS-specific
+/// branching, same on macOS/Linux/Windows). Unlike `$XDG_CONFIG_HOME`,
+/// `$OPENCODE_CONFIG_DIR` is used as-is (it replaces the whole resolved
+/// config dir, not just the XDG base). Mirrors
+/// `screenpipe_connect::connections::opencode::resolve_home_path`'s
+/// precedence (that function additionally supports a per-connection
+/// `home_path` override, which doesn't apply here).
+fn opencode_config_home(h: &Path) -> PathBuf {
+    if let Ok(v) = std::env::var("OPENCODE_CONFIG_DIR") {
+        if !v.trim().is_empty() {
+            return PathBuf::from(v.trim());
+        }
+    }
+    match std::env::var("XDG_CONFIG_HOME") {
+        Ok(v) if !v.trim().is_empty() => PathBuf::from(v.trim()).join("opencode"),
+        _ => h.join(".config/opencode"),
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -531,6 +574,29 @@ fn desktop_mcp_ready(layout: &AgentLayout, launch: &McpLaunchConfig) -> bool {
                         == launch.transport.as_deref()
                     && entry.get("type").and_then(|value| value.as_str())
                         == launch.server_type.as_deref()
+            }),
+        // OpenCode flattens command+args into one array and names the
+        // environment block `environment`, so the Json arm's field-by-field
+        // comparison does not apply.
+        McpFormat::OpenCodeJson => serde_json::from_str::<serde_json::Value>(&existing)
+            .ok()
+            .and_then(|root| root.get("mcp")?.get("screenpipe").cloned())
+            .is_some_and(|entry| {
+                let mut expected = vec![launch.command.clone()];
+                expected.extend(launch.args.iter().cloned());
+                entry
+                    .get("command")
+                    .and_then(|value| serde_json::from_value::<Vec<String>>(value.clone()).ok())
+                    .as_ref()
+                    == Some(&expected)
+                    && entry.get("enabled").and_then(|value| value.as_bool()) == Some(true)
+                    && entry
+                        .get("environment")
+                        .and_then(|value| {
+                            serde_json::from_value::<BTreeMap<String, String>>(value.clone()).ok()
+                        })
+                        .unwrap_or_default()
+                        == launch.env
             }),
         McpFormat::Toml => render_mcp_toml_block(launch)
             .ok()
@@ -758,8 +824,21 @@ fn layout_in(target: &str, h: &Path) -> Result<AgentLayout> {
             mcp_path: h.join(".codeium/windsurf/mcp_config.json"),
             mcp_format: McpFormat::Json,
         },
+        // OpenCode reads global skills from ~/.config/opencode/skills (also
+        // falls back to ~/.claude/skills for Claude Code compatibility) and
+        // MCP servers from the top-level `mcp` key in opencode.json — see
+        // https://opencode.ai/docs/skills/ and /docs/mcp-servers/.
+        "opencode" => {
+            let config_home = opencode_config_home(h);
+            AgentLayout {
+                name: "OpenCode",
+                skills_dir: Some(config_home.join("skills")),
+                mcp_path: config_home.join("opencode.json"),
+                mcp_format: McpFormat::OpenCodeJson,
+            }
+        }
         other => anyhow::bail!(
-            "unknown agent target '{other}' (use: openclaw, hermes, claude-code, claude-desktop, codex, cursor, gemini, runner, windsurf)"
+            "unknown agent target '{other}' (use: openclaw, hermes, claude-code, claude-desktop, codex, cursor, gemini, runner, windsurf, opencode)"
         ),
     })
 }
@@ -907,6 +986,7 @@ fn setup(target: &str, api_url: &str) -> Result<()> {
         McpFormat::Json => merge_mcp_json(&l.mcp_path, remote, api_url)?,
         McpFormat::Yaml => merge_mcp_yaml(&l.mcp_path, remote, api_url)?,
         McpFormat::Toml => merge_mcp_toml(&l.mcp_path, remote, api_url)?,
+        McpFormat::OpenCodeJson => merge_mcp_opencode_json(&l.mcp_path, remote, api_url)?,
     }
 
     println!(
@@ -993,6 +1073,7 @@ fn remove(target: &str) -> Result<()> {
         McpFormat::Json => remove_mcp_json(&l.mcp_path)?,
         McpFormat::Toml => remove_mcp_toml(&l.mcp_path)?,
         McpFormat::Yaml => remove_mcp_yaml(&l.mcp_path)?,
+        McpFormat::OpenCodeJson => remove_mcp_opencode_json(&l.mcp_path)?,
     }
 
     println!(
@@ -1031,6 +1112,38 @@ fn remove_mcp_json(path: &Path) -> Result<()> {
             removed
         })
         .unwrap_or(false);
+    if !removed {
+        println!("  · no screenpipe mcp entry in {}", path.display());
+        return Ok(());
+    }
+    replace_config(
+        path,
+        Some(&existing),
+        &(serde_json::to_string_pretty(&root)? + "\n"),
+    )?;
+    println!("  ✓ mcp removed from {}", path.display());
+    Ok(())
+}
+
+/// Remove `mcp.screenpipe` from OpenCode's `opencode.json`, preserving
+/// everything else (other MCP servers, `$schema`, `instructions`, etc.).
+/// Same shape as [`remove_mcp_json`] but keyed on `mcp`, not `mcpServers`.
+fn remove_mcp_opencode_json(path: &Path) -> Result<()> {
+    use serde_json::Value;
+    let existing = match read_config_text(path)? {
+        Some(s) if !s.trim().is_empty() => s,
+        _ => {
+            println!("  · no screenpipe mcp entry in {}", path.display());
+            return Ok(());
+        }
+    };
+    let mut root: Value = serde_json::from_str(&existing)
+        .with_context(|| format!("{} is not valid JSON; fix or remove it", path.display()))?;
+    let removed = root
+        .get_mut("mcp")
+        .and_then(|s| s.as_object_mut())
+        .and_then(|s| s.remove("screenpipe"))
+        .is_some();
     if !removed {
         println!("  · no screenpipe mcp entry in {}", path.display());
         return Ok(());
@@ -1203,6 +1316,7 @@ fn cli_launch_config(remote: bool, api_url: &str) -> McpLaunchConfig {
 fn merge_mcp_launch(layout: &AgentLayout, launch: &McpLaunchConfig) -> Result<()> {
     match layout.mcp_format {
         McpFormat::Json => merge_mcp_json_launch(&layout.mcp_path, launch),
+        McpFormat::OpenCodeJson => merge_mcp_opencode_json_launch(&layout.mcp_path, launch),
         McpFormat::Yaml => merge_mcp_yaml_launch(&layout.mcp_path, launch),
         McpFormat::Toml => merge_mcp_toml_launch(&layout.mcp_path, launch),
     }
@@ -1248,6 +1362,61 @@ fn merge_mcp_json_launch(path: &Path, launch: &McpLaunchConfig) -> Result<()> {
         .as_object_mut()
         .context("mcpServers is present but not an object")?;
     servers.retain(|key, _| !key.eq_ignore_ascii_case("screenpipe"));
+    servers.insert("screenpipe".to_string(), entry);
+    replace_config(
+        path,
+        existing.as_deref(),
+        &(serde_json::to_string_pretty(&root)? + "\n"),
+    )?;
+    println!("  ✓ mcp   {}", path.display());
+    Ok(())
+}
+
+/// Add the `screenpipe` server to OpenCode's `opencode.json`. Different
+/// schema from every other JSON-format agent here — top-level `mcp` key
+/// (not `mcpServers`), `command` as an array (not split `command`+`args`),
+/// an explicit `enabled` flag, and `environment` instead of `env` — see
+/// https://opencode.ai/docs/mcp-servers/#local-server. Same
+/// read-merge-write structure as [`merge_mcp_json`], just a different shape.
+fn merge_mcp_opencode_json(path: &Path, remote: bool, api_url: &str) -> Result<()> {
+    merge_mcp_opencode_json_launch(path, &cli_launch_config(remote, api_url))
+}
+
+/// OpenCode's MCP config does not match the shape every other JSON tool here
+/// uses: servers nest under a top-level `mcp` key rather than `mcpServers`,
+/// `command` is one array rather than split command+args, `enabled` is
+/// explicit, and the environment block is `environment` rather than `env`.
+/// See https://opencode.ai/docs/mcp-servers/#local-server.
+fn merge_mcp_opencode_json_launch(path: &Path, launch: &McpLaunchConfig) -> Result<()> {
+    use serde_json::{json, Value};
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    let existing = read_config_text(path)?;
+    let mut root: Value = match existing.as_deref() {
+        Some(s) if !s.trim().is_empty() => serde_json::from_str(s)
+            .with_context(|| format!("{} is not valid JSON; fix or remove it", path.display()))?,
+        _ => json!({}),
+    };
+    if !root.is_object() {
+        anyhow::bail!("{} is not a JSON object", path.display());
+    }
+    let mut command = vec![launch.command.clone()];
+    command.extend(launch.args.iter().cloned());
+    let mut entry = json!({
+        "type": "local",
+        "command": command,
+        "enabled": true,
+    });
+    if !launch.env.is_empty() {
+        entry["environment"] = serde_json::to_value(&launch.env)?;
+    }
+    let obj = root.as_object_mut().unwrap();
+    let servers = obj
+        .entry("mcp")
+        .or_insert_with(|| json!({}))
+        .as_object_mut()
+        .context("mcp is present but not an object")?;
     servers.insert("screenpipe".to_string(), entry);
     replace_config(
         path,
@@ -1451,6 +1620,7 @@ fn merge_mcp_toml_launch(path: &Path, launch: &McpLaunchConfig) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
 
     #[test]
     fn test_host_port() {
@@ -1497,6 +1667,132 @@ mod tests {
             .as_deref()
             .is_some_and(|path| path.ends_with(".gemini/skills")));
         assert!(gemini.mcp_path.ends_with(".gemini/settings.json"));
+    }
+
+    /// `OPENCODE_CONFIG_DIR`/`XDG_CONFIG_HOME` are process-wide global state,
+    /// so every test that reads or sets either (directly or via
+    /// `opencode_config_home`) must hold this lock to avoid racing with the
+    /// others (cargo test runs in parallel by default).
+    static XDG_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// RAII guard: sets (or clears, if `None`) both OpenCode-relevant env
+    /// vars for the duration of a test and restores their original values
+    /// on drop — including on panic, unlike the manual save/restore this
+    /// replaces. Caller must still hold `XDG_ENV_LOCK` for the guard's
+    /// lifetime; this only handles the env vars themselves.
+    struct OpencodeEnvGuard {
+        saved_opencode_config_dir: Option<String>,
+        saved_xdg_config_home: Option<String>,
+    }
+
+    impl OpencodeEnvGuard {
+        fn new(opencode_config_dir: Option<&str>, xdg_config_home: Option<&str>) -> Self {
+            let saved_opencode_config_dir = std::env::var("OPENCODE_CONFIG_DIR").ok();
+            let saved_xdg_config_home = std::env::var("XDG_CONFIG_HOME").ok();
+            match opencode_config_dir {
+                Some(v) => std::env::set_var("OPENCODE_CONFIG_DIR", v),
+                None => std::env::remove_var("OPENCODE_CONFIG_DIR"),
+            }
+            match xdg_config_home {
+                Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+            Self {
+                saved_opencode_config_dir,
+                saved_xdg_config_home,
+            }
+        }
+    }
+
+    impl Drop for OpencodeEnvGuard {
+        fn drop(&mut self) {
+            match self.saved_opencode_config_dir.take() {
+                Some(v) => std::env::set_var("OPENCODE_CONFIG_DIR", v),
+                None => std::env::remove_var("OPENCODE_CONFIG_DIR"),
+            }
+            match self.saved_xdg_config_home.take() {
+                Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                None => std::env::remove_var("XDG_CONFIG_HOME"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_opencode_config_home_defaults_without_any_override() {
+        let _lock = XDG_ENV_LOCK.lock().unwrap();
+        let _env = OpencodeEnvGuard::new(None, None);
+
+        let home = Path::new("/tmp/fake-home");
+        assert_eq!(
+            opencode_config_home(home),
+            Path::new("/tmp/fake-home/.config/opencode")
+        );
+    }
+
+    #[test]
+    fn test_opencode_config_home_respects_xdg_override() {
+        let _lock = XDG_ENV_LOCK.lock().unwrap();
+        let _env = OpencodeEnvGuard::new(None, Some("/tmp/custom-xdg-config"));
+
+        let home = Path::new("/tmp/fake-home");
+        assert_eq!(
+            opencode_config_home(home),
+            Path::new("/tmp/custom-xdg-config/opencode")
+        );
+    }
+
+    // OPENCODE_CONFIG_DIR takes priority over XDG_CONFIG_HOME — mirrors
+    // OpenCode's own `Flag.OPENCODE_CONFIG_DIR ?? Path.config`
+    // (packages/core/src/global.ts), where `Path.config` is itself derived
+    // from XDG. Getting this backwards would mean screenpipe writes
+    // opencode.json/skills to a directory the user's real OpenCode never
+    // reads once they've set OPENCODE_CONFIG_DIR.
+    #[test]
+    fn test_opencode_config_home_respects_opencode_config_dir_override_over_xdg() {
+        let _lock = XDG_ENV_LOCK.lock().unwrap();
+        let _env = OpencodeEnvGuard::new(
+            Some("/tmp/custom-opencode-config-dir"),
+            Some("/tmp/custom-xdg-config"),
+        );
+
+        let home = Path::new("/tmp/fake-home");
+        // Used as-is — no "opencode" suffix appended, unlike XDG_CONFIG_HOME
+        // (see doc comment on opencode_config_home).
+        assert_eq!(
+            opencode_config_home(home),
+            Path::new("/tmp/custom-opencode-config-dir")
+        );
+    }
+
+    #[test]
+    fn test_opencode_config_home_treats_blank_opencode_config_dir_as_unset() {
+        let _lock = XDG_ENV_LOCK.lock().unwrap();
+        let _env = OpencodeEnvGuard::new(Some("   "), Some("/tmp/custom-xdg-config"));
+
+        let home = Path::new("/tmp/fake-home");
+        assert_eq!(
+            opencode_config_home(home),
+            Path::new("/tmp/custom-xdg-config/opencode")
+        );
+    }
+
+    #[test]
+    fn test_opencode_layout_uses_config_skills_dir_and_json_mcp() {
+        let _lock = XDG_ENV_LOCK.lock().unwrap();
+        let _env = OpencodeEnvGuard::new(None, None);
+
+        let home = Path::new("/tmp/fake-home");
+        let layout = layout_in("opencode", home).unwrap();
+        assert_eq!(layout.name, "OpenCode");
+        assert_eq!(
+            layout.skills_dir.as_deref(),
+            Some(Path::new("/tmp/fake-home/.config/opencode/skills"))
+        );
+        assert_eq!(
+            layout.mcp_path,
+            Path::new("/tmp/fake-home/.config/opencode/opencode.json")
+        );
+        assert!(layout.mcp_format == McpFormat::OpenCodeJson);
     }
 
     #[test]
@@ -1557,6 +1853,89 @@ mod tests {
             "http://box:3030"
         );
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_merge_mcp_opencode_json_fresh_and_idempotent() {
+        let dir = std::env::temp_dir().join(format!("sp-agent-oc-test-{}", std::process::id()));
+        let path = dir.join("opencode.json");
+        let _ = std::fs::remove_dir_all(&dir);
+
+        merge_mcp_opencode_json(&path, false, "http://localhost:3030").unwrap();
+        let v: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(v["mcp"]["screenpipe"]["type"], "local");
+        assert_eq!(v["mcp"]["screenpipe"]["command"][0], "npx");
+        assert_eq!(v["mcp"]["screenpipe"]["enabled"], true);
+        assert!(v["mcp"]["screenpipe"]["environment"].is_null());
+        // Must not use the generic mcpServers key other JSON agents use.
+        assert!(v["mcpServers"].is_null());
+
+        // Idempotent + preserves a pre-existing server and unrelated keys
+        // (e.g. `$schema`, `instructions` — real opencode.json content).
+        std::fs::write(
+            &path,
+            serde_json::json!({
+                "$schema": "https://opencode.ai/config.json",
+                "mcp": {"other": {"type": "local", "command": ["x"]}}
+            })
+            .to_string(),
+        )
+        .unwrap();
+        merge_mcp_opencode_json(&path, true, "http://box:3030").unwrap();
+        let v: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(v["$schema"], "https://opencode.ai/config.json");
+        assert_eq!(v["mcp"]["other"]["command"][0], "x");
+        assert_eq!(
+            v["mcp"]["screenpipe"]["environment"]["SCREENPIPE_API_URL"],
+            "http://box:3030"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_remove_mcp_opencode_json_preserves_other_servers() {
+        let dir = std::env::temp_dir().join(format!("sp-agent-oc-rm-{}", std::process::id()));
+        let path = dir.join("opencode.json");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        std::fs::write(
+            &path,
+            serde_json::json!({
+                "mcp": {
+                    "other": {"type": "local", "command": ["x"]},
+                    "screenpipe": {"type": "local", "command": ["bun"], "enabled": true}
+                },
+                "instructions": ["CONTRIBUTING.md"]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        remove_mcp_opencode_json(&path).unwrap();
+        let v: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(v["mcp"]["other"]["command"][0], "x");
+        assert_eq!(v["instructions"][0], "CONTRIBUTING.md");
+        assert!(v["mcp"]["screenpipe"].is_null());
+
+        // Idempotent + missing file is a no-op.
+        remove_mcp_opencode_json(&path).unwrap();
+        remove_mcp_opencode_json(&dir.join("missing.json")).unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_opencode_detected_when_config_dir_exists() {
+        let _lock = XDG_ENV_LOCK.lock().unwrap();
+        let _env = OpencodeEnvGuard::new(None, None);
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".config/opencode")).unwrap();
+
+        let detected = detected_agents_in(dir.path());
+        assert!(detected.iter().any(|a| a.target == "opencode"));
     }
 
     #[test]

--- a/docs/coverage/CORE.md
+++ b/docs/coverage/CORE.md
@@ -9,10 +9,10 @@ confidence, and criticality.
 - Tracked crates: screenpipe-engine, screenpipe-db, screenpipe-sqlite-coordinator, screenpipe-audio, screenpipe-screen, screenpipe-a11y
 - Mapped suites: 32
 - Mapped Rust files: 330
-- Active test blocks: 3205
+- Active test blocks: 3213
 - Ignored/manual test blocks: 137
-- Declared test blocks: 3342
-- Weighted coverage points: 2628.4
+- Declared test blocks: 3350
+- Weighted coverage points: 2634.0
 
 Confidence weights: strong=1.0, partial=0.7, conditional=0.4, smoke=0.3.
 Criticality weights: high=1.0, medium=0.7, low=0.4.
@@ -23,15 +23,15 @@ are explicitly enabled in a runtime lane.
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 3066 | 132 | 2565.0 | 21 | 11 | 100% |
-| macos | 29 | 3124 | 112 | 2577.4 | 22 | 11 | 100% |
-| linux | 25 | 2740 | 105 | 2268.3 | 20 | 11 | 100% |
+| windows | 29 | 3074 | 132 | 2570.6 | 21 | 11 | 100% |
+| macos | 29 | 3132 | 112 | 2583.0 | 22 | 11 | 100% |
+| linux | 25 | 2748 | 105 | 2273.9 | 20 | 11 | 100% |
 
 ## Crate Summary
 
 | Crate | Suites | Integration files | Source unit files | Active tests | Ignored tests | Weighted points | Flows |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| screenpipe-engine | 10 | 19 | 109 | 1549 | 42 | 1185.0 | 10 |
+| screenpipe-engine | 10 | 19 | 109 | 1557 | 42 | 1190.6 | 10 |
 | screenpipe-db | 5 | 52 | 15 | 453 | 16 | 430.2 | 9 |
 | screenpipe-sqlite-coordinator | 1 | 0 | 2 | 17 | 0 | 17.0 | 2 |
 | screenpipe-audio | 6 | 25 | 51 | 591 | 43 | 517.4 | 5 |
@@ -69,19 +69,19 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | db-search | 2 suites / 112 active / 9 ignored / 112.0 pts | 2 suites / 112 active / 9 ignored / 112.0 pts | 2 suites / 112 active / 9 ignored / 112.0 pts |
 | engine-lifecycle | 6 suites / 210 active / 1 ignored / 185.3 pts | 6 suites / 210 active / 1 ignored / 185.3 pts | 5 suites / 204 active / 1 ignored / 183.6 pts |
 | local-api | 2 suites / 375 active / 9 ignored / 264.6 pts | 2 suites / 375 active / 9 ignored / 264.6 pts | 2 suites / 375 active / 9 ignored / 264.6 pts |
-| meeting | 6 suites / 1482 active / 19 ignored / 1207.2 pts | 6 suites / 1482 active / 19 ignored / 1207.2 pts | 4 suites / 1189 active / 15 ignored / 936.7 pts |
+| meeting | 6 suites / 1490 active / 19 ignored / 1212.8 pts | 6 suites / 1490 active / 19 ignored / 1212.8 pts | 4 suites / 1197 active / 15 ignored / 942.3 pts |
 | ocr | 4 suites / 125 active / 7 ignored / 119.0 pts | 4 suites / 129 active / 7 ignored / 124.5 pts | 3 suites / 120 active / 6 ignored / 115.5 pts |
 | os-integration | 1 suites / 6 active / 0 ignored / 1.7 pts | 1 suites / 6 active / 0 ignored / 1.7 pts | - |
 | performance | 13 suites / 1418 active / 67 ignored / 1246.9 pts | 14 suites / 1521 active / 70 ignored / 1288.1 pts | 13 suites / 1418 active / 67 ignored / 1246.9 pts |
-| pipes | 1 suites / 473 active / 3 ignored / 331.1 pts | 1 suites / 473 active / 3 ignored / 331.1 pts | 1 suites / 473 active / 3 ignored / 331.1 pts |
-| privacy | 5 suites / 890 active / 36 ignored / 723.2 pts | 5 suites / 944 active / 16 ignored / 730.1 pts | 5 suites / 868 active / 14 ignored / 702.1 pts |
+| pipes | 1 suites / 481 active / 3 ignored / 336.7 pts | 1 suites / 481 active / 3 ignored / 336.7 pts | 1 suites / 481 active / 3 ignored / 336.7 pts |
+| privacy | 5 suites / 898 active / 36 ignored / 728.8 pts | 5 suites / 952 active / 16 ignored / 735.7 pts | 5 suites / 876 active / 14 ignored / 707.7 pts |
 | real-app | - | 1 suites / 103 active / 3 ignored / 41.2 pts | - |
 | speaker | 2 suites / 348 active / 8 ignored / 348.0 pts | 2 suites / 348 active / 8 ignored / 348.0 pts | 2 suites / 348 active / 8 ignored / 348.0 pts |
 | storage | 3 suites / 509 active / 29 ignored / 410.6 pts | 3 suites / 509 active / 29 ignored / 410.6 pts | 3 suites / 509 active / 29 ignored / 410.6 pts |
-| sync | 1 suites / 473 active / 3 ignored / 331.1 pts | 1 suites / 473 active / 3 ignored / 331.1 pts | 1 suites / 473 active / 3 ignored / 331.1 pts |
+| sync | 1 suites / 481 active / 3 ignored / 336.7 pts | 1 suites / 481 active / 3 ignored / 336.7 pts | 1 suites / 481 active / 3 ignored / 336.7 pts |
 | timeline | 4 suites / 1023 active / 33 ignored / 825.6 pts | 4 suites / 1023 active / 33 ignored / 825.6 pts | 4 suites / 1023 active / 33 ignored / 825.6 pts |
 | transcription | 5 suites / 747 active / 40 ignored / 585.5 pts | 5 suites / 747 active / 40 ignored / 585.5 pts | 5 suites / 747 active / 40 ignored / 585.5 pts |
-| ui-events | 4 suites / 713 active / 28 ignored / 542.6 pts | 3 suites / 664 active / 5 ignored / 508.3 pts | 3 suites / 664 active / 5 ignored / 508.3 pts |
+| ui-events | 4 suites / 721 active / 28 ignored / 548.2 pts | 3 suites / 672 active / 5 ignored / 513.9 pts | 3 suites / 672 active / 5 ignored / 513.9 pts |
 | vision-capture | 5 suites / 533 active / 32 ignored / 420.1 pts | 5 suites / 537 active / 32 ignored / 425.6 pts | 4 suites / 528 active / 31 ignored / 416.6 pts |
 
 ## Critical Flow Matrix
@@ -139,7 +139,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | engine-db-recovery-cli | screenpipe-engine | windows, macos, linux | database, engine-lifecycle | engine-health-lifecycle, performance-liveness | high | strong | unit | 1 | 8 | 0 | Exact DB/WAL/SHM working-copy preservation, rollback on archive failure, and restart repair for crashes during the multi-file generation swap. |
 | engine-focus-os | screenpipe-engine | windows, macos | engine-lifecycle, os-integration | engine-health-lifecycle, performance-liveness | medium | conditional | unit | 3 | 6 | 0 | Platform focus-tracker parsing/helpers. These files are cfg-gated and only execute on their target OS. |
 | engine-local-api-search-integration | screenpipe-engine | windows, macos, linux | local-api, db-search | local-api-search | high | strong | integration | 1 | 7 | 5 | Active /search route test builds an audio-disabled router, seeds captured-screen-shaped OCR data into an in-memory DB, and asserts the HTTP response and pagination. |
-| engine-meeting-privacy-sync | screenpipe-engine | windows, macos, linux | meeting, privacy, ui-events, pipes, sync | meeting-live-notes, privacy-and-redaction, accessibility-ui-events, performance-liveness | medium | strong | unit | 31 | 473 | 3 | Unit-heavy coverage for privacy filter policy, capture exclusions, UI recorder safety, pipes/live-view/structured-output helpers, sync helpers, and CLI parsing. Meeting detection moved to the engine-meeting-watcher suite. |
+| engine-meeting-privacy-sync | screenpipe-engine | windows, macos, linux | meeting, privacy, ui-events, pipes, sync | meeting-live-notes, privacy-and-redaction, accessibility-ui-events, performance-liveness | medium | strong | unit | 31 | 481 | 3 | Unit-heavy coverage for privacy filter policy, capture exclusions, UI recorder safety, pipes/live-view/structured-output helpers, sync helpers, and CLI parsing. Meeting detection moved to the engine-meeting-watcher suite. |
 | engine-meeting-watcher | screenpipe-engine | windows, macos | meeting | meeting-live-notes | high | strong | mixed | 9 | 218 | 3 | Successor of src/meeting_detector.rs and src/meeting_telemetry.rs. Audio-process and UI-scan backend state machines, candidate resolution, shared telemetry, and a scored trajectory eval. ui_scan/macos.rs and ui_scan/windows.rs are cfg-gated and only execute on their target OS; both backends are null on Linux. |
 | engine-retention-storage | screenpipe-engine | windows, macos, linux | storage, engine-lifecycle, performance | engine-health-lifecycle, performance-liveness | medium | strong | mixed | 5 | 38 | 0 | Local retention deletion (including lean-mode heavy-text stripping), cloud archive watermarking, atomic state-file replacement, and the low-disk capture monitor. |
 | engine-telemetry-observability | screenpipe-engine | windows, macos, linux | engine-lifecycle, performance | engine-health-lifecycle, performance-liveness | medium | strong | unit | 6 | 30 | 0 | PostHog capture gating, telemetry context shaping, piggyback telemetry forwarding, crash-log helpers, resource monitoring, and the recording-coverage reliability metric. |
@@ -338,7 +338,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | engine-config-lifecycle | screenpipe-engine | src/bin/screenpipe-engine.rs | source | 3 | 0 | 3 |
 | engine-meeting-privacy-sync | screenpipe-engine | src/calendar_speaker_id.rs | source | 41 | 0 | 41 |
 | engine-meeting-privacy-sync | screenpipe-engine | src/capture_exclusions.rs | source | 5 | 0 | 5 |
-| engine-meeting-privacy-sync | screenpipe-engine | src/cli/agent.rs | source | 32 | 0 | 32 |
+| engine-meeting-privacy-sync | screenpipe-engine | src/cli/agent.rs | source | 40 | 0 | 40 |
 | engine-db-recovery-cli | screenpipe-engine | src/cli/db.rs | source | 8 | 0 | 8 |
 | engine-meeting-privacy-sync | screenpipe-engine | src/cli/install.rs | source | 4 | 0 | 4 |
 | engine-meeting-privacy-sync | screenpipe-engine | src/cli/login.rs | source | 1 | 0 | 1 |


### PR DESCRIPTION
(This still need a bit of work, but I wanted to push it for now, in case you are into adding such tools these days.)

## description

Adds OpenCode to the "connect all AI tools" matrix, so it gets the screenpipe MCP server and the global SKILL.md skills alongside Claude, Codex, Cursor, Gemini, OpenClaw, Hermes, Runner and Windsurf.

OpenCode already ships as a first-class agent in screenpipe. It is in the ACP agent list next to Pi, Codex and Claude Code (#5921), with its icon vendored at `public/images/opencode.svg`. It was the only markdown-instruction agent there with no MCP or skills wiring.

Two things make OpenCode different from every other tool in this matrix, and both needed bespoke handling rather than reusing the shared paths:

**Its MCP config does not use the `mcpServers` convention.** Servers nest under a top-level `mcp` key, `command` is a single array rather than split `command`/`args`, `enabled` is explicit, and the environment block is named `environment` rather than `env` ([docs](https://opencode.ai/docs/mcp-servers/#local-server)). Both the frontend installer and the CLI's merge/remove helpers therefore need their own implementation.

**Its skills live two segments below `$HOME`**: `~/.config/opencode/skills` rather than a single dot-directory ([docs](https://opencode.ai/docs/skills/)). `skillsDirectoryName()` returned one string, so it became `skillsDirectorySegments()` returning `string[]`, spread into `join()`. Every existing agent keeps its previous behaviour, now expressed as a one-element array.

The CLI resolver honours OpenCode's own config-directory precedence: `$OPENCODE_CONFIG_DIR` -> `$XDG_CONFIG_HOME/opencode` -> `~/.config/opencode`. This matches `packages/core/src/global.ts`, so screenpipe writes where the user's OpenCode actually reads.

### Relationship to other PRs

Split out of #5394 (closed by the stale bot), alongside #6351 (merged) and #6323 (the memory-sync connection). This one is independent of #6323: they touch disjoint files and can land in either order.

Overlaps #6422 (Gemini CLI) on three files. No semantic conflict. Gemini uses the standard `mcpServers` schema. But whichever lands second will need a trivial rebase.

## AI assistance and human ownership

read the [AI-assisted contribution policy](https://github.com/screenpipe/screenpipe/blob/main/CONTRIBUTING.md#ai-assisted-contributions).

- AI tool(s) used (`none` if not used): Claude Opus 5 and Gemini 3.7 Flash
- autonomy level (`none`, `autocomplete`, `chat`, or `agent`): agent
- what I personally verified:


- [X] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [X] The problem statement, rationale, and replies to maintainers are my own.

## evidence type

check every category that applies and provide its required evidence below.

- [X] UI or behavior change — before/after recording
- [X] Backend change — regression tests and relevant logs/results


### Tests

```
$ cargo test -p screenpipe-engine --lib agent
test result: ok. 39 passed; 0 failed; 0 ignored

$ bun x vitest run --config vitest.config.ts \
    lib/__tests__/ai-tools-mcp.test.ts \
    components/settings/__tests__/ai-tools-card.test.tsx
 ✓ lib/__tests__/ai-tools-mcp.test.ts  (26 tests)
 ✓ components/settings/__tests__/ai-tools-card.test.tsx  (4 tests)
 Test Files  2 passed (2)
      Tests  30 passed (30)

$ bun run typecheck
(no errors)

$ cargo fmt -p screenpipe-engine -- --check
(clean)
```

Rust side, four OpenCode cases: detection from the config dir, the layout's skills dir and MCP format, a fresh-and-idempotent merge, and a remove that preserves other servers. `test_runner_is_connected_only_with_stdio_type` still
passes. The new `OpenCodeJson` arm sits beside Runner's `stdio` check rather than replacing it.

Frontend side, six new cases covering XDG-directory detection, the bespoke schema, preserving unrelated settings across install/remove, installed-state plus idempotent uninstall, refusing an invalid config, and skills install/removal alongside the MCP entry.

## before

OpenCode is absent from Settings -> Connections -> AI tools and from `screenpipe agent setup`, so it receives neither the MCP server nor the screenpipe skills, despite already being a supported ACP agent.

## after

OpenCode appears in the AI tools card, is detected from `~/.config/opencode`, and connect/disconnect installs and removes both its MCP entry and its skills.

## how to test

1. Ensure OpenCode is installed so `~/.config/opencode` exists.
2. `cargo run --bin screenpipe -- record` in one terminal.
3. `cd apps/screenpipe-app-tauri && SCREENPIPE_LOCAL_API_KEY=<your local API key> bun run dev:web:live` in another.
4. Open `http://localhost:1420/home?section=connections` and confirm **OpenCode** is listed and detected in the AI tools card.
5. Connect it, then check `~/.config/opencode/opencode.json` — the entry must sit under `mcp` (not `mcpServers`), with `command` as one array, `enabled: true`, and an `environment` block containing `SCREENPIPE_MCP_CLIENT=opencode`.
6. Confirm `~/.config/opencode/skills` now contains the screenpipe skills.
7. Disconnect and confirm both are removed while any other servers in the file survive.
8. CLI parity: `screenpipe agent setup opencode` then `screenpipe agent remove opencode` produce the same result.
9. Point `$OPENCODE_CONFIG_DIR` somewhere else and confirm setup follows it, with no `opencode` suffix appended.

## desktop app checklist (if applicable)

Not applicable. No `#[tauri::command]` handlers or exported Rust types changed. `skills.rs` gains a target-name mapping only, so no bindings regenerate.
