### PR TITLE
feat(analytics): track effective continuous audio mode

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -32,15 +32,15 @@ results and `cargo llvm-cov` data on top when judging release confidence.
 
 - Mapped suites: 32
 - Mapped Rust files: 330
-- Active test blocks: 3186
+- Active test blocks: 3194
 - Ignored/manual test blocks: 137
-- Weighted coverage points: 2613.9
+- Weighted coverage points: 2620.1
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 3047 | 132 | 2550.5 | 21 | 11 | 100% |
-| macos | 29 | 3105 | 112 | 2562.9 | 22 | 11 | 100% |
-| linux | 25 | 2721 | 105 | 2253.8 | 20 | 11 | 100% |
+| windows | 29 | 3055 | 132 | 2556.7 | 21 | 11 | 100% |
+| macos | 29 | 3113 | 112 | 2569.1 | 22 | 11 | 100% |
+| linux | 25 | 2729 | 105 | 2259.9 | 20 | 11 | 100% |
 
 ## Refresh
 

--- a/apps/screenpipe-app-tauri/src-tauri/src/analytics.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/analytics.rs
@@ -51,6 +51,10 @@ fn pipeline_ocr_cache_hit_rate(health: &serde_json::Value) -> Option<f64> {
     health["pipeline"]["ocr_cache_hit_rate"].as_f64()
 }
 
+fn health_audio_capture_mode(health: &serde_json::Value) -> &str {
+    health["audio_capture_mode"].as_str().unwrap_or("unknown")
+}
+
 fn audio_capture_mode_setting(settings: &serde_json::Value) -> &'static str {
     match settings
         .get("audioCaptureMode")
