### PR TITLE
docs(agents): require local evals before PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,10 @@ for UI validation. Drive the real app only when the change crosses a native
 boundary listed there. Put before/after visuals in every issue and PR body:
 screen recording, screenshots, HTML mockup screenshot, or ASCII.
 
+Before opening or updating a PR, run every eval relevant to the changed behavior
+locally and put the exact commands and results in the PR body. CI is a second
+signal, not a substitute.
+
 ## git
 
 Many agents work this repo in parallel. Never `git reset`, never delete local

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,6 @@
 # CLAUDE.md
 
-Conventions live in one file so they cannot drift. Read `AGENTS.md`.
+Conventions live in one file so they cannot drift. Read and follow `AGENTS.md`,
+including its mandatory local PR eval requirement.
 
 @AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,9 @@
 # CLAUDE.md
 
-Conventions live in one file so they cannot drift. Read and follow `AGENTS.md`,
-including its mandatory local PR eval requirement.
+Conventions live in one file so they cannot drift. Read `AGENTS.md`.
+
+Before opening or updating a PR, run every eval relevant to the changed behavior
+locally and put the exact commands and results in the PR body. CI is a second
+signal, not a substitute.
 
 @AGENTS.md


### PR DESCRIPTION
## description

Require agents to run every eval relevant to changed behavior locally before opening or updating a PR, and to report the exact commands and results. CI remains a second signal rather than a substitute.

The exact same requirement now appears verbatim in both `AGENTS.md` and `CLAUDE.md`. Claude also continues to load the complete conventions through `@AGENTS.md`.

related issue: none

## AI assistance and human ownership

- AI tool(s) used (`none` if not used): Codex
- autonomy level (`none`, `autocomplete`, `chat`, or `agent`): agent
- what I personally verified: no human verification claimed; Codex ran the checks below at Louis's direction

- [ ] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [ ] The problem statement, rationale, and replies to maintainers are my own.

## evidence type

- [ ] UI or behavior change — before/after recording
- [ ] Backend change — regression tests and relevant logs/results
- [ ] Performance change — reproducible before/after benchmarks
- [x] Docs, CI, or pure refactor — relevant checks and an explanation; no video required

## before

Not applicable. This is an instruction-only change with no product UI or runtime behavior.

## after

Agents are explicitly required to run relevant evals locally and report the exact commands/results before opening or updating a PR. The text is identical in both instruction files.

## how to test

1. `git diff --check` — passed.
2. `diff -u <(sed -n '/^Before opening or updating a PR, run every eval relevant to the changed behavior$/,+2p' AGENTS.md) <(sed -n '/^Before opening or updating a PR, run every eval relevant to the changed behavior$/,+2p' CLAUDE.md)` — passed; the requirement is byte-for-byte identical.
3. `rg -n "Before opening or updating a PR, run every eval relevant to the changed behavior|CI is a second|^@AGENTS.md$" AGENTS.md CLAUDE.md` — matched the requirement in both files and the Claude import.
4. Product evals were not run because this docs-only change does not alter audio, meeting, UI, or other product behavior.

## desktop app checklist (if applicable)

Not applicable.
