### PR TITLE
fix(app): simplify AI preset creation

### DIFF
--- a/apps/screenpipe-app-tauri/components/rewind/ai-presets-selector.test.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/ai-presets-selector.test.tsx
@@ -102,6 +102,15 @@ vi.mock("@/lib/http/tauri-fetch", () => ({
 vi.mock("@/lib/utils/tauri", () => ({
   commands: {
     piCheck: vi.fn(async () => ({ status: "ok", data: { available: false } })),
+    piAcpAgentInstallStatus: vi.fn(async () => ({
+      requiresInstall: false,
+      installed: true,
+    })),
+    piAcpAgentDownloadPending: vi.fn(async () => false),
+    piAcpProbeAgent: vi.fn(async () => ({
+      status: "error",
+      error: "model and mode choices unavailable",
+    })),
     chatgptOauthStatus: vi.fn(async () => ({ status: "ok", data: { logged_in: false } })),
     chatgptOauthGetToken: vi.fn(async () => ({ status: "error" })),
   },
@@ -215,6 +224,9 @@ describe("AIPresetsSelector controlled preset creation", () => {
       "GitHub Copilot",
       "Pi",
     ]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Pi" }));
+    expect(screen.queryByText("how this works")).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "screenpipe" }));
     const nameInput = screen.getByLabelText("name");

--- a/apps/screenpipe-app-tauri/components/settings/acp-agent-picker.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/acp-agent-picker.tsx
@@ -231,22 +231,9 @@ export function AcpAgentPicker({
         </div>
       )}
 
-      {/* Keep the quick dialog calm; the full settings editor still shows the
-          ownership split because that is where people troubleshoot setup. */}
-      {compact ? (
-        <details className="border border-border/60 bg-muted/20 p-2 text-[10px]">
-          <summary className="cursor-pointer text-muted-foreground hover:text-foreground">
-            how this works
-          </summary>
-          <AcpBoundaries
-            agentName={info.name}
-            compact
-            className="mt-2 border-0 bg-transparent p-0"
-          />
-        </details>
-      ) : (
-        <AcpBoundaries agentName={info.name} />
-      )}
+      {/* Keep the quick dialog focused on setup; the full settings editor shows
+          the ownership split where people troubleshoot configuration. */}
+      {!compact && <AcpBoundaries agentName={info.name} />}
 
       <AcpInstallGate
         compact={compact}


### PR DESCRIPTION
## description

- remove the `how this works` disclosure from the compact ACP setup in Create New Preset
- keep the detailed agent and Screenpipe ownership panel in the full Settings AI preset editor
- add a regression assertion for the compact dialog

## AI assistance and human ownership

read the [AI-assisted contribution policy](https://github.com/screenpipe/screenpipe/blob/main/CONTRIBUTING.md#ai-assisted-contributions).

- AI tool(s) used (`none` if not used): Codex
- autonomy level (`none`, `autocomplete`, `chat`, or `agent`): agent
- what I personally verified: no personal human verification recorded yet; Codex ran the checks and captured the visual evidence below

- [ ] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [ ] The problem statement, rationale, and replies to maintainers are my own.

## evidence type

- [x] UI or behavior change: same-viewport before/after screenshots below
- [ ] Backend change: regression tests and relevant logs/results
- [ ] Performance change: reproducible before/after benchmarks
- [ ] Docs, CI, or pure refactor: relevant checks and an explanation; no video required

## before

The compact ACP setup included an extra `how this works` disclosure.

![Before: compact AI preset creation with how this works](https://github.com/screenpipe/screenpipe/releases/download/media/ai-preset-before.png)

## after

The compact setup leads directly from the selected agent to setup status and preset naming.

![After: compact AI preset creation without how this works](https://github.com/screenpipe/screenpipe/releases/download/media/ai-preset-after.png)

## how to test

1. `bun run test:vitest -- components/rewind/ai-presets-selector.test.tsx` from `apps/screenpipe-app-tauri`: 8 passed.
2. `bun run typecheck` from `apps/screenpipe-app-tauri`: passed.
3. `bun x eslint components/settings/acp-agent-picker.tsx components/rewind/ai-presets-selector.test.tsx`: passed with no output.
4. `NEXT_PUBLIC_SCREENPIPE_E2E=true bun run dev:web`, then Home, model selector, create new preset, Pi: the compact dialog no longer renders `how this works`; the before and after states were captured at 1280x720.

## desktop app checklist

No Tauri commands or exported Rust types changed.

- [ ] `bun run bindings:generate` (not applicable)
- [ ] `bun run bindings:check` (not applicable)
- [x] `bun run typecheck`