@@ -425,6 +429,7 @@ impl AnalyticsManager {
         // Extract relevant status fields
         let frame_status = health["frame_status"].as_str().unwrap_or("unknown");
         let audio_status = health["audio_status"].as_str().unwrap_or("unknown");
+        let audio_capture_mode = health_audio_capture_mode(&health);
         let ui_status = health["ui_status"].as_str().unwrap_or("unknown");
 
         // Consider healthy if all enabled systems are "ok"
@@ -442,6 +447,7 @@ impl AnalyticsManager {
             "is_healthy": is_healthy,
             "frame_status": frame_status,
             "audio_status": audio_status,
+            "audio_capture_mode": audio_capture_mode,
             "ui_status": ui_status,
             // Vision pipeline quality
             "pipeline_uptime_secs": pipeline["uptime_secs"].as_f64(),
@@ -597,6 +603,15 @@ mod tests {
         let health = json!({"pipeline": {"ocr_cache_hit_rate": 0.4}});
 
         assert_eq!(pipeline_ocr_cache_hit_rate(&health), Some(0.4));
+    }
+
+    #[test]
+    fn health_properties_forward_effective_audio_capture_mode() {
+        assert_eq!(
+            health_audio_capture_mode(&json!({"audio_capture_mode": "meetings-only"})),
+            "meetings-only"
+        );
+        assert_eq!(health_audio_capture_mode(&json!({})), "unknown");
     }
 
     #[test]

--- a/apps/screenpipe-app-tauri/src-tauri/src/analytics.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/analytics.rs
@@ -51,6 +51,18 @@ fn pipeline_ocr_cache_hit_rate(health: &serde_json::Value) -> Option<f64> {
     health["pipeline"]["ocr_cache_hit_rate"].as_f64()
 }
 
+fn audio_capture_mode_setting(settings: &serde_json::Value) -> &'static str {
+    match settings
+        .get("audioCaptureMode")
+        .and_then(|value| value.as_str())
+    {
+        Some("meetings-only") => "meetings-only",
+        Some("disabled") => "disabled",
+        // Missing and malformed values follow the engine's historical default.
+        _ => "always",
+    }
+}
+
 impl AnalyticsManager {
     pub fn new(
         posthog_api_key: String,
@@ -370,6 +382,7 @@ impl AnalyticsManager {
 
             // Audio
             "setting_disable_audio": get_bool("disableAudio").unwrap_or(false),
+            "setting_audio_capture_mode": audio_capture_mode_setting(settings),
             "setting_audio_device_count": get_arr_len("audioDevices"),
             "setting_audio_transcription_engine": get_str("audioTranscriptionEngine").unwrap_or("unknown"),
             "setting_audio_chunk_duration": get_f64("audioChunkDuration").unwrap_or(30.0),
@@ -584,5 +597,34 @@ mod tests {
         let health = json!({"pipeline": {"ocr_cache_hit_rate": 0.4}});
 
         assert_eq!(pipeline_ocr_cache_hit_rate(&health), Some(0.4));
+    }
+
+    #[test]
+    fn audio_capture_mode_setting_tracks_supported_modes() {
+        assert_eq!(
+            audio_capture_mode_setting(&json!({"audioCaptureMode": "always"})),
+            "always"
+        );
+        assert_eq!(
+            audio_capture_mode_setting(&json!({"audioCaptureMode": "meetings-only"})),
+            "meetings-only"
+        );
+        assert_eq!(
+            audio_capture_mode_setting(&json!({"audioCaptureMode": "disabled"})),
+            "disabled"
+        );
+    }
+
+    #[test]
+    fn audio_capture_mode_setting_uses_engine_default_for_missing_or_malformed_values() {
+        assert_eq!(audio_capture_mode_setting(&json!({})), "always");
+        assert_eq!(
+            audio_capture_mode_setting(&json!({"audioCaptureMode": "unexpected"})),
+            "always"
+        );
+        assert_eq!(
+            audio_capture_mode_setting(&json!({"audioCaptureMode": false})),
+            "always"
+        );
     }
 }

--- a/crates/screenpipe-engine/src/routes/health.rs
+++ b/crates/screenpipe-engine/src/routes/health.rs
@@ -417,6 +417,22 @@ struct MeetingsOnlyAudioIdleState {
     detector_unavailable: bool,
 }
 
+fn effective_audio_capture_mode(
+    audio_disabled: bool,
+    configured_mode: Option<&AudioCaptureMode>,
+    meetings_only_supported: bool,
+) -> &'static str {
+    if audio_disabled {
+        "disabled"
+    } else if meetings_only_supported
+        && matches!(configured_mode, Some(AudioCaptureMode::MeetingsOnly))
+    {
+        "meetings-only"
+    } else {
+        "always"
+    }
+}
+
 fn meetings_only_audio_idle_state(
     configured: bool,
     meeting_detected: Option<bool>,
@@ -631,6 +647,10 @@ pub struct HealthCheckResponse {
     /// are what turn "stale" into a locatable freeze point.
     pub loop_stage: String,
     pub loop_stage_age_secs: Option<u64>,
+    /// Effective runtime audio capture mode: `always`, `meetings-only`, or
+    /// `disabled`. This can differ from the saved preference when policy or
+    /// platform support changes the mode used by the recorder.
+    pub audio_capture_mode: String,
     pub audio_status: String,
     pub message: String,
     pub verbose_instructions: Option<String>,
@@ -950,6 +970,7 @@ fn degraded_response() -> HealthCheckResponse {
         vision_reason: "unknown".to_string(),
         loop_stage: "unknown".to_string(),
         loop_stage_age_secs: None,
+        audio_capture_mode: "unknown".to_string(),
         audio_status: "unknown".to_string(),
         message: "health check timed out before producing a snapshot".to_string(),
         verbose_instructions: None,
@@ -1207,11 +1228,13 @@ async fn health_check_inner(state: &Arc<AppState>) -> HealthCheckResponse {
     // Report intentional meetings-only idleness only after every configured
     // stream has actually been released. During teardown, health continues to
     // describe the observed active streams instead of claiming an early pause.
-    let meetings_only_configured = cfg!(any(target_os = "macos", target_os = "windows"))
-        && matches!(
-            state.audio_manager.configured_audio_capture_mode(),
-            Some(AudioCaptureMode::MeetingsOnly)
-        );
+    let configured_audio_capture_mode = state.audio_manager.configured_audio_capture_mode();
+    let audio_capture_mode = effective_audio_capture_mode(
+        state.audio_disabled,
+        configured_audio_capture_mode.as_ref(),
+        cfg!(any(target_os = "macos", target_os = "windows")),
+    );
+    let meetings_only_configured = audio_capture_mode == "meetings-only";
     // Detector absence is not ordinary idle: the device gate fails closed, and
     // health must make the missing prerequisite visible. A timed-out health
     // probe is kept as unknown so lock contention cannot manufacture an error.
@@ -1819,6 +1842,7 @@ async fn health_check_inner(state: &Arc<AppState>) -> HealthCheckResponse {
         loop_stage: vision_loop_stage.as_str().to_string(),
         loop_stage_age_secs: vision_loop_stage_entered_ts
             .and_then(|ts| (ts > 0).then(|| now_ts.saturating_sub(ts))),
+        audio_capture_mode: audio_capture_mode.to_string(),
         audio_status,
         message,
         verbose_instructions,
@@ -2468,6 +2492,7 @@ mod tests {
             vision_reason: "ok".to_string(),
             loop_stage: "unknown".to_string(),
             loop_stage_age_secs: None,
+            audio_capture_mode: "always".to_string(),
             audio_status: "ok".to_string(),
             message: "test".to_string(),
             verbose_instructions: None,
@@ -2571,6 +2596,24 @@ mod tests {
         assert_eq!(
             state.reason,
             "audio capture is paused while the screen is locked"
+        );
+    }
+
+    #[test]
+    fn effective_audio_capture_mode_reports_the_mode_the_recorder_can_run() {
+        assert_eq!(effective_audio_capture_mode(true, None, true), "disabled");
+        assert_eq!(effective_audio_capture_mode(false, None, true), "always");
+        assert_eq!(
+            effective_audio_capture_mode(false, Some(&AudioCaptureMode::Always), true),
+            "always"
+        );
+        assert_eq!(
+            effective_audio_capture_mode(false, Some(&AudioCaptureMode::MeetingsOnly), true),
+            "meetings-only"
+        );
+        assert_eq!(
+            effective_audio_capture_mode(false, Some(&AudioCaptureMode::MeetingsOnly), false),
+            "always"
         );
     }
 

--- a/docs/coverage/CORE.md
+++ b/docs/coverage/CORE.md
@@ -9,10 +9,10 @@ confidence, and criticality.
 - Tracked crates: screenpipe-engine, screenpipe-db, screenpipe-sqlite-coordinator, screenpipe-audio, screenpipe-screen, screenpipe-a11y
 - Mapped suites: 32
 - Mapped Rust files: 330
-- Active test blocks: 3186
+- Active test blocks: 3194
 - Ignored/manual test blocks: 137
-- Declared test blocks: 3323
-- Weighted coverage points: 2613.9
+- Declared test blocks: 3331
+- Weighted coverage points: 2620.1
 
 Confidence weights: strong=1.0, partial=0.7, conditional=0.4, smoke=0.3.
 Criticality weights: high=1.0, medium=0.7, low=0.4.
@@ -23,16 +23,16 @@ are explicitly enabled in a runtime lane.
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 3047 | 132 | 2550.5 | 21 | 11 | 100% |
-| macos | 29 | 3105 | 112 | 2562.9 | 22 | 11 | 100% |
-| linux | 25 | 2721 | 105 | 2253.8 | 20 | 11 | 100% |
+| windows | 29 | 3055 | 132 | 2556.7 | 21 | 11 | 100% |
+| macos | 29 | 3113 | 112 | 2569.1 | 22 | 11 | 100% |
+| linux | 25 | 2729 | 105 | 2259.9 | 20 | 11 | 100% |
 
 ## Crate Summary
 
 | Crate | Suites | Integration files | Source unit files | Active tests | Ignored tests | Weighted points | Flows |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| screenpipe-engine | 10 | 19 | 109 | 1533 | 42 | 1173.5 | 10 |
-| screenpipe-db | 5 | 52 | 15 | 451 | 16 | 428.2 | 9 |
+| screenpipe-engine | 10 | 19 | 109 | 1540 | 42 | 1178.7 | 10 |
+| screenpipe-db | 5 | 52 | 15 | 452 | 16 | 429.2 | 9 |
 | screenpipe-sqlite-coordinator | 1 | 0 | 2 | 16 | 0 | 16.0 | 2 |
 | screenpipe-audio | 6 | 25 | 51 | 591 | 43 | 517.4 | 5 |
 | screenpipe-screen | 6 | 9 | 18 | 252 | 9 | 226.1 | 4 |
@@ -65,22 +65,22 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | audio | 7 suites / 701 active / 44 ignored / 627.4 pts | 7 suites / 701 active / 44 ignored / 627.4 pts | 6 suites / 626 active / 43 ignored / 574.9 pts |
 | audio-device | 2 suites / 212 active / 7 ignored / 189.5 pts | 2 suites / 212 active / 7 ignored / 189.5 pts | 1 suites / 137 active / 6 ignored / 137.0 pts |
 | configuration | 2 suites / 138 active / 3 ignored / 124.2 pts | 2 suites / 138 active / 3 ignored / 124.2 pts | 2 suites / 138 active / 3 ignored / 124.2 pts |
-| database | 6 suites / 370 active / 12 ignored / 347.2 pts | 6 suites / 370 active / 12 ignored / 347.2 pts | 6 suites / 370 active / 12 ignored / 347.2 pts |
-| db-search | 2 suites / 111 active / 9 ignored / 111.0 pts | 2 suites / 111 active / 9 ignored / 111.0 pts | 2 suites / 111 active / 9 ignored / 111.0 pts |
+| database | 6 suites / 371 active / 12 ignored / 348.2 pts | 6 suites / 371 active / 12 ignored / 348.2 pts | 6 suites / 371 active / 12 ignored / 348.2 pts |
+| db-search | 2 suites / 112 active / 9 ignored / 112.0 pts | 2 suites / 112 active / 9 ignored / 112.0 pts | 2 suites / 112 active / 9 ignored / 112.0 pts |
 | engine-lifecycle | 6 suites / 209 active / 1 ignored / 184.3 pts | 6 suites / 209 active / 1 ignored / 184.3 pts | 5 suites / 203 active / 1 ignored / 182.6 pts |
-| local-api | 2 suites / 363 active / 9 ignored / 255.9 pts | 2 suites / 363 active / 9 ignored / 255.9 pts | 2 suites / 363 active / 9 ignored / 255.9 pts |
-| meeting | 6 suites / 1467 active / 19 ignored / 1196.7 pts | 6 suites / 1467 active / 19 ignored / 1196.7 pts | 4 suites / 1174 active / 15 ignored / 926.2 pts |
+| local-api | 2 suites / 370 active / 9 ignored / 261.1 pts | 2 suites / 370 active / 9 ignored / 261.1 pts | 2 suites / 370 active / 9 ignored / 261.1 pts |
+| meeting | 6 suites / 1473 active / 19 ignored / 1200.9 pts | 6 suites / 1473 active / 19 ignored / 1200.9 pts | 4 suites / 1180 active / 15 ignored / 930.4 pts |
 | ocr | 4 suites / 125 active / 7 ignored / 119.0 pts | 4 suites / 129 active / 7 ignored / 124.5 pts | 3 suites / 120 active / 6 ignored / 115.5 pts |
 | os-integration | 1 suites / 6 active / 0 ignored / 1.7 pts | 1 suites / 6 active / 0 ignored / 1.7 pts | - |
-| performance | 13 suites / 1416 active / 67 ignored / 1244.9 pts | 14 suites / 1519 active / 70 ignored / 1286.1 pts | 13 suites / 1416 active / 67 ignored / 1244.9 pts |
+| performance | 13 suites / 1417 active / 67 ignored / 1245.9 pts | 14 suites / 1520 active / 70 ignored / 1287.1 pts | 13 suites / 1417 active / 67 ignored / 1245.9 pts |
 | pipes | 1 suites / 469 active / 3 ignored / 328.3 pts | 1 suites / 469 active / 3 ignored / 328.3 pts | 1 suites / 469 active / 3 ignored / 328.3 pts |
 | privacy | 5 suites / 886 active / 36 ignored / 720.4 pts | 5 suites / 940 active / 16 ignored / 727.3 pts | 5 suites / 864 active / 14 ignored / 699.3 pts |
 | real-app | - | 1 suites / 103 active / 3 ignored / 41.2 pts | - |
 | speaker | 2 suites / 348 active / 8 ignored / 348.0 pts | 2 suites / 348 active / 8 ignored / 348.0 pts | 2 suites / 348 active / 8 ignored / 348.0 pts |
-| storage | 3 suites / 507 active / 29 ignored / 408.6 pts | 3 suites / 507 active / 29 ignored / 408.6 pts | 3 suites / 507 active / 29 ignored / 408.6 pts |
+| storage | 3 suites / 508 active / 29 ignored / 409.6 pts | 3 suites / 508 active / 29 ignored / 409.6 pts | 3 suites / 508 active / 29 ignored / 409.6 pts |
 | sync | 1 suites / 469 active / 3 ignored / 328.3 pts | 1 suites / 469 active / 3 ignored / 328.3 pts | 1 suites / 469 active / 3 ignored / 328.3 pts |
-| timeline | 4 suites / 1010 active / 33 ignored / 815.9 pts | 4 suites / 1010 active / 33 ignored / 815.9 pts | 4 suites / 1010 active / 33 ignored / 815.9 pts |
-| transcription | 5 suites / 736 active / 40 ignored / 577.8 pts | 5 suites / 736 active / 40 ignored / 577.8 pts | 5 suites / 736 active / 40 ignored / 577.8 pts |
+| timeline | 4 suites / 1017 active / 33 ignored / 821.1 pts | 4 suites / 1017 active / 33 ignored / 821.1 pts | 4 suites / 1017 active / 33 ignored / 821.1 pts |
+| transcription | 5 suites / 742 active / 40 ignored / 582.0 pts | 5 suites / 742 active / 40 ignored / 582.0 pts | 5 suites / 742 active / 40 ignored / 582.0 pts |
 | ui-events | 4 suites / 709 active / 28 ignored / 539.8 pts | 3 suites / 660 active / 5 ignored / 505.5 pts | 3 suites / 660 active / 5 ignored / 505.5 pts |
 | vision-capture | 5 suites / 533 active / 32 ignored / 420.1 pts | 5 suites / 537 active / 32 ignored / 425.6 pts | 4 suites / 528 active / 31 ignored / 416.6 pts |
 
@@ -132,13 +132,13 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | db-audio-meetings-speakers | screenpipe-db | windows, macos, linux | database, audio, meeting, speaker | audio-record-transcribe, audio-device-health, meeting-live-notes | high | strong | integration | 15 | 110 | 1 | Audio transcript dedupe, live meeting mirroring, end-generation and open-meeting invariants, liveness, and speaker reassignment coverage. |
 | db-runtime-reliability | screenpipe-db | windows, macos, linux | database, performance | performance-liveness | high | partial | mixed | 13 | 30 | 6 | SQLite hard-fault classification, failpoint VFS injection, fresh-identity recovery verification with integrity/FK/write canaries, query cancellation, close-severs-connections regressions, multi-pool WAL parity, runtime version pinning, and WAL chaos plus memory-pressure probes, plus read-only quarantine self-heal verification for transient IOERR faults. |
 | db-search-indexing | screenpipe-db | windows, macos, linux | db-search, ocr, accessibility, performance | local-api-search, capture-ocr-pipeline, accessibility-ui-events, performance-liveness | high | strong | mixed | 13 | 105 | 4 | FTS, tokenizer, OCR snapshot search, query planning, ordering, accessibility search, and contention coverage. |
-| db-timeline-frames | screenpipe-db | windows, macos, linux | database, timeline, storage, performance | timeline-streaming, performance-liveness | high | strong | mixed | 19 | 179 | 3 | Frame/audio joins, timeline query shape, suggestions frames, write queue, DB primitives (src/db.rs split into src/db/ modules), feedback record upserts, media eviction anti-join regressions, SAF output registry, semantic storage, and timeline performance. |
-| engine-api-routes | screenpipe-engine | windows, macos, linux | local-api, timeline, meeting, transcription | local-api-search, timeline-streaming, meeting-live-notes, audio-record-transcribe | high | partial | mixed | 36 | 357 | 4 | Route/unit coverage for search, health, streaming, meetings, time/timezone, and transcription. Legacy endpoint/websocket tests require local data and remain ignored. |
+| db-timeline-frames | screenpipe-db | windows, macos, linux | database, timeline, storage, performance | timeline-streaming, performance-liveness | high | strong | mixed | 19 | 180 | 3 | Frame/audio joins, timeline query shape, suggestions frames, write queue, DB primitives (src/db.rs split into src/db/ modules), feedback record upserts, media eviction anti-join regressions, SAF output registry, semantic storage, and timeline performance. |
+| engine-api-routes | screenpipe-engine | windows, macos, linux | local-api, timeline, meeting, transcription | local-api-search, timeline-streaming, meeting-live-notes, audio-record-transcribe | high | partial | mixed | 36 | 363 | 4 | Route/unit coverage for search, health, streaming, meetings, time/timezone, and transcription. Legacy endpoint/websocket tests require local data and remain ignored. |
 | engine-capture-timeline | screenpipe-engine | windows, macos, linux | vision-capture, timeline, storage, performance | capture-ocr-pipeline, timeline-streaming, performance-liveness | high | partial | mixed | 25 | 290 | 26 | Covers capture trigger logic, frame/audio linking, hot cache, timeline refresh regressions, fragmented MP4 extraction, and HD-mode control. Several real-data tests are intentionally ignored by default. |
 | engine-config-lifecycle | screenpipe-engine | windows, macos, linux | configuration, engine-lifecycle, performance | settings-to-engine-config, engine-health-lifecycle, performance-liveness | high | strong | mixed | 11 | 111 | 1 | Fast logic coverage for the config bridge, tray health debounce, sleep/power policies, and queue backpressure. |
 | engine-db-recovery-cli | screenpipe-engine | windows, macos, linux | database, engine-lifecycle | engine-health-lifecycle, performance-liveness | high | strong | unit | 1 | 8 | 0 | Exact DB/WAL/SHM working-copy preservation, rollback on archive failure, and restart repair for crashes during the multi-file generation swap. |
 | engine-focus-os | screenpipe-engine | windows, macos | engine-lifecycle, os-integration | engine-health-lifecycle, performance-liveness | medium | conditional | unit | 3 | 6 | 0 | Platform focus-tracker parsing/helpers. These files are cfg-gated and only execute on their target OS. |
-| engine-local-api-search-integration | screenpipe-engine | windows, macos, linux | local-api, db-search | local-api-search | high | strong | integration | 1 | 6 | 5 | Active /search route test builds an audio-disabled router, seeds captured-screen-shaped OCR data into an in-memory DB, and asserts the HTTP response and pagination. |
+| engine-local-api-search-integration | screenpipe-engine | windows, macos, linux | local-api, db-search | local-api-search | high | strong | integration | 1 | 7 | 5 | Active /search route test builds an audio-disabled router, seeds captured-screen-shaped OCR data into an in-memory DB, and asserts the HTTP response and pagination. |
 | engine-meeting-privacy-sync | screenpipe-engine | windows, macos, linux | meeting, privacy, ui-events, pipes, sync | meeting-live-notes, privacy-and-redaction, accessibility-ui-events, performance-liveness | medium | strong | unit | 31 | 469 | 3 | Unit-heavy coverage for privacy filter policy, capture exclusions, UI recorder safety, pipes/live-view/structured-output helpers, sync helpers, and CLI parsing. Meeting detection moved to the engine-meeting-watcher suite. |
 | engine-meeting-watcher | screenpipe-engine | windows, macos | meeting | meeting-live-notes | high | strong | mixed | 9 | 218 | 3 | Successor of src/meeting_detector.rs and src/meeting_telemetry.rs. Audio-process and UI-scan backend state machines, candidate resolution, shared telemetry, and a scored trajectory eval. ui_scan/macos.rs and ui_scan/windows.rs are cfg-gated and only execute on their target OS; both backends are null on Linux. |
 | engine-retention-storage | screenpipe-engine | windows, macos, linux | storage, engine-lifecycle, performance | engine-health-lifecycle, performance-liveness | medium | strong | mixed | 5 | 38 | 0 | Local retention deletion (including lean-mode heavy-text stripping), cloud archive watermarking, atomic state-file replacement, and the low-disk capture monitor. |
@@ -267,7 +267,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | db-timeline-frames | screenpipe-db | src/db/feedback.rs | source | 2 | 0 | 2 |
 | db-timeline-frames | screenpipe-db | src/db/maintenance.rs | source | 4 | 1 | 5 |
 | db-timeline-frames | screenpipe-db | src/db/setup.rs | source | 6 | 0 | 6 |
-| db-timeline-frames | screenpipe-db | src/db/tests.rs | source | 25 | 1 | 26 |
+| db-timeline-frames | screenpipe-db | src/db/tests.rs | source | 26 | 1 | 27 |
 | db-timeline-frames | screenpipe-db | src/db/truncation_tests.rs | source | 1 | 0 | 1 |
 | db-runtime-reliability | screenpipe-db | src/failpoint_vfs.rs | source | 4 | 0 | 4 |
 | db-runtime-reliability | screenpipe-db | src/recovery.rs | source | 5 | 0 | 5 |
@@ -403,8 +403,8 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | engine-api-routes | screenpipe-engine | src/routes/content.rs | source | 8 | 0 | 8 |
 | engine-api-routes | screenpipe-engine | src/routes/data.rs | source | 2 | 0 | 2 |
 | engine-api-routes | screenpipe-engine | src/routes/elements.rs | source | 25 | 1 | 26 |
-| engine-api-routes | screenpipe-engine | src/routes/frames.rs | source | 7 | 1 | 8 |
-| engine-api-routes | screenpipe-engine | src/routes/health.rs | source | 46 | 0 | 46 |
+| engine-api-routes | screenpipe-engine | src/routes/frames.rs | source | 12 | 1 | 13 |
+| engine-api-routes | screenpipe-engine | src/routes/health.rs | source | 47 | 0 | 47 |
 | engine-api-routes | screenpipe-engine | src/routes/live_views.rs | source | 1 | 0 | 1 |
 | engine-api-routes | screenpipe-engine | src/routes/meeting_summary_status.rs | source | 10 | 0 | 10 |
 | engine-api-routes | screenpipe-engine | src/routes/meetings.rs | source | 6 | 0 | 6 |
@@ -440,7 +440,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | engine-capture-timeline | screenpipe-engine | tests/audio_vision_integration_test.rs | integration | 0 | 1 | 1 |
 | engine-capture-timeline | screenpipe-engine | tests/compaction_encoder_test.rs | integration | 3 | 0 | 3 |
 | engine-config-lifecycle | screenpipe-engine | tests/consumer_sleep_test.rs | integration | 5 | 0 | 5 |
-| engine-local-api-search-integration | screenpipe-engine | tests/endpoint_test.rs | integration | 6 | 5 | 11 |
+| engine-local-api-search-integration | screenpipe-engine | tests/endpoint_test.rs | integration | 7 | 5 | 12 |
 | engine-capture-timeline | screenpipe-engine | tests/first_frames_test.rs | integration | 0 | 4 | 4 |
 | engine-capture-timeline | screenpipe-engine | tests/frame_extraction_test.rs | integration | 1 | 5 | 6 |
 | engine-capture-timeline | screenpipe-engine | tests/frame_linker_actor_integration.rs | integration | 7 | 0 | 7 |


### PR DESCRIPTION
## Summary

- add `setting_audio_capture_mode` to desktop `app_started` and six-hour `app_still_running` telemetry for the saved preference
- expose the engine effective `audio_capture_mode` through `/health` and forward it on `app_still_running`
- report only coarse values: `always`, `meetings-only`, `disabled`, or `unknown`
- normalize missing and malformed legacy settings to `always`, matching the engine default

## Telemetry flow

    store.bin audioCaptureMode
      +-> setting_audio_capture_mode
          +-> app_started
          +-> app_still_running (every 6h)

    recorder configured mode + platform support + audio disabled state
      +-> /health audio_capture_mode
          +-> app_still_running (every 6h)

The two properties keep requested preference separate from effective recorder behavior. Existing subscription properties can then segment continuous-audio adoption by Free versus paid plan without inferring mode from audio activity.

## Privacy

Only capture-mode enums are added. No audio, transcript, device name, meeting data, or captured content is sent.

## Verification

- `CARGO_TARGET_DIR=apps/screenpipe-app-tauri/src-tauri/target cargo test -p screenpipe-engine effective_audio_capture_mode_reports_the_mode_the_recorder_can_run -- --nocapture` - 1 passed
- `cargo test analytics::tests -- --nocapture` - 4 passed
- `bun run coverage:all:check`
- `rustfmt --edition 2021 --check apps/screenpipe-app-tauri/src-tauri/src/analytics.rs crates/screenpipe-engine/src/routes/health.rs`
- `git diff --check origin/main...HEAD`

No UI or recorder behavior changes, so no visual before and after is applicable.