### PR TITLE
fix(chat): keep effort trigger usable while saving

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat/standalone/acp-config-selector.test.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/acp-config-selector.test.tsx
@@ -243,6 +243,50 @@ describe("ACP config trigger", () => {
     );
   });
 
+  it("keeps the effort trigger usable while Ultra is being applied", async () => {
+    seedSession([
+      {
+        id: "reasoning_effort",
+        name: "Reasoning effort",
+        type: "select",
+        currentValue: "high",
+        values: [
+          { value: "low", name: "Low" },
+          { value: "medium", name: "Medium" },
+          { value: "high", name: "High" },
+          { value: "ultra", name: "Ultra" },
+        ],
+      },
+    ]);
+    let resolveChange!: (value: { status: "ok"; data: null }) => void;
+    mocks.setConfigOption.mockReturnValue(
+      new Promise((resolve) => {
+        resolveChange = resolve;
+      }),
+    );
+
+    render(<AcpEffortSelector sessionId={SESSION} agentId="codex-acp" />);
+
+    const trigger = screen.getByTestId("acp-effort-trigger");
+    fireEvent.click(trigger);
+    fireEvent.click(
+      document.querySelector('[data-effort-step="ultra"]') as HTMLElement,
+    );
+
+    expect(trigger).not.toBeDisabled();
+    expect(screen.getByTestId("acp-effort-slider")).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+
+    resolveChange({ status: "ok", data: null });
+    await waitFor(() =>
+      expect(screen.getByTestId("acp-effort-slider")).not.toHaveAttribute(
+        "aria-disabled",
+      ),
+    );
+  });
+
   it("keeps a two-value effort axis visible as a select", () => {
     seedSession([
       {

--- a/apps/screenpipe-app-tauri/components/chat/standalone/acp-config-selector.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/acp-config-selector.tsx
@@ -399,7 +399,6 @@ export function AcpEffortSelector({
       contentTestId="acp-effort-popover"
       open={open}
       onOpenChange={setOpen}
-      disabled={pending}
     >
       {isEffortOption(option) ? (
         <ComposerEffortSlider


### PR DESCRIPTION
## description

Keeps the ACP reasoning-effort trigger usable while an effort change is being applied. The slider itself remains temporarily locked to prevent duplicate writes, but the visible composer control no longer fades or becomes disabled after choosing Ultra.

Related issue: none

## AI assistance and human ownership

- AI tool(s) used: Codex
- autonomy level: agent
- what I personally verified: focused component tests, targeted ESLint, and the app TypeScript check

- [ ] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [ ] The problem statement, rationale, and replies to maintainers are my own.

## evidence type

- [x] UI or behavior change — automated regression coverage and all-state screenshot included
- [ ] Backend change — regression tests and relevant logs/results
- [ ] Performance change — reproducible before/after benchmarks
- [ ] Docs, CI, or pure refactor — relevant checks and an explanation; no video required

## before

Choosing an effort such as Ultra disabled and faded the whole composer effort trigger until the adapter write resolved.

## after

The trigger remains usable and visually stable. Only the open effort slider is temporarily locked while the write is in flight.

### all possible states

Low, Medium, High, Ultra, and Saving Ultra. In the saving state, the trigger remains enabled while only the slider is temporarily locked.

![Reasoning effort states: Low, Medium, High, Ultra, and Saving Ultra](https://github.com/screenpipe/screenpipe/releases/download/assets/pr-6479-effort-states.png)

## how to test

1. bun x vitest run components/chat/standalone/acp-config-selector.test.tsx components/chat/standalone/composer-effort-slider.test.tsx components/chat/standalone/composer-settings-popover.test.tsx — 26 passed
2. bun x eslint components/chat/standalone/acp-config-selector.tsx components/chat/standalone/acp-config-selector.test.tsx — passed
3. bun x tsc --noEmit --pretty false — passed

## desktop app checklist (if applicable)

No Tauri commands or generated Rust bindings changed.

- [ ] bun run bindings:generate (if bindings changed)
- [ ] bun run bindings:check
- [x] bun run typecheck (equivalent command: bun x tsc --noEmit --pretty false)
