### PR TITLE
fix(ci): handle masked first-time contributor status

### DIFF
--- a/.github/workflows/close-new-contributor-prs.yml
+++ b/.github/workflows/close-new-contributor-prs.yml
@@ -32,6 +32,9 @@ jobs:
               query($owner: String!, $repo: String!, $number: Int!) {
                 repository(owner: $owner, name: $repo) {
                   pullRequest(number: $number) {
+                    author {
+                      __typename
+                    }
                     authorAssociation
                     number
                     state
@@ -53,7 +56,16 @@ jobs:
                 return;
               }
 
-              if (!newContributorAssociations.has(pullRequest.authorAssociation)) {
+              // GitHub masks both first-time associations as NONE when this
+              // query uses the workflow GITHUB_TOKEN. Existing contributors
+              // retain CONTRIBUTOR, while bot actors are excluded explicitly.
+              const isMaskedNewContributor =
+                pullRequest.authorAssociation === "NONE" &&
+                pullRequest.author?.__typename === "User";
+              if (
+                !newContributorAssociations.has(pullRequest.authorAssociation) &&
+                !isMaskedNewContributor
+              ) {
                 core.info(
                   `Leaving PR #${pullRequest.number} open: author association is ${pullRequest.authorAssociation}.`,
                 );


### PR DESCRIPTION
## What changed
- treat `NONE` from the restricted workflow token as GitHub’s masked first-time-user status
- exclude bot actors explicitly
- continue leaving `CONTRIBUTOR`, `COLLABORATOR`, `MEMBER`, and `OWNER` open

## Live evidence
Workflow dispatch run 32309311620 used GraphQL from the deployed workflow and still received `NONE` for all 13 PRs that the maintainer-visible API identifies as `FIRST_TIME_CONTRIBUTOR`.

## Validation
- `actionlint .github/workflows/close-new-contributor-prs.yml`
- `git diff --check`
- behavior matrix for direct first-time associations, masked users, bots, and established repository roles