### PR TITLE
feat: prefill post-learning agent prompts

### DIFF
--- a/apps/screenpipe-app-tauri/components/first-run/agent-handoff-picker.tsx
+++ b/apps/screenpipe-app-tauri/components/first-run/agent-handoff-picker.tsx
@@ -23,13 +23,16 @@ function AgentLogo({ id }: { id: ConnectAllToolId }) {
       // eslint-disable-next-line @next/next/no-img-element
       return <img src="/images/claude-ai.svg" alt="" className={size} />;
     case "codex":
-      // No `dark:invert` here, unlike the Settings tools card. codex.svg is
-      // LobeHub's COLOUR variant: a white plate behind a blue gradient glyph.
-      // Inverting it turns the plate black and the glyph yellow, which is not
-      // the Codex mark and reads as a rendering bug next to Claude's.
+      // The desktop destination is the ChatGPT app (its registered protocol is
+      // still `codex://`), so use the ChatGPT/OpenAI mark rather than the CLI
+      // Codex mark shown in Settings.
       return (
         // eslint-disable-next-line @next/next/no-img-element
-        <img src="/images/codex.svg" alt="" className={cn(size, "rounded-[2px]")} />
+        <img
+          src="/images/openai.svg"
+          alt=""
+          className={cn(size, "dark:invert")}
+        />
       );
     case "cursor":
       return <CursorLogo className={size} />;
@@ -108,7 +111,11 @@ export function AgentHandoffPicker({
             title={verb(target)}
             aria-label={verb(target)}
             onClick={() => onPick(target)}
-            style={{ "--fan-rotate": `${restRotation(index)}deg` } as React.CSSProperties}
+            style={
+              {
+                "--fan-rotate": `${restRotation(index)}deg`,
+              } as React.CSSProperties
+            }
             className={cn(
               "flex h-6 w-6 shrink-0 items-center justify-center border border-border bg-background",
               "transition-all duration-200 ease-out motion-reduce:transition-none",

--- a/apps/screenpipe-app-tauri/components/first-run/learning-banner.test.tsx
+++ b/apps/screenpipe-app-tauri/components/first-run/learning-banner.test.tsx
@@ -121,7 +121,9 @@ describe("first-run learning banner", () => {
     });
     render(<FirstRunLearningBanner />);
     expect(screen.getByText("Reading from")).toBeInTheDocument();
-    expect(screen.getByTestId("first-run-captured-app-Arc")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("first-run-captured-app-Arc"),
+    ).toBeInTheDocument();
     expect(
       screen.getByTestId("first-run-captured-app-Cursor"),
     ).toBeInTheDocument();
@@ -169,7 +171,9 @@ describe("first-run learning banner", () => {
     expect(
       screen.queryByText("screenpipe learned enough to help"),
     ).not.toBeInTheDocument();
-    expect(screen.queryByTestId("first-run-next-steps")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("first-run-next-steps"),
+    ).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId("first-run-toggle-setup"));
     expect(screen.getByTestId("first-run-next-steps")).toBeInTheDocument();
@@ -260,13 +264,14 @@ describe("first-run learning banner", () => {
 const CLAUDE = {
   id: "claude",
   label: "Claude",
-  deeplink: "claude://claude",
-  hint: "Claude opens with the question copied. Paste it to run.",
+  deeplink: "claude://claude.ai/new?q=test",
+  hint: "Question ready in Claude. Review and send it.",
 };
 const CODEX = {
   id: "codex",
-  label: "Codex",
-  hint: "Question copied. Paste it into your Codex terminal session.",
+  label: "ChatGPT",
+  deeplink: "codex://threads/new?prompt=test",
+  hint: "Question ready in ChatGPT. Review and send it.",
 };
 
 describe("agent handoff on the ready summary", () => {
@@ -293,11 +298,11 @@ describe("agent handoff on the ready summary", () => {
     expect(screen.getByTestId("first-run-open-summary")).toBeInTheDocument();
   });
 
-  it("says copy, not ask, for an agent it cannot bring forward", () => {
+  it("offers the verified prompt handoff for ChatGPT", () => {
     mocks.handoff.targets = [CODEX];
     render(<FirstRunLearningBanner />);
     expect(screen.getByTestId("first-run-ask-agent")).toHaveTextContent(
-      "Copy for Codex",
+      "Ask ChatGPT",
     );
   });
 
@@ -316,7 +321,9 @@ describe("agent handoff on the ready summary", () => {
     mocks.handoff.targets = [CLAUDE, CODEX];
     render(<FirstRunLearningBanner />);
 
-    expect(screen.getByTestId("first-run-ask-agent-picker")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("first-run-ask-agent-picker"),
+    ).toBeInTheDocument();
     const asks = screen.getAllByTestId("first-run-ask-agent");
     expect(asks.map((el) => el.getAttribute("data-agent"))).toEqual([
       "claude",
@@ -324,7 +331,7 @@ describe("agent handoff on the ready summary", () => {
     ]);
     // Logos carry no text, so the accessible name is the only affordance a
     // screen reader or keyboard user gets.
-    expect(asks[1]).toHaveAccessibleName("Copy for Codex");
+    expect(asks[1]).toHaveAccessibleName("Ask ChatGPT");
 
     fireEvent.click(asks[1]);
     expect(mocks.handoff.askAgent).toHaveBeenCalledWith(
@@ -332,17 +339,17 @@ describe("agent handoff on the ready summary", () => {
     );
   });
 
-  it("shows the paste instruction only once there is one", () => {
+  it("shows the review instruction only once there is one", () => {
     mocks.handoff.targets = [CLAUDE];
     const { rerender } = render(<FirstRunLearningBanner />);
     expect(
       screen.queryByTestId("first-run-ask-agent-hint"),
     ).not.toBeInTheDocument();
 
-    mocks.handoff.hint = "Claude opens with the question copied. Paste it to run.";
+    mocks.handoff.hint = "Question ready in Claude. Review and send it.";
     rerender(<FirstRunLearningBanner />);
     expect(screen.getByTestId("first-run-ask-agent-hint")).toHaveTextContent(
-      /paste it to run/i,
+      /review and send it/i,
     );
   });
 });

--- a/apps/screenpipe-app-tauri/e2e/specs/first-run-agent-handoff.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/first-run-agent-handoff.spec.ts
@@ -31,12 +31,12 @@
 // Does NOT assert which agent is offered. `detectAiTools()` runs in the
 // webview and resolves the REAL home directory: `SCREENPIPE_E2E_AI_TOOLS_HOME`
 // is read only by Rust (`skills.rs`), so the frontend probe sees whatever
-// Claude/Codex state the host happens to have. Asserting a specific agent
+// connected-agent state the host happens to have. Asserting a specific agent
 // here would pass on a developer laptop and fail on a clean CI runner, or the
-// reverse. Which agent wins, the connected-not-merely-detected rule, clipboard
-// and deeplink failure handling, and copy-only for terminal agents are covered
-// deterministically in lib/first-run/agent-handoff.test.ts (10 cases),
-// lib/first-run/use-agent-handoff.test.ts (11 cases) and the banner render in
+// reverse. Which agent wins, the connected-not-merely-detected rule, prompt
+// routes, and clipboard/deeplink failure handling are covered
+// deterministically in lib/first-run/agent-handoff.test.ts (13 cases),
+// lib/first-run/use-agent-handoff.test.ts (15 cases) and the banner render in
 // components/first-run/learning-banner.test.tsx.
 //
 // The one thing this spec DOES assert about the handoff is conditional and
@@ -75,7 +75,10 @@ const bannerPhase = async (): Promise<string | null> =>
     BANNER,
   )) as string | null;
 
-const readHandoff = async (): Promise<{ agent: string; label: string } | null> =>
+const readHandoff = async (): Promise<{
+  agent: string;
+  label: string;
+} | null> =>
   (await browser.execute((selector: string) => {
     const el = document.querySelector(selector);
     if (!el) return null;
@@ -85,7 +88,9 @@ const readHandoff = async (): Promise<{ agent: string; label: string } | null> =
       // buttons, so the name lives in aria-label. Reading textContent alone
       // reported an unnamed target on exactly the hosts that had the most
       // agents wired.
-      label: (el.textContent ?? "").trim() || (el.getAttribute("aria-label") ?? "").trim(),
+      label:
+        (el.textContent ?? "").trim() ||
+        (el.getAttribute("aria-label") ?? "").trim(),
     };
   }, ASK_AGENT)) as { agent: string; label: string } | null;
 
@@ -247,11 +252,12 @@ describeOrSkip("first-run agent handoff", () => {
     });
   });
 
-  it("shows the paste instruction only after the handoff runs", async () => {
+  it("shows the handoff result only after the handoff runs", async () => {
     await openHomeWith(readyState());
 
     const before = await browser.execute(
-      () => !!document.querySelector('[data-testid="first-run-ask-agent-hint"]'),
+      () =>
+        !!document.querySelector('[data-testid="first-run-ask-agent-hint"]'),
     );
     // The hint is a result, not a label. Rendering it up front would be
     // instructions for something the user has not done.
@@ -263,8 +269,8 @@ describeOrSkip("first-run agent handoff", () => {
     const button = await browser.$(ASK_AGENT);
     await button.click();
 
-    // Clicking must produce a visible next step, whether the agent opened or
-    // the handoff degraded to copy-only.
+    // Clicking must produce a visible next step, whether the agent opened with
+    // the prompt prefilled or the handoff degraded to clipboard recovery.
     await browser.waitUntil(
       async () =>
         Boolean(

--- a/apps/screenpipe-app-tauri/lib/first-run/agent-handoff.test.ts
+++ b/apps/screenpipe-app-tauri/lib/first-run/agent-handoff.test.ts
@@ -15,15 +15,15 @@ describe("pickHandoffTargets", () => {
   it("returns every connected agent, in preference order", () => {
     // Order is ours, choice is the user's. Returning only the first hid Codex
     // from anyone who also had Claude installed.
-    expect(pickHandoffTargets(["codex", "cursor", "claude"]).map((t) => t.id)).toEqual(
-      ["claude", "cursor", "codex"],
-    );
+    expect(
+      pickHandoffTargets(["codex", "cursor", "claude"]).map((t) => t.id),
+    ).toEqual(["claude", "cursor", "codex"]);
   });
 
   it("drops unsupported tools instead of offering a dead button", () => {
-    expect(pickHandoffTargets(["hermes", "windsurf", "codex"]).map((t) => t.id)).toEqual(
-      ["codex"],
-    );
+    expect(
+      pickHandoffTargets(["hermes", "windsurf", "codex"]).map((t) => t.id),
+    ).toEqual(["codex"]);
   });
 
   it("returns nothing when no connected agent is supported", () => {
@@ -43,7 +43,7 @@ describe("pickHandoffTarget", () => {
     expect(pickHandoffTarget(["hermes", "windsurf", "openclaw"])).toBeNull();
   });
 
-  it("prefers Claude, the most connected tool and the only reliable deeplink", () => {
+  it("prefers Claude, the most connected tool", () => {
     expect(pickHandoffTarget(["codex", "cursor", "claude"])?.id).toBe("claude");
   });
 
@@ -52,36 +52,28 @@ describe("pickHandoffTarget", () => {
     expect(pickHandoffTarget(["codex"])?.id).toBe("codex");
   });
 
-  it("only Claude ships a deeplink, because it is the only verified scheme", () => {
-    // Claude registers CFBundleURLSchemes = ["claude"]. Cursor and Codex were
-    // NOT verified on a real install, and an unregistered scheme produces a
-    // button that silently does nothing — strictly worse than copy-only.
+  it("ships a prompt-prefill deeplink for every supported desktop agent", () => {
     const withDeeplink = handoffTargets()
       .filter((t) => t.deeplink)
       .map((t) => t.id);
-    expect(withDeeplink).toEqual(["claude"]);
+    expect(withDeeplink).toEqual(["claude", "cursor", "codex"]);
   });
 
-  it("gives Codex no deeplink, because no scheme was verified", () => {
-    const codex = pickHandoffTarget(["codex"]);
-    expect(codex?.deeplink).toBeUndefined();
-    expect(codex?.hint).toMatch(/paste it into your codex terminal/i);
+  it("pins the verified prompt routes and URL-encodes the question", () => {
+    const encoded = encodeURIComponent(HANDOFF_PROMPT);
+    expect(
+      Object.fromEntries(handoffTargets().map((t) => [t.id, t.deeplink])),
+    ).toEqual({
+      claude: `claude://claude.ai/new?q=${encoded}`,
+      cursor: `cursor://anysphere.cursor-deeplink/prompt?text=${encoded}`,
+      codex: `codex://threads/new?prompt=${encoded}`,
+    });
   });
 
-  it("pins the one verified scheme exactly", () => {
-    // Format alone is not verification: a well-formed but unregistered scheme
-    // fails silently. Pin the literal value that was read out of
-    // /Applications/Claude.app CFBundleURLSchemes.
-    for (const target of handoffTargets()) {
-      if (!target.deeplink) continue;
-      expect(target.deeplink).toBe("claude://claude");
-    }
-  });
-
-  it("every target explains how to get from clipboard to answer", () => {
+  it("every target leaves the prompt for review instead of auto-sending", () => {
     for (const target of handoffTargets()) {
       expect(target.label.length).toBeGreaterThan(0);
-      expect(target.hint).toMatch(/paste/i);
+      expect(target.hint).toMatch(/review and send/i);
     }
   });
 });

--- a/apps/screenpipe-app-tauri/lib/first-run/agent-handoff.ts
+++ b/apps/screenpipe-app-tauri/lib/first-run/agent-handoff.ts
@@ -7,7 +7,8 @@
  *
  * Setup connects every detected AI tool over MCP in a native background task
  * (`skills.rs::connect_detected_ai_tools_in_background`), so by the time the
- * first-run summary resolves, Claude or Codex can already query this machine.
+ * first-run summary resolves, Claude, Cursor, or Codex can already query this
+ * machine.
  * That is the product thesis, and it is also the stickiest thing we measure:
  * MCP users repeat across days at 48% against a 7-9% D7 baseline.
  *
@@ -19,11 +20,12 @@
  * - Only tools that are actually CONNECTED are offered. Detected-but-unwired
  *   would send the user to an agent that cannot see anything, which is worse
  *   than not asking.
- * - `deeplink` is optional and only set where a real URL scheme exists.
- *   Claude Desktop registers `claude://` (routes: claude, cowork, resume).
- *   None of them accept a prompt, so we copy the question to the clipboard and
- *   open the app; the user pastes. Codex is a terminal CLI with no scheme at
- *   all, so it gets copy-only and says so.
+ * - `deeplink` is optional and only set where a real prompt-prefill route has
+ *   been verified. Claude, Cursor, and Codex all leave the prompt unsent so the
+ *   user can review it before handing any captured context to the agent.
+ * - The clipboard remains a fallback. Older app builds may know the URL scheme
+ *   but not the prompt route, and a machine can have MCP configured without the
+ *   desktop app installed.
  */
 
 import type { ConnectAllToolId } from "@/lib/ai-tools-mcp";
@@ -33,51 +35,54 @@ export type AgentHandoffTarget = {
   /** Shown on the button. */
   label: string;
   /**
-   * URL that brings the app forward. Absent for terminal tools, which turns
-   * the handoff into copy-only rather than pretending we can focus them.
+   * Verified URL that opens the app with the prompt prefilled. Optional so a
+   * future target can explicitly degrade to clipboard-only.
    */
   deeplink?: string;
-  /** How the user gets from the clipboard to an answer. */
+  /** What the user should do after the handoff. */
   hint: string;
 };
 
 /**
- * The question we hand over. Short on purpose: it has to survive being pasted
- * by hand, and a long prompt reads as work. Five minutes matches the window
- * the user just watched fill up, so the agent answers about the session they
- * were part of rather than an arbitrary range.
+ * The question we hand over. Short on purpose: it has to fit cleanly in a URL
+ * or survive being pasted by hand, and a long prompt reads as work. Five
+ * minutes matches the window the user just watched fill up, so the agent
+ * answers about the session they were part of rather than an arbitrary range.
  */
 export const HANDOFF_PROMPT =
   "Using screenpipe, summarize what I worked on in the last 5 minutes.";
 
+const ENCODED_HANDOFF_PROMPT = encodeURIComponent(HANDOFF_PROMPT);
+
 /**
- * Preference order, not an alphabetical list. Claude first because it is both
- * the most connected tool (107 people/21d against Codex 97) and the only one
- * that can be brought forward with a deeplink, so it is the shortest path from
- * the button to an answer.
+ * Preference order, not an alphabetical list. Every shipped target has a
+ * prompt-prefill route; the order therefore follows connection usage rather
+ * than an implementation limitation.
  */
 const HANDOFF_TARGETS: AgentHandoffTarget[] = [
   {
     id: "claude",
     label: "Claude",
-    deeplink: "claude://claude",
-    hint: "Claude opens with the question copied. Paste it to run.",
+    // Claude Desktop handles this as a new Claude chat and maps `q` into the
+    // composer without submitting it.
+    deeplink: `claude://claude.ai/new?q=${ENCODED_HANDOFF_PROMPT}`,
+    hint: "Question ready in Claude. Review and send it.",
   },
   {
     id: "cursor",
     label: "Cursor",
-    // No deeplink until someone verifies the scheme on a real install. An
-    // earlier revision shipped `cursor://` from memory rather than from a
-    // registered CFBundleURLSchemes entry; if the scheme is wrong the button
-    // silently does nothing, which is the exact failure copy-only avoids.
-    hint: "Question copied. Open Cursor and paste it into chat.",
+    // Cursor's documented prompt deeplink opens Chat with the text prefilled
+    // and explicitly never executes it automatically.
+    deeplink: `cursor://anysphere.cursor-deeplink/prompt?text=${ENCODED_HANDOFF_PROMPT}`,
+    hint: "Question ready in Cursor. Review and send it.",
   },
   {
     id: "codex",
-    label: "Codex",
-    // Ships as a terminal CLI writing to ~/.codex/config.toml, and no URL
-    // scheme has been verified. Copy-only, and the hint says where to paste.
-    hint: "Question copied. Paste it into your Codex terminal session.",
+    label: "ChatGPT",
+    // The ChatGPT/Codex desktop app accepts exactly one `prompt` parameter on
+    // its new-thread route. CLI-only installs fall back to the copied prompt.
+    deeplink: `codex://threads/new?prompt=${ENCODED_HANDOFF_PROMPT}`,
+    hint: "Question ready in ChatGPT. Review and send it.",
   },
 ];
 

--- a/apps/screenpipe-app-tauri/lib/first-run/use-agent-handoff.test.ts
+++ b/apps/screenpipe-app-tauri/lib/first-run/use-agent-handoff.test.ts
@@ -29,7 +29,9 @@ vi.mock("posthog-js", () => ({ default: { capture } }));
 vi.mock("@tauri-apps/plugin-opener", () => ({ openUrl }));
 vi.mock("@/lib/utils/tauri", () => ({ commands: { copyTextToClipboard } }));
 vi.mock("@/lib/ai-tools-mcp", () => ({ detectAiTools }));
-vi.mock("@/lib/external-agent-skills", () => ({ areExternalAgentSkillsInstalled }));
+vi.mock("@/lib/external-agent-skills", () => ({
+  areExternalAgentSkillsInstalled,
+}));
 vi.mock("@/lib/hooks/use-hardcoded-tiles", () => ({
   getInstalledMcpVersion,
   isCodexMcpInstalled,
@@ -85,7 +87,9 @@ describe("useAgentHandoff — resolving a target", () => {
     detectAiTools.mockResolvedValue(["claude"]);
     areExternalAgentSkillsInstalled.mockResolvedValue(false);
     const { result } = renderHook(() => useAgentHandoff(true));
-    await waitFor(() => expect(areExternalAgentSkillsInstalled).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(areExternalAgentSkillsInstalled).toHaveBeenCalled(),
+    );
     expect(result.current.targets).toEqual([]);
   });
 
@@ -96,7 +100,10 @@ describe("useAgentHandoff — resolving a target", () => {
     isCodexMcpInstalled.mockResolvedValue(true);
     const { result } = renderHook(() => useAgentHandoff(true));
     await waitFor(() => expect(result.current.targets).toHaveLength(2));
-    expect(result.current.targets.map((t) => t.id)).toEqual(["claude", "codex"]);
+    expect(result.current.targets.map((t) => t.id)).toEqual([
+      "claude",
+      "codex",
+    ]);
   });
 
   it("reports the offer so the click has a denominator", async () => {
@@ -118,7 +125,9 @@ describe("useAgentHandoff — resolving a target", () => {
     renderHook(() => useAgentHandoff(true));
     await waitFor(() => expect(detectAiTools).toHaveBeenCalled());
     expect(
-      capture.mock.calls.filter((c) => c[0] === "first_run_agent_handoff_shown"),
+      capture.mock.calls.filter(
+        (c) => c[0] === "first_run_agent_handoff_shown",
+      ),
     ).toHaveLength(0);
   });
 
@@ -132,7 +141,7 @@ describe("useAgentHandoff — resolving a target", () => {
 });
 
 describe("useAgentHandoff — performing the handoff", () => {
-  it("copies the question and opens the app", async () => {
+  it("copies the question and opens the app with it prefilled", async () => {
     detectAiTools.mockResolvedValue(["claude"]);
     const { result } = renderHook(() => useAgentHandoff(true));
     await waitFor(() => expect(result.current.targets[0]?.id).toBe("claude"));
@@ -142,18 +151,21 @@ describe("useAgentHandoff — performing the handoff", () => {
     });
 
     expect(copyTextToClipboard).toHaveBeenCalledWith(HANDOFF_PROMPT);
-    expect(openUrl).toHaveBeenCalledWith("claude://claude");
-    expect(result.current.hint).toMatch(/paste/i);
+    expect(openUrl).toHaveBeenCalledWith(
+      `claude://claude.ai/new?q=${encodeURIComponent(HANDOFF_PROMPT)}`,
+    );
+    expect(result.current.hint).toMatch(/review and send/i);
     expect(clicked()[0]?.[1]).toMatchObject({
       agent: "claude",
       opened: true,
+      prefilled: true,
       copy_only: false,
+      clipboard_copied: true,
     });
   });
 
-  it("does not open the app when the clipboard write fails", async () => {
-    // Opening with nothing to paste strands the user in an empty composer
-    // with no way back to the question.
+  it("still opens the prefilled app when the clipboard fallback fails", async () => {
+    // The prompt is in the deeplink itself; clipboard is recovery, not a gate.
     detectAiTools.mockResolvedValue(["claude"]);
     copyTextToClipboard.mockRejectedValue(new Error("no clipboard access"));
     const { result } = renderHook(() => useAgentHandoff(true));
@@ -163,10 +175,17 @@ describe("useAgentHandoff — performing the handoff", () => {
       await result.current.askAgent(result.current.targets[0]);
     });
 
-    expect(openUrl).not.toHaveBeenCalled();
-    expect(result.current.hint).toMatch(/open the summary instead/i);
-    expect(failed()[0]?.[1]).toMatchObject({ agent: "claude", stage: "clipboard" });
-    expect(clicked()).toHaveLength(0);
+    expect(openUrl).toHaveBeenCalledTimes(1);
+    expect(result.current.hint).toMatch(/review and send/i);
+    expect(failed()[0]?.[1]).toMatchObject({
+      agent: "claude",
+      stage: "clipboard",
+    });
+    expect(clicked()[0]?.[1]).toMatchObject({
+      opened: true,
+      prefilled: true,
+      clipboard_copied: false,
+    });
   });
 
   it("degrades to copy-only when the deeplink fails", async () => {
@@ -185,7 +204,26 @@ describe("useAgentHandoff — performing the handoff", () => {
     expect(clicked()[0]?.[1]).toMatchObject({ opened: false });
   });
 
-  it("never tries to open a terminal agent", async () => {
+  it("keeps the in-app summary as recovery when open and copy both fail", async () => {
+    detectAiTools.mockResolvedValue(["claude"]);
+    copyTextToClipboard.mockRejectedValue(new Error("no clipboard access"));
+    openUrl.mockRejectedValue(new Error("no handler"));
+    const { result } = renderHook(() => useAgentHandoff(true));
+    await waitFor(() => expect(result.current.targets[0]?.id).toBe("claude"));
+
+    await act(async () => {
+      await result.current.askAgent(result.current.targets[0]);
+    });
+
+    expect(result.current.hint).toMatch(/open the summary instead/i);
+    expect(failed().map((call) => call[1]?.stage)).toEqual([
+      "clipboard",
+      "open",
+    ]);
+    expect(clicked()).toHaveLength(0);
+  });
+
+  it("opens the ChatGPT/Codex desktop app with the prompt prefilled", async () => {
     detectAiTools.mockResolvedValue(["codex"]);
     isCodexMcpInstalled.mockResolvedValue(true);
     getInstalledMcpVersion.mockResolvedValue(null);
@@ -197,8 +235,10 @@ describe("useAgentHandoff — performing the handoff", () => {
     });
 
     expect(copyTextToClipboard).toHaveBeenCalledWith(HANDOFF_PROMPT);
-    expect(openUrl).not.toHaveBeenCalled();
-    expect(clicked()[0]?.[1]).toMatchObject({ copy_only: true, opened: false });
+    expect(openUrl).toHaveBeenCalledWith(
+      `codex://threads/new?prompt=${encodeURIComponent(HANDOFF_PROMPT)}`,
+    );
+    expect(clicked()[0]?.[1]).toMatchObject({ copy_only: false, opened: true });
   });
 
   it("does nothing when there is no target", async () => {

--- a/apps/screenpipe-app-tauri/lib/first-run/use-agent-handoff.ts
+++ b/apps/screenpipe-app-tauri/lib/first-run/use-agent-handoff.ts
@@ -120,18 +120,18 @@ export function useAgentHandoff(enabled: boolean): AgentHandoffView {
   const askAgent = useCallback(async (target: AgentHandoffTarget) => {
     if (!target) return;
 
-    // Copy first. If the clipboard write fails there is nothing to paste, so
-    // opening the app would strand the user in an empty composer with no way
-    // back to the question.
+    // Copy first as a fallback for older app builds, missing protocol handlers,
+    // and CLI-only Codex installs. The verified deeplinks carry their own prompt,
+    // so a clipboard failure must not block the primary prefilled handoff.
+    let copied = false;
     try {
       await commands.copyTextToClipboard(HANDOFF_PROMPT);
+      copied = true;
     } catch {
-      setHint("Could not copy the question. Open the summary instead.");
       posthog.capture("first_run_agent_handoff_failed", {
         agent: target.id,
         stage: "clipboard",
       });
-      return;
     }
 
     let opened = false;
@@ -141,8 +141,8 @@ export function useAgentHandoff(enabled: boolean): AgentHandoffView {
         await openUrl(target.deeplink);
         opened = true;
       } catch {
-        // The question is already on the clipboard, so this degrades to the
-        // copy-only path rather than failing outright.
+        // When the clipboard succeeded this degrades to copy-only. When both
+        // paths fail, the in-app summary remains the recovery action.
         posthog.capture("first_run_agent_handoff_failed", {
           agent: target.id,
           stage: "open",
@@ -150,11 +150,16 @@ export function useAgentHandoff(enabled: boolean): AgentHandoffView {
       }
     }
 
-    setHint(
-      opened || !target.deeplink
-        ? target.hint
-        : `Question copied. Open ${target.label} and paste it.`,
-    );
+    if (opened) {
+      setHint(target.hint);
+    } else if (copied) {
+      setHint(`Question copied. Open ${target.label} and paste it.`);
+    } else {
+      setHint(
+        `Could not open ${target.label} or copy the question. Open the summary instead.`,
+      );
+      return;
+    }
 
     // The loop closes outside this app: screenpipe-mcp reports a privacy-safe
     // `client` on every tool call, so a call arriving from this agent shortly
@@ -162,7 +167,9 @@ export function useAgentHandoff(enabled: boolean): AgentHandoffView {
     posthog.capture("first_run_agent_handoff_clicked", {
       agent: target.id,
       opened,
-      copy_only: !target.deeplink,
+      prefilled: opened,
+      copy_only: !opened,
+      clipboard_copied: copied,
     });
   }, []);
 

--- a/apps/screenpipe-app-tauri/src-tauri/capabilities/main.json
+++ b/apps/screenpipe-app-tauri/src-tauri/capabilities/main.json
@@ -83,6 +83,15 @@
         },
         {
           "url": "^obsidian://.*"
+        },
+        {
+          "url": "^claude://claude\\.ai/new\\?q=.*$"
+        },
+        {
+          "url": "^cursor://anysphere\\.cursor-deeplink/prompt\\?text=.*$"
+        },
+        {
+          "url": "^codex://threads/new\\?prompt=.*$"
         }
       ]
     },


### PR DESCRIPTION
## Summary

- open Claude, Cursor, or ChatGPT with the post-learning question already prefilled
- leave every prompt unsent so the user can review it before sharing captured context
- keep the clipboard as a fallback when an app or protocol handler is unavailable
- allow only the verified prompt routes through the Tauri opener scope

## Before / after

```text
before: Ask Claude | Copy for Cursor | Copy for Codex
        -> open or switch apps, then paste manually

after:  Ask Claude | Ask Cursor | Ask ChatGPT
        -> chosen app opens with the question ready to review and send
```

## Route verification

- Claude and ChatGPT/Codex routes were checked against the parsers in the currently installed macOS apps
- Cursor uses its documented prompt deeplink: https://prod.cursor.com/docs/reference/deeplinks

## Verification

- `bun x vitest run --config vitest.config.ts lib/first-run/agent-handoff.test.ts lib/first-run/use-agent-handoff.test.ts components/first-run/learning-banner.test.tsx` (47 passed)
- `bun x tsc --noEmit --pretty false`
- targeted ESLint on all changed TypeScript files
- `bun run e2e:coverage:check`
- validated all 3 generated URLs against `src-tauri/capabilities/main.json`
