### PR TITLE
fix(pipes): teach agents how Continue in chat works

### DIFF
--- a/crates/screenpipe-core/assets/skills/screenpipe-cli/SKILL.md
+++ b/crates/screenpipe-core/assets/skills/screenpipe-cli/SKILL.md
@@ -112,6 +112,8 @@ curl -sS -H "$auth" "$api/pipes/my-pipe/logs"
 
 `{"success":true}` means the run started, not that it passed. Poll for a new terminal log. Bind only after `success: true`; otherwise report its `stderr` and leave the Live View unchanged.
 
+This endpoint always runs the Pipe in the background; never claim its output will appear in Chat. To offer **Continue in chat**, the Pipe itself must `POST http://localhost:11435/notify` with an action containing `{"type":"pipe","pipe":"<name>","open_in_chat":true}`. The action opens a fresh Chat only after the user clicks it.
+
 ### Editing Config
 
 Edit frontmatter in `~/.screenpipe/pipes/<name>/pipe.md` directly, or use the API:

--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -4023,6 +4023,16 @@ mod tests {
         );
     }
 
+    #[test]
+    fn consumer_pipe_skill_explains_continue_in_chat_handoff() {
+        let consumer_skill = include_str!("../../assets/skills/screenpipe-cli/SKILL.md");
+
+        assert!(consumer_skill.contains("always runs the Pipe in the background"));
+        assert!(consumer_skill
+            .contains("{\"type\":\"pipe\",\"pipe\":\"<name>\",\"open_in_chat\":true}"));
+        assert!(consumer_skill.contains("only after the user clicks it"));
+    }
+
     #[cfg(not(feature = "enterprise-build"))]
     #[test]
     fn consumer_build_never_enables_enterprise_team_skill() {


### PR DESCRIPTION
## Summary

- clarify that the authenticated Pipe run endpoint always runs in the background
- give in-app and ACP agents the exact Continue in chat notification action: `{"type":"pipe","pipe":"<name>","open_in_chat":true}`
- state that a fresh Chat opens only after the user clicks the action
- add a focused regression test for the bundled agent skill

## Root cause

The bundled CLI skill explained how to start an authenticated test run but did not distinguish that background execution from the existing notification handoff. The agent inferred that authentication made the run appear in Chat and reported success without creating the required action.

## Scope

Two files, 12 added lines. No history, API, MCP, generated-skill, or UI changes.

## Validation

- `cargo fmt --package screenpipe-core -- --check`
- `cargo test -p screenpipe-core consumer_pipe_skill_explains_continue_in_chat_handoff`
- `git diff --check`