### PR TITLE
fix(activity): remove manual append button

### DIFF
--- a/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
@@ -990,7 +990,7 @@ describe("ActivityLedger", () => {
     );
   });
 
-  it("restores the bottom append control without a rolling page clock", async () => {
+  it("does not show a bottom append control", async () => {
     mocks.loadPersistedActivityHistory.mockImplementation(
       async (_producer: string, range: { start: Date; end: Date }) => ({
         entries: parseActivityHistoryResponse(HISTORY_RESPONSE, range).entries,
@@ -1006,63 +1006,12 @@ describe("ActivityLedger", () => {
     render(<ActivityLedger />);
 
     await screen.findByText("Fixed a capture reliability regression");
-    const addRecent = screen.getByRole("button", {
-      name: "Generate more results",
-    });
-    expect(addRecent).toBeVisible();
-    expect(addRecent).toBeDisabled();
     expect(
-      screen.getByText("More results can be generated every 10 minutes."),
-    ).toBeVisible();
-
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(10 * 60_000 + 1_002);
-    });
-
-    await waitFor(() => expect(addRecent).toBeEnabled());
-    fireEvent.click(addRecent);
-
-    await waitFor(() =>
-      expect(mocks.runDailySummaryWithPi).toHaveBeenCalledWith(
-        expect.objectContaining({
-          range: {
-            start: expect.stringMatching(/^2026-08-17T20:00:00\.\d{3}Z$/),
-            end: expect.stringMatching(/^2026-08-17T20:10:01\.\d{3}Z$/),
-          },
-        }),
-      ),
-    );
-  });
-
-  it("shows the append control only for Today and Last 24 hours", async () => {
-    mocks.loadPersistedActivityHistory.mockImplementation(
-      async (_producer: string, range: { start: Date; end: Date }) => ({
-        entries: parseActivityHistoryResponse(HISTORY_RESPONSE, range).entries,
-        coverage: [
-          {
-            start: range.start.toISOString(),
-            end: range.end.toISOString(),
-          },
-        ],
-      }),
-    );
-
-    for (const [preset, expected] of [
-      ["today", true],
-      ["24h", true],
-      ["7d", false],
-      ["custom", false],
-    ] as const) {
-      window.localStorage.setItem("screenpipe:activity-history:range", preset);
-      render(<ActivityLedger />);
-      await screen.findByText("Fixed a capture reliability regression");
-      const addRecent = screen.queryByRole("button", {
-        name: "Generate more results",
-      });
-      if (expected) expect(addRecent).toBeVisible();
-      else expect(addRecent).toBeNull();
-      cleanup();
-    }
+      screen.queryByRole("button", { name: "Generate more results" }),
+    ).toBeNull();
+    expect(
+      screen.queryByText("Include activity recorded since your last update."),
+    ).toBeNull();
   });
 
   it("shows the exhausted AI preset instead of a generic failure", async () => {

--- a/apps/screenpipe-app-tauri/components/activity-ledger.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.tsx
@@ -791,7 +791,6 @@ export function ActivityLedger({
       selectableReviewPresets[0],
     [selectableReviewPresets, selectedReviewPresetId],
   );
-  const supportsRecentActivity = preset === "today" || preset === "24h";
   const recentRange = useMemo(
     () => rangeForPreset(preset, new Date(), customStart, customEnd),
     [
@@ -1640,31 +1639,6 @@ Re-query Screenpipe only inside the cited time range and use the cited frames an
                   ))}
                 </div>
               ))}
-              {supportsRecentActivity ? (
-                <div className="flex flex-col items-center border-t border-border py-10 text-center">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    className="h-10 rounded-none px-5 uppercase tracking-wide"
-                    onClick={addRecentActivity}
-                    disabled={recentActivityDisabled}
-                  >
-                    <RefreshCw
-                      className={cn(
-                        "mr-2 h-3.5 w-3.5",
-                        historyLoading && "animate-spin",
-                      )}
-                      aria-hidden="true"
-                    />
-                    Generate more results
-                  </Button>
-                  <p className="mt-2 text-xs text-muted-foreground">
-                    {recentActivityAvailable
-                      ? "Include activity recorded since your last update."
-                      : "More results can be generated every 10 minutes."}
-                  </p>
-                </div>
-              ) : null}
             </section>
           ) : loading && !summary ? (
             <ActivityLedgerSkeleton label="Reading your day…" />


### PR DESCRIPTION
## description

Remove the footer “Generate more results” button and its helper text from Activity history now that new entries are generated automatically. The separate header refresh action remains unchanged.

related issue: none

## AI assistance and human ownership

- AI tool(s) used: Codex
- autonomy level: agent
- what I personally verified: focused ActivityLedger Vitest suite and exact Git diff

- [ ] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [ ] The problem statement, rationale, and replies to maintainers are my own.

## evidence type

- [x] UI or behavior change — before/after evidence below
- [ ] Backend change — regression tests and relevant logs/results
- [ ] Performance change — reproducible before/after benchmarks
- [ ] Docs, CI, or pure refactor — relevant checks and an explanation; no video required

## before

```text
Activity entries
────────────────────────────────
        [ ↻ GENERATE MORE RESULTS ]
 Include activity recorded since your last update.
```

## after

```text
Activity entries
────────────────────────────────

Footer append control removed.
Header Refresh history action remains available.
```

## how to test

1. `cd apps/screenpipe-app-tauri`
2. `bun x vitest run --config vitest.config.ts components/activity-ledger.test.tsx`
3. Result: 1 test file passed, 36 tests passed.

## desktop app checklist

Not applicable: no Tauri commands or exported Rust types changed.