### PR TITLE
fix(ai): keep silent reasoning streams connected

### DIFF
--- a/apps/screenpipe-app-tauri/lib/chat/__tests__/provider-errors.test.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/__tests__/provider-errors.test.ts
@@ -96,6 +96,20 @@ describe("provider error copy", () => {
     expect(msg?.toLowerCase()).not.toContain("ollama");
   });
 
+  it("maps Bun socket-close errors to retryable connectivity copy", () => {
+    const raw =
+      "The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()";
+    const presentation = buildProviderErrorPresentation(raw, {
+      provider: "pi",
+      model: "auto",
+    });
+
+    expect(presentation).toMatchObject({ kind: "provider", retryable: true });
+    expect(presentation?.message).toContain("screenpipe cloud");
+    expect(presentation?.message.toLowerCase()).toContain("try again");
+    expect(presentation?.message).not.toContain("verbose: true");
+  });
+
   it("maps the gateway TLS-handshake / send-request signatures the same way", () => {
     // exact strings observed reaching the app during the 2026-06-18 outage
     for (const raw of [

--- a/apps/screenpipe-app-tauri/lib/chat/provider-errors.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/provider-errors.ts
@@ -93,6 +93,7 @@ function isConnectionLikeError(errorStr: string): boolean {
     normalized.includes("connection error") ||
     normalized.includes("failed to fetch") ||
     normalized.includes("fetch failed") ||
+    normalized.includes("socket connection was closed unexpectedly") ||
     normalized.includes("econnrefused") ||
     normalized.includes("connection refused") ||
     // network/TLS signatures seen reaching the chat from the gateway, e.g. the


### PR DESCRIPTION
## Source

- User feedback: Windows 10, Screenpipe 2.6.68, Pi/Screenpipe Cloud chat
- Exact failures in the submitted log:
  - prompt sent 09:40:12, socket closed 09:41:19
  - prompt sent 09:45:52, socket closed 09:46:58
- Updater and gateway model-list requests succeeded around the failures, isolating this from a general offline state.

## Root cause

High-thinking models can remain silent for over a minute before visible text. Screenpipe forwarded only visible provider deltas, leaving the client connection byte-idle for roughly 67 seconds. The users network path then closed the otherwise healthy Bun fetch stream.

The previous revision only classified the resulting Bun error and improved its presentation. That did not make chat work.

## Fix

- Emit a protocol-valid SSE comment every 15 seconds while the provider stream is silent.
- Preserve provider bytes, final token usage, cancellation, and conservative cost settlement.
- Keep the Bun socket-close classifier as a fallback for genuine connection failures.

## Before / after

```text
Before: prompt -> provider thinking silently -> 67s idle socket close -> chat fails
After:  prompt -> SSE heartbeat every 15s -> provider output -> chat completes
```

## Tests

- `bun test src/test/stream-usage-tracker.unit.test.ts --timeout=10000` — 10 passed
- `bun test src/test --timeout=10000` — 758 passed
- `bunx tsc --noEmit` — passed
- `git diff --check` — passed

The regression holds a model stream silent, verifies heartbeat bytes arrive before the idle boundary, then verifies the real terminal event and usage arrive unchanged. Existing cancellation tests prove abandoned requests still cancel and settle correctly.

## Scope

The report came from Windows/Bun, but the defect is in the hosted SSE gateway. No desktop-native code changed, so a Windows VM build would not exercise the modified boundary.