### PR TITLE
fix(db): preserve macOS sqlite process ownership

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -32,15 +32,15 @@ results and `cargo llvm-cov` data on top when judging release confidence.
 
 - Mapped suites: 32
 - Mapped Rust files: 330
-- Active test blocks: 3196
+- Active test blocks: 3198
 - Ignored/manual test blocks: 137
-- Weighted coverage points: 2621.5
+- Weighted coverage points: 2623.5
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 3057 | 132 | 2558.1 | 21 | 11 | 100% |
-| macos | 29 | 3115 | 112 | 2570.5 | 22 | 11 | 100% |
-| linux | 25 | 2731 | 105 | 2261.4 | 20 | 11 | 100% |
+| windows | 29 | 3059 | 132 | 2560.1 | 21 | 11 | 100% |
+| macos | 29 | 3117 | 112 | 2572.5 | 22 | 11 | 100% |
+| linux | 25 | 2733 | 105 | 2263.4 | 20 | 11 | 100% |
 
 ## Refresh
 

--- a/crates/screenpipe-audio/src/audio_manager/reconciliation.rs
+++ b/crates/screenpipe-audio/src/audio_manager/reconciliation.rs
@@ -1759,8 +1759,8 @@ mod tests {
     // ── pending-chunk durable recovery (SCREENPIPE-CLI-RC) ──────────────────
 
     async fn temp_db(dir: &Path) -> DatabaseManager {
-        let db_path = dir.join("db.sqlite");
-        DatabaseManager::new(&format!("sqlite:{}", db_path.display()), Default::default())
+        let db_path = dir.join("db.sqlite").to_string_lossy().into_owned();
+        DatabaseManager::new(&db_path, Default::default())
             .await
             .expect("open temp db")
     }

--- a/crates/screenpipe-db/src/db/mod.rs
+++ b/crates/screenpipe-db/src/db/mod.rs
@@ -7,7 +7,6 @@ use image::DynamicImage;
 use libsqlite3_sys::sqlite3_auto_extension;
 use screenpipe_config::DbConfig;
 use sqlite_vec::sqlite3_vec_init;
-use sqlx::migrate::MigrateDatabase;
 use sqlx::pool::PoolConnection;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePool};
 use sqlx::Column;
