### PR TITLE
fix(ai): keep silent reasoning streams connected

### DIFF
--- a/packages/ai-gateway/src/test/stream-usage-tracker.unit.test.ts
+++ b/packages/ai-gateway/src/test/stream-usage-tracker.unit.test.ts
@@ -91,6 +91,36 @@ describe('trackStreamUsage — anthropic format', () => {
 });
 
 describe('trackStreamUsage — openai format', () => {
+	it('keeps a silent thinking stream connected without fabricating output', async () => {
+		const finalEvent = `data: ${JSON.stringify({
+			choices: [],
+			usage: { prompt_tokens: 44, completion_tokens: 7 },
+		})}\n\ndata: [DONE]\n\n`;
+		const source = new ReadableStream<Uint8Array>({
+			start(controller) {
+				setTimeout(() => {
+					controller.enqueue(new TextEncoder().encode(finalEvent));
+					controller.close();
+				}, 35);
+			},
+		});
+		const { response, usage } = trackResponseUsage(
+			new Response(source),
+			'openai',
+			10,
+		);
+
+		const out = await drain(response.body!);
+		expect(out).toContain(': keep-alive\n\n');
+		expect(out.endsWith(finalEvent)).toBe(true);
+		expect(await usage).toMatchObject({
+			input_tokens: 44,
+			output_tokens: 7,
+			usage_complete: true,
+			termination: 'complete',
+		});
+	});
+
 	it('captures cached_tokens from prompt_tokens_details and custom cache_creation field', async () => {
 		const events = [
 			`data: ${JSON.stringify({ choices: [{ delta: { content: 'hello' } }] })}\n\n`,

--- a/packages/ai-gateway/src/utils/stream-usage-tracker.ts
+++ b/packages/ai-gateway/src/utils/stream-usage-tracker.ts
@@ -20,6 +20,9 @@ export interface StreamUsage {
 	termination: 'complete' | 'cancelled' | 'error';
 }
 
+const SSE_KEEP_ALIVE_INTERVAL_MS = 15_000;
+const SSE_KEEP_ALIVE = new TextEncoder().encode(': keep-alive\n\n');
+
 /**
  * Wrap a streaming Response body to extract token usage from SSE events.
  * Data passes through unchanged to the client; usage is captured via callback.
@@ -33,6 +36,7 @@ export function trackStreamUsage(
   body: ReadableStream<Uint8Array>,
   format: 'anthropic' | 'openai',
   onComplete: (usage: StreamUsage) => void,
+	keepAliveIntervalMs = SSE_KEEP_ALIVE_INTERVAL_MS,
 ): ReadableStream<Uint8Array> {
   let buffer = '';
   let inputTokens = 0;
@@ -43,6 +47,7 @@ export function trackStreamUsage(
   const decoder = new TextDecoder();
   const reader = body.getReader();
   let completed = false;
+	let pendingRead: Promise<ReadableStreamReadResult<Uint8Array>> | null = null;
 
   const completeOnce = (termination: StreamUsage['termination']) => {
     if (completed) return;
@@ -107,7 +112,36 @@ export function trackStreamUsage(
   return new ReadableStream<Uint8Array>({
     async pull(controller) {
       try {
-        const { done, value } = await reader.read();
+				pendingRead ??= reader.read();
+				let timer: ReturnType<typeof setTimeout> | undefined;
+				let next: { type: 'heartbeat' } | {
+					type: 'read';
+					result: ReadableStreamReadResult<Uint8Array>;
+				};
+				try {
+					next = await Promise.race([
+						pendingRead.then((result) => ({ type: 'read' as const, result })),
+						new Promise<{ type: 'heartbeat' }>((resolve) => {
+							timer = setTimeout(
+								() => resolve({ type: 'heartbeat' }),
+								keepAliveIntervalMs,
+							);
+						}),
+					]);
+				} finally {
+					if (timer !== undefined) clearTimeout(timer);
+				}
+
+				if (next.type === 'heartbeat') {
+					// SSE comments are protocol-valid and ignored by clients. Sending
+					// one during provider silence prevents idle network hops from
+					// closing a healthy high-reasoning request before its first token.
+					controller.enqueue(SSE_KEEP_ALIVE);
+					return;
+				}
+
+				pendingRead = null;
+				const { done, value } = next.result;
         if (done) {
           // Providers occasionally omit the trailing newline. Flush the final
           // decoder bytes and buffered SSE line before settling the request.
@@ -144,6 +178,7 @@ export function trackStreamUsage(
 export function trackResponseUsage(
   response: Response,
   format: 'anthropic' | 'openai',
+	keepAliveIntervalMs = SSE_KEEP_ALIVE_INTERVAL_MS,
 ): { response: Response; usage: Promise<StreamUsage> } {
   if (!response.body) {
     return {
@@ -162,7 +197,12 @@ export function trackResponseUsage(
   let resolveUsage!: (u: StreamUsage) => void;
   const usage = new Promise<StreamUsage>(r => resolveUsage = r);
 
-  const trackedBody = trackStreamUsage(response.body, format, u => resolveUsage(u));
+  const trackedBody = trackStreamUsage(
+		response.body,
+		format,
+		u => resolveUsage(u),
+		keepAliveIntervalMs,
+	);
 
   return {
     response: new Response(trackedBody, {


### PR DESCRIPTION
## Source

Follow-up to #6486. That PR classified the Windows Bun socket-close error but did not prevent it.

The submitted Windows 10 / Screenpipe 2.6.68 log shows two hosted-chat requests closing after the same idle interval:

- prompt sent 09:40:12, socket closed 09:41:19
- prompt sent 09:45:52, socket closed 09:46:58

Updater and gateway model-list requests succeeded around both failures, ruling out a general offline state.

## Root cause

High-thinking models can remain silent for over a minute before visible text. Screenpipe forwarded only visible provider deltas, leaving the client connection byte-idle for roughly 67 seconds. The users network path closed the otherwise healthy Bun fetch stream.

## Fix

- Emit a protocol-valid SSE comment every 15 seconds while the provider stream is silent.
- Preserve provider bytes, final token usage, cancellation, and conservative cost settlement.

## Before / after

```text
Before: prompt -> provider thinking silently -> 67s idle socket close -> chat fails
After:  prompt -> SSE heartbeat every 15s -> provider output -> chat completes
```

## Tests

- `bun test src/test/stream-usage-tracker.unit.test.ts --timeout=10000` — 10 passed
- `bun test src/test --timeout=10000` — 758 passed
- `bunx tsc --noEmit` — passed
- `git diff --check` — passed

The regression holds a model stream silent, verifies heartbeat bytes arrive before the idle boundary, then verifies the real terminal event and usage arrive unchanged. Existing cancellation tests prove abandoned requests still cancel and settle correctly.

## Scope

The report came from Windows/Bun, but the defect is in the hosted SSE gateway. No desktop-native code changed, so a Windows VM build would not exercise the modified boundary.