### PR TITLE
fix(onboarding): keep card requests dismissible

### DIFF
--- a/apps/screenpipe-app-tauri/app/onboarding/page.test.tsx
+++ b/apps/screenpipe-app-tauri/app/onboarding/page.test.tsx
@@ -31,8 +31,7 @@ const mocks = vi.hoisted(() => ({
       entitlement_source?: string;
       subscription_plan?: string;
       enterprise_account?: { org_name?: string; role?: string };
-      // Plan selection needs a token to open checkout, so page.tsx keeps the
-      // slide out of visibleOrder. Seed it wherever a signed-in user is intended.
+      // Plan selection needs a token when reconciling a hosted checkout return.
       token?: string;
     },
   },
@@ -266,8 +265,8 @@ describe("enterprise onboarding authentication", () => {
     );
   });
 
-  // Per-slide sizes made the window jump on every step and blew up to 760x720
-  // on the payment slide. One size, applied once, for the whole flow.
+  // Per-slide sizes made the window jump on every step. One size, applied once,
+  // for the whole flow.
   it("sizes the window once instead of resizing per slide", async () => {
     mocks.enterprisePolicy.isManagedDeployment = false;
     mocks.settings.user = {
@@ -282,12 +281,16 @@ describe("enterprise onboarding authentication", () => {
       expect(mocks.setWindowSize).toHaveBeenCalledWith("Onboarding", 500, 680),
     );
 
-    // Advancing onto the payment slide, the step that used to widen the window
-    // to 760x720, must not resize it again.
+    // Completing the final setup slide must not resize the window again.
     fireEvent.click(
       await screen.findByRole("button", { name: "finish engine" }),
     );
-    expect(await screen.findByText("plan selection")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mocks.completeOnboarding).toHaveBeenCalledWith({
+        method: "setup_finished",
+      }),
+    );
+    expect(screen.queryByText("plan selection")).not.toBeInTheDocument();
 
     expect(mocks.setWindowSize).toHaveBeenCalledTimes(1);
   });
@@ -308,7 +311,7 @@ describe("enterprise onboarding authentication", () => {
     expect(screen.queryByText("connect apps")).not.toBeInTheDocument();
   });
 
-  it("shows plan selection last for a new free consumer account", async () => {
+  it("finishes setup for a cardless consumer without mandatory checkout", async () => {
     mocks.enterprisePolicy.isManagedDeployment = false;
     mocks.settings.user = {
       has_payment_method: false,
@@ -322,15 +325,12 @@ describe("enterprise onboarding authentication", () => {
       await screen.findByRole("button", { name: "finish engine" }),
     );
 
-    expect(await screen.findByText("plan selection")).toBeInTheDocument();
-    expect(mocks.completeOnboarding).not.toHaveBeenCalled();
-
-    fireEvent.click(screen.getByRole("button", { name: "continue free plan" }));
     await waitFor(() =>
       expect(mocks.completeOnboarding).toHaveBeenCalledWith({
         method: "setup_finished",
       }),
     );
+    expect(screen.queryByText("plan selection")).not.toBeInTheDocument();
   });
 
   // Regression: "plan" is the last slide, so showing it to a user who skipped
@@ -486,7 +486,7 @@ describe("enterprise onboarding authentication", () => {
     expect(screen.queryByText("plan selection")).not.toBeInTheDocument();
   });
 
-  it("marks checkout as required while keeping funnel keys stable", async () => {
+  it("marks ordinary card collection as a post-onboarding modal", async () => {
     mocks.enterprisePolicy.isManagedDeployment = false;
     mocks.settings.user = {
       has_payment_method: false,
@@ -504,8 +504,8 @@ describe("enterprise onboarding authentication", () => {
       expect(mocks.capture).toHaveBeenCalledWith(
         "onboarding_step_reached",
         expect.objectContaining({
-          card_ask_arm: "required",
-          card_ask_placement_active: true,
+          card_ask_arm: "post_onboarding_modal",
+          card_ask_placement_active: false,
         }),
       ),
     );

--- a/apps/screenpipe-app-tauri/app/onboarding/page.tsx
+++ b/apps/screenpipe-app-tauri/app/onboarding/page.tsx
@@ -21,7 +21,6 @@ import { commands } from "@/lib/utils/tauri";
 import { onboardingFunnel } from "@/lib/analytics/onboarding-funnel";
 import type { AppUser } from "@/lib/app-entitlement";
 import { readOnboardingCheckoutStatus } from "@/lib/onboarding-checkout-navigation";
-import { requiresOnboardingCheckout } from "@/lib/onboarding-checkout";
 
 type SlideKey =
   "login" | "acquisition" | "permissions" | "timeline" | "engine" | "plan";
@@ -173,24 +172,14 @@ export default function OnboardingPage() {
     settings.deviceTier === "high"
       ? settings.deviceTier
       : "unknown";
-  const needsOnboardingCheckout = requiresOnboardingCheckout(user);
   const shouldShowPlanSelection =
-    !isManagedDeployment &&
-    (checkoutReturnStatus !== null || needsOnboardingCheckout);
-  // Only a fully resolved new consumer account enters mandatory checkout.
-  // Manual grants, lifetime ownership, Enterprise membership, subscriptions,
-  // and partially hydrated account responses all stay out. A later contextual
-  // card ask may still be appropriate for an expiring manual grant, but that is
-  // a different intervention from first-run setup.
-  // "plan" is the last slide, so auto-advancing onto it without a token traps
-  // the user in onboarding: PlanSelectionStep cannot open hosted checkout
-  // (it renders "sign in to continue"),
-  // and handleNextSlide stops calling completeOnboarding once a next slide
-  // exists. Someone who skipped sign-in would sit on /onboarding forever.
-  //
-  // This gates only the automatic walk out of the engine slide. An eligible
-  // account keeps plan in visibleOrder and can enter it; every other account
-  // excludes it from progress and saved-step restoration as well.
+    !isManagedDeployment && checkoutReturnStatus !== null;
+  // Ordinary setup must always be completable without payment. A reinstall or
+  // unreadable local store replays onboarding even for an existing account,
+  // and local state cannot reliably distinguish that recovery path from a new
+  // install. Card collection therefore happens later through the dismissible
+  // PostHog-owned Home modal. The plan controller remains reachable only while
+  // reconciling an already-started hosted checkout return.
   const canAdvanceIntoPlanSelection =
     shouldShowPlanSelection && Boolean(user?.token);
   const visibleOrder = useMemo(
@@ -363,9 +352,12 @@ export default function OnboardingPage() {
     posthog.capture("onboarding_step_reached", {
       step_name: `${currentSlide}_completed`,
       step_index: visibleOrder.indexOf(currentSlide) + 1,
-      // Keep the existing analytics keys stable across the release cutover.
-      card_ask_arm: "required",
-      card_ask_placement_active: true,
+      // Keep the existing analytics keys stable while recording that ordinary
+      // setup now hands card collection to a dismissible Home placement.
+      card_ask_arm: shouldShowPlanSelection
+        ? "checkout_return"
+        : "post_onboarding_modal",
+      card_ask_placement_active: shouldShowPlanSelection,
     });
 
     // Hidden enterprise deployments only need authentication + permissions.
@@ -444,6 +436,7 @@ export default function OnboardingPage() {
     currentSlide,
     deviceTierForAnalytics,
     isManagedDeployment,
+    shouldShowPlanSelection,
     timelineChoiceLocked,
     timelineChoiceVisible,
     visibleOrder,

--- a/apps/screenpipe-app-tauri/components/__tests__/card-ask-provider.test.tsx
+++ b/apps/screenpipe-app-tauri/components/__tests__/card-ask-provider.test.tsx
@@ -171,6 +171,33 @@ describe("CardAskProvider login trigger", () => {
   });
 });
 
+describe("CardAskProvider onboarding trigger", () => {
+  beforeEach(() => {
+    flagVariant = "at_onboarding";
+    localStorageValues.set(CARD_ASK_ARM_STORAGE_KEY, "at_onboarding");
+  });
+
+  it("shows a dismissible Home modal after onboarding", () => {
+    render(<CardAskProvider />);
+    expect(modal()).not.toBeNull();
+    expect(
+      JSON.parse(
+        window.localStorage.getItem(CARD_ASK_SHOWN_STORAGE_KEY) ?? "[]",
+      ),
+    ).toEqual(["onboarding"]);
+  });
+
+  it("waits for account hydration before emitting", () => {
+    settingsState = { settings: { user: null }, isSettingsLoaded: false };
+    const { rerender } = render(<CardAskProvider />);
+    expect(modal()).toBeNull();
+
+    settingsState = { settings: { user: cardlessUser }, isSettingsLoaded: true };
+    rerender(<CardAskProvider />);
+    expect(modal()).not.toBeNull();
+  });
+});
+
 /**
  * The expiry ask in a process that outlives the window it is looking for.
  *
@@ -191,9 +218,9 @@ describe("CardAskProvider grant expiry trigger", () => {
   }
 
   beforeEach(() => {
-    flagVariant = "at_onboarding";
+    flagVariant = "control";
     businessTrialReminderEnabled = true;
-    localStorageValues.set(CARD_ASK_ARM_STORAGE_KEY, "at_onboarding");
+    localStorageValues.set(CARD_ASK_ARM_STORAGE_KEY, "control");
   });
 
   afterEach(() => {

--- a/apps/screenpipe-app-tauri/components/card-ask-modal.tsx
+++ b/apps/screenpipe-app-tauri/components/card-ask-modal.tsx
@@ -34,9 +34,9 @@ const COPY: Record<
   CardAskTrigger,
   { title: string; body: string; cta: string }
 > = {
-  // The onboarding placement is rendered by PlanSelectionStep, not this modal.
-  // Copy still lives here so the map stays exhaustive over CardAskTrigger and
-  // a remote payload cannot route `onboarding` to the modal and find nothing.
+  // This appears after setup in Home. Keeping it dismissible is deliberate: a
+  // local-store reset can replay onboarding for an existing account, and card
+  // collection must never turn that recovery path into a lockout.
   onboarding: {
     title: "Start your 7-day Business trial",
     body: "Full access to AI, unlimited pipes, and cloud transcription. Cancel anytime before day 7 and you are not charged.",

--- a/apps/screenpipe-app-tauri/components/card-ask-provider.tsx
+++ b/apps/screenpipe-app-tauri/components/card-ask-provider.tsx
@@ -20,13 +20,13 @@ import type { AppUser } from "@/lib/app-entitlement";
 /**
  * Mounts the card-ask experiment in the Home window.
  *
- * Why the `login` trigger fires here rather than from onboarding: onboarding
+ * Why the entry triggers fire here rather than from onboarding: onboarding
  * runs in its own webview, and webviews do not share a localStorage partition.
  * Emitting `login` there would resolve and persist a *separate* arm, so one
  * user could sit in two arms at once and contaminate both. Home is the single
- * window that owns the experiment, so "login" is defined as the first Home
- * mount for an eligible user who has not been asked yet — which is the same
- * moment from the user's point of view, immediately after getting into the app.
+ * window that owns the experiment. The onboarding placement is therefore the
+ * first Home mount after setup, where the request is dismissible and cannot
+ * block recovery after a reinstall or local-store reset.
  *
  * `first_value` and `limit` arrive on the trigger bus from product code in this
  * same window.
@@ -56,8 +56,9 @@ export function CardAskProvider() {
     });
   }, [loadUser, user?.token]);
 
-  // Fire the login trigger once the arm has resolved *and* the account is
-  // actually known.
+  // Fire the entry trigger once the arm has resolved *and* the account is
+  // actually known. Both placements are owned by Home so they share one sticky
+  // assignment and shown-list; only their analytics trigger differs.
   //
   // The arm comes from a synchronous localStorage read, the user comes from an
   // async store load, so the arm almost always resolves first. Emitting on
@@ -70,9 +71,15 @@ export function CardAskProvider() {
   // mounted. Re-emission is safe: the controller's shown-list keeps it to one
   // ask per install, and an ineligible emission is a dropped no-op.
   useEffect(() => {
-    if (arm !== "at_login") return;
+    const trigger =
+      arm === "at_login"
+        ? "login"
+        : arm === "at_onboarding"
+          ? "onboarding"
+          : null;
+    if (!trigger) return;
     if (!isSettingsLoaded) return;
-    emitCardAskTrigger("login");
+    emitCardAskTrigger(trigger);
   }, [arm, isSettingsLoaded, settings?.user]);
 
   // Re-arm the expiry check while the app keeps running.

--- a/apps/screenpipe-app-tauri/e2e/specs/onboarding-first-run.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/onboarding-first-run.spec.ts
@@ -17,8 +17,8 @@
 //   2. One tap writes through to store.bin via the real settings command,
 //      not a mocked updateSettings.
 //   3. Skip records nothing at all.
-//   4. Existing entitlements cannot be restored into mandatory checkout, even
-//      when an older build persisted the plan step.
+//   4. No ordinary install can be restored into mandatory checkout, even when
+//      an older build persisted the plan step.
 //
 // The post-setup learning window lives in first-run-learning-window.spec.ts:
 // it renders on Brain, which is behind the account gate, so it needs the
@@ -261,7 +261,7 @@ const seedLearningWindow = async (state: Record<string, unknown>) => {
     }
   });
 
-  it("keeps lifetime ownership out of mandatory checkout", async () => {
+  it("recovers a legacy plan step without mandatory checkout", async () => {
     await seedOnboardingUser({
       id: "e2e-lifetime-owner",
       email: "lifetime-owner@screenpipe.test",
@@ -298,5 +298,36 @@ const seedLearningWindow = async (state: Record<string, unknown>) => {
 
     const filepath = await saveScreenshot("onboarding-lifetime-checkout-skip");
     expect(existsSync(filepath)).toBe(true);
+  });
+
+  it("keeps a cardless existing account out of mandatory checkout", async () => {
+    await seedOnboardingUser({
+      id: "e2e-existing-cardless-user",
+      email: "existing-cardless@screenpipe.test",
+      token: "e2e-token",
+      app_entitled: false,
+      cloud_subscribed: false,
+      subscription_plan: "free",
+      entitlement_source: "none",
+      has_payment_method: false,
+    });
+
+    // This is the server shape that previously made a reset or reinstalled app
+    // restore a saved plan step into forced checkout.
+    await gotoSlide("plan");
+    await waitForTestId("onboarding-engine-startup", 30_000);
+
+    const text = await bodyText();
+    expect(text).not.toContain("opening secure checkout");
+    expect(
+      await browser.execute(
+        () => !!document.querySelector('[data-testid="onboarding-card-capture"]'),
+      ),
+    ).toBe(false);
+
+    const match = text.match(/setup[^0-9]*(\d+)\s*of\s*(\d+)/);
+    expect(match).not.toBeNull();
+    const [, current, total] = match!.map(Number);
+    expect(current).toBe(total);
   });
 });

--- a/apps/screenpipe-app-tauri/lib/onboarding-checkout.test.ts
+++ b/apps/screenpipe-app-tauri/lib/onboarding-checkout.test.ts
@@ -4,10 +4,7 @@
 
 import { describe, expect, it } from "vitest";
 import type { AppUser } from "@/lib/app-entitlement";
-import {
-  isOnboardingCheckoutResolved,
-  requiresOnboardingCheckout,
-} from "@/lib/onboarding-checkout";
+import { isOnboardingCheckoutResolved } from "@/lib/onboarding-checkout";
 
 const user = (overrides: Partial<AppUser> = {}) =>
   ({
@@ -19,17 +16,10 @@ const user = (overrides: Partial<AppUser> = {}) =>
     ...overrides,
   }) as AppUser;
 
-describe("onboarding checkout eligibility", () => {
-  it("requires checkout only for an authoritatively cardless free account", () => {
-    expect(requiresOnboardingCheckout(user())).toBe(true);
-  });
-
+describe("onboarding checkout return resolution", () => {
   it.each(["subscription", "manual", "enterprise", "lifetime", "dev"])(
-    "does not request checkout for an existing %s entitlement",
+    "accepts an existing %s entitlement as resolved",
     (source) => {
-      expect(
-        requiresOnboardingCheckout(user({ entitlement_source: source })),
-      ).toBe(false);
       expect(
         isOnboardingCheckoutResolved(user({ entitlement_source: source })),
       ).toBe(true);
@@ -38,7 +28,7 @@ describe("onboarding checkout eligibility", () => {
 
   it("does not guess while account payment state is partially hydrated", () => {
     expect(
-      requiresOnboardingCheckout(
+      isOnboardingCheckoutResolved(
         user({ has_payment_method: undefined, entitlement_source: undefined }),
       ),
     ).toBe(false);
@@ -48,7 +38,6 @@ describe("onboarding checkout eligibility", () => {
     const enterpriseUser = user({
       enterprise_account: { org_name: "acme", role: "member" },
     });
-    expect(requiresOnboardingCheckout(enterpriseUser)).toBe(false);
     expect(isOnboardingCheckoutResolved(enterpriseUser)).toBe(true);
   });
 

--- a/apps/screenpipe-app-tauri/lib/onboarding-checkout.ts
+++ b/apps/screenpipe-app-tauri/lib/onboarding-checkout.ts
@@ -28,23 +28,6 @@ function hasEnterpriseAccount(user: AppUser | null | undefined): boolean {
 }
 
 /**
- * Mandatory checkout is deliberately narrower than the later card-ask
- * experiment. It is only part of first-run setup for a signed-in consumer
- * account whose modern server response authoritatively says both "free" and
- * "no card". Unknown or partially hydrated account data must never open a
- * purchase flow by guesswork.
- */
-export function requiresOnboardingCheckout(
-  user: AppUser | null | undefined,
-): boolean {
-  if (!user?.token || hasEnterpriseAccount(user)) return false;
-  return (
-    user.has_payment_method === false &&
-    normalizedEntitlementSource(user) === "none"
-  );
-}
-
-/**
  * A hosted-checkout return may race with entitlement reconciliation. Existing
  * access is enough to leave onboarding even when a higher manual, lifetime, or
  * Enterprise entitlement intentionally remains authoritative over the new


### PR DESCRIPTION
## Summary

- let ordinary onboarding finish without entering hosted checkout
- retain the plan controller only for an already-started checkout return
- emit the `at_onboarding` PostHog placement from Home so it uses the existing dismissible modal
- cover reinstall/local-store-reset recovery for an existing cardless account

## Why

A local settings reset can replay onboarding for an existing account. The previous guard treated any signed-in account with `has_payment_method: false` and `entitlement_source: none` as a first-run buyer and routed it into mandatory checkout. That made a reinstall or unreadable store look like a lockout.

```text
reinstall or store reset
  -> onboarding
  -> setup completes
  -> Home
  -> optional dismissible card modal

already-started checkout return
  -> plan controller
  -> entitlement reconciliation
```

## Validation

- `bun x vitest run --config vitest.config.ts app/onboarding/page.test.tsx components/__tests__/card-ask-provider.test.tsx components/__tests__/card-ask-modal.test.tsx lib/onboarding-checkout.test.ts lib/hooks/__tests__/use-card-ask.test.tsx`
  - 5 files, 103 tests passed
- `bun run typecheck`
- `bun run lint:effects`
  - 0 errors, existing warnings only
- `git diff --check`

## Visual impact

No new UI. The change replaces the blocking onboarding checkout with the existing dismissible card-request modal in Home.