### PR TITLE
fix(windows): avoid terminal flashes from app launchers

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/connections-section.tsx
@@ -153,6 +153,7 @@ async function findCursorExeOnWindows(): Promise<string | null> {
     const localAppData = await join(home, "AppData", "Local");
     const candidates = [
       await join(localAppData, "Programs", "Cursor", "Cursor.exe"),
+      await join(localAppData, "Programs", "cursor", "Cursor.exe"),
       await join(localAppData, "cursor", "Cursor.exe"),
       await join(localAppData, "Microsoft", "WindowsApps", "Cursor.exe"),
     ];
@@ -1248,7 +1249,11 @@ function CursorPanel({ onConnected, onDisconnected }: { onConnected?: () => void
     try {
       const os = platform();
       if (os === "macos") await Command.create("open", ["-a", "Cursor"]).execute();
-      else if (os === "windows") await openWindowsShellTarget("cursor");
+      else if (os === "windows") {
+        const exe = await findCursorExeOnWindows();
+        if (exe) await openWindowsShellTarget(exe);
+        else await openUrl("https://cursor.com/download");
+      }
       else await openUrl("https://cursor.com");
     } catch { await openUrl("https://cursor.com"); }
   };
@@ -1327,7 +1332,6 @@ function CodexPanel({ onConnected, onDisconnected }: { onConnected?: () => void;
     try {
       const os = platform();
       if (os === "macos") await Command.create("open", ["-a", "Codex"]).execute();
-      else if (os === "windows") await openWindowsShellTarget("Codex");
       else await openUrl("https://chatgpt.com/codex");
     } catch { await openUrl("https://chatgpt.com/codex"); }
   };

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -4475,16 +4475,12 @@ pub async fn open_note_path(path: String) -> Result<(), String> {
     }
     #[cfg(target_os = "windows")]
     {
-        use std::os::windows::process::CommandExt;
-        use std::process::Command;
         let obsidian_uri = format!("obsidian://open?path={}", urlencoding::encode(&path));
-        let mut a = Command::new("cmd");
-        a.args(["/C", "start", "", &obsidian_uri]);
-        a.creation_flags(0x08000000); // CREATE_NO_WINDOW
-        let mut b = Command::new("cmd");
-        b.args(["/C", "start", "", &path]);
-        b.creation_flags(0x08000000); // CREATE_NO_WINDOW
-        if a.spawn().is_ok() || b.spawn().is_ok() {
+        if open_windows_shell_target(obsidian_uri).is_ok() {
+            return Ok(());
+        }
+
+        if open_windows_shell_target(path.clone()).is_ok() {
             Ok(())
         } else {
             Err(format!("failed to open note path: {}", path))
@@ -4506,23 +4502,43 @@ pub async fn open_note_path(path: String) -> Result<(), String> {
 pub fn open_windows_shell_target(target: String) -> Result<(), String> {
     #[cfg(target_os = "windows")]
     {
-        use std::os::windows::process::CommandExt;
-        use std::process::Command;
+        use windows::core::PCWSTR;
+        use windows::Win32::UI::Shell::ShellExecuteW;
+        use windows::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
 
-        let mut cmd = Command::new("cmd");
-        cmd.args(["/C", "start", "", &target])
-            .creation_flags(0x08000000); // CREATE_NO_WINDOW
+        let target = target.trim().to_string();
+        if target.is_empty() {
+            return Err("failed to open Windows shell target: target is empty".to_string());
+        }
 
-        match cmd.status() {
-            Ok(status) if status.success() => Ok(()),
-            Ok(status) => Err(format!(
-                "failed to open Windows shell target {}: {}",
-                target, status
-            )),
-            Err(e) => Err(format!(
-                "failed to open Windows shell target {}: {}",
-                target, e
-            )),
+        let operation = "open"
+            .encode_utf16()
+            .chain(std::iter::once(0))
+            .collect::<Vec<u16>>();
+        let target_wide = target
+            .encode_utf16()
+            .chain(std::iter::once(0))
+            .collect::<Vec<u16>>();
+
+        let result = unsafe {
+            ShellExecuteW(
+                None,
+                PCWSTR(operation.as_ptr()),
+                PCWSTR(target_wide.as_ptr()),
+                PCWSTR::null(),
+                PCWSTR::null(),
+                SW_SHOWNORMAL,
+            )
+        };
+
+        let result_code = result.0 as isize;
+        if result_code > 32 {
+            Ok(())
+        } else {
+            Err(format!(
+                "failed to open Windows shell target {}: ShellExecuteW returned {}",
+                target, result_code
+            ))
         }
     }
 


### PR DESCRIPTION
## Summary
- replace the Windows launcher helper's `cmd /C start` path with native `ShellExecuteW`
- open Cursor through the resolved desktop `Cursor.exe` instead of the `cursor` CLI shim, including the lowercase `Programs\cursor` install path
- stop the Windows Codex button from shell-resolving `Codex`; send users to the Codex web entrypoint instead
- reuse the native launcher for Windows note/citation opening so that path also avoids console flashes

## Testing
- `git diff --check`
- `bun install --frozen-lockfile`
- `bun x tsc --noEmit`
- `CARGO_TARGET_DIR=C:\Users\louis030195\AppData\Local\Temp\spb-acp cargo check -j 1 --manifest-path apps\screenpipe-app-tauri\src-tauri\Cargo.toml`