### PR TITLE
feat(chat): add five evidence-shaped chart patterns

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat/charts/chart-marks.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/charts/chart-marks.tsx
@@ -101,7 +101,10 @@ export function StatChart({ spec, palette }: MarkProps<StatChartSpec>) {
 
 export function BarChart({ spec, palette }: MarkProps<BarChartSpec>) {
   const { tooltip, activeKey, show, hide } = useChartHover();
-  const maximum = Math.max(...spec.items.map((item) => Math.abs(item.value)), 0);
+  const maximum = Math.max(
+    ...spec.items.map((item) => Math.abs(item.value)),
+    0,
+  );
 
   return (
     <ChartFrame
@@ -249,7 +252,9 @@ export function LineChart({ spec, palette }: MarkProps<LineChartSpec>) {
             1,
             Math.max(0, (event.clientX - bounds.left) / bounds.width),
           );
-          setActiveIndex(Math.round(ratio * Math.max(0, spec.items.length - 1)));
+          setActiveIndex(
+            Math.round(ratio * Math.max(0, spec.items.length - 1)),
+          );
         }}
         onPointerLeave={() => setActiveIndex(null)}
       >
@@ -457,7 +462,10 @@ export function StackedBarChart({
                   style={{ width: `${rowWidth}%` }}
                 >
                   {spec.series.map((series, seriesIndex) => {
-                    const value = Math.max(0, series.values[categoryIndex] ?? 0);
+                    const value = Math.max(
+                      0,
+                      series.values[categoryIndex] ?? 0,
+                    );
                     if (value <= 0 || total <= 0) return null;
                     const key = `${categoryIndex}-${seriesIndex}`;
                     return (
@@ -795,29 +803,35 @@ function isoDate(date: Date): string {
   return date.toISOString().slice(0, 10);
 }
 
-export function CalendarChart({
-  spec,
-  palette,
-}: MarkProps<CalendarChartSpec>) {
+export function CalendarChart({ spec, palette }: MarkProps<CalendarChartSpec>) {
   const { tooltip, show, hide } = useChartHover();
   const geometry = useMemo(() => {
     const byDate = new Map(spec.items.map((item) => [item.date, item.value]));
     const first = new Date(`${spec.items[0].date}T00:00:00Z`);
-    const last = new Date(`${spec.items[spec.items.length - 1].date}T00:00:00Z`);
+    const last = new Date(
+      `${spec.items[spec.items.length - 1].date}T00:00:00Z`,
+    );
     const start = new Date(first);
     start.setUTCDate(start.getUTCDate() - ((start.getUTCDay() + 6) % 7));
     const end = new Date(last);
     end.setUTCDate(end.getUTCDate() + (6 - ((end.getUTCDay() + 6) % 7)));
     const cells: Array<{ date: string; value: number | null }> = [];
-    for (const cursor = new Date(start); cursor <= end; cursor.setUTCDate(cursor.getUTCDate() + 1)) {
+    for (
+      const cursor = new Date(start);
+      cursor <= end;
+      cursor.setUTCDate(cursor.getUTCDate() + 1)
+    ) {
       const date = isoDate(cursor);
       cells.push({ date, value: byDate.get(date) ?? null });
     }
     const values = spec.items.map((item) => item.value);
+    const total = values.reduce((sum, value) => sum + value, 0);
     return {
       cells,
       minimum: Math.min(...values),
       maximum: Math.max(...values),
+      average: total / values.length,
+      total,
       span: `${spec.items[0].date} – ${spec.items[spec.items.length - 1].date}`,
     };
   }, [spec.items]);
@@ -838,44 +852,72 @@ export function CalendarChart({
       }
     >
       <ChartTooltip state={tooltip} />
-      <div className="mb-1.5 flex items-center justify-between gap-3 text-[11px] text-muted-foreground">
-        <span>daily</span>
+      <div className="mb-2 flex items-center justify-between gap-3 text-[11px] text-muted-foreground">
         <span className="truncate tabular-nums">{geometry.span}</span>
+        <span className="shrink-0 tabular-nums">
+          {spec.items.length} recorded days
+        </span>
       </div>
-      <div className="grid grid-cols-7 gap-px text-center text-[10px] text-muted-foreground">
-        {WEEKDAYS.map((day, index) => (
-          <span key={`${day}-${index}`}>{day}</span>
-        ))}
-      </div>
-      <div className="mt-1 grid grid-cols-7 gap-px">
-        {geometry.cells.map((cell) => (
-          <span
-            key={cell.date}
-            className="h-5 transition-colors duration-150"
-            style={{
-              backgroundColor:
-                cell.value === null
-                  ? palette.track
-                  : magnitudeColor(
-                      palette,
-                      cell.value,
-                      geometry.minimum,
-                      geometry.maximum,
-                    ),
-            }}
-            onPointerMove={
-              cell.value === null
-                ? undefined
-                : (event) =>
-                    show(
-                      event,
-                      `${cell.date} · ${formatChartValue(cell.value!, spec.unit)}`,
-                      cell.date,
-                    )
-            }
-            onPointerLeave={cell.value === null ? undefined : hide}
-          />
-        ))}
+      <div className="flex flex-wrap items-end justify-between gap-x-6 gap-y-3">
+        <div className="min-w-0">
+          <div className="grid grid-cols-7 gap-px text-center text-[10px] text-muted-foreground">
+            {WEEKDAYS.map((day, index) => (
+              <span key={`${day}-${index}`} className="w-7">
+                {day}
+              </span>
+            ))}
+          </div>
+          <div className="mt-1 grid grid-cols-7 gap-px">
+            {geometry.cells.map((cell) => (
+              <span
+                key={cell.date}
+                className="h-7 w-7 transition-colors duration-150"
+                style={{
+                  backgroundColor:
+                    cell.value === null
+                      ? palette.track
+                      : magnitudeColor(
+                          palette,
+                          cell.value,
+                          geometry.minimum,
+                          geometry.maximum,
+                        ),
+                }}
+                onPointerMove={
+                  cell.value === null
+                    ? undefined
+                    : (event) =>
+                        show(
+                          event,
+                          `${cell.date} · ${formatChartValue(cell.value!, spec.unit)}`,
+                          cell.date,
+                        )
+                }
+                onPointerLeave={cell.value === null ? undefined : hide}
+              />
+            ))}
+          </div>
+        </div>
+        <dl className="grid min-w-[11rem] flex-1 grid-cols-3 divide-x divide-border text-right">
+          <div className="pr-3">
+            <dt className="text-[10px] text-muted-foreground">average</dt>
+            <dd className="mt-0.5 text-xs tabular-nums text-foreground">
+              {formatChartValue(geometry.average, spec.unit)}
+            </dd>
+          </div>
+          <div className="px-3">
+            <dt className="text-[10px] text-muted-foreground">peak</dt>
+            <dd className="mt-0.5 text-xs tabular-nums text-foreground">
+              {formatChartValue(geometry.maximum, spec.unit)}
+            </dd>
+          </div>
+          <div className="pl-3">
+            <dt className="text-[10px] text-muted-foreground">total</dt>
+            <dd className="mt-0.5 text-xs tabular-nums text-foreground">
+              {formatChartValue(geometry.total, spec.unit)}
+            </dd>
+          </div>
+        </dl>
       </div>
     </ChartFrame>
   );
@@ -913,30 +955,39 @@ export function FunnelChart({ spec, palette }: MarkProps<FunnelChartSpec>) {
       }
     >
       <ChartTooltip state={tooltip} />
-      <div className="space-y-2">
+      <div className="space-y-2.5">
         {spec.items.map((item, index) => {
           const key = String(index);
           const percent = (item.value / first) * 100;
+          const prior = index === 0 ? null : spec.items[index - 1].value;
+          const priorPercent =
+            prior === null || prior <= 0 ? 100 : (item.value / prior) * 100;
           return (
             <div
               key={`${item.label}-${index}`}
-              className="grid items-center gap-2.5"
-              style={{ gridTemplateColumns: `${LABEL_COL} 1fr 4.5rem` }}
+              className="grid items-center gap-x-2.5"
+              style={{ gridTemplateColumns: `1.5rem ${LABEL_COL} 1fr auto` }}
               onPointerMove={(event) =>
                 show(
                   event,
-                  `${item.label} · ${formatChartValue(item.value, spec.unit)} · ${Math.round(percent)}% of start`,
+                  `${item.label} · ${formatChartValue(item.value, spec.unit)} · ${Math.round(priorPercent)}% from prior · ${Math.round(percent)}% of start`,
                   key,
                 )
               }
               onPointerLeave={hide}
             >
+              <span className="text-[10px] tabular-nums text-muted-foreground">
+                {String(index + 1).padStart(2, "0")}
+              </span>
               <span className="truncate text-xs text-muted-foreground">
                 {item.label}
               </span>
-              <span className="block h-3 w-full" style={{ backgroundColor: palette.track }}>
+              <span
+                className="block h-1.5 w-full"
+                style={{ backgroundColor: palette.track }}
+              >
                 <span
-                  className="mx-auto block h-full transition-colors duration-150"
+                  className="block h-full transition-colors duration-150"
                   style={{
                     width: `${percent}%`,
                     minWidth: item.value > 0 ? 2 : 0,
@@ -947,8 +998,13 @@ export function FunnelChart({ spec, palette }: MarkProps<FunnelChartSpec>) {
                   }}
                 />
               </span>
-              <span className="text-right text-xs tabular-nums text-foreground">
-                {formatChartValue(item.value, spec.unit)}
+              <span className="flex min-w-[7.5rem] items-baseline justify-end gap-2 text-right tabular-nums">
+                <span className="text-xs text-foreground">
+                  {formatChartValue(item.value, spec.unit)}
+                </span>
+                <span className="w-14 text-[10px] text-muted-foreground">
+                  {index === 0 ? "start" : `${Math.round(priorPercent)}% prior`}
+                </span>
               </span>
             </div>
           );
@@ -1009,7 +1065,14 @@ export function WaterfallChart({
     const maximum = Math.max(...endpoints);
     const spread = maximum > minimum ? maximum - minimum : 1;
     const position = (value: number) => ((maximum - value) / spread) * 100;
-    return { steps, minimum, maximum, position };
+    return {
+      steps,
+      minimum,
+      maximum,
+      ending: running,
+      net: running - spec.start.value,
+      position,
+    };
   }, [spec.items, spec.start]);
 
   return (
@@ -1033,14 +1096,19 @@ export function WaterfallChart({
       }
     >
       <ChartTooltip state={tooltip} />
-      <div className="mb-1 flex items-center justify-between text-[11px] tabular-nums text-muted-foreground">
-        <span>scale</span>
-        <span>
-          {formatChartValue(geometry.minimum, spec.unit)}–
-          {formatChartValue(geometry.maximum, spec.unit)}
+      <div className="mb-2 flex items-baseline justify-between gap-3 tabular-nums">
+        <span className="flex items-baseline gap-2 text-xs text-foreground">
+          <span>{formatChartValue(spec.start.value, spec.unit)}</span>
+          <span aria-hidden="true" className="text-muted-foreground">
+            →
+          </span>
+          <span>{formatChartValue(geometry.ending, spec.unit)}</span>
+        </span>
+        <span className="text-[11px] text-muted-foreground">
+          {signedChartValue(geometry.net, spec.unit)} net
         </span>
       </div>
-      <div className="relative flex h-36 items-stretch gap-1.5">
+      <div className="relative flex h-28 items-stretch gap-1.5">
         <span
           aria-hidden="true"
           className="pointer-events-none absolute inset-x-0 border-t border-border"
@@ -1048,13 +1116,33 @@ export function WaterfallChart({
         />
         {geometry.steps.map((step, index) => {
           const key = String(index);
-          const top = Math.min(geometry.position(step.from), geometry.position(step.to));
-          const bottom = Math.max(geometry.position(step.from), geometry.position(step.to));
+          const top = Math.min(
+            geometry.position(step.from),
+            geometry.position(step.to),
+          );
+          const bottom = Math.max(
+            geometry.position(step.from),
+            geometry.position(step.to),
+          );
           return (
-            <div key={`${step.label}-${index}`} className="relative min-w-0 flex-1">
+            <div
+              key={`${step.label}-${index}`}
+              className="relative min-w-0 flex-1"
+            >
+              {index < geometry.steps.length - 1 ? (
+                <span
+                  data-waterfall-connector
+                  aria-hidden="true"
+                  className="pointer-events-none absolute left-1/2 z-0 border-t border-border"
+                  style={{
+                    top: `${geometry.position(step.to)}%`,
+                    width: "calc(100% + 0.375rem)",
+                  }}
+                />
+              ) : null}
               <span
                 data-waterfall-bar
-                className="absolute inset-x-1 transition-colors duration-150"
+                className="absolute inset-x-1 z-[1] transition-colors duration-150"
                 style={{
                   top: `${top}%`,
                   height: `${Math.max(bottom - top, 1.5)}%`,
@@ -1063,7 +1151,7 @@ export function WaterfallChart({
                       ? palette.focus
                       : step.kind === "total"
                         ? seriesColor(palette, 0, 2)
-                        : palette.single,
+                        : seriesColor(palette, step.delta >= 0 ? 1 : 2, 3),
                 }}
                 onPointerMove={(event) =>
                   show(
@@ -1076,19 +1164,29 @@ export function WaterfallChart({
                 }
                 onPointerLeave={hide}
               />
-              <span className="absolute inset-x-0 bottom-0 translate-y-full truncate pt-1 text-center text-[10px] text-muted-foreground">
-                {step.label}
-              </span>
             </div>
           );
         })}
       </div>
-      <div className="mt-4 grid gap-1.5" style={{ gridTemplateColumns: `repeat(${geometry.steps.length}, minmax(0, 1fr))` }}>
+      <div
+        className="mt-1.5 grid gap-1.5"
+        style={{
+          gridTemplateColumns: `repeat(${geometry.steps.length}, minmax(0, 1fr))`,
+        }}
+      >
         {geometry.steps.map((step, index) => (
-          <span key={`${step.label}-value-${index}`} className="truncate text-center text-[10px] tabular-nums text-foreground">
-            {step.kind === "change"
-              ? signedChartValue(step.delta, spec.unit)
-              : formatChartValue(step.total, spec.unit)}
+          <span
+            key={`${step.label}-value-${index}`}
+            className="flex min-w-0 flex-col items-center text-center text-[10px] tabular-nums"
+          >
+            <span className="max-w-full truncate text-muted-foreground">
+              {step.label}
+            </span>
+            <span className="text-foreground">
+              {step.kind === "change"
+                ? signedChartValue(step.delta, spec.unit)
+                : formatChartValue(step.total, spec.unit)}
+            </span>
           </span>
         ))}
       </div>
@@ -1141,7 +1239,9 @@ export function RangeChart({ spec, palette }: MarkProps<RangeChartSpec>) {
               onPointerMove={(event) => show(event, text, key)}
               onPointerLeave={hide}
             >
-              <span className="truncate text-xs text-muted-foreground">{item.label}</span>
+              <span className="truncate text-xs text-muted-foreground">
+                {item.label}
+              </span>
               <span className="relative block h-3">
                 <span className="absolute left-0 right-0 top-1/2 border-t border-border" />
                 <span
@@ -1149,24 +1249,45 @@ export function RangeChart({ spec, palette }: MarkProps<RangeChartSpec>) {
                   style={{
                     left: `${left}%`,
                     width: `${Math.max(width, 0.5)}%`,
-                    backgroundColor: activeKey === key ? palette.focus : palette.single,
+                    backgroundColor:
+                      activeKey === key ? palette.focus : palette.single,
                   }}
                 />
-                <span className="absolute top-1/2 h-2 w-0.5 -translate-x-1/2 -translate-y-1/2" style={{ left: `${left}%`, backgroundColor: palette.single }} />
-                <span className="absolute top-1/2 h-2 w-0.5 -translate-x-1/2 -translate-y-1/2" style={{ left: `${left + width}%`, backgroundColor: palette.single }} />
+                <span
+                  className="absolute top-1/2 h-2 w-0.5 -translate-x-1/2 -translate-y-1/2"
+                  style={{ left: `${left}%`, backgroundColor: palette.single }}
+                />
+                <span
+                  className="absolute top-1/2 h-2 w-0.5 -translate-x-1/2 -translate-y-1/2"
+                  style={{
+                    left: `${left + width}%`,
+                    backgroundColor: palette.single,
+                  }}
+                />
                 {item.mid !== null ? (
                   <span
                     className="absolute top-1/2 h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 border"
                     style={{
                       left: `${position(item.mid)}%`,
                       borderColor: palette.surface,
-                      backgroundColor: activeKey === key ? palette.focus : seriesColor(palette, 0, 2),
+                      backgroundColor:
+                        activeKey === key
+                          ? palette.focus
+                          : seriesColor(palette, 0, 2),
                     }}
                   />
                 ) : null}
               </span>
-              <span className="text-right text-[11px] tabular-nums text-foreground">
-                {formatChartValue(item.min, spec.unit)}–{formatChartValue(item.max, spec.unit)}
+              <span className="flex min-w-[7rem] flex-col text-right tabular-nums">
+                <span className="text-xs text-foreground">
+                  {item.mid === null
+                    ? formatChartValue(item.max, spec.unit)
+                    : formatChartValue(item.mid, spec.unit)}
+                </span>
+                <span className="text-[10px] text-muted-foreground">
+                  {formatChartValue(item.min, spec.unit)}–
+                  {formatChartValue(item.max, spec.unit)}
+                </span>
               </span>
             </div>
           );
@@ -1198,7 +1319,8 @@ export function ScatterChart({ spec, palette }: MarkProps<ScatterChartSpec>) {
     return { minX, maxX, minY, maxY, spreadX, spreadY, coordinates };
   }, [spec.items]);
   const active = activeIndex === null ? null : spec.items[activeIndex];
-  const activeCoordinate = activeIndex === null ? null : geometry.coordinates[activeIndex];
+  const activeCoordinate =
+    activeIndex === null ? null : geometry.coordinates[activeIndex];
 
   return (
     <ChartFrame
@@ -1224,14 +1346,17 @@ export function ScatterChart({ spec, palette }: MarkProps<ScatterChartSpec>) {
             ? active.label
             : `${spec.yLabel} ${formatChartValue(geometry.minY, spec.yUnit)}–${formatChartValue(geometry.maxY, spec.yUnit)} ↑`}
         </span>
-        <span className="shrink-0 tabular-nums text-foreground" aria-live="polite">
+        <span
+          className="shrink-0 tabular-nums text-foreground"
+          aria-live="polite"
+        >
           {active
             ? `${formatChartValue(active.x, spec.xUnit)} · ${formatChartValue(active.y, spec.yUnit)}`
             : `${spec.items.length} points`}
         </span>
       </div>
       <div
-        className="relative h-40 w-full"
+        className="relative h-32 w-full"
         onPointerMove={(event) => {
           const bounds = event.currentTarget.getBoundingClientRect();
           if (bounds.width <= 0 || bounds.height <= 0) return;
@@ -1250,13 +1375,71 @@ export function ScatterChart({ spec, palette }: MarkProps<ScatterChartSpec>) {
         }}
         onPointerLeave={() => setActiveIndex(null)}
       >
-        <svg role="img" aria-label={`${spec.title || "scatter"} plot`} viewBox="0 0 100 100" preserveAspectRatio="none" className="h-full w-full">
-          <line x1="6" x2="94" y1="94" y2="94" stroke={palette.grid} strokeWidth="1" vectorEffect="non-scaling-stroke" />
-          <line x1="6" x2="6" y1="6" y2="94" stroke={palette.grid} strokeWidth="1" vectorEffect="non-scaling-stroke" />
+        <svg
+          role="img"
+          aria-label={`${spec.title || "scatter"} plot`}
+          viewBox="0 0 100 100"
+          preserveAspectRatio="none"
+          className="h-full w-full"
+        >
+          <line
+            x1="6"
+            x2="94"
+            y1="94"
+            y2="94"
+            stroke={palette.grid}
+            strokeWidth="1"
+            vectorEffect="non-scaling-stroke"
+          />
+          <line
+            x1="6"
+            x2="6"
+            y1="6"
+            y2="94"
+            stroke={palette.grid}
+            strokeWidth="1"
+            vectorEffect="non-scaling-stroke"
+          />
+          <line
+            x1="50"
+            x2="50"
+            y1="6"
+            y2="94"
+            stroke={palette.grid}
+            strokeWidth="1"
+            strokeDasharray="2 2"
+            vectorEffect="non-scaling-stroke"
+          />
+          <line
+            x1="6"
+            x2="94"
+            y1="50"
+            y2="50"
+            stroke={palette.grid}
+            strokeWidth="1"
+            strokeDasharray="2 2"
+            vectorEffect="non-scaling-stroke"
+          />
           {activeCoordinate ? (
             <>
-              <line x1={activeCoordinate.x} x2={activeCoordinate.x} y1="6" y2="94" stroke={palette.grid} strokeWidth="1" vectorEffect="non-scaling-stroke" />
-              <line x1="6" x2="94" y1={activeCoordinate.y} y2={activeCoordinate.y} stroke={palette.grid} strokeWidth="1" vectorEffect="non-scaling-stroke" />
+              <line
+                x1={activeCoordinate.x}
+                x2={activeCoordinate.x}
+                y1="6"
+                y2="94"
+                stroke={palette.grid}
+                strokeWidth="1"
+                vectorEffect="non-scaling-stroke"
+              />
+              <line
+                x1="6"
+                x2="94"
+                y1={activeCoordinate.y}
+                y2={activeCoordinate.y}
+                stroke={palette.grid}
+                strokeWidth="1"
+                vectorEffect="non-scaling-stroke"
+              />
             </>
           ) : null}
         </svg>
@@ -1264,15 +1447,18 @@ export function ScatterChart({ spec, palette }: MarkProps<ScatterChartSpec>) {
           <span
             key={`${spec.items[index].label}-${index}`}
             aria-hidden="true"
-            className="pointer-events-none absolute h-2 w-2 -translate-x-1/2 -translate-y-1/2 border transition-colors duration-150"
+            className="pointer-events-none absolute flex h-3 w-3 -translate-x-1/2 -translate-y-1/2 items-center justify-center border text-[8px] tabular-nums transition-colors duration-150"
             style={{
               left: `${point.x}%`,
               top: `${point.y}%`,
               borderColor: palette.surface,
+              color: palette.surface,
               backgroundColor:
                 activeIndex === index ? palette.focus : palette.single,
             }}
-          />
+          >
+            {index < 9 ? index + 1 : ""}
+          </span>
         ))}
       </div>
       <div className="mt-1 flex items-center justify-between gap-3 text-[11px] text-muted-foreground">
@@ -1280,6 +1466,37 @@ export function ScatterChart({ spec, palette }: MarkProps<ScatterChartSpec>) {
         <span className="truncate">{spec.xLabel} →</span>
         <span>{formatChartValue(geometry.maxX, spec.xUnit)}</span>
       </div>
+      <ul className="mt-2 grid grid-cols-2 gap-x-4 gap-y-1 border-t border-border pt-2">
+        {spec.items.slice(0, 6).map((item, index) => (
+          <li
+            key={`${item.label}-key-${index}`}
+            className="flex min-w-0 items-center gap-1.5 text-[10px]"
+          >
+            <span
+              aria-hidden="true"
+              className="flex h-3 w-3 shrink-0 items-center justify-center text-[8px] tabular-nums"
+              style={{
+                color: palette.surface,
+                backgroundColor: palette.single,
+              }}
+            >
+              {index + 1}
+            </span>
+            <span className="min-w-0 flex-1 truncate text-muted-foreground">
+              {item.label}
+            </span>
+            <span className="shrink-0 tabular-nums text-foreground">
+              {formatChartValue(item.x, spec.xUnit)} ·{" "}
+              {formatChartValue(item.y, spec.yUnit)}
+            </span>
+          </li>
+        ))}
+      </ul>
+      {spec.items.length > 6 ? (
+        <div className="mt-1 text-right text-[10px] text-muted-foreground">
+          +{spec.items.length - 6} more · hover to inspect
+        </div>
+      ) : null}
     </ChartFrame>
   );
 }

--- a/apps/screenpipe-app-tauri/components/chat/charts/chart-marks.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/charts/chart-marks.tsx
@@ -7,7 +7,7 @@
 /**
  * The marks for each chart type.
  *
- * All eight consume typed values from `chart-spec.ts` and colours from
+ * All thirteen consume typed values from `chart-spec.ts` and colours from
  * `chart-palette.ts`. Text is rendered as React children, so model output is
  * escaped by construction; nothing here builds markup from a string.
  *
@@ -21,13 +21,18 @@ import {
   formatChartValue,
   formatClock,
   type BarChartSpec,
+  type CalendarChartSpec,
+  type FunnelChartSpec,
   type GroupedBarChartSpec,
   type HeatmapChartSpec,
   type LineChartSpec,
   type ProportionChartSpec,
+  type RangeChartSpec,
+  type ScatterChartSpec,
   type StackedBarChartSpec,
   type StatChartSpec,
   type TimelineChartSpec,
+  type WaterfallChartSpec,
 } from "./chart-spec";
 import {
   magnitudeColor,
@@ -775,6 +780,505 @@ export function TimelineChart({ spec, palette }: MarkProps<TimelineChartSpec>) {
             <span>{formatClock(axisEnd)}</span>
           </span>
         </div>
+      </div>
+    </ChartFrame>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// calendar — daily magnitude on a familiar Monday–Sunday grid
+// ---------------------------------------------------------------------------
+
+const WEEKDAYS = ["mo", "tu", "we", "th", "fr", "sa", "su"] as const;
+
+function isoDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+export function CalendarChart({
+  spec,
+  palette,
+}: MarkProps<CalendarChartSpec>) {
+  const { tooltip, show, hide } = useChartHover();
+  const geometry = useMemo(() => {
+    const byDate = new Map(spec.items.map((item) => [item.date, item.value]));
+    const first = new Date(`${spec.items[0].date}T00:00:00Z`);
+    const last = new Date(`${spec.items[spec.items.length - 1].date}T00:00:00Z`);
+    const start = new Date(first);
+    start.setUTCDate(start.getUTCDate() - ((start.getUTCDay() + 6) % 7));
+    const end = new Date(last);
+    end.setUTCDate(end.getUTCDate() + (6 - ((end.getUTCDay() + 6) % 7)));
+    const cells: Array<{ date: string; value: number | null }> = [];
+    for (const cursor = new Date(start); cursor <= end; cursor.setUTCDate(cursor.getUTCDate() + 1)) {
+      const date = isoDate(cursor);
+      cells.push({ date, value: byDate.get(date) ?? null });
+    }
+    const values = spec.items.map((item) => item.value);
+    return {
+      cells,
+      minimum: Math.min(...values),
+      maximum: Math.max(...values),
+      span: `${spec.items[0].date} – ${spec.items[spec.items.length - 1].date}`,
+    };
+  }, [spec.items]);
+
+  return (
+    <ChartFrame
+      spec={spec}
+      palette={palette}
+      table={
+        <DataTable
+          caption={spec.title || "calendar"}
+          columns={["date", "value"]}
+          rows={spec.items.map((item) => ({
+            header: item.date,
+            cells: [formatChartValue(item.value, spec.unit)],
+          }))}
+        />
+      }
+    >
+      <ChartTooltip state={tooltip} />
+      <div className="mb-1.5 flex items-center justify-between gap-3 text-[11px] text-muted-foreground">
+        <span>daily</span>
+        <span className="truncate tabular-nums">{geometry.span}</span>
+      </div>
+      <div className="grid grid-cols-7 gap-px text-center text-[10px] text-muted-foreground">
+        {WEEKDAYS.map((day, index) => (
+          <span key={`${day}-${index}`}>{day}</span>
+        ))}
+      </div>
+      <div className="mt-1 grid grid-cols-7 gap-px">
+        {geometry.cells.map((cell) => (
+          <span
+            key={cell.date}
+            className="h-5 transition-colors duration-150"
+            style={{
+              backgroundColor:
+                cell.value === null
+                  ? palette.track
+                  : magnitudeColor(
+                      palette,
+                      cell.value,
+                      geometry.minimum,
+                      geometry.maximum,
+                    ),
+            }}
+            onPointerMove={
+              cell.value === null
+                ? undefined
+                : (event) =>
+                    show(
+                      event,
+                      `${cell.date} · ${formatChartValue(cell.value!, spec.unit)}`,
+                      cell.date,
+                    )
+            }
+            onPointerLeave={cell.value === null ? undefined : hide}
+          />
+        ))}
+      </div>
+    </ChartFrame>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// funnel — ordered stages with honest conversion between each step
+// ---------------------------------------------------------------------------
+
+export function FunnelChart({ spec, palette }: MarkProps<FunnelChartSpec>) {
+  const { tooltip, activeKey, show, hide } = useChartHover();
+  const first = spec.items[0].value;
+
+  return (
+    <ChartFrame
+      spec={spec}
+      palette={palette}
+      table={
+        <DataTable
+          caption={spec.title || "funnel"}
+          columns={["stage", "value", "from prior", "from start"]}
+          rows={spec.items.map((item, index) => ({
+            header: item.label,
+            cells: [
+              formatChartValue(item.value, spec.unit),
+              index === 0
+                ? "100%"
+                : spec.items[index - 1].value <= 0
+                  ? "—"
+                  : `${Math.round((item.value / spec.items[index - 1].value) * 100)}%`,
+              `${Math.round((item.value / first) * 100)}%`,
+            ],
+          }))}
+        />
+      }
+    >
+      <ChartTooltip state={tooltip} />
+      <div className="space-y-2">
+        {spec.items.map((item, index) => {
+          const key = String(index);
+          const percent = (item.value / first) * 100;
+          return (
+            <div
+              key={`${item.label}-${index}`}
+              className="grid items-center gap-2.5"
+              style={{ gridTemplateColumns: `${LABEL_COL} 1fr 4.5rem` }}
+              onPointerMove={(event) =>
+                show(
+                  event,
+                  `${item.label} · ${formatChartValue(item.value, spec.unit)} · ${Math.round(percent)}% of start`,
+                  key,
+                )
+              }
+              onPointerLeave={hide}
+            >
+              <span className="truncate text-xs text-muted-foreground">
+                {item.label}
+              </span>
+              <span className="block h-3 w-full" style={{ backgroundColor: palette.track }}>
+                <span
+                  className="mx-auto block h-full transition-colors duration-150"
+                  style={{
+                    width: `${percent}%`,
+                    minWidth: item.value > 0 ? 2 : 0,
+                    backgroundColor:
+                      activeKey === key
+                        ? palette.focus
+                        : seriesColor(palette, index, spec.items.length),
+                  }}
+                />
+              </span>
+              <span className="text-right text-xs tabular-nums text-foreground">
+                {formatChartValue(item.value, spec.unit)}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </ChartFrame>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// waterfall — starting total, signed changes, and the computed ending total
+// ---------------------------------------------------------------------------
+
+function signedChartValue(value: number, unit: string): string {
+  const formatted = formatChartValue(Math.abs(value), unit);
+  return value > 0 ? `+${formatted}` : value < 0 ? `−${formatted}` : formatted;
+}
+
+export function WaterfallChart({
+  spec,
+  palette,
+}: MarkProps<WaterfallChartSpec>) {
+  const { tooltip, activeKey, show, hide } = useChartHover();
+  const geometry = useMemo(() => {
+    let running = spec.start.value;
+    const steps = [
+      {
+        label: spec.start.label,
+        delta: spec.start.value,
+        from: 0,
+        to: spec.start.value,
+        total: spec.start.value,
+        kind: "total" as const,
+      },
+      ...spec.items.map((item) => {
+        const from = running;
+        running += item.value;
+        return {
+          label: item.label,
+          delta: item.value,
+          from,
+          to: running,
+          total: running,
+          kind: "change" as const,
+        };
+      }),
+      {
+        label: "total",
+        delta: running,
+        from: 0,
+        to: running,
+        total: running,
+        kind: "total" as const,
+      },
+    ];
+    const endpoints = steps.flatMap((step) => [step.from, step.to, 0]);
+    const minimum = Math.min(...endpoints);
+    const maximum = Math.max(...endpoints);
+    const spread = maximum > minimum ? maximum - minimum : 1;
+    const position = (value: number) => ((maximum - value) / spread) * 100;
+    return { steps, minimum, maximum, position };
+  }, [spec.items, spec.start]);
+
+  return (
+    <ChartFrame
+      spec={spec}
+      palette={palette}
+      table={
+        <DataTable
+          caption={spec.title || "waterfall"}
+          columns={["step", "change", "running total"]}
+          rows={geometry.steps.map((step) => ({
+            header: step.label,
+            cells: [
+              step.kind === "change"
+                ? signedChartValue(step.delta, spec.unit)
+                : "—",
+              formatChartValue(step.total, spec.unit),
+            ],
+          }))}
+        />
+      }
+    >
+      <ChartTooltip state={tooltip} />
+      <div className="mb-1 flex items-center justify-between text-[11px] tabular-nums text-muted-foreground">
+        <span>scale</span>
+        <span>
+          {formatChartValue(geometry.minimum, spec.unit)}–
+          {formatChartValue(geometry.maximum, spec.unit)}
+        </span>
+      </div>
+      <div className="relative flex h-36 items-stretch gap-1.5">
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-x-0 border-t border-border"
+          style={{ top: `${geometry.position(0)}%` }}
+        />
+        {geometry.steps.map((step, index) => {
+          const key = String(index);
+          const top = Math.min(geometry.position(step.from), geometry.position(step.to));
+          const bottom = Math.max(geometry.position(step.from), geometry.position(step.to));
+          return (
+            <div key={`${step.label}-${index}`} className="relative min-w-0 flex-1">
+              <span
+                data-waterfall-bar
+                className="absolute inset-x-1 transition-colors duration-150"
+                style={{
+                  top: `${top}%`,
+                  height: `${Math.max(bottom - top, 1.5)}%`,
+                  backgroundColor:
+                    activeKey === key
+                      ? palette.focus
+                      : step.kind === "total"
+                        ? seriesColor(palette, 0, 2)
+                        : palette.single,
+                }}
+                onPointerMove={(event) =>
+                  show(
+                    event,
+                    step.kind === "change"
+                      ? `${step.label} · ${signedChartValue(step.delta, spec.unit)} · total ${formatChartValue(step.total, spec.unit)}`
+                      : `${step.label} · ${formatChartValue(step.total, spec.unit)}`,
+                    key,
+                  )
+                }
+                onPointerLeave={hide}
+              />
+              <span className="absolute inset-x-0 bottom-0 translate-y-full truncate pt-1 text-center text-[10px] text-muted-foreground">
+                {step.label}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+      <div className="mt-4 grid gap-1.5" style={{ gridTemplateColumns: `repeat(${geometry.steps.length}, minmax(0, 1fr))` }}>
+        {geometry.steps.map((step, index) => (
+          <span key={`${step.label}-value-${index}`} className="truncate text-center text-[10px] tabular-nums text-foreground">
+            {step.kind === "change"
+              ? signedChartValue(step.delta, spec.unit)
+              : formatChartValue(step.total, spec.unit)}
+          </span>
+        ))}
+      </div>
+    </ChartFrame>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// range — low/high interval with an optional typical or target marker
+// ---------------------------------------------------------------------------
+
+export function RangeChart({ spec, palette }: MarkProps<RangeChartSpec>) {
+  const { tooltip, activeKey, show, hide } = useChartHover();
+  const minimum = Math.min(...spec.items.map((item) => item.min));
+  const maximum = Math.max(...spec.items.map((item) => item.max));
+  const spread = maximum > minimum ? maximum - minimum : 1;
+  const position = (value: number) => ((value - minimum) / spread) * 100;
+
+  return (
+    <ChartFrame
+      spec={spec}
+      palette={palette}
+      table={
+        <DataTable
+          caption={spec.title || "range"}
+          columns={["label", "minimum", "middle", "maximum"]}
+          rows={spec.items.map((item) => ({
+            header: item.label,
+            cells: [
+              formatChartValue(item.min, spec.unit),
+              item.mid === null ? "—" : formatChartValue(item.mid, spec.unit),
+              formatChartValue(item.max, spec.unit),
+            ],
+          }))}
+        />
+      }
+    >
+      <ChartTooltip state={tooltip} />
+      <div className="space-y-2.5">
+        {spec.items.map((item, index) => {
+          const key = String(index);
+          const left = position(item.min);
+          const width = position(item.max) - left;
+          const text = `${item.label} · ${formatChartValue(item.min, spec.unit)}–${formatChartValue(item.max, spec.unit)}${item.mid === null ? "" : ` · middle ${formatChartValue(item.mid, spec.unit)}`}`;
+          return (
+            <div
+              key={`${item.label}-${index}`}
+              className="grid items-center gap-2.5"
+              style={{ gridTemplateColumns: `${LABEL_COL} 1fr 6rem` }}
+              onPointerMove={(event) => show(event, text, key)}
+              onPointerLeave={hide}
+            >
+              <span className="truncate text-xs text-muted-foreground">{item.label}</span>
+              <span className="relative block h-3">
+                <span className="absolute left-0 right-0 top-1/2 border-t border-border" />
+                <span
+                  className="absolute top-1/2 h-0.5 -translate-y-1/2 transition-colors duration-150"
+                  style={{
+                    left: `${left}%`,
+                    width: `${Math.max(width, 0.5)}%`,
+                    backgroundColor: activeKey === key ? palette.focus : palette.single,
+                  }}
+                />
+                <span className="absolute top-1/2 h-2 w-0.5 -translate-x-1/2 -translate-y-1/2" style={{ left: `${left}%`, backgroundColor: palette.single }} />
+                <span className="absolute top-1/2 h-2 w-0.5 -translate-x-1/2 -translate-y-1/2" style={{ left: `${left + width}%`, backgroundColor: palette.single }} />
+                {item.mid !== null ? (
+                  <span
+                    className="absolute top-1/2 h-2.5 w-2.5 -translate-x-1/2 -translate-y-1/2 border"
+                    style={{
+                      left: `${position(item.mid)}%`,
+                      borderColor: palette.surface,
+                      backgroundColor: activeKey === key ? palette.focus : seriesColor(palette, 0, 2),
+                    }}
+                  />
+                ) : null}
+              </span>
+              <span className="text-right text-[11px] tabular-nums text-foreground">
+                {formatChartValue(item.min, spec.unit)}–{formatChartValue(item.max, spec.unit)}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </ChartFrame>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// scatter — two numeric dimensions with a nearest-point crosshair readout
+// ---------------------------------------------------------------------------
+
+export function ScatterChart({ spec, palette }: MarkProps<ScatterChartSpec>) {
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const geometry = useMemo(() => {
+    const xs = spec.items.map((item) => item.x);
+    const ys = spec.items.map((item) => item.y);
+    const minX = Math.min(...xs);
+    const maxX = Math.max(...xs);
+    const minY = Math.min(...ys);
+    const maxY = Math.max(...ys);
+    const spreadX = maxX > minX ? maxX - minX : 1;
+    const spreadY = maxY > minY ? maxY - minY : 1;
+    const coordinates = spec.items.map((item) => ({
+      x: 6 + ((item.x - minX) / spreadX) * 88,
+      y: 94 - ((item.y - minY) / spreadY) * 88,
+    }));
+    return { minX, maxX, minY, maxY, spreadX, spreadY, coordinates };
+  }, [spec.items]);
+  const active = activeIndex === null ? null : spec.items[activeIndex];
+  const activeCoordinate = activeIndex === null ? null : geometry.coordinates[activeIndex];
+
+  return (
+    <ChartFrame
+      spec={spec}
+      palette={palette}
+      table={
+        <DataTable
+          caption={spec.title || "scatter"}
+          columns={["label", spec.xLabel, spec.yLabel]}
+          rows={spec.items.map((item) => ({
+            header: item.label,
+            cells: [
+              formatChartValue(item.x, spec.xUnit),
+              formatChartValue(item.y, spec.yUnit),
+            ],
+          }))}
+        />
+      }
+    >
+      <div className="mb-1.5 flex min-h-5 items-baseline justify-between gap-3 text-xs">
+        <span className="truncate text-muted-foreground">
+          {active
+            ? active.label
+            : `${spec.yLabel} ${formatChartValue(geometry.minY, spec.yUnit)}–${formatChartValue(geometry.maxY, spec.yUnit)} ↑`}
+        </span>
+        <span className="shrink-0 tabular-nums text-foreground" aria-live="polite">
+          {active
+            ? `${formatChartValue(active.x, spec.xUnit)} · ${formatChartValue(active.y, spec.yUnit)}`
+            : `${spec.items.length} points`}
+        </span>
+      </div>
+      <div
+        className="relative h-40 w-full"
+        onPointerMove={(event) => {
+          const bounds = event.currentTarget.getBoundingClientRect();
+          if (bounds.width <= 0 || bounds.height <= 0) return;
+          const x = ((event.clientX - bounds.left) / bounds.width) * 100;
+          const y = ((event.clientY - bounds.top) / bounds.height) * 100;
+          let nearest = 0;
+          let distance = Number.POSITIVE_INFINITY;
+          geometry.coordinates.forEach((point, index) => {
+            const next = (point.x - x) ** 2 + (point.y - y) ** 2;
+            if (next < distance) {
+              nearest = index;
+              distance = next;
+            }
+          });
+          setActiveIndex(nearest);
+        }}
+        onPointerLeave={() => setActiveIndex(null)}
+      >
+        <svg role="img" aria-label={`${spec.title || "scatter"} plot`} viewBox="0 0 100 100" preserveAspectRatio="none" className="h-full w-full">
+          <line x1="6" x2="94" y1="94" y2="94" stroke={palette.grid} strokeWidth="1" vectorEffect="non-scaling-stroke" />
+          <line x1="6" x2="6" y1="6" y2="94" stroke={palette.grid} strokeWidth="1" vectorEffect="non-scaling-stroke" />
+          {activeCoordinate ? (
+            <>
+              <line x1={activeCoordinate.x} x2={activeCoordinate.x} y1="6" y2="94" stroke={palette.grid} strokeWidth="1" vectorEffect="non-scaling-stroke" />
+              <line x1="6" x2="94" y1={activeCoordinate.y} y2={activeCoordinate.y} stroke={palette.grid} strokeWidth="1" vectorEffect="non-scaling-stroke" />
+            </>
+          ) : null}
+        </svg>
+        {geometry.coordinates.map((point, index) => (
+          <span
+            key={`${spec.items[index].label}-${index}`}
+            aria-hidden="true"
+            className="pointer-events-none absolute h-2 w-2 -translate-x-1/2 -translate-y-1/2 border transition-colors duration-150"
+            style={{
+              left: `${point.x}%`,
+              top: `${point.y}%`,
+              borderColor: palette.surface,
+              backgroundColor:
+                activeIndex === index ? palette.focus : palette.single,
+            }}
+          />
+        ))}
+      </div>
+      <div className="mt-1 flex items-center justify-between gap-3 text-[11px] text-muted-foreground">
+        <span>{formatChartValue(geometry.minX, spec.xUnit)}</span>
+        <span className="truncate">{spec.xLabel} →</span>
+        <span>{formatChartValue(geometry.maxX, spec.xUnit)}</span>
       </div>
     </ChartFrame>
   );

--- a/apps/screenpipe-app-tauri/components/chat/charts/chart-prompt-contract.test.ts
+++ b/apps/screenpipe-app-tauri/components/chat/charts/chart-prompt-contract.test.ts
@@ -61,6 +61,11 @@ describe("chart system prompt contract", () => {
       ["line", CHART_LIMITS.lineItems],
       ["proportion", CHART_LIMITS.proportionItems],
       ["timeline", CHART_LIMITS.timelineItems],
+      ["calendar", CHART_LIMITS.calendarItems],
+      ["funnel", CHART_LIMITS.funnelItems],
+      ["waterfall", CHART_LIMITS.waterfallItems],
+      ["range", CHART_LIMITS.rangeItems],
+      ["scatter", CHART_LIMITS.scatterItems],
     ];
     for (const [type, cap] of caps) {
       const row = section
@@ -91,8 +96,8 @@ describe("chart system prompt contract", () => {
 
   it("stays small enough to earn a permanent seat in context", () => {
     // Guard against the section growing back into a per-type example dump.
-    expect(section.length).toBeLessThan(2200);
-    expect(section.length / CHART_TYPES.length).toBeLessThan(300);
+    expect(section.length).toBeLessThan(2900);
+    expect(section.length / CHART_TYPES.length).toBeLessThan(225);
   });
 
   it("carries exactly one worked example, not one per type", () => {

--- a/apps/screenpipe-app-tauri/components/chat/charts/chart-spec.test.ts
+++ b/apps/screenpipe-app-tauri/components/chat/charts/chart-spec.test.ts
@@ -350,6 +350,134 @@ describe("parseChartSpec — grouped_bar", () => {
   });
 });
 
+describe("parseChartSpec — calendar", () => {
+  it("parses and sorts unique local dates", () => {
+    const spec = parseChartSpec(
+      '{"type":"calendar","unit":"h","items":[{"date":"2026-08-02","value":3},{"date":"2026-08-01","value":2}]}',
+    );
+    expect(spec?.type).toBe("calendar");
+    expect(spec && "items" in spec && spec.items[0]).toEqual({
+      date: "2026-08-01",
+      value: 2,
+    });
+  });
+
+  it("rejects invalid, duplicate, or negative day values", () => {
+    expect(
+      parseChartSpec(
+        '{"type":"calendar","items":[{"date":"2026-02-30","value":1}]}',
+      ),
+    ).toBeNull();
+    expect(
+      parseChartSpec(
+        '{"type":"calendar","items":[{"date":"2026-08-01","value":1},{"date":"2026-08-01","value":2}]}',
+      ),
+    ).toBeNull();
+    expect(
+      parseChartSpec(
+        '{"type":"calendar","items":[{"date":"2026-08-01","value":-1}]}',
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("parseChartSpec — funnel", () => {
+  it("parses ordered non-increasing stages", () => {
+    const spec = parseChartSpec(
+      '{"type":"funnel","items":[{"label":"opened","value":100},{"label":"activated","value":42},{"label":"retained","value":18}]}',
+    );
+    expect(spec?.type).toBe("funnel");
+  });
+
+  it("rejects a single stage, an increase, or a zero starting stage", () => {
+    expect(
+      parseChartSpec(
+        '{"type":"funnel","items":[{"label":"opened","value":100}]}',
+      ),
+    ).toBeNull();
+    expect(
+      parseChartSpec(
+        '{"type":"funnel","items":[{"label":"opened","value":10},{"label":"activated","value":11}]}',
+      ),
+    ).toBeNull();
+    expect(
+      parseChartSpec(
+        '{"type":"funnel","items":[{"label":"opened","value":0},{"label":"activated","value":0}]}',
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("parseChartSpec — waterfall", () => {
+  it("parses a starting total and signed changes", () => {
+    const spec = parseChartSpec(
+      '{"type":"waterfall","start":{"label":"start","value":120},"items":[{"label":"new","value":30},{"label":"churn","value":-20}]}',
+    );
+    expect(spec?.type).toBe("waterfall");
+    expect(spec && "start" in spec && spec.start.value).toBe(120);
+  });
+
+  it("rejects a missing start or an empty change list", () => {
+    expect(
+      parseChartSpec(
+        '{"type":"waterfall","items":[{"label":"new","value":30}]}',
+      ),
+    ).toBeNull();
+    expect(
+      parseChartSpec(
+        '{"type":"waterfall","start":{"label":"start","value":120},"items":[]}',
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("parseChartSpec — range", () => {
+  it("parses low, high, and an optional middle marker", () => {
+    const spec = parseChartSpec(
+      '{"type":"range","items":[{"label":"meeting","min":18,"mid":31,"max":54}]}',
+    );
+    expect(spec?.type).toBe("range");
+    expect(spec && "items" in spec && spec.items[0]).toEqual({
+      label: "meeting",
+      min: 18,
+      max: 54,
+      mid: 31,
+    });
+  });
+
+  it("rejects reversed bounds or a middle outside the range", () => {
+    expect(
+      parseChartSpec(
+        '{"type":"range","items":[{"label":"a","min":5,"max":2}]}',
+      ),
+    ).toBeNull();
+    expect(
+      parseChartSpec(
+        '{"type":"range","items":[{"label":"a","min":2,"mid":8,"max":5}]}',
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("parseChartSpec — scatter", () => {
+  it("parses axes and labeled points", () => {
+    const spec = parseChartSpec(
+      '{"type":"scatter","x_label":"time","y_label":"value","x_unit":"h","items":[{"label":"support","x":4,"y":9}]}',
+    );
+    expect(spec?.type).toBe("scatter");
+    expect(spec && "xLabel" in spec && spec.xLabel).toBe("time");
+    expect(spec && "yLabel" in spec && spec.yLabel).toBe("value");
+  });
+
+  it("rejects a point with a missing coordinate", () => {
+    expect(
+      parseChartSpec(
+        '{"type":"scatter","items":[{"label":"support","x":4}]}',
+      ),
+    ).toBeNull();
+  });
+});
+
 describe("formatClock", () => {
   it("renders hours since midnight as a clock time", () => {
     expect(formatClock(9)).toBe("9:00");

--- a/apps/screenpipe-app-tauri/components/chat/charts/chart-spec.ts
+++ b/apps/screenpipe-app-tauri/components/chat/charts/chart-spec.ts
@@ -42,6 +42,11 @@ export const CHART_LIMITS = {
   heatmapColumns: 24,
   heatmapRows: 14,
   timelineItems: 24,
+  calendarItems: 84,
+  funnelItems: 8,
+  waterfallItems: 10,
+  rangeItems: 20,
+  scatterItems: 40,
   titleChars: 120,
   labelChars: 48,
   unitChars: 12,
@@ -113,6 +118,62 @@ export type TimelineChartSpec = ChartSpecBase & {
   items: TimelineBlock[];
 };
 
+export type CalendarPoint = {
+  /** Local calendar date, normalized as YYYY-MM-DD. */
+  date: string;
+  value: number;
+};
+
+export type CalendarChartSpec = ChartSpecBase & {
+  type: "calendar";
+  items: CalendarPoint[];
+};
+
+export type FunnelChartSpec = ChartSpecBase & {
+  type: "funnel";
+  items: ChartPoint[];
+};
+
+export type WaterfallStart = {
+  label: string;
+  value: number;
+};
+
+export type WaterfallChartSpec = ChartSpecBase & {
+  type: "waterfall";
+  start: WaterfallStart;
+  /** Signed changes applied in order to the starting value. */
+  items: ChartPoint[];
+};
+
+export type RangePoint = {
+  label: string;
+  min: number;
+  max: number;
+  /** Optional typical or target value within the range. */
+  mid: number | null;
+};
+
+export type RangeChartSpec = ChartSpecBase & {
+  type: "range";
+  items: RangePoint[];
+};
+
+export type ScatterPoint = {
+  label: string;
+  x: number;
+  y: number;
+};
+
+export type ScatterChartSpec = ChartSpecBase & {
+  type: "scatter";
+  xLabel: string;
+  yLabel: string;
+  xUnit: string;
+  yUnit: string;
+  items: ScatterPoint[];
+};
+
 export type LineChartSpec = ChartSpecBase & {
   type: "line";
   items: ChartPoint[];
@@ -139,7 +200,12 @@ export type ChartSpec =
   | StackedBarChartSpec
   | ProportionChartSpec
   | HeatmapChartSpec
-  | TimelineChartSpec;
+  | TimelineChartSpec
+  | CalendarChartSpec
+  | FunnelChartSpec
+  | WaterfallChartSpec
+  | RangeChartSpec
+  | ScatterChartSpec;
 
 export type ChartType = ChartSpec["type"];
 
@@ -152,6 +218,11 @@ export const CHART_TYPES: readonly ChartType[] = [
   "proportion",
   "heatmap",
   "timeline",
+  "calendar",
+  "funnel",
+  "waterfall",
+  "range",
+  "scatter",
 ] as const;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -173,6 +244,15 @@ function readOptionalString(value: unknown, maxChars: number): string {
 function readNumber(value: unknown): number | null {
   if (typeof value !== "number" || !Number.isFinite(value)) return null;
   return value;
+}
+
+function readDate(value: unknown): string | null {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return null;
+  }
+  const parsed = new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toISOString().slice(0, 10) === value ? value : null;
 }
 
 function readNumberArray(value: unknown, maxLength: number): number[] | null {
@@ -293,6 +373,121 @@ function parseTimeline(
     type: "timeline",
     items: out,
     truncatedNote: truncationNote(raw.items.length, out.length, "blocks"),
+  };
+}
+
+function parseCalendar(
+  raw: Record<string, unknown>,
+  base: ChartSpecBase,
+): CalendarChartSpec | null {
+  if (!Array.isArray(raw.items) || raw.items.length === 0) return null;
+  const out: CalendarPoint[] = [];
+  const dates = new Set<string>();
+  for (const entry of raw.items.slice(0, CHART_LIMITS.calendarItems)) {
+    if (!isRecord(entry)) return null;
+    const date = readDate(entry.date);
+    const value = readNumber(entry.value);
+    if (date === null || value === null || value < 0 || dates.has(date)) {
+      return null;
+    }
+    dates.add(date);
+    out.push({ date, value });
+  }
+  out.sort((a, b) => a.date.localeCompare(b.date));
+  return {
+    ...base,
+    type: "calendar",
+    items: out,
+    truncatedNote: truncationNote(raw.items.length, out.length, "days"),
+  };
+}
+
+function parseFunnel(
+  raw: Record<string, unknown>,
+  base: ChartSpecBase,
+): FunnelChartSpec | null {
+  const items = readPoints(raw.items, CHART_LIMITS.funnelItems);
+  if (items === null || items.length < 2 || items[0].value <= 0) return null;
+  for (let index = 0; index < items.length; index += 1) {
+    if (items[index].value < 0) return null;
+    if (index > 0 && items[index].value > items[index - 1].value) return null;
+  }
+  const received = Array.isArray(raw.items) ? raw.items.length : items.length;
+  return {
+    ...base,
+    type: "funnel",
+    items,
+    truncatedNote: truncationNote(received, items.length, "stages"),
+  };
+}
+
+function parseWaterfall(
+  raw: Record<string, unknown>,
+  base: ChartSpecBase,
+): WaterfallChartSpec | null {
+  if (!isRecord(raw.start)) return null;
+  const label = readString(raw.start.label, CHART_LIMITS.labelChars);
+  const value = readNumber(raw.start.value);
+  const items = readPoints(raw.items, CHART_LIMITS.waterfallItems);
+  if (label === null || value === null || items === null) return null;
+  const received = Array.isArray(raw.items) ? raw.items.length : items.length;
+  return {
+    ...base,
+    type: "waterfall",
+    start: { label, value },
+    items,
+    truncatedNote: truncationNote(received, items.length, "changes"),
+  };
+}
+
+function parseRange(
+  raw: Record<string, unknown>,
+  base: ChartSpecBase,
+): RangeChartSpec | null {
+  if (!Array.isArray(raw.items) || raw.items.length === 0) return null;
+  const out: RangePoint[] = [];
+  for (const entry of raw.items.slice(0, CHART_LIMITS.rangeItems)) {
+    if (!isRecord(entry)) return null;
+    const label = readString(entry.label, CHART_LIMITS.labelChars);
+    const min = readNumber(entry.min);
+    const max = readNumber(entry.max);
+    const mid = entry.mid === undefined ? null : readNumber(entry.mid);
+    if (label === null || min === null || max === null || max < min) return null;
+    if (entry.mid !== undefined && mid === null) return null;
+    if (mid !== null && (mid < min || mid > max)) return null;
+    out.push({ label, min, max, mid });
+  }
+  return {
+    ...base,
+    type: "range",
+    items: out,
+    truncatedNote: truncationNote(raw.items.length, out.length, "ranges"),
+  };
+}
+
+function parseScatter(
+  raw: Record<string, unknown>,
+  base: ChartSpecBase,
+): ScatterChartSpec | null {
+  if (!Array.isArray(raw.items) || raw.items.length === 0) return null;
+  const out: ScatterPoint[] = [];
+  for (const entry of raw.items.slice(0, CHART_LIMITS.scatterItems)) {
+    if (!isRecord(entry)) return null;
+    const label = readString(entry.label, CHART_LIMITS.labelChars);
+    const x = readNumber(entry.x);
+    const y = readNumber(entry.y);
+    if (label === null || x === null || y === null) return null;
+    out.push({ label, x, y });
+  }
+  return {
+    ...base,
+    type: "scatter",
+    xLabel: readOptionalString(raw.x_label, CHART_LIMITS.labelChars) || "x",
+    yLabel: readOptionalString(raw.y_label, CHART_LIMITS.labelChars) || "y",
+    xUnit: readOptionalString(raw.x_unit, CHART_LIMITS.unitChars),
+    yUnit: readOptionalString(raw.y_unit, CHART_LIMITS.unitChars),
+    items: out,
+    truncatedNote: truncationNote(raw.items.length, out.length, "points"),
   };
 }
 
@@ -445,6 +640,16 @@ export function parseChartSpec(source: string): ChartSpec | null {
       return parseHeatmap(raw, base);
     case "timeline":
       return parseTimeline(raw, base);
+    case "calendar":
+      return parseCalendar(raw, base);
+    case "funnel":
+      return parseFunnel(raw, base);
+    case "waterfall":
+      return parseWaterfall(raw, base);
+    case "range":
+      return parseRange(raw, base);
+    case "scatter":
+      return parseScatter(raw, base);
     default:
       return null;
   }

--- a/apps/screenpipe-app-tauri/components/chat/charts/chat-chart.test.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/charts/chat-chart.test.tsx
@@ -368,6 +368,10 @@ describe("ChatChart — new mark types", () => {
       />,
     );
     expect(screen.getByText("2026-08-01 – 2026-08-02")).toBeInTheDocument();
+    expect(screen.getByText("2 recorded days")).toBeInTheDocument();
+    expect(screen.getByText("average")).toBeInTheDocument();
+    expect(screen.getByText("peak")).toBeInTheDocument();
+    expect(screen.getByText("total")).toBeInTheDocument();
     expect(screen.getAllByText("4 h").length).toBeGreaterThan(0);
   });
 
@@ -386,10 +390,12 @@ describe("ChatChart — new mark types", () => {
     );
     expect(screen.getAllByText("activated").length).toBeGreaterThan(0);
     expect(screen.getAllByText("42%").length).toBeGreaterThan(0);
+    expect(screen.getByText("42% prior")).toBeInTheDocument();
+    expect(screen.getByText("43% prior")).toBeInTheDocument();
   });
 
   it("computes and exposes the waterfall running total", () => {
-    render(
+    const { container } = render(
       <ChatChart
         spec={specFrom({
           type: "waterfall",
@@ -404,6 +410,10 @@ describe("ChatChart — new mark types", () => {
     );
     expect(screen.getAllByText("+3 h").length).toBeGreaterThan(0);
     expect(screen.getAllByText("11 h").length).toBeGreaterThan(0);
+    expect(screen.getByText("+1 h net")).toBeInTheDocument();
+    expect(
+      container.querySelectorAll("[data-waterfall-connector]"),
+    ).toHaveLength(3);
   });
 
   it("renders range endpoints and a middle marker", () => {
@@ -417,7 +427,7 @@ describe("ChatChart — new mark types", () => {
       />,
     );
     expect(screen.getAllByText("support call").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("31 min").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("31 min")).toHaveLength(2);
   });
 
   it("renders scatter axes and every labeled point in the data table", () => {
@@ -436,7 +446,8 @@ describe("ChatChart — new mark types", () => {
       />,
     );
     expect(screen.getByText("time →")).toBeInTheDocument();
-    expect(screen.getAllByText("support").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("support")).toHaveLength(2);
+    expect(screen.getByText("4 h · 9")).toBeInTheDocument();
     expect(screen.getByText("2 points")).toBeInTheDocument();
   });
 });

--- a/apps/screenpipe-app-tauri/components/chat/charts/chat-chart.test.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/charts/chat-chart.test.tsx
@@ -242,6 +242,29 @@ describe("ChatChart — brand geometry", () => {
         type: "timeline",
         items: [{ label: "standup", start: 9, end: 9.5 }],
       },
+      {
+        type: "calendar",
+        items: [{ date: "2026-08-01", value: 3 }],
+      },
+      {
+        type: "funnel",
+        items: [{ label: "opened", value: 10 }, { label: "retained", value: 4 }],
+      },
+      {
+        type: "waterfall",
+        start: { label: "start", value: 10 },
+        items: [{ label: "new", value: 3 }, { label: "churn", value: -1 }],
+      },
+      {
+        type: "range",
+        items: [{ label: "meeting", min: 12, mid: 22, max: 38 }],
+      },
+      {
+        type: "scatter",
+        x_label: "time",
+        y_label: "value",
+        items: [{ label: "support", x: 4, y: 9 }],
+      },
     ];
 
     for (const payload of specs) {
@@ -329,5 +352,91 @@ describe("ChatChart — new mark types", () => {
     );
     expect(screen.getAllByText("this week").length).toBeGreaterThan(0);
     expect(screen.getAllByText("last week").length).toBeGreaterThan(0);
+  });
+
+  it("renders a calendar grid with its date span", () => {
+    render(
+      <ChatChart
+        spec={specFrom({
+          type: "calendar",
+          unit: "h",
+          items: [
+            { date: "2026-08-01", value: 2 },
+            { date: "2026-08-02", value: 4 },
+          ],
+        })}
+      />,
+    );
+    expect(screen.getByText("2026-08-01 – 2026-08-02")).toBeInTheDocument();
+    expect(screen.getAllByText("4 h").length).toBeGreaterThan(0);
+  });
+
+  it("renders funnel stage values and conversion percentages", () => {
+    render(
+      <ChatChart
+        spec={specFrom({
+          type: "funnel",
+          items: [
+            { label: "opened", value: 100 },
+            { label: "activated", value: 42 },
+            { label: "retained", value: 18 },
+          ],
+        })}
+      />,
+    );
+    expect(screen.getAllByText("activated").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("42%").length).toBeGreaterThan(0);
+  });
+
+  it("computes and exposes the waterfall running total", () => {
+    render(
+      <ChatChart
+        spec={specFrom({
+          type: "waterfall",
+          unit: "h",
+          start: { label: "planned", value: 10 },
+          items: [
+            { label: "added", value: 3 },
+            { label: "cut", value: -2 },
+          ],
+        })}
+      />,
+    );
+    expect(screen.getAllByText("+3 h").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("11 h").length).toBeGreaterThan(0);
+  });
+
+  it("renders range endpoints and a middle marker", () => {
+    render(
+      <ChatChart
+        spec={specFrom({
+          type: "range",
+          unit: "min",
+          items: [{ label: "support call", min: 18, mid: 31, max: 54 }],
+        })}
+      />,
+    );
+    expect(screen.getAllByText("support call").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("31 min").length).toBeGreaterThan(0);
+  });
+
+  it("renders scatter axes and every labeled point in the data table", () => {
+    render(
+      <ChatChart
+        spec={specFrom({
+          type: "scatter",
+          x_label: "time",
+          y_label: "value",
+          x_unit: "h",
+          items: [
+            { label: "support", x: 4, y: 9 },
+            { label: "coding", x: 8, y: 7 },
+          ],
+        })}
+      />,
+    );
+    expect(screen.getByText("time →")).toBeInTheDocument();
+    expect(screen.getAllByText("support").length).toBeGreaterThan(0);
+    expect(screen.getByText("2 points")).toBeInTheDocument();
   });
 });

--- a/apps/screenpipe-app-tauri/components/chat/charts/chat-chart.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/charts/chat-chart.tsx
@@ -18,13 +18,18 @@ import {
 import { useChartPalette } from "./chart-palette";
 import {
   BarChart,
+  CalendarChart,
+  FunnelChart,
   GroupedBarChart,
   HeatmapChart,
   LineChart,
   ProportionChart,
+  RangeChart,
+  ScatterChart,
   StackedBarChart,
   StatChart,
   TimelineChart,
+  WaterfallChart,
 } from "./chart-marks";
 
 export function ChatChart({ spec }: { spec: ChartSpec }) {
@@ -47,6 +52,16 @@ export function ChatChart({ spec }: { spec: ChartSpec }) {
       return <HeatmapChart spec={spec} palette={palette} />;
     case "timeline":
       return <TimelineChart spec={spec} palette={palette} />;
+    case "calendar":
+      return <CalendarChart spec={spec} palette={palette} />;
+    case "funnel":
+      return <FunnelChart spec={spec} palette={palette} />;
+    case "waterfall":
+      return <WaterfallChart spec={spec} palette={palette} />;
+    case "range":
+      return <RangeChart spec={spec} palette={palette} />;
+    case "scatter":
+      return <ScatterChart spec={spec} palette={palette} />;
   }
 }
 

--- a/apps/screenpipe-app-tauri/e2e/specs/chat-inline-charts.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/chat-inline-charts.spec.ts
@@ -47,6 +47,28 @@ function chartMessage(marker: string): string {
     '  "items": [{ "label": "standup", "start": 9.5, "end": 10 }, { "label": "deep work", "start": 10, "end": 12.5 }] }',
     "```",
     "",
+    "Five more patterns for the questions a work history creates:",
+    "",
+    "```chart",
+    '{ "type": "calendar", "title": "daily focus", "unit": "h", "items": [{ "date": "2026-08-03", "value": 2.1 }, { "date": "2026-08-04", "value": 4.8 }, { "date": "2026-08-05", "value": 3.2 }, { "date": "2026-08-06", "value": 5.1 }, { "date": "2026-08-07", "value": 4.4 }, { "date": "2026-08-08", "value": 1.2 }, { "date": "2026-08-09", "value": 0.8 }, { "date": "2026-08-10", "value": 3.9 }, { "date": "2026-08-11", "value": 5.6 }, { "date": "2026-08-12", "value": 4.7 }, { "date": "2026-08-13", "value": 6.1 }, { "date": "2026-08-14", "value": 4.2 }] }',
+    "```",
+    "",
+    "```chart",
+    '{ "type": "funnel", "title": "activation path", "unit": "users", "items": [{ "label": "installed", "value": 100 }, { "label": "recorded", "value": 68 }, { "label": "asked", "value": 41 }, { "label": "returned", "value": 24 }] }',
+    "```",
+    "",
+    "```chart",
+    '{ "type": "waterfall", "title": "weekly time change", "unit": "h", "start": { "label": "last week", "value": 42 }, "items": [{ "label": "deep work", "value": 8 }, { "label": "meetings", "value": -5 }, { "label": "support", "value": 3 }] }',
+    "```",
+    "",
+    "```chart",
+    '{ "type": "range", "title": "meeting duration", "unit": "min", "items": [{ "label": "customer", "min": 18, "mid": 31, "max": 54 }, { "label": "team", "min": 12, "mid": 24, "max": 41 }, { "label": "sales", "min": 22, "mid": 38, "max": 67 }] }',
+    "```",
+    "",
+    "```chart",
+    '{ "type": "scatter", "title": "time vs value", "x_label": "time", "y_label": "value", "x_unit": "h", "items": [{ "label": "coding", "x": 12, "y": 9 }, { "label": "support", "x": 6, "y": 8 }, { "label": "meetings", "x": 9, "y": 6 }, { "label": "admin", "x": 5, "y": 3 }, { "label": "planning", "x": 3, "y": 7 }] }',
+    "```",
+    "",
     "And one that is broken on purpose:",
     "",
     "```chart",
@@ -106,16 +128,16 @@ describe("Inline charts in chat", function () {
     marker = randomUUID().slice(0, 8);
     await seedAssistant(randomUUID(), chartMessage(marker));
 
-    // Both valid fences must have become charts before anything is asserted.
+    // All valid fences must have become charts before anything is asserted.
     await browser.waitUntil(
       async () =>
         (await browser.execute(
           () => document.querySelectorAll('[data-testid="chat-chart"]').length,
-        )) === 2,
+        )) === 7,
       {
         timeout: t(20_000),
         interval: 200,
-        timeoutMsg: "the two seeded charts never rendered",
+        timeoutMsg: "the seven seeded charts never rendered",
       },
     );
   });
@@ -146,7 +168,15 @@ describe("Inline charts in chat", function () {
     }, LEAD, TRAIL);
 
     expect(layout).not.toBe(null);
-    expect(layout!.types).toEqual(["bar", "timeline"]);
+    expect(layout!.types).toEqual([
+      "bar",
+      "timeline",
+      "calendar",
+      "funnel",
+      "waterfall",
+      "range",
+      "scatter",
+    ]);
     // The ordering assertion is the point: a chart sits where its fence sat.
     expect(layout!.leadAboveBar).toBe(true);
     expect(layout!.barAboveTrail).toBe(true);
@@ -224,11 +254,11 @@ describe("Inline charts in chat", function () {
     });
     expect(fallback).toBe(true);
 
-    // And it did not silently become a third chart.
+    // And it did not silently become an eighth chart.
     const chartCount = await browser.execute(
       () => document.querySelectorAll('[data-testid="chat-chart"]').length,
     );
-    expect(chartCount).toBe(2);
+    expect(chartCount).toBe(7);
   });
 
   it("uses sharp corners everywhere, per DESIGN.md", async () => {
@@ -264,9 +294,29 @@ describe("Inline charts in chat", function () {
     expect(tables).toEqual([
       { hasTable: true, rows: 3 },
       { hasTable: true, rows: 2 },
+      { hasTable: true, rows: 12 },
+      { hasTable: true, rows: 4 },
+      { hasTable: true, rows: 5 },
+      { hasTable: true, rows: 3 },
+      { hasTable: true, rows: 5 },
     ]);
 
-    const filepath = await saveScreenshot(`chat-inline-charts-${marker}`);
-    expect(existsSync(filepath)).toBe(true);
+    await browser.execute(() => {
+      document.querySelector('[data-chart-type="calendar"]')?.scrollIntoView({
+        block: "start",
+      });
+    });
+    await browser.pause(250);
+    const overview = await saveScreenshot(`chat-chart-patterns-overview-${marker}`);
+    expect(existsSync(overview)).toBe(true);
+
+    await browser.execute(() => {
+      document.querySelector('[data-chart-type="range"]')?.scrollIntoView({
+        block: "start",
+      });
+    });
+    await browser.pause(250);
+    const analysis = await saveScreenshot(`chat-chart-patterns-analysis-${marker}`);
+    expect(existsSync(analysis)).toBe(true);
   });
 });

--- a/apps/screenpipe-app-tauri/e2e/specs/chat-inline-charts.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/chat-inline-charts.spec.ts
@@ -30,6 +30,14 @@ import { openHomeWindow, waitForAppReady, t } from "../helpers/test-utils.js";
 
 const LEAD = "Here is where your time went";
 const TRAIL = "Slack stayed quiet all afternoon";
+const CALENDAR_VALUES = [
+  2.1, 4.8, 3.2, 5.1, 4.4, 1.2, 0.8, 3.9, 5.6, 4.7, 6.1, 4.2, 1.5, 0.6,
+  4.4, 5.2, 3.8, 6.4, 5.7, 1.8, 0.9, 4.9, 6.2, 5.4, 6.8, 5.1, 2.2, 1.1,
+];
+const CALENDAR_ITEMS = CALENDAR_VALUES.map((value, index) => {
+  const date = new Date(Date.UTC(2026, 7, 3 + index));
+  return { date: date.toISOString().slice(0, 10), value };
+});
 
 function chartMessage(marker: string): string {
   return [
@@ -50,7 +58,12 @@ function chartMessage(marker: string): string {
     "Five more patterns for the questions a work history creates:",
     "",
     "```chart",
-    '{ "type": "calendar", "title": "daily focus", "unit": "h", "items": [{ "date": "2026-08-03", "value": 2.1 }, { "date": "2026-08-04", "value": 4.8 }, { "date": "2026-08-05", "value": 3.2 }, { "date": "2026-08-06", "value": 5.1 }, { "date": "2026-08-07", "value": 4.4 }, { "date": "2026-08-08", "value": 1.2 }, { "date": "2026-08-09", "value": 0.8 }, { "date": "2026-08-10", "value": 3.9 }, { "date": "2026-08-11", "value": 5.6 }, { "date": "2026-08-12", "value": 4.7 }, { "date": "2026-08-13", "value": 6.1 }, { "date": "2026-08-14", "value": 4.2 }] }',
+    JSON.stringify({
+      type: "calendar",
+      title: "deep work rhythm",
+      unit: "h",
+      items: CALENDAR_ITEMS,
+    }),
     "```",
     "",
     "```chart",
@@ -294,7 +307,7 @@ describe("Inline charts in chat", function () {
     expect(tables).toEqual([
       { hasTable: true, rows: 3 },
       { hasTable: true, rows: 2 },
-      { hasTable: true, rows: 12 },
+      { hasTable: true, rows: 28 },
       { hasTable: true, rows: 4 },
       { hasTable: true, rows: 5 },
       { hasTable: true, rows: 3 },

--- a/apps/screenpipe-app-tauri/lib/chat/system-prompt.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/system-prompt.ts
@@ -118,7 +118,7 @@ Don't reach for these on short answers.
 
 A \`\`\`chart fence renders inline where you put it. One JSON object, \`type\` picks the shape. You send data only — the app owns colors, axes, legend and hover.
 
-Reach for one when the answer is a comparison, a trend, a split, or the shape of a day. Skip it for one or two numbers.
+Reach for one when the answer is a comparison, trend, split, sequence, range, relationship, or shape of a day. Skip it for one or two numbers.
 
 \`\`\`chart
 { "type": "bar", "title": "time by app", "unit": "min", "items": [{ "label": "Cursor", "value": 148 }, { "label": "Chrome", "value": 92 }] }
@@ -127,13 +127,18 @@ Reach for one when the answer is a comparison, a trend, a split, or the shape of
 | type | use it for | fields (caps) |
 | --- | --- | --- |
 | stat | 1–4 independent headline numbers, not parts of a whole | items[{label, value, unit?, note?}] (4) |
-| bar | compare amounts, sorted high first | items[{label, value}] (20) |
+| bar | one amount per label, sorted high first | items[{label, value}] (20) |
 | line | one measure over time — "is X trending?" | items[{label, value}] (60) |
 | grouped_bar | series side by side | categories (12) + series[{name, values}] (5) |
 | stacked_bar | part-to-whole per category | same as grouped_bar |
 | proportion | how one total splits up, non-negative | items[{label, value}] (5) |
 | heatmap | two dimensions at once, e.g. daypart × weekday — prefer this over bar whenever the data has a row AND a column axis | x (24) + y (14) + values, one row per y |
 | timeline | when things happened across a day | items[{label, start, end}] hours 0–24 (24) |
+| calendar | activity or streak by date | items[{date, value}] YYYY-MM-DD (84) |
+| funnel | ordered stage drop-off | descending items[{label, value}] (8) |
+| waterfall | how signed changes build from a starting total | start{label, value} + items[{label, value}] (10) |
+| range | low/high span with optional typical or target | items[{label, min, max, mid?}] (20) |
+| scatter | each item has an x AND y measure; use instead of bar | x_label, y_label, x_unit?, y_unit?, items[{label, x, y}] (40) |
 
 RULES:
 - Put the fence on its own lines — \`\`\`chart, then the JSON, then \`\`\` — never inline inside a sentence, or it renders as a code chip instead of a chart
@@ -141,6 +146,8 @@ RULES:
 - Values are real numbers, never strings or null
 - \`title\` and \`unit\` are optional; unit is a short suffix like "min", "h", "%"
 - Never send colors
+- Funnel values must be non-negative and never increase; calendar dates must be unique; range \`mid\` must sit between \`min\` and \`max\`
+- Waterfall = start + signed changes; scatter = x and y per label. Don't use bar for either
 - Each \`values\` array must be exactly as long as \`categories\`; each heatmap row as long as \`x\`
 - A single number is a \`stat\`, never a one-bar bar chart
 - Only chart numbers you actually retrieved. Never estimate, never invent a point to fill a gap

--- a/apps/screenpipe-app-tauri/scripts/eval-chart-fence.ts
+++ b/apps/screenpipe-app-tauri/scripts/eval-chart-fence.ts
@@ -111,6 +111,36 @@ const CASES: EvalCase[] = [
     expect: { expectChart: true, expectTypes: ["grouped_bar", "bar"] },
   },
   {
+    id: "calendar-streak",
+    question:
+      "My focus hours by local date: 2026-08-01 2.1, 2026-08-02 3.8, 2026-08-03 0.5, 2026-08-04 4.2, 2026-08-05 5.1, 2026-08-06 3.4, 2026-08-07 4.8. Show the daily pattern.",
+    expect: { expectChart: true, expectTypes: ["calendar", "line"] },
+  },
+  {
+    id: "funnel-dropoff",
+    question:
+      "Activation stages: 100 people installed, 68 recorded, 41 asked a question, and 24 returned the next week. Where is the drop-off?",
+    expect: { expectChart: true, expectTypes: ["funnel"] },
+  },
+  {
+    id: "waterfall-change",
+    question:
+      "I worked 42 hours last week. This week deep work added 8 hours, meetings removed 5, and support added 3. Show what changed the total.",
+    expect: { expectChart: true, expectTypes: ["waterfall"] },
+  },
+  {
+    id: "range-variability",
+    question:
+      "Meeting duration in minutes: customer calls min 18 typical 31 max 54; team calls min 12 typical 24 max 41; sales calls min 22 typical 38 max 67. Compare the spread.",
+    expect: { expectChart: true, expectTypes: ["range"] },
+  },
+  {
+    id: "scatter-relationship",
+    question:
+      "Time spent vs value score: coding 12h/9, support 6h/8, meetings 9h/6, admin 5h/3, planning 3h/7. Is more time associated with more value?",
+    expect: { expectChart: true, expectTypes: ["scatter"] },
+  },
+  {
     id: "no-chart-two-numbers",
     question: "I had 2 meetings today totalling 45 minutes. How many meetings did I have?",
     // The other trap: two numbers is a sentence, not a chart.


### PR DESCRIPTION
## Why

Chat already rendered 8 safe chart types, but several common questions still had to be flattened into bars or prose. I reviewed the full locally retained screenpipe range (July 8-August 20, 2026), with all 7 weekly aggregate activity-summary windows returning `data_status=ok`, plus privacy-safe durable summaries. The recurring shapes were daily cadence, stage drop-off, signed contribution, low/high bounds, and two-variable relationships.

This PR adds the 5 patterns with the clearest distinct jobs. All fixtures and screenshots are synthetic; no captured content or private history is included.

## What changed

| New pattern | Use it for | Guardrail |
| --- | --- | --- |
| `calendar` | habits, consistency, daily activity | valid unique ISO dates, 84-day cap |
| `funnel` | stages and conversion drop-off | non-increasing values, 8-stage cap |
| `waterfall` | a starting total plus signed changes | one start plus changes, 10-item cap |
| `range` | low/high uncertainty or spread | ordered bounds and in-range midpoint, 20-item cap |
| `scatter` | correlation, clusters, and outliers | finite x/y points, 40-point cap |

- Extends the strict chart-spec parser and renderer switch from 8 to 13 types.
- Adds monochrome, square-corner renderers with phosphor hover/readout states.
- Keeps the useful answer visible before hover: calendar summaries, prior-stage conversion, waterfall net change and connectors, range midpoints, and a numbered scatter key.
- Preserves screen-reader data tables and readable malformed-fence fallback.
- Teaches the system prompt when each type is appropriate, including explicit waterfall/scatter selection guidance.
- Extends unit, prompt-contract, offline fence-eval, and browser E2E coverage.

## 10-pattern exploration

1. Calendar heatmap - included
2. Funnel - included
3. Waterfall - included
4. Range plot - included
5. Scatter/quadrant - included
6. Slopegraph - next candidate for before/after rank changes
7. Bullet/goal chart - next candidate for target-versus-actual questions
8. Flow map - keep in Mermaid until a safe data contract is justified
9. Distribution/box plot - defer until chat regularly returns raw distributions
10. Decision/dependency diagram - keep in Mermaid, which already handles this job

## Screenshots

Light theme:

![Five new chat chart patterns in the light theme](https://raw.githubusercontent.com/screenpipe/screenpipe/assets-chat-chart-patterns/assets/chat-chart-patterns/light.png?v=2)

Dark theme:

![Five new chat chart patterns in the dark theme](https://raw.githubusercontent.com/screenpipe/screenpipe/assets-chat-chart-patterns/assets/chat-chart-patterns/dark.png?v=2)

## Verification

- `bun x vitest run ...` - 96/96 focused chart tests pass
- `bun run typecheck` - pass
- targeted ESLint for all 9 changed files - pass
- `git diff --check` - pass
- E2E coverage map - up to date; inline fixture now covers all 5 new types, malformed fallback, hover, corners, and accessible tables
- local `qwen3.5:4b` prompt canary - 11/13 (85%); all four new type-selection cases pass, with timeline and heatmap schema generation the remaining failures

The full packaged Tauri E2E suite was not run locally; screenshots render the real React chart components in the browser harness. `bun run coverage:all:check` also reports three pre-existing unmapped engine files outside this diff (`agent_profile.rs`, `agent_skills.rs`, and `cli/team_skills.rs`); its E2E coverage-map portion passes. Hosted full Vitest currently reaches 4,033 passing tests before one unchanged MCP tool-list assertion fails because `skill_manage` and `user_profile` are present but absent from that baseline expectation.
