### PR TITLE
fix(chat): unify GitHub Copilot ACP controls

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat/standalone/acp-config-selector.test.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/acp-config-selector.test.tsx
@@ -204,6 +204,45 @@ describe("ACP config trigger", () => {
     expect(screen.queryByLabelText("Mode")).not.toBeInTheDocument();
   });
 
+  it("keeps Copilot's mode visible while moving Allow All into permissions", () => {
+    seedSession([
+      {
+        id: "mode",
+        name: "Mode",
+        category: "mode",
+        type: "select",
+        currentValue: "agent",
+        values: [
+          { value: "ask", name: "Ask" },
+          { value: "agent", name: "Agent" },
+        ],
+      },
+      {
+        id: "allow_all",
+        name: "Allow All",
+        description: "Allow all tools without confirmation",
+        type: "boolean",
+        currentValue: false,
+        values: [],
+      },
+    ]);
+
+    render(
+      <AcpConfigSelector
+        sessionId={SESSION}
+        agentId="github-copilot-cli"
+        hideModeControl
+      />,
+    );
+
+    const trigger = screen.getByTestId("acp-config-trigger");
+    expect(trigger).toHaveTextContent("Agent");
+    expect(trigger).not.toHaveTextContent("config");
+    fireEvent.click(trigger);
+    expect(screen.getByLabelText("Mode")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Allow All")).not.toBeInTheDocument();
+  });
+
   it("can move effort into its dedicated composer control", () => {
     seedSession([
       modelOption("sonnet"),

--- a/apps/screenpipe-app-tauri/components/chat/standalone/acp-config-selector.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/acp-config-selector.tsx
@@ -20,6 +20,7 @@ import { commands, type AIPreset } from "@/lib/utils/tauri";
 import {
   dedupedModes,
   findAcpModeOption,
+  findAcpPermissionBooleanOption,
   findAcpPermissionModeOption,
   hasAcpPermissionModes,
   useAcpSessionConfig,
@@ -139,8 +140,8 @@ export function AcpConfigSelector({
   /** Sign the agent out and respawn so the sign-in card returns. */
   onReauthenticate?: () => void;
   /** A client can promote an agent's permission/mode axis into a dedicated
-   *  composer control. Hide that duplicated select from this general config
-   *  popover. */
+   *  composer control. Hide that duplicated select or boolean toggle from
+   *  this general config popover. */
   hideModeControl?: boolean;
   /** The composer promotes effort into its own visible control beside model.
    *  Hide the duplicate from this general configuration popover. */
@@ -169,18 +170,24 @@ export function AcpConfigSelector({
   const allSelects = (config?.options ?? []).filter(
     (option) => option.type === "select" && option.values.length > 0,
   );
-  const modeOption = hideModeControl
+  const permissionModeOption = hideModeControl
     ? findAcpPermissionModeOption(config)
-    : findAcpModeOption(config);
+    : null;
+  const permissionBooleanOption = hideModeControl
+    ? findAcpPermissionBooleanOption(config)
+    : null;
   const modeFilteredSelects = hideModeControl
-    ? allSelects.filter((option) => option.id !== modeOption?.id)
+    ? allSelects.filter((option) => option.id !== permissionModeOption?.id)
     : allSelects;
   const selects = hideEffortControl
     ? modeFilteredSelects.filter((option) => !isEffortAxis(option))
     : modeFilteredSelects;
   // Boolean options (e.g. Codex "fast mode") advertise no value list; render
   // them as toggles rather than dropping them.
-  const toggles = (config?.options ?? []).filter((option) => option.type === "boolean");
+  const toggles = (config?.options ?? []).filter(
+    (option) =>
+      option.type === "boolean" && option.id !== permissionBooleanOption?.id,
+  );
   const modes =
     hideModeControl && hasAcpPermissionModes(config)
       ? null
@@ -203,8 +210,17 @@ export function AcpConfigSelector({
   const advertisedModelValue = modelOption?.values.find(
     (value) => value.value === modelValue,
   );
+  const advertisedModeOption = findAcpModeOption(config);
+  const visibleModeOption = selects.find(
+    (option) => option.id === advertisedModeOption?.id,
+  );
+  const visibleModeValue = visibleModeOption
+    ? selectedValue(visibleModeOption)
+    : "";
   const triggerLabel =
     (modelOption && acpConfigValueLabel(modelOption, modelValue)) ||
+    visibleModeOption?.values.find((value) => value.value === visibleModeValue)
+      ?.name ||
     modes?.availableModes.find((mode) => mode.value === selectedModeId)?.name ||
     "config";
   const resolvedAliasHint =

--- a/apps/screenpipe-app-tauri/components/chat/standalone/acp-permission-selector.test.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/acp-permission-selector.test.tsx
@@ -279,6 +279,71 @@ describe("AcpPermissionSelector", () => {
     );
   });
 
+  it("maps Copilot's boolean Allow All capability into the shared permission control", async () => {
+    useAcpSessionConfig.setState({
+      sessions: {
+        [SESSION]: {
+          options: [
+            {
+              id: "mode",
+              name: "Mode",
+              category: "mode",
+              type: "select",
+              currentValue: "agent",
+              values: [
+                { value: "ask", name: "Ask" },
+                { value: "agent", name: "Agent" },
+              ],
+            },
+            {
+              id: "allow_all",
+              name: "Allow All",
+              description: "Allow all tools without confirmation",
+              type: "boolean",
+              currentValue: false,
+              values: [],
+            },
+          ],
+          modes: null,
+        },
+      } as never,
+      byAgent: {},
+    });
+    mocks.setConfigOption.mockResolvedValue({ status: "ok", data: null });
+    const onPersistDefault = vi.fn();
+
+    render(
+      <AcpPermissionSelector
+        sessionId={SESSION}
+        agentId="github-copilot-cli"
+        onPersistDefault={onPersistDefault}
+      />,
+    );
+
+    const trigger = screen.getByTestId("acp-permission-trigger");
+    expect(trigger).toHaveTextContent("Ask for approval");
+    expect(trigger).toHaveAttribute(
+      "aria-label",
+      "GitHub Copilot permissions: Ask for approval",
+    );
+    fireEvent.click(trigger);
+    fireEvent.click(screen.getByTestId("acp-permission-option-true"));
+
+    expect(onPersistDefault).toHaveBeenCalledWith({
+      optionId: "allow_all",
+      value: "true",
+    });
+    await waitFor(() =>
+      expect(mocks.setConfigOption).toHaveBeenCalledWith(
+        SESSION,
+        "allow_all",
+        "true",
+        true,
+      ),
+    );
+    expect(mocks.setMode).not.toHaveBeenCalled();
+  });
+
   it.each([
     ["pi-acp", "Pi"],
     ["cursor", "Cursor"],

--- a/apps/screenpipe-app-tauri/components/chat/standalone/acp-permission-selector.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/acp-permission-selector.tsx
@@ -23,6 +23,7 @@ import {
 import { commands, type AIPreset } from "@/lib/utils/tauri";
 import {
   findAcpModeOption,
+  findAcpPermissionBooleanOption,
   findAcpPermissionModeOption,
   hasAcpPermissionModes,
   useAcpSessionConfig,
@@ -33,11 +34,13 @@ import type { AcpConfigDefaultChange } from "@/components/chat/standalone/acp-co
 import { acpAdapterInfo } from "@/lib/utils/preset-appearance";
 import { cn } from "@/lib/utils";
 
-type ModeSource =
-  { kind: "option"; optionId: string } | { kind: "session-mode" };
+type PermissionSource =
+  | { kind: "select"; optionId: string }
+  | { kind: "boolean"; optionId: string }
+  | { kind: "session-mode" };
 
 interface PermissionControl {
-  source: ModeSource;
+  source: PermissionSource;
   currentValue: string;
   values: AcpConfigValue[];
 }
@@ -60,12 +63,38 @@ function permissionControl(
         : (config?.modes?.currentModeId ?? option.values[0]?.value);
     if (!currentValue) return null;
     return {
-      source: { kind: "option", optionId: option.id },
+      source: { kind: "select", optionId: option.id },
       currentValue,
       values: option.values,
     };
   }
-  if (findAcpModeOption(config) || !config?.modes || !hasAcpPermissionModes(config))
+  const booleanOption = findAcpPermissionBooleanOption(config);
+  if (booleanOption) {
+    const enabled =
+      booleanOption.currentValue === true ||
+      booleanOption.currentValue === "true";
+    return {
+      source: { kind: "boolean", optionId: booleanOption.id },
+      currentValue: String(enabled),
+      values: [
+        {
+          value: "false",
+          name: "Ask for approval",
+          description: "Ask before running tools that need approval.",
+        },
+        {
+          value: "true",
+          name: "Full access",
+          description: "Run every requested tool without asking for approval.",
+        },
+      ],
+    };
+  }
+  if (
+    findAcpModeOption(config) ||
+    !config?.modes ||
+    !hasAcpPermissionModes(config)
+  )
     return null;
   return {
     source: { kind: "session-mode" },
@@ -88,6 +117,22 @@ function isUnrestrictedMode(mode: AcpConfigValue): boolean {
 
 function permissionPresentation(mode: AcpConfigValue): PermissionPresentation {
   switch (mode.value) {
+    case "false":
+      return {
+        label: "Ask for approval",
+        description:
+          mode.description || "Ask before running tools that need approval.",
+        icon: Hand,
+      };
+    case "true":
+      return {
+        label: "Full access",
+        description:
+          mode.description ||
+          "Run every requested tool without asking for approval.",
+        icon: ShieldAlert,
+        warning: true,
+      };
     case "read-only":
     case "default":
       return {
@@ -192,7 +237,7 @@ export function AcpPermissionSelector({
   const presetModeId = activePreset?.acpAgent?.modeId ?? null;
   const selectedValue = liveControl
     ? liveControl.currentValue
-    : control.source.kind === "option"
+    : control.source.kind !== "session-mode"
       ? (presetConfig[control.source.optionId] ?? control.currentValue)
       : (presetModeId ?? control.currentValue);
   const selectedMode =
@@ -205,18 +250,18 @@ export function AcpPermissionSelector({
   const apply = async (mode: AcpConfigValue) => {
     setPendingValue(mode.value);
     const change: AcpConfigDefaultChange =
-      control.source.kind === "option"
+      control.source.kind !== "session-mode"
         ? { optionId: control.source.optionId, value: mode.value }
         : { modeId: mode.value };
     onPersistDefault?.(change);
     try {
       const result =
-        control.source.kind === "option"
+        control.source.kind !== "session-mode"
           ? await commands.piAcpSetConfigOption(
               sessionId,
               control.source.optionId,
               mode.value,
-              null,
+              control.source.kind === "boolean" ? true : null,
             )
           : await commands.piAcpSetMode(sessionId, mode.value);
       if (

--- a/apps/screenpipe-app-tauri/lib/stores/acp-session-config.test.ts
+++ b/apps/screenpipe-app-tauri/lib/stores/acp-session-config.test.ts
@@ -5,6 +5,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   dedupedModes,
+  findAcpPermissionBooleanOption,
   useAcpSessionConfig,
   type AcpSessionConfig,
 } from "./acp-session-config";
@@ -160,5 +161,36 @@ describe("acp-session-config boolean options", () => {
     expect(fast?.type).toBe("boolean");
     expect(fast?.currentValue).toBe(true);
     expect(fast?.values).toEqual([]);
+  });
+
+  it("recognizes a boolean approval capability without an adapter-id special case", () => {
+    const config: AcpSessionConfig = {
+      options: [
+        {
+          id: "allow_all",
+          name: "Allow All",
+          description: "Allow all tools without confirmation",
+          type: "boolean",
+          currentValue: false,
+          values: [],
+        },
+        {
+          id: "fast",
+          name: "Fast mode",
+          type: "boolean",
+          currentValue: true,
+          values: [],
+        },
+      ],
+      modes: null,
+    };
+
+    expect(findAcpPermissionBooleanOption(config)?.id).toBe("allow_all");
+    expect(
+      findAcpPermissionBooleanOption({
+        ...config,
+        options: config.options.filter((option) => option.id === "fast"),
+      }),
+    ).toBeNull();
   });
 });

--- a/apps/screenpipe-app-tauri/lib/stores/acp-session-config.ts
+++ b/apps/screenpipe-app-tauri/lib/stores/acp-session-config.ts
@@ -12,8 +12,7 @@ export interface AcpConfigValue {
 }
 
 /** An ACP session configuration option (model, ...) as advertised by the
- *  adapter in acp_session_config events. Only select options are surfaced
- *  in the UI for now. */
+ *  adapter in acp_session_config events. */
 export interface AcpConfigOption {
   id: string;
   name: string;
@@ -54,7 +53,7 @@ export function findAcpModeOption(
 }
 
 const PERMISSION_MODE_SIGNAL =
-  /permission|approval|sandbox|read.?only|full.?access|accept.?edit|dont.?ask|bypass|unrestricted/;
+  /permission|approval|sandbox|read.?only|full.?access|allow.?all|accept.?edit|dont.?ask|bypass|unrestricted/;
 
 function looksLikePermissionModes(
   values: AcpConfigValue[],
@@ -84,6 +83,24 @@ export function findAcpPermissionModeOption(
   )
     ? option
     : null;
+}
+
+/** Some adapters expose the approval boundary as one boolean instead of a
+ *  list of modes. GitHub Copilot's `Allow All` is the canonical example. Keep
+ *  the detection capability-driven so another ACP adapter with the same
+ *  contract gets the shared permission control without an agent-id matrix. */
+export function findAcpPermissionBooleanOption(
+  config: AcpSessionConfig | null | undefined,
+): AcpConfigOption | null {
+  return (
+    (config?.options ?? []).find(
+      (option) =>
+        option.type === "boolean" &&
+        PERMISSION_MODE_SIGNAL.test(
+          `${option.id} ${option.name} ${option.description ?? ""}`.toLowerCase(),
+        ),
+    ) ?? null
+  );
 }
 
 export function hasAcpPermissionModes(


### PR DESCRIPTION
## what changed

- recognize boolean ACP permission capabilities such as GitHub Copilot's Allow All
- route that capability through the shared Ask for approval / Full access control
- keep Copilot's distinct agent mode visible as Agent instead of the generic CONFIG label
- preserve adapter-advertised values and avoid a Copilot-specific provider matrix

## why

The shared composer only promoted permission lists. GitHub Copilot advertises the same approval boundary as a boolean, so it fell through into the generic config popover and made the footer look unlike every other ACP adapter.

## UI contract

```text
before
GitHub Copilot  |  CONFIG
                   Mode       Agent
                   Allow All  Off

after
Ask for approval  |  GitHub Copilot  |  Agent
     shared permission control             mode

Full access uses the same warning treatment as other ACP adapters.
```

## verification

- 36 focused Vitest tests pass across the ACP store, config, permission, composer row, and shared popover
- TypeScript passes
- effects lint passes with 0 errors (existing repository warnings remain)
- hosted coverage, Knip, Clippy/format, dependency, secret scan, CodeQL, and Linux Wayland checks pass
- the hosted frontend job's typecheck passes; its full Vitest run is blocked by an unrelated stale MCP expectation in screenpipe-tools.test.ts that omits the existing skill_manage and user_profile tools
- the local full coverage script stops on three unrelated screenpipe-engine source files already missing from the base core manifest; the hosted coverage check passes

Follow-up to #6478.