@@ -319,6 +318,9 @@ pub struct DatabaseManager {
     /// Slot for the persistent-failure hook, wired by the app after construction.
     /// Shared with the drain loop so a late `set_persistent_failure_hook` takes effect.
     persistent_failure_hook: crate::write_queue::PersistentFailureSlot,
+    /// Prevents a second independently managed pool generation from opening
+    /// this physical path and invalidating macOS unix-excl's process lock.
+    manager_lease: Option<screenpipe_sqlite_coordinator::SqliteManagerLease>,
     /// Cancelled by [`DatabaseManager::close`]. Stops the WAL-maintenance task and
     /// the write-queue drain loop so no background task keeps a SQLite connection
     /// (and the shared `-shm` WAL-index mapping) alive after teardown — a leaked

--- a/crates/screenpipe-db/src/db/setup.rs
+++ b/crates/screenpipe-db/src/db/setup.rs
@@ -133,6 +133,16 @@ impl DatabaseManager {
         // path can durably quarantine this generation with a metadata-only
         // rename even when allocating a new marker would fail.
         let database_file = Path::new(database_path);
+        let is_in_memory =
+            database_path.contains(":memory:") || database_path.contains("mode=memory");
+        let manager_lease = if is_in_memory {
+            None
+        } else {
+            Some(
+                screenpipe_sqlite_coordinator::acquire_sqlite_manager_lease(database_file)
+                    .map_err(SqlxError::Protocol)?,
+            )
+        };
         screenpipe_sqlite_coordinator::prepare_sqlite_quarantine_reserve(database_file).map_err(
             |error| {
                 SqlxError::Protocol(format!(
@@ -167,16 +177,32 @@ impl DatabaseManager {
             }
         }
 
-        // Create the database if it doesn't exist
-        if !sqlx::Sqlite::database_exists(&connection_string)
-            .await
-            .map_err(|error| quarantine_startup_error(database_file, error))?
-        {
-            sqlx::Sqlite::create_database(&connection_string)
-                .await
-                .map_err(|error| quarantine_startup_error(database_file, error))?;
+        // Do not use `Sqlite::database_exists` or `Sqlite::create_database`
+        // here. Those helpers open the file through SQLite's default VFS. If a
+        // second DatabaseManager starts while the recorder is live, that
+        // default-VFS handle issues real POSIX unlocks against the same inode,
+        // silently releasing unix-excl's process-wide lock. Existing
+        // unix-excl handles still believe `bProcessLock` is set and never
+        // reacquire it, so an external sqlite3 process can then attach to the
+        // live WAL and invalidate the mapped WAL index (observed code 522).
+        // A filesystem create has no SQLite locking side effects; every actual
+        // SQLite open below therefore enters through the configured VFS.
+        let created_database = if is_in_memory {
+            false
+        } else {
+            match std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(database_file)
+            {
+                Ok(_) => true,
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => false,
+                Err(error) => return Err(SqlxError::Io(error)),
+            }
+        };
+        if created_database {
             // The pre-open reserve had no file identity because this was a new
-            // path. Refresh it now that SQLite created the physical generation.
+            // path. Refresh it now that the physical generation exists.
             screenpipe_sqlite_coordinator::prepare_sqlite_quarantine_reserve(database_file)
                 .map_err(|error| {
                     SqlxError::Protocol(format!(
@@ -198,8 +224,6 @@ impl DatabaseManager {
         // cache_size + mmap_size are tier-configurable and applied here; the
         // WAL-safety pragmas that MUST be identical on every connection over this
         // file come from the single source of truth `WAL_SAFETY_PRAGMAS`.
-        let is_in_memory =
-            database_path.contains(":memory:") || database_path.contains("mode=memory");
         let mut connect_options: SqliteConnectOptions = connection_string
             .parse::<SqliteConnectOptions>()?
             .busy_timeout(Duration::from_secs(5))
@@ -334,6 +358,7 @@ impl DatabaseManager {
             write_queue,
             write_queue_health,
             persistent_failure_hook,
+            manager_lease,
             close_token,
         };
 
@@ -424,6 +449,9 @@ impl DatabaseManager {
         // pinning the poisoned WAL-index while DB-wedge recovery was trying to
         // rebuild it.
         tokio::join!(self.write_pool.close(), self.pool.close());
+        if let Some(lease) = self.manager_lease.as_ref() {
+            lease.release();
+        }
     }
 
     async fn run_migrations(pool: &SqlitePool) -> Result<(), sqlx::Error> {
@@ -1075,6 +1103,72 @@ mod shutdown_tests {
         );
 
         database.close().await;
+    }
+
+    #[cfg(target_os = "macos")]
+    fn assert_foreign_sqlite_is_locked(db_path: &Path) {
+        let output = std::process::Command::new("/usr/bin/sqlite3")
+            .arg(db_path)
+            .arg(".schema foreign_process_probe")
+            .output()
+            .expect("run the macOS sqlite3 client");
+        assert!(
+            !output.status.success(),
+            "a foreign SQLite process bypassed unix-excl: stdout={}, stderr={}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stderr).contains("database is locked"),
+            "unexpected foreign-process failure: {}",
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[tokio::test]
+    async fn duplicate_manager_cannot_drop_unix_excl_process_lock() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let db_path = dir.path().join("foreign-process.sqlite");
+        let database = DatabaseManager::new(
+            db_path.to_str().expect("utf-8 temp path"),
+            DbConfig::for_tier(screenpipe_config::DeviceTier::Low),
+        )
+        .await
+        .expect("database init");
+
+        database
+            .execute_raw_sql_write("CREATE TABLE foreign_process_probe (value INTEGER NOT NULL)")
+            .await
+            .expect("create probe table");
+
+        assert_foreign_sqlite_is_locked(&db_path);
+
+        let duplicate_error = DatabaseManager::new(
+            db_path.to_str().expect("utf-8 temp path"),
+            DbConfig::for_tier(screenpipe_config::DeviceTier::Low),
+        )
+        .await
+        .err()
+        .expect("second in-process manager must be rejected");
+        assert!(
+            duplicate_error
+                .to_string()
+                .contains("already owns a live DatabaseManager"),
+            "unexpected duplicate-manager error: {duplicate_error}"
+        );
+        assert_foreign_sqlite_is_locked(&db_path);
+
+        database.close().await;
+
+        let replacement = DatabaseManager::new(
+            db_path.to_str().expect("utf-8 temp path"),
+            DbConfig::for_tier(screenpipe_config::DeviceTier::Low),
+        )
+        .await
+        .expect("closed manager releases its ownership lease");
+        assert_foreign_sqlite_is_locked(&db_path);
+        replacement.close().await;
     }
 
     #[test]

--- a/crates/screenpipe-db/src/write_queue.rs
+++ b/crates/screenpipe-db/src/write_queue.rs
@@ -19,7 +19,6 @@
 //! to ~5ms amortized over the entire batch.
 
 use chrono::{DateTime, Utc};
-use sqlx::migrate::MigrateDatabase;
 use sqlx::{Pool, Sqlite};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -2614,16 +2613,31 @@ async fn ensure_db_openable(db_path: &str) -> bool {
         Some(p) if !p.as_os_str().is_empty() && !p.exists() => return false,
         _ => {}
     }
-    let connection_string = format!("sqlite:{}", db_path);
-    // create_database opens with create_if_missing(true) then closes; it is a
-    // no-op (does not truncate) if the file already exists.
-    match sqlx::Sqlite::create_database(&connection_string).await {
+    let path = std::path::Path::new(db_path);
+    if path.exists() {
+        return true;
+    }
+
+    // Opening an existing live database through SQLite's default VFS can
+    // release macOS unix-excl's process-wide POSIX lock while its pooled
+    // handles still believe the lock is held. Only create a genuinely missing
+    // file here; the rebuilt capture pool performs the first SQLite open with
+    // the recorder's configured VFS.
+    match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+    {
         Ok(_) => {
             warn!("db: recreated empty database file {}", db_path);
             true
         }
-        Err(e) => {
-            warn!("db: failed to recreate database file {}: {}", db_path, e);
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => true,
+        Err(error) => {
+            warn!(
+                "db: failed to recreate database file {}: {}",
+                db_path, error
+            );
             false
         }
     }
@@ -2634,6 +2648,7 @@ async fn ensure_db_openable(db_path: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sqlx::migrate::MigrateDatabase;
 
     #[test]
     fn capture_pool_connections_live_until_authoritative_shutdown() {

--- a/crates/screenpipe-db/tests/sqlite_architecture_invariants_test.rs
+++ b/crates/screenpipe-db/tests/sqlite_architecture_invariants_test.rs
@@ -78,12 +78,16 @@ fn sqlite_lifecycle_has_one_owner_per_physical_database() {
     assert!(maintenance.contains("online SQLite repair is disabled"));
 
     let setup = production_source(&crate_dir.join("src/db/setup.rs"));
+    assert!(setup.contains("acquire_sqlite_manager_lease"));
+    assert!(!setup.contains("sqlx::Sqlite::database_exists("));
+    assert!(!setup.contains("sqlx::Sqlite::create_database("));
     assert_eq!(
         setup.matches("capture_pool_options()").count(),
         2,
         "both capture read and write pools must disable autonomous connection reaping"
     );
     let write_queue = production_source(&crate_dir.join("src/write_queue.rs"));
+    assert!(!write_queue.contains("sqlx::Sqlite::create_database("));
     assert!(write_queue.contains(".idle_timeout(None)"));
     assert!(write_queue.contains(".max_lifetime(None)"));
     assert!(

--- a/crates/screenpipe-gateway/src/ingest.rs
+++ b/crates/screenpipe-gateway/src/ingest.rs
@@ -1282,7 +1282,7 @@ mod tests {
             .unwrap();
         let ingestor = Ingestor::new(
             src as Arc<dyn BlobSource>,
-            db,
+            db.clone(),
             "lic-1".to_string(),
             dir.path().join("snapshots"),
         )
@@ -1332,7 +1332,7 @@ mod tests {
         .unwrap();
         let clean = Ingestor::new(
             src2 as Arc<dyn BlobSource>,
-            test_db(&dir).await,
+            db,
             "lic-1".to_string(),
             dir.path().join("snapshots2"),
         )

--- a/crates/screenpipe-sqlite-coordinator/src/lib.rs
+++ b/crates/screenpipe-sqlite-coordinator/src/lib.rs
@@ -5,6 +5,7 @@
 use std::collections::HashMap;
 use std::ffi::CStr;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, Weak};
 use std::time::Duration;
 
@@ -23,6 +24,8 @@ pub use quarantine::{
 pub const FIRST_WAL_RESET_SAFE_SQLITE: i32 = 3_051_003;
 
 static SQLITE_WRITE_LOCKS: OnceLock<Mutex<HashMap<PathBuf, Weak<Semaphore>>>> = OnceLock::new();
+static SQLITE_MANAGER_OWNERS: OnceLock<Mutex<HashMap<PathBuf, u64>>> = OnceLock::new();
+static NEXT_SQLITE_MANAGER_OWNER: AtomicU64 = AtomicU64::new(1);
 /// Process-lifetime path tombstones. These deliberately outlive individual
 /// DatabaseManager generations so an in-process respawn cannot reopen a path
 /// after SQLite reported IOERR, CORRUPT, FULL, or NOTADB.
@@ -91,6 +94,63 @@ pub struct SqliteRuntimeIdentity {
 
 fn lock_key(path: &Path) -> PathBuf {
     quarantine::canonical_database_path(path)
+}
+
+/// Process-wide ownership of one live database-manager generation.
+///
+/// macOS `unix-excl` stores one POSIX process lock per SQLite inode. A second
+/// independently managed pool set can unlock that inode while the first set's
+/// handles still believe the process lock is held. Keep exactly one manager
+/// generation alive per physical path; separate databases remain independent.
+pub struct SqliteManagerLease {
+    key: PathBuf,
+    owner: u64,
+    released: AtomicBool,
+}
+
+impl SqliteManagerLease {
+    pub fn release(&self) {
+        if self.released.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        let owners = SQLITE_MANAGER_OWNERS.get_or_init(|| Mutex::new(HashMap::new()));
+        let mut owners = owners
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if owners.get(&self.key) == Some(&self.owner) {
+            owners.remove(&self.key);
+        }
+    }
+}
+
+impl Drop for SqliteManagerLease {
+    fn drop(&mut self) {
+        self.release();
+    }
+}
+
+/// Claim the only live `DatabaseManager` generation for a physical path.
+pub fn acquire_sqlite_manager_lease(
+    db_path: impl AsRef<Path>,
+) -> Result<SqliteManagerLease, String> {
+    let key = lock_key(db_path.as_ref());
+    let owners = SQLITE_MANAGER_OWNERS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut owners = owners
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if owners.contains_key(&key) {
+        return Err(format!(
+            "this process already owns a live DatabaseManager for {}",
+            key.display()
+        ));
+    }
+    let owner = NEXT_SQLITE_MANAGER_OWNER.fetch_add(1, Ordering::Relaxed);
+    owners.insert(key.clone(), owner);
+    Ok(SqliteManagerLease {
+        key,
+        owner,
+        released: AtomicBool::new(false),
+    })
 }
 
 pub fn is_sqlite_hard_fault_code(code: i32) -> bool {
@@ -358,6 +418,23 @@ mod tests {
         let alias = sqlite_write_lock(db.parent().unwrap().join(".").join("db.sqlite"));
 
         assert!(Arc::ptr_eq(&canonical, &alias));
+    }
+
+    #[test]
+    fn manager_lease_rejects_aliases_until_release() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let db = dir.path().join("manager.sqlite");
+        std::fs::File::create(&db).expect("create db placeholder");
+
+        let first = acquire_sqlite_manager_lease(&db).expect("first manager lease");
+        let alias = dir.path().join(".").join("manager.sqlite");
+        let duplicate = acquire_sqlite_manager_lease(&alias)
+            .err()
+            .expect("alias must not create a second manager generation");
+        assert!(duplicate.contains("already owns a live DatabaseManager"));
+
+        first.release();
+        acquire_sqlite_manager_lease(&alias).expect("released path can be reopened");
     }
 
     #[test]

--- a/docs/coverage/CORE.md
+++ b/docs/coverage/CORE.md
@@ -9,10 +9,10 @@ confidence, and criticality.
 - Tracked crates: screenpipe-engine, screenpipe-db, screenpipe-sqlite-coordinator, screenpipe-audio, screenpipe-screen, screenpipe-a11y
 - Mapped suites: 32
 - Mapped Rust files: 330
-- Active test blocks: 3196
+- Active test blocks: 3198
 - Ignored/manual test blocks: 137
-- Declared test blocks: 3333
-- Weighted coverage points: 2621.5
+- Declared test blocks: 3335
+- Weighted coverage points: 2623.5
 
 Confidence weights: strong=1.0, partial=0.7, conditional=0.4, smoke=0.3.
 Criticality weights: high=1.0, medium=0.7, low=0.4.
@@ -23,17 +23,17 @@ are explicitly enabled in a runtime lane.
 
 | Platform | Suites | Active tests | Ignored tests | Weighted points | Layers | Flows | Critical score |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| windows | 29 | 3057 | 132 | 2558.1 | 21 | 11 | 100% |
-| macos | 29 | 3115 | 112 | 2570.5 | 22 | 11 | 100% |
-| linux | 25 | 2731 | 105 | 2261.4 | 20 | 11 | 100% |
+| windows | 29 | 3059 | 132 | 2560.1 | 21 | 11 | 100% |
+| macos | 29 | 3117 | 112 | 2572.5 | 22 | 11 | 100% |
+| linux | 25 | 2733 | 105 | 2263.4 | 20 | 11 | 100% |
 
 ## Crate Summary
 
 | Crate | Suites | Integration files | Source unit files | Active tests | Ignored tests | Weighted points | Flows |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | screenpipe-engine | 10 | 19 | 109 | 1542 | 42 | 1180.1 | 10 |
-| screenpipe-db | 5 | 52 | 15 | 452 | 16 | 429.2 | 9 |
-| screenpipe-sqlite-coordinator | 1 | 0 | 2 | 16 | 0 | 16.0 | 2 |
+| screenpipe-db | 5 | 52 | 15 | 453 | 16 | 430.2 | 9 |
+| screenpipe-sqlite-coordinator | 1 | 0 | 2 | 17 | 0 | 17.0 | 2 |
 | screenpipe-audio | 6 | 25 | 51 | 591 | 43 | 517.4 | 5 |
 | screenpipe-screen | 6 | 9 | 18 | 252 | 9 | 226.1 | 4 |
 | screenpipe-a11y | 4 | 2 | 28 | 343 | 27 | 252.7 | 3 |
@@ -65,21 +65,21 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | audio | 7 suites / 701 active / 44 ignored / 627.4 pts | 7 suites / 701 active / 44 ignored / 627.4 pts | 6 suites / 626 active / 43 ignored / 574.9 pts |
 | audio-device | 2 suites / 212 active / 7 ignored / 189.5 pts | 2 suites / 212 active / 7 ignored / 189.5 pts | 1 suites / 137 active / 6 ignored / 137.0 pts |
 | configuration | 2 suites / 138 active / 3 ignored / 124.2 pts | 2 suites / 138 active / 3 ignored / 124.2 pts | 2 suites / 138 active / 3 ignored / 124.2 pts |
-| database | 6 suites / 371 active / 12 ignored / 348.2 pts | 6 suites / 371 active / 12 ignored / 348.2 pts | 6 suites / 371 active / 12 ignored / 348.2 pts |
+| database | 6 suites / 373 active / 12 ignored / 350.2 pts | 6 suites / 373 active / 12 ignored / 350.2 pts | 6 suites / 373 active / 12 ignored / 350.2 pts |
 | db-search | 2 suites / 112 active / 9 ignored / 112.0 pts | 2 suites / 112 active / 9 ignored / 112.0 pts | 2 suites / 112 active / 9 ignored / 112.0 pts |
-| engine-lifecycle | 6 suites / 209 active / 1 ignored / 184.3 pts | 6 suites / 209 active / 1 ignored / 184.3 pts | 5 suites / 203 active / 1 ignored / 182.6 pts |
+| engine-lifecycle | 6 suites / 210 active / 1 ignored / 185.3 pts | 6 suites / 210 active / 1 ignored / 185.3 pts | 5 suites / 204 active / 1 ignored / 183.6 pts |
 | local-api | 2 suites / 370 active / 9 ignored / 261.1 pts | 2 suites / 370 active / 9 ignored / 261.1 pts | 2 suites / 370 active / 9 ignored / 261.1 pts |
 | meeting | 6 suites / 1475 active / 19 ignored / 1202.3 pts | 6 suites / 1475 active / 19 ignored / 1202.3 pts | 4 suites / 1182 active / 15 ignored / 931.8 pts |
 | ocr | 4 suites / 125 active / 7 ignored / 119.0 pts | 4 suites / 129 active / 7 ignored / 124.5 pts | 3 suites / 120 active / 6 ignored / 115.5 pts |
 | os-integration | 1 suites / 6 active / 0 ignored / 1.7 pts | 1 suites / 6 active / 0 ignored / 1.7 pts | - |
-| performance | 13 suites / 1417 active / 67 ignored / 1245.9 pts | 14 suites / 1520 active / 70 ignored / 1287.1 pts | 13 suites / 1417 active / 67 ignored / 1245.9 pts |
+| performance | 13 suites / 1418 active / 67 ignored / 1246.9 pts | 14 suites / 1521 active / 70 ignored / 1288.1 pts | 13 suites / 1418 active / 67 ignored / 1246.9 pts |
 | pipes | 1 suites / 471 active / 3 ignored / 329.7 pts | 1 suites / 471 active / 3 ignored / 329.7 pts | 1 suites / 471 active / 3 ignored / 329.7 pts |
 | privacy | 5 suites / 888 active / 36 ignored / 721.8 pts | 5 suites / 942 active / 16 ignored / 728.7 pts | 5 suites / 866 active / 14 ignored / 700.7 pts |
 | real-app | - | 1 suites / 103 active / 3 ignored / 41.2 pts | - |
 | speaker | 2 suites / 348 active / 8 ignored / 348.0 pts | 2 suites / 348 active / 8 ignored / 348.0 pts | 2 suites / 348 active / 8 ignored / 348.0 pts |
-| storage | 3 suites / 508 active / 29 ignored / 409.6 pts | 3 suites / 508 active / 29 ignored / 409.6 pts | 3 suites / 508 active / 29 ignored / 409.6 pts |
+| storage | 3 suites / 509 active / 29 ignored / 410.6 pts | 3 suites / 509 active / 29 ignored / 410.6 pts | 3 suites / 509 active / 29 ignored / 410.6 pts |
 | sync | 1 suites / 471 active / 3 ignored / 329.7 pts | 1 suites / 471 active / 3 ignored / 329.7 pts | 1 suites / 471 active / 3 ignored / 329.7 pts |
-| timeline | 4 suites / 1017 active / 33 ignored / 821.1 pts | 4 suites / 1017 active / 33 ignored / 821.1 pts | 4 suites / 1017 active / 33 ignored / 821.1 pts |
+| timeline | 4 suites / 1018 active / 33 ignored / 822.1 pts | 4 suites / 1018 active / 33 ignored / 822.1 pts | 4 suites / 1018 active / 33 ignored / 822.1 pts |
 | transcription | 5 suites / 742 active / 40 ignored / 582.0 pts | 5 suites / 742 active / 40 ignored / 582.0 pts | 5 suites / 742 active / 40 ignored / 582.0 pts |
 | ui-events | 4 suites / 711 active / 28 ignored / 541.2 pts | 3 suites / 662 active / 5 ignored / 506.9 pts | 3 suites / 662 active / 5 ignored / 506.9 pts |
 | vision-capture | 5 suites / 533 active / 32 ignored / 420.1 pts | 5 suites / 537 active / 32 ignored / 425.6 pts | 4 suites / 528 active / 31 ignored / 416.6 pts |
@@ -132,7 +132,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | db-audio-meetings-speakers | screenpipe-db | windows, macos, linux | database, audio, meeting, speaker | audio-record-transcribe, audio-device-health, meeting-live-notes | high | strong | integration | 15 | 110 | 1 | Audio transcript dedupe, live meeting mirroring, end-generation and open-meeting invariants, liveness, and speaker reassignment coverage. |
 | db-runtime-reliability | screenpipe-db | windows, macos, linux | database, performance | performance-liveness | high | partial | mixed | 13 | 30 | 6 | SQLite hard-fault classification, failpoint VFS injection, fresh-identity recovery verification with integrity/FK/write canaries, query cancellation, close-severs-connections regressions, multi-pool WAL parity, runtime version pinning, and WAL chaos plus memory-pressure probes, plus read-only quarantine self-heal verification for transient IOERR faults. |
 | db-search-indexing | screenpipe-db | windows, macos, linux | db-search, ocr, accessibility, performance | local-api-search, capture-ocr-pipeline, accessibility-ui-events, performance-liveness | high | strong | mixed | 13 | 105 | 4 | FTS, tokenizer, OCR snapshot search, query planning, ordering, accessibility search, and contention coverage. |
-| db-timeline-frames | screenpipe-db | windows, macos, linux | database, timeline, storage, performance | timeline-streaming, performance-liveness | high | strong | mixed | 19 | 180 | 3 | Frame/audio joins, timeline query shape, suggestions frames, write queue, DB primitives (src/db.rs split into src/db/ modules), feedback record upserts, media eviction anti-join regressions, SAF output registry, semantic storage, and timeline performance. |
+| db-timeline-frames | screenpipe-db | windows, macos, linux | database, timeline, storage, performance | timeline-streaming, performance-liveness | high | strong | mixed | 19 | 181 | 3 | Frame/audio joins, timeline query shape, suggestions frames, write queue, DB primitives (src/db.rs split into src/db/ modules), feedback record upserts, media eviction anti-join regressions, SAF output registry, semantic storage, and timeline performance. |
 | engine-api-routes | screenpipe-engine | windows, macos, linux | local-api, timeline, meeting, transcription | local-api-search, timeline-streaming, meeting-live-notes, audio-record-transcribe | high | partial | mixed | 36 | 363 | 4 | Route/unit coverage for search, health, streaming, meetings, time/timezone, and transcription. Legacy endpoint/websocket tests require local data and remain ignored. |
 | engine-capture-timeline | screenpipe-engine | windows, macos, linux | vision-capture, timeline, storage, performance | capture-ocr-pipeline, timeline-streaming, performance-liveness | high | partial | mixed | 25 | 290 | 26 | Covers capture trigger logic, frame/audio linking, hot cache, timeline refresh regressions, fragmented MP4 extraction, and HD-mode control. Several real-data tests are intentionally ignored by default. |
 | engine-config-lifecycle | screenpipe-engine | windows, macos, linux | configuration, engine-lifecycle, performance | settings-to-engine-config, engine-health-lifecycle, performance-liveness | high | strong | mixed | 11 | 111 | 1 | Fast logic coverage for the config bridge, tray health debounce, sleep/power policies, and queue backpressure. |
@@ -149,7 +149,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | screen-macos-ocr | screenpipe-screen | macos | ocr, vision-capture | capture-ocr-pipeline | high | strong | mixed | 2 | 9 | 1 | Apple Vision OCR source/unit coverage and fixture OCR assertions. |
 | screen-monitor-platform | screenpipe-screen | windows, macos, linux | vision-capture | capture-ocr-pipeline | medium | partial | unit | 5 | 39 | 5 | Per-OS monitor enumeration (Windows, macOS, Wayland/portal on Linux) and the persistent Windows.Graphics.Capture session. Each file is cfg-gated and only executes on its target OS. |
 | screen-windows-ocr | screenpipe-screen | windows | ocr, vision-capture | capture-ocr-pipeline | high | partial | integration | 2 | 5 | 1 | Windows OCR fixture coverage plus an ignored continuous-capture probe that requires a live desktop. |
-| sqlite-coordinator-durable-quarantine | screenpipe-sqlite-coordinator | windows, macos, linux | database, engine-lifecycle | engine-health-lifecycle, performance-liveness | high | strong | unit | 2 | 16 | 0 | Process-wide single-writer gates, SQLite runtime pinning, atomic hard-fault markers, OS file identity, fail-closed malformed metadata, fresh-identity resolution, and a real cross-process restart test. |
+| sqlite-coordinator-durable-quarantine | screenpipe-sqlite-coordinator | windows, macos, linux | database, engine-lifecycle | engine-health-lifecycle, performance-liveness | high | strong | unit | 2 | 17 | 0 | Process-wide single-writer gates, SQLite runtime pinning, atomic hard-fault markers, OS file identity, fail-closed malformed metadata, fresh-identity resolution, and a real cross-process restart test. |
 
 ## File Inventory
 
@@ -266,7 +266,7 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | db-accessibility-ui-events | screenpipe-db | src/db/elements.rs | source | 5 | 0 | 5 |
 | db-timeline-frames | screenpipe-db | src/db/feedback.rs | source | 2 | 0 | 2 |
 | db-timeline-frames | screenpipe-db | src/db/maintenance.rs | source | 4 | 1 | 5 |
-| db-timeline-frames | screenpipe-db | src/db/setup.rs | source | 6 | 0 | 6 |
+| db-timeline-frames | screenpipe-db | src/db/setup.rs | source | 7 | 0 | 7 |
 | db-timeline-frames | screenpipe-db | src/db/tests.rs | source | 26 | 1 | 27 |
 | db-timeline-frames | screenpipe-db | src/db/truncation_tests.rs | source | 1 | 0 | 1 |
 | db-runtime-reliability | screenpipe-db | src/failpoint_vfs.rs | source | 4 | 0 | 4 |
@@ -483,5 +483,5 @@ bun run coverage:core -- --llvm-cov-summary ../../docs/coverage/core-llvm-cov-su
 | screen-capture-windowing | screenpipe-screen | tests/monitor_cache_test.rs | integration | 7 | 0 | 7 |
 | screen-capture-windowing | screenpipe-screen | tests/url_timing_test.rs | integration | 7 | 0 | 7 |
 | screen-windows-ocr | screenpipe-screen | tests/windows_vision_test.rs | integration | 1 | 1 | 2 |
-| sqlite-coordinator-durable-quarantine | screenpipe-sqlite-coordinator | src/lib.rs | source | 5 | 0 | 5 |
+| sqlite-coordinator-durable-quarantine | screenpipe-sqlite-coordinator | src/lib.rs | source | 6 | 0 | 6 |
 | sqlite-coordinator-durable-quarantine | screenpipe-sqlite-coordinator | src/quarantine.rs | source | 11 | 0 | 11 |


### PR DESCRIPTION
## What broke

On macOS, `unix-excl` owns one process-wide POSIX lock for the SQLite inode. The shipped lifecycle still allowed a second independently managed `DatabaseManager` generation, and startup/runtime file creation helpers opened the capture DB through SQLite's default VFS.

The failure is deterministic: manager A initially blocks a foreign writable `/usr/bin/sqlite3 ... ".schema"` opener; constructing manager B for the same canonical path makes that foreign opener succeed while manager A is still live. SQLite's existing `unix-excl` handles still believe `bProcessLock` is set, so they do not reacquire the missing OS lock. A foreign process can then attach to the live WAL and invalidate the recorder's WAL-index state, matching the observed `SQLITE_IOERR_SHORT_READ` (522) failure.

Git history explains the gap: the Aug 3 `unix-excl` hardening was layered over the older default-VFS existence/create path, and no cross-process test covered a duplicate manager generation.

## Fix

- add a canonical-path, process-wide manager lease and reject a second live manager generation before SQLite opens the file
- release that lease only after both capture pools finish authoritative shutdown
- create genuinely missing database files with the filesystem, so every actual SQLite open enters through the configured VFS
- remove the same default-VFS reopen from CANTOPEN recovery
- make the gateway test reuse its existing live manager instead of constructing a second owner for the same file
- make the audio recovery test helper pass the filesystem path expected by `DatabaseManager::new` instead of a double-prefixed SQLite URI
- add a macOS regression that exercises the exact writable foreign `.schema` opener before/after a duplicate-manager attempt and after clean close/reopen
- extend the architecture invariant so default-VFS database creation cannot return to production setup/recovery paths

## Verification

- `cargo test -p screenpipe-sqlite-coordinator` (17 passed)
- `cargo test -p screenpipe-db --lib` (142 passed, 2 manual tests ignored)
- `cargo test -p screenpipe-db --test close_severs_connections_test` (2 passed)
- `cargo test -p screenpipe-db --test sqlite_architecture_invariants_test` (2 passed)
- `cargo test -p screenpipe-db --test wal_chaos_e2e_test` (process-crash smoke passed; 3 manual tests ignored)
- `cargo test -p screenpipe-gateway -p screenpipe-telemetry-wire -p screenpipe-sync` (all passed)
- `cargo test -p screenpipe-audio --lib` (456 passed, 8 environment/manual tests ignored)
- `cargo clippy -p screenpipe-sqlite-coordinator -p screenpipe-db --all-targets --no-deps -- -D warnings -A clippy::type-complexity`
- `cargo fmt --all --check`
- `bun run coverage:all:check`
