### PR TITLE
fix(macos): keep window-mode timeline and tray menu interactive

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
@@ -407,6 +407,170 @@ static PENDING_TRAY_MENU: Lazy<Mutex<Option<(MenuState, TrayMenuData)>>> =
 #[cfg(target_os = "macos")]
 static TRAY_MENU_DIRTY: AtomicBool = AtomicBool::new(false);
 
+/// Keep the native status-item menu above Screenpipe's fullscreen-capable
+/// panels. Window mode deliberately lives at level 1001 so it works over a
+/// fullscreen Space; AppKit's popup-menu level is only 101, which otherwise
+/// leaves the tray menu behind the overlay and its attached Timeline child.
+///
+/// This raises only a menu whose delegate is an `NSStatusItem`. The overlay is
+/// never lowered, and ordinary in-app/context menus retain their native level.
+#[cfg(target_os = "macos")]
+mod tray_menu_level {
+    use core_foundation_sys::runloop::{
+        kCFRunLoopBeforeWaiting, kCFRunLoopCommonModes, CFRunLoopActivity, CFRunLoopAddObserver,
+        CFRunLoopGetMain, CFRunLoopObserverContext, CFRunLoopObserverCreate, CFRunLoopObserverRef,
+    };
+    use objc::declare::ClassDecl;
+    use objc::runtime::{Class, Object, Sel};
+    use objc::{class, msg_send, sel, sel_impl};
+    use std::os::raw::c_void;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Once;
+    use tauri_nspanel::cocoa::base::{id, nil};
+    use tracing::{debug, error};
+
+    const OVERLAY_LEVEL: i64 = 1001;
+    const TRAY_MENU_LEVEL: i64 = OVERLAY_LEVEL + 1;
+    const NS_POPUP_MENU_LEVEL: i64 = 101;
+
+    static TRAY_MENU_TRACKING: AtomicBool = AtomicBool::new(false);
+
+    unsafe fn notification_belongs_to_status_item(notification: id) -> bool {
+        if notification == nil {
+            return false;
+        }
+        let menu: id = msg_send![notification, object];
+        if menu == nil {
+            return false;
+        }
+        let delegate: id = msg_send![menu, delegate];
+        delegate != nil && msg_send![delegate, isKindOfClass: class!(NSStatusItem)]
+    }
+
+    extern "C" fn menu_did_begin(_this: &Object, _selector: Sel, notification: id) {
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+            if notification_belongs_to_status_item(notification) {
+                TRAY_MENU_TRACKING.store(true, Ordering::Release);
+                // Usually the menu window already exists by this notification.
+                // The common-mode observer below catches the later case.
+                raise_visible_popup_menu_windows();
+            }
+        }));
+    }
+
+    extern "C" fn menu_did_end(_this: &Object, _selector: Sel, notification: id) {
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+            if notification_belongs_to_status_item(notification) {
+                TRAY_MENU_TRACKING.store(false, Ordering::Release);
+            }
+        }));
+    }
+
+    unsafe fn raise_visible_popup_menu_windows() {
+        let app: id = msg_send![class!(NSApplication), sharedApplication];
+        let windows: id = msg_send![app, orderedWindows];
+        if windows == nil {
+            return;
+        }
+        let count: usize = msg_send![windows, count];
+        for index in 0..count {
+            let window: id = msg_send![windows, objectAtIndex: index];
+            let level: i64 = msg_send![window, level];
+            let visible: bool = msg_send![window, isVisible];
+            if visible && level == NS_POPUP_MENU_LEVEL {
+                let _: () = msg_send![window, setLevel: TRAY_MENU_LEVEL];
+                debug!("raised tray menu above Screenpipe overlay");
+            }
+        }
+    }
+
+    extern "C" fn on_menu_tracking_idle(
+        _observer: CFRunLoopObserverRef,
+        _activity: CFRunLoopActivity,
+        _info: *mut c_void,
+    ) {
+        if !TRAY_MENU_TRACKING.load(Ordering::Acquire) {
+            return;
+        }
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe {
+            raise_visible_popup_menu_windows();
+        }));
+    }
+
+    pub fn install() {
+        static INSTALLED: Once = Once::new();
+        INSTALLED.call_once(|| unsafe {
+            let superclass = Class::get("NSObject").expect("NSObject must exist");
+            let observer_class = if let Some(existing) = Class::get("ScreenpipeTrayMenuObserver") {
+                existing
+            } else {
+                let Some(mut declaration) =
+                    ClassDecl::new("ScreenpipeTrayMenuObserver", superclass)
+                else {
+                    error!("failed to declare tray-menu observer");
+                    return;
+                };
+                declaration.add_method(
+                    sel!(trayMenuDidBegin:),
+                    menu_did_begin as extern "C" fn(&Object, Sel, id),
+                );
+                declaration.add_method(
+                    sel!(trayMenuDidEnd:),
+                    menu_did_end as extern "C" fn(&Object, Sel, id),
+                );
+                declaration.register()
+            };
+
+            let notification_observer: id = msg_send![observer_class, new];
+            let center: id = msg_send![class!(NSNotificationCenter), defaultCenter];
+            let begin_name: id = msg_send![
+                class!(NSString),
+                stringWithUTF8String: b"NSMenuDidBeginTrackingNotification\0".as_ptr()
+            ];
+            let end_name: id = msg_send![
+                class!(NSString),
+                stringWithUTF8String: b"NSMenuDidEndTrackingNotification\0".as_ptr()
+            ];
+            let _: () = msg_send![
+                center,
+                addObserver: notification_observer
+                selector: sel!(trayMenuDidBegin:)
+                name: begin_name
+                object: nil
+            ];
+            let _: () = msg_send![
+                center,
+                addObserver: notification_observer
+                selector: sel!(trayMenuDidEnd:)
+                name: end_name
+                object: nil
+            ];
+
+            let mut context = CFRunLoopObserverContext {
+                version: 0,
+                info: std::ptr::null_mut(),
+                retain: None,
+                release: None,
+                copyDescription: None,
+            };
+            let run_loop_observer = CFRunLoopObserverCreate(
+                std::ptr::null(),
+                kCFRunLoopBeforeWaiting,
+                1,
+                0,
+                on_menu_tracking_idle,
+                &mut context,
+            );
+            if run_loop_observer.is_null() {
+                error!("failed to create tray-menu level observer");
+                return;
+            }
+            CFRunLoopAddObserver(CFRunLoopGetMain(), run_loop_observer, kCFRunLoopCommonModes);
+            // Both observers intentionally live for the app lifetime.
+        });
+    }
+}
+
 fn install_tray_menu(tray: &TrayIcon, menu: tauri::menu::Menu<Wry>) -> Result<()> {
     // `ACTIVE_TRAY_MENU` is our record of what Windows/macOS actually owns.
     // Only publish the replacement after the native tray accepted it. If
@@ -686,6 +850,9 @@ pub fn setup_tray(app: &AppHandle, update_item: Option<&tauri::menu::MenuItem<Wr
         // open (flash-free, crash-free). Once-guarded, so recreate_tray is fine.
         #[cfg(target_os = "macos")]
         menu_refresh_observer::install(app);
+
+        #[cfg(target_os = "macos")]
+        tray_menu_level::install();
 
         #[cfg(target_os = "macos")]
         crate::tray_monitor_preview::install(app);

--- a/apps/screenpipe-app-tauri/src-tauri/src/window/show.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/window/show.rs
@@ -918,12 +918,26 @@ impl ShowRewindWindow {
 
                     // Auto-hide on focus loss (debounced to survive workspace swipe animations)
                     let app_clone = app.clone();
+                    let window_clone = window.clone();
                     let focus_cancel =
                         std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
                     window.on_window_event(move |event| {
                         match event {
                             tauri::WindowEvent::Focused(is_focused) => {
                                 if !is_focused {
+                                    #[cfg(target_os = "macos")]
+                                    if appkit_focus_is_descendant_of(&window_clone) {
+                                        info!(
+                                            "Window-mode focus moved to an attached child; keeping overlay visible"
+                                        );
+                                        focus_cancel
+                                            .store(true, std::sync::atomic::Ordering::SeqCst);
+                                        MAIN_PANEL_SHOWN.store(
+                                            true,
+                                            std::sync::atomic::Ordering::SeqCst,
+                                        );
+                                        return;
+                                    }
                                     // Synchronous alpha=0 — no order_out (which
                                     // causes focus-fight loops when restored).
                                     #[cfg(target_os = "macos")]
@@ -939,10 +953,56 @@ impl ShowRewindWindow {
                                     focus_cancel.store(false, std::sync::atomic::Ordering::SeqCst);
                                     let cancel = focus_cancel.clone();
                                     let app = app_clone.clone();
+                                    #[cfg(target_os = "macos")]
+                                    let window = window_clone.clone();
                                     std::thread::spawn(move || {
                                         std::thread::sleep(std::time::Duration::from_millis(300));
                                         if cancel.load(std::sync::atomic::Ordering::SeqCst) {
                                             return;
+                                        }
+                                        // AppKit may deliver the parent's blur before
+                                        // keyWindow points at the attached Timeline. Re-check
+                                        // after the debounce and treat the two native windows
+                                        // as one logical overlay.
+                                        #[cfg(target_os = "macos")]
+                                        {
+                                            let (sender, receiver) =
+                                                std::sync::mpsc::sync_channel(1);
+                                            let app2 = app.clone();
+                                            let window2 = window.clone();
+                                            if app
+                                                .run_on_main_thread(move || {
+                                                    let keep_visible =
+                                                        appkit_focus_is_descendant_of(&window2);
+                                                    if keep_visible {
+                                                        if let Ok(panel) =
+                                                            app2.get_webview_panel("main-window")
+                                                        {
+                                                            unsafe {
+                                                                use objc::{msg_send, sel, sel_impl};
+                                                                let _: () = msg_send![
+                                                                    &*panel,
+                                                                    setAlphaValue: 1.0f64
+                                                                ];
+                                                            }
+                                                        }
+                                                        MAIN_PANEL_SHOWN.store(
+                                                            true,
+                                                            std::sync::atomic::Ordering::SeqCst,
+                                                        );
+                                                    }
+                                                    let _ = sender.send(keep_visible);
+                                                })
+                                                .is_ok()
+                                                && receiver
+                                                    .recv_timeout(std::time::Duration::from_secs(1))
+                                                    .unwrap_or(false)
+                                            {
+                                                info!(
+                                                    "Window-mode focus settled on an attached child; keeping overlay visible"
+                                                );
+                                                return;
+                                            }
                                         }
                                         // Dispatch all AppKit work to main thread — this
                                         // closure runs on a spawned background thread.


### PR DESCRIPTION
## Problem

On macOS window mode, clicking the attached native Timeline makes the child window key. The Tauri parent interpreted that internal focus transfer as external blur and hid the overlay. The same level-1001 overlay could also cover the native tray menu, whose default popup level is 101.

## Fix

- apply the existing attached-descendant focus guard and delayed recheck to window mode
- treat the Tauri parent and native Timeline child as one logical overlay
- keep the overlay at level 1001 and raise only actively tracked NSStatusItem menu windows to 1002
- leave ordinary in-app/context menus at their native level

## Before / after

```text
before: Timeline click -> parent blur -> overlay closes
before: overlay 1001 > tray menu 101

after:  parent <-> Timeline focus stays inside one overlay
after:  tray menu 1002 > overlay 1001
```

## Historical intent

Inspected the native Timeline introduction and first-click selection changes (#6300 and #6463), plus the existing window-mode/fullscreen focus-loss handling. The descendant-focus helper was introduced specifically to distinguish an attached Timeline child from external focus, but only the fullscreen branch used it. This PR extends that invariant to the duplicated window-mode branch and preserves the existing fullscreen-capable overlay level.

## Validation

- `git diff --check`
- `SEM_NO_TELEMETRY=1 sem diff upstream/main..HEAD --format plain --no-cosmetics`
- `bun run build:tauri:dev` passed before the clean rebase onto current `upstream/main`
- final-head rebuild was stopped during compilation at user direction; CI is pending

## Manual check remaining

With Stage Manager enabled and overlay mode set to Window: click throughout Timeline and open the tray menu above it. The Timeline should stay open on internal clicks and the tray menu should render above it.