### PR TITLE
fix activity AI selector border contrast

### DIFF
--- a/apps/screenpipe-app-tauri/components/activity-ledger.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.tsx
@@ -1855,7 +1855,7 @@ Re-query Screenpipe only inside the cited time range and use the cited frames an
                   includeAgentPresets={false}
                   triggerAriaLabel="AI preset"
                   containerClassName="w-[190px] max-w-[36vw] min-w-[132px] shrink-0 gap-0"
-                  triggerClassName="h-9 rounded-none text-xs"
+                  triggerClassName="h-9 rounded-none border-border text-xs"
                   controlledPresetId={reviewPreset.id}
                   onControlledSelect={(nextPreset) => {
                     if (!nextPreset) return;


### PR DESCRIPTION
## Summary

- match the Activity AI selector's idle border to the subdued time-range control
- preserve the existing hover inversion and keyboard `focus-visible` ring

## Root cause

The shared AI selector uses the outline button variant, whose default border is `border-foreground`. In dark mode that made this one idle control look selected or focused even when it was not.

This activity-header instance now overrides the idle border with the existing `border-border` design token. The change is local to this surface.

## Before / after

```text
before  [ Today ]  ╔  AUTO  ═╗  ↻   bright idle frame
after   [ Today ]  ┌  AUTO  ─┐  ↻   matching trace borders
```

## Verification

- browser-mock pass on `/home?section=activity` in dark mode
- Vitest: 398 files passed, 4,128 tests passed
- Bun tests: 239 passed across 21 files
- `git diff --check`
