### PR TITLE
fix(activity): keep date range picker open while selecting

### DIFF
--- a/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
@@ -1477,20 +1477,6 @@ describe("ActivityLedger", () => {
       await screen.findByRole("option", { name: "Custom range" }),
     );
     fireEvent.click(
-      screen.getByRole("button", { name: "Choose custom date range" }),
-    );
-
-    expect(
-      screen.getByRole("button", { name: "Choose custom date range" }),
-    ).toHaveAttribute("aria-expanded", "true");
-    fireEvent.click(screen.getByRole("gridcell", { name: "16", exact: true }));
-    await waitFor(() =>
-      expect(
-        screen.getByRole("button", { name: "Choose custom date range" }),
-      ).toHaveAttribute("aria-expanded", "false"),
-    );
-
-    fireEvent.click(
       screen.getByRole("combobox", { name: "Time range: Custom range" }),
     );
     fireEvent.click(await screen.findByRole("option", { name: "Today" }));

--- a/apps/screenpipe-app-tauri/components/activity-ledger.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.tsx
@@ -1341,7 +1341,6 @@ export function ActivityLedger({
   const [customDateRange, setCustomDateRange] = useState<DateRange | undefined>(
     () => selectedDateRange(customStart, customEnd),
   );
-  const [customCalendarOpen, setCustomCalendarOpen] = useState(false);
   const [summary, setSummary] = useState<ActivitySummaryResponse | null>(null);
   const [meetings, setMeetings] = useState<ActivityReviewMeeting[]>([]);
   const [ledgerIntervals, setLedgerIntervals] = useState<
@@ -1822,7 +1821,6 @@ Re-query Screenpipe only inside the cited time range and use the cited frames an
                 value={preset}
                 onValueChange={(value) => {
                   const nextPreset = value as RangePreset;
-                  setCustomCalendarOpen(false);
                   setPreset(nextPreset);
                   posthog.capture("activity_range_changed", {
                     range: nextPreset,
@@ -1903,10 +1901,7 @@ Re-query Screenpipe only inside the cited time range and use the cited frames an
 
           {preset === "custom" ? (
             <div className="mt-4 flex justify-end">
-              <Popover
-                open={customCalendarOpen}
-                onOpenChange={setCustomCalendarOpen}
-              >
+              <Popover>
                 <PopoverTrigger asChild>
                   <Button
                     variant="outline"
@@ -1934,7 +1929,6 @@ Re-query Screenpipe only inside the cited time range and use the cited frames an
                       setCustomEnd(
                         toLocalInputValue(endOfSelectedDay(nextRange.to, now)),
                       );
-                      setCustomCalendarOpen(false);
                     }}
                     defaultMonth={customDateRange?.from}
                     disabled={{ after: new Date() }}


### PR DESCRIPTION
## Summary

- let the shadcn/Radix Popover own its open state
- remove the application-level close after a range selection
- remove the test assertion that encoded date-click dismissal

## Why

The standard shadcn range picker uses an uncontrolled Popover around Calendar mode="range". Activity diverged from that composition by explicitly closing the popover whenever DayPicker returned a complete range, so ordinary date clicks dismissed it.

## Before / after

```text
Before: date click -> picker closes
After:  first date click -> picker remains open
        second date click -> picker remains open
        Escape -> picker closes
```

Verified in the rendered browser-mock Activity page. The selected label changed from Aug 18–18 to Aug 16–18 and then Aug 16–17 while the picker remained expanded.

## Verification

- bun x vitest run --config vitest.config.ts components/activity-ledger.test.tsx — 46 passed
- browser-mock interaction at /home?section=activity — passed
