### PR TITLE
fix(chat): strengthen home card affordance

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat/summary-cards.test.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/summary-cards.test.tsx
@@ -89,6 +89,32 @@ describe("SummaryCards", () => {
     expect(screen.queryByTestId("summary-cards-more")).not.toBeInTheDocument();
   });
 
+  it("makes available home actions visibly interactive and keyboard focusable", () => {
+    render(
+      <SummaryCards
+        onSendMessage={vi.fn()}
+        customTemplates={[]}
+        onSaveCustomTemplate={vi.fn()}
+        onUpdateCustomTemplate={vi.fn()}
+        onDeleteCustomTemplate={vi.fn()}
+        userGoalCategory="work_memory"
+      />,
+    );
+
+    for (const slug of ["day-recap", "missed-todos"]) {
+      const card = screen.getByTestId(`summary-card-${slug}`);
+      expect(card).toHaveClass("bg-card", "cursor-pointer");
+      expect(card.className).toContain("border-foreground/");
+      expect(card.className).toContain("focus-visible:ring-1");
+      expect(card.className).toContain("motion-reduce:transition-none");
+      expect(screen.getByTestId(`home-card-arrow-${slug}`)).toBeInTheDocument();
+    }
+
+    const quickAction = screen.getByRole("button", { name: "Time Breakdown" });
+    expect(quickAction).toHaveClass("bg-card", "text-foreground/75");
+    expect(quickAction.className).toContain("focus-visible:ring-1");
+  });
+
   it("keeps the user's saved templates alongside the built-in actions", () => {
     render(
       <SummaryCards

--- a/apps/screenpipe-app-tauri/components/chat/summary-cards.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/summary-cards.tsx
@@ -93,6 +93,17 @@ function HomeCardIcon({ slug, className }: { slug: string; className: string }) 
   return <Zap {...props} />;
 }
 
+function HomeCardArrow({ slug }: { slug: string }) {
+  return (
+    <ArrowRight
+      data-testid={`home-card-arrow-${slug}`}
+      className="h-4 w-4 shrink-0 text-foreground/55 transition-transform duration-150 group-hover:translate-x-0.5 group-hover:text-background motion-reduce:transition-none"
+      strokeWidth={1.5}
+      aria-hidden
+    />
+  );
+}
+
 // ─── Main component ──────────────────────────────────────────────────────────
 
 export function SummaryCards({
@@ -184,9 +195,10 @@ export function SummaryCards({
       {/* The onboarding goal or General Settings choice determines priority. */}
       {featured[0] && (
         <button
+          type="button"
           data-testid={`summary-card-${featured[0].name}`}
           onClick={() => handleCardClick(featured[0])}
-          className="group relative w-full max-w-lg mb-1.5 text-left px-4 py-3.5 border border-border/60 border-l-2 border-l-signal hover:!bg-foreground hover:text-background hover:border-foreground transition-all duration-150 cursor-pointer"
+          className="group relative mb-1.5 w-full max-w-lg cursor-pointer border border-foreground/25 border-l-2 border-l-signal bg-card px-4 py-3.5 text-left text-foreground transition-colors duration-150 hover:border-foreground hover:bg-foreground hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground focus-visible:ring-offset-2 focus-visible:ring-offset-background motion-reduce:transition-none"
         >
           <div className="flex items-center gap-3">
             <HomeCardIcon
@@ -201,32 +213,34 @@ export function SummaryCards({
                 {featured[0].description}
               </div>
             </div>
-            <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground/30 group-hover:text-background/50" strokeWidth={1.5} />
+            <HomeCardArrow slug={featured[0].name} />
           </div>
         </button>
       )}
 
       {featured[1] && (
-          <button
-            data-testid={`summary-card-${featured[1].name}`}
-            onClick={() => handleCardClick(featured[1])}
-            className="group w-full max-w-lg mb-1.5 text-left px-3 py-2.5 border border-border/20 hover:bg-foreground hover:text-background hover:border-foreground transition-all duration-150 cursor-pointer"
-          >
-            <div className="flex items-center gap-2">
-              <HomeCardIcon
-                slug={featured[1].name}
-                className="h-4 w-4 shrink-0 text-muted-foreground group-hover:text-background"
-              />
-              <div className="flex-1">
-                <div className="text-xs font-medium text-muted-foreground group-hover:text-background leading-tight">
-                  {featured[1].title}
-                </div>
-                <div className="text-xs text-muted-foreground/60 group-hover:text-background/60 leading-tight mt-0.5">
-                  {featured[1].description}
-                </div>
+        <button
+          type="button"
+          data-testid={`summary-card-${featured[1].name}`}
+          onClick={() => handleCardClick(featured[1])}
+          className="group mb-1.5 w-full max-w-lg cursor-pointer border border-foreground/20 bg-card px-4 py-3 text-left text-foreground transition-colors duration-150 hover:border-foreground hover:bg-foreground hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground focus-visible:ring-offset-2 focus-visible:ring-offset-background motion-reduce:transition-none"
+        >
+          <div className="flex items-center gap-3">
+            <HomeCardIcon
+              slug={featured[1].name}
+              className="h-4 w-4 shrink-0 text-foreground/65 group-hover:text-background"
+            />
+            <div className="flex-1">
+              <div className="text-xs font-semibold text-foreground/85 group-hover:text-background leading-tight">
+                {featured[1].title}
+              </div>
+              <div className="text-xs text-muted-foreground group-hover:text-background/70 leading-tight mt-0.5">
+                {featured[1].description}
               </div>
             </div>
-          </button>
+            <HomeCardArrow slug={featured[1].name} />
+          </div>
+        </button>
       )}
 
       {/* ─── Quick action chips ───────────────────────────────────────────── */}
@@ -241,10 +255,11 @@ export function SummaryCards({
         {/* Template-backed chips (Time Breakdown, Missed To-Dos) */}
         {featured.slice(2).map((pipe) => (
           <button
+            type="button"
             key={pipe.name}
             data-testid={`summary-card-${pipe.name}`}
             onClick={() => handleCardClick(pipe)}
-            className="grow px-2 py-0.5 text-[11px] bg-muted/20 hover:bg-foreground hover:text-background border border-border/30 hover:border-foreground text-muted-foreground transition-all duration-150 cursor-pointer"
+            className="grow cursor-pointer border border-foreground/20 bg-card px-2 py-0.5 text-[11px] text-foreground/75 transition-colors duration-150 hover:border-foreground hover:bg-foreground hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground focus-visible:ring-offset-1 focus-visible:ring-offset-background motion-reduce:transition-none"
           >
             {pipe.title}
           </button>
@@ -255,6 +270,7 @@ export function SummaryCards({
           { label: "Blockers", prompt: "What problems, errors, or blockers did I encounter?" },
         ].map((qt) => (
           <button
+            type="button"
             key={qt.label}
             onClick={() => {
               posthog.capture("home_card_clicked", {
@@ -268,7 +284,7 @@ export function SummaryCards({
                 "other_builtin",
               );
             }}
-            className="grow px-2 py-0.5 text-[11px] bg-muted/20 hover:bg-foreground hover:text-background border border-border/30 hover:border-foreground text-muted-foreground transition-all duration-150 cursor-pointer"
+            className="grow cursor-pointer border border-foreground/20 bg-card px-2 py-0.5 text-[11px] text-foreground/75 transition-colors duration-150 hover:border-foreground hover:bg-foreground hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground focus-visible:ring-offset-1 focus-visible:ring-offset-background motion-reduce:transition-none"
           >
             {qt.label}
           </button>
@@ -278,21 +294,23 @@ export function SummaryCards({
             (edit/delete) live in the edit dialog. */}
         {customTemplates.map((ct) => (
           <button
+            type="button"
             key={ct.id}
             onClick={() => handleCustomTemplateClick(ct)}
             title={ct.description || ct.timeRange}
-            className="grow inline-flex items-center justify-center gap-1 px-2 py-0.5 text-[11px] bg-muted/10 hover:bg-foreground hover:text-background border border-border/20 hover:border-foreground text-muted-foreground/80 transition-all duration-150 cursor-pointer max-w-[140px]"
+            className="inline-flex max-w-[140px] grow cursor-pointer items-center justify-center gap-1 border border-foreground/20 bg-card px-2 py-0.5 text-[11px] text-foreground/70 transition-colors duration-150 hover:border-foreground hover:bg-foreground hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground focus-visible:ring-offset-1 focus-visible:ring-offset-background motion-reduce:transition-none"
           >
             <Pin className="w-3 h-3 shrink-0" strokeWidth={1.5} />
             <span className="truncate">{ct.title}</span>
           </button>
         ))}
         <button
+          type="button"
           onClick={() => {
             posthog.capture("home_card_clicked", { kind: "custom_summary_open" });
             setShowBuilder(true);
           }}
-          className="px-2 py-0.5 text-[11px] border border-dashed border-border/40 text-muted-foreground/50 hover:text-foreground hover:border-foreground transition-all duration-150 cursor-pointer"
+          className="cursor-pointer border border-dashed border-foreground/25 px-2 py-0.5 text-[11px] text-muted-foreground transition-colors duration-150 hover:border-foreground hover:bg-foreground hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground focus-visible:ring-offset-1 focus-visible:ring-offset-background motion-reduce:transition-none"
         >
           + custom
         </button>


### PR DESCRIPTION
## Summary

- make the home cards read as available actions instead of disabled copy
- strengthen neutral card borders, surfaces, titles, icons, and quick-action chips
- add a visible arrow to both full-width cards with a restrained 150ms hover shift
- add explicit keyboard focus rings, button types, and reduced-motion fallbacks
- keep the interaction monochrome with sharp corners and no decorative shadow or accent color

## Visual review

### Before

The secondary card and quick actions used very low-opacity borders and text, so clickable actions looked unavailable.

![before](https://github.com/screenpipe/screenpipe/releases/download/media/home-card-affordance-before.png)

### Light, default

![light default](https://github.com/screenpipe/screenpipe/releases/download/media/home-card-affordance-light.png)

### Light, hover

![light hover](https://github.com/screenpipe/screenpipe/releases/download/media/home-card-affordance-light-hover.png)

### Dark, default

![dark default](https://github.com/screenpipe/screenpipe/releases/download/media/home-card-affordance-dark.png)

## Verification

- `PATH=/opt/homebrew/opt/node@22/bin:$PATH bun x vitest run --config vitest.config.ts components/chat/summary-cards.test.tsx`: 12 passed
- `git diff --check origin/main...HEAD`: passed
- real browser-mock app checked in light and dark mode at 1280 by 720
- default and hover computed colors verified in both modes; transition resolves to 150ms
- repository-wide `bun x tsc --noEmit` was stopped after seven minutes under shared-machine load without completing; CI remains the typecheck signal

Draft for visual feedback.
