### PR TITLE
fix(ci): avoid SIGPIPE in release revision validation

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -75,9 +75,9 @@ jobs:
           }
 
           MANIFEST_VERSION=$(git show "${RELEASE_SHA}:apps/screenpipe-app-tauri/src-tauri/Cargo.toml" |
-            sed -n 's/^version = "\([^"]*\)"/\1/p' | head -1)
+            sed -n 's/^version = "\([^"]*\)"/\1/p')
           LOCK_VERSION=$(git show "${RELEASE_SHA}:apps/screenpipe-app-tauri/src-tauri/Cargo.lock" |
-            awk '/^name = "screenpipe-app"$/ { found=1; next } found && /^version = / { gsub(/"/, "", $3); print $3; exit }')
+            awk '/^name = "screenpipe-app"$/ { found=1; next } found && /^version = / && !printed { gsub(/"/, "", $3); print $3; printed=1 }')
 
           if [[ -z "$MANIFEST_VERSION" || "$MANIFEST_VERSION" != "$LOCK_VERSION" ]]; then
             echo "Cargo.toml version '$MANIFEST_VERSION' does not match Cargo.lock '$LOCK_VERSION'" >&2

--- a/.github/workflows/release-enterprise.yml
+++ b/.github/workflows/release-enterprise.yml
@@ -71,9 +71,9 @@ jobs:
           }
 
           MANIFEST_VERSION=$(git show "${RELEASE_SHA}:apps/screenpipe-app-tauri/src-tauri/Cargo.toml" |
-            sed -n 's/^version = "\([^"]*\)"/\1/p' | head -1)
+            sed -n 's/^version = "\([^"]*\)"/\1/p')
           LOCK_VERSION=$(git show "${RELEASE_SHA}:apps/screenpipe-app-tauri/src-tauri/Cargo.lock" |
-            awk '/^name = "screenpipe-app"$/ { found=1; next } found && /^version = / { gsub(/"/, "", $3); print $3; exit }')
+            awk '/^name = "screenpipe-app"$/ { found=1; next } found && /^version = / && !printed { gsub(/"/, "", $3); print $3; printed=1 }')
 
           if [[ -z "$MANIFEST_VERSION" || "$MANIFEST_VERSION" != "$LOCK_VERSION" ]]; then
             echo "Cargo.toml version '$MANIFEST_VERSION' does not match Cargo.lock '$LOCK_VERSION'" >&2


### PR DESCRIPTION
## Summary

The first post-merge dry runs of both release workflows failed in their shared revision validator with exit 141. Under `set -o pipefail`, `head -1` and early `awk exit` stopped reading while `git show` was still writing, so Git received SIGPIPE.

```text
before: git show -> early reader exit -> SIGPIPE 141
 after: git show -> full reader      -> validated 2.6.76
```

Both readers now consume the full input while emitting only the required version.

## Validation

- reproduced in Release App run `32525506668` and Release Enterprise run `32525508805`
- executed the exact validator locally under `bash -euo pipefail` against merge SHA `de803592be67ca1cc208ddaf2ece9294c4832547`
- result: `manifest=2.6.76 lock=2.6.76`
- `git diff --check`
- Actionlint diagnostic count is unchanged from current `main`

After merge I will rerun both workflows with `dry_run=true`; no R2, Sentry, tag, release, updater-pointer, or publication writes.
