### PR TITLE
fix(timeline): select text on the first click

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/swift/timeline/TimelineLiveText.swift
+++ b/apps/screenpipe-app-tauri/src-tauri/swift/timeline/TimelineLiveText.swift
@@ -94,6 +94,11 @@ final class TimelineLiveTextContainer: NSView {
         )
     }
 
+    /// The pointer lands on VisionKit's overlay, not here, so this only
+    /// covers clicks on the frame's margins. `TimelineWindow.sendEvent`
+    /// is what keeps the first selection gesture alive over the text.
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+
     override func layout() {
         super.layout()
         let fitted = Self.aspectFitRect(imageSize: imageView.image?.size ?? .zero, inside: bounds)

--- a/apps/screenpipe-app-tauri/src-tauri/swift/timeline/TimelineWindow.swift
+++ b/apps/screenpipe-app-tauri/src-tauri/swift/timeline/TimelineWindow.swift
@@ -429,6 +429,32 @@ struct TimelineSearchNavigationRequest: Equatable {
 final class TimelineWindow: NSWindow {
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { false }
+
+    /// The click that focuses an attached timeline must also do its job.
+    ///
+    /// AppKit spends the mouse-down that makes a window key on the activation
+    /// alone, unless the view under the pointer accepts first mouse. Over a
+    /// frame that view is VisionKit's `ImageAnalysisOverlayView`, which is
+    /// `final` — there is no override to add. Taking key before the event is
+    /// dispatched turns it into an ordinary click, so the first drag selects
+    /// text instead of only waking the window up.
+    override func sendEvent(_ event: NSEvent) {
+        if event.type == .leftMouseDown, !isKeyWindow { makeKey() }
+        super.sendEvent(event)
+    }
+}
+
+/// Being able to become key is not the same as becoming key.
+///
+/// Attached mode never makes this window key — the host webview keeps that, so
+/// the timeline does not steal keystrokes the moment it appears. The click that
+/// does make it key is AppKit's "first mouse", and by default a view is not
+/// sent that event: it only activates the window. So the first drag over a
+/// transcript selected nothing, and the user had to click something else first
+/// to wake the window up. Accepting first mouse spends that click on the
+/// gesture as well as the activation.
+final class TimelineHostingView<Content: View>: NSHostingView<Content> {
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
 }
 
 @MainActor
@@ -759,7 +785,7 @@ final class TimelineWindowController: NSObject, NSWindowDelegate {
             model.beginExternalNavigation()
         }
 
-        let hosting = NSHostingView(
+        let hosting = TimelineHostingView(
             rootView: TimelineHostView(
                 model: model,
                 originChrome: originChrome,

--- a/apps/screenpipe-app-tauri/src-tauri/swift/timeline_interaction_tests.swift
+++ b/apps/screenpipe-app-tauri/src-tauri/swift/timeline_interaction_tests.swift
@@ -273,6 +273,28 @@ private func testNoOverlaySwallowsHitTests(window: NSWindow) {
     }
 }
 
+/// The click that activates the timeline has to do its job too.
+///
+/// An attached timeline is a child window: the host webview keeps key focus, so
+/// the first click over the timeline is AppKit's "first mouse". A view that
+/// declines it spends that event on activation alone, and the user's first drag
+/// over a frame or a transcript selects nothing — they have to click something
+/// else first and try again. Asserted structurally, because a test binary is
+/// never the active app and so cannot be clicked (see the note at the top).
+@MainActor
+private func testFirstMouseReachesContent(window: NSWindow) {
+    expect(window is TimelineWindow,
+           "the timeline must use TimelineWindow, got \(type(of: window))")
+    guard let content = window.contentView else {
+        failures.append("the window has no content view")
+        return
+    }
+    expect(content.acceptsFirstMouse(for: nil),
+           "the SwiftUI host must accept first mouse, or the activating click is swallowed")
+    expect(TimelineLiveTextContainer().acceptsFirstMouse(for: nil),
+           "the frame canvas must accept first mouse")
+}
+
 /// Buttons have to actually run their action. Found through accessibility, then
 /// pressed the way an assistive client presses them.
 @MainActor
@@ -1117,6 +1139,7 @@ private func runTests() {
     let groups: [(String, () -> Void)] = [
         ("idle and hidden lifecycle", { testIdleAndHiddenLifecycle(model: model) }),
         ("no overlay swallows hit tests", { testNoOverlaySwallowsHitTests(window: window) }),
+        ("first mouse reaches content", { testFirstMouseReachesContent(window: window) }),
         ("control bar buttons respond",
          { testControlBarButtonsRespond(window: window, model: model) }),
         ("scrubber is reachable", { testScrubberIsReachable(window: window, model: model) }),


### PR DESCRIPTION
## problem

Text on the timeline does not select on the first try. You drag over OCR text on a frame, or over a transcript, and nothing happens. Click anything else on the timeline first and it works.

## where found

Reported from daily use: "sometimes i cannot select text on the timeline until i click a button on the timeline".

## evidence

The timeline is rendered entirely in Swift, but it is not a standalone window. `NativeTimeline` measures its own rect in the webview and emits `native-timeline-attach`; Rust resolves the host window pointer and `timeline_show` takes the rect branch into `attach()`, which calls `host.addChildWindow`. So the timeline is a borderless child `NSWindow` pinned over a slice of the Tauri webview.

`attach()` never makes that window key. It calls `orderFront` only, deliberately, so the timeline does not steal keystrokes the moment it appears. The webview keeps key focus.

AppKit then spends the mouse-down that makes a non-key window key on the activation alone, unless the view under the pointer answers `acceptsFirstMouse` with true. Nothing in the timeline did. The first drag is consumed waking the window up; the second one selects.

Two comments already in the tree describe the same dependency, both written after earlier rounds of this bug:

- `timeline_interaction_tests.swift`: "SwiftUI drops mouse events in a window that is not key"
- `timeline_interaction_tests.swift`: "Native controls and Live Text need the child to become key"

"Sometimes" is whether the window already had focus. Anything that had made it key, using its controls, arrows, escape, leaves selection working immediately. The standalone window (`timeline_show` with no rect) calls `makeKeyAndOrderFront` and never had the bug.

## reproduction

1. Open the app, go to the Timeline section.
2. Click the main window somewhere outside the timeline region, so the webview holds key focus.
3. Drag across OCR text on the frame, or across a transcript line.

Before: nothing is selected. Click a timeline button, drag again, and it selects.
After: the first drag selects.

```
before                                  after

webview window  [key]                   webview window
  └── timeline child window               └── timeline child window
        click #1  -> activation only            click #1  -> makeKey + mouseDown
        click #2  -> selection                              -> selection
```

## root cause

The activating click was never delivered to a view. Fixed in three places because the views differ:

- `TimelineWindow.sendEvent` takes key before dispatching a left mouse-down. This is the only option over a frame: the view under the pointer there is VisionKit's `ImageAnalysisOverlayView`, which is `final`, so there is no `acceptsFirstMouse` to override. The compiler catches the attempt.
- `TimelineHostingView`, a small `NSHostingView` subclass, accepts first mouse for everything SwiftUI draws: transcripts, the control bar, the filter rail.
- `TimelineLiveTextContainer` accepts first mouse for the margins around the frame image.

Taking key on click was already an expected transition, so it does not trip the resign-key dismissal: `windowDidResignKey` walks the parent chain through `attachedHierarchyHasKeyWindow()` before emitting `close_window`, and the attached key-focus lifecycle test already covers that path.

## validation

Ran on the rebased head, `arm64-apple-macos13.0`:

| stage | result |
| --- | --- |
| swiftc typecheck, whole timeline module | clean |
| timeline core | 309 checks passed |
| timeline render | 170 checks passed |
| timeline interaction | 127 checks, 1 pre-existing failure |
| timeline ffi | 11 checks passed |
| static library build (what `build.rs` links) | builds |

Adds a `first mouse reaches content` group to the interaction suite: asserts the window is a `TimelineWindow`, its content view accepts first mouse, and the frame container does. Structural rather than a synthesized click, for the reason that file documents at the top: a test binary is never the active app, so `isKey` stays false and clicks cannot be delivered.

The one interaction failure, `the zoom timer stops after reaching its target`, is pre-existing. A clean `git archive HEAD` build fails the identical assertion at 124 checks, versus 127 here (the 3 added are mine). Tracked separately, not touched by this PR.

`scripts/test-timeline.sh` runs stages under `set -euo pipefail` and aborted before the interaction stage on `stable lane grouping exceeded 100 ms` in the performance stage on a loaded machine, so each stage above was compiled and run directly with the script's own flags.

## not validated

The drag itself, in a real app. Test binaries cannot become the active application, so first-mouse behaviour is not reachable from the suite. The manual check is the reproduction above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
