### PR TITLE
fix(release): keep Mac node modules job-local

### DIFF
--- a/.github/actions/setup-persistent-macos-cache/action.yml
+++ b/.github/actions/setup-persistent-macos-cache/action.yml
@@ -22,6 +22,7 @@ runs:
 
         CACHE_ROOT="$HOME/screenpipe-cache"
         WORKSPACE_TARGET="$GITHUB_WORKSPACE/apps/screenpipe-app-tauri/src-tauri/target"
+        WORKSPACE_NODE_MODULES="$GITHUB_WORKSPACE/apps/screenpipe-app-tauri/node_modules"
         PERSISTENT_TARGET="$CACHE_ROOT/targets/$SCREENPIPE_RELEASE_TARGET"
 
         mkdir -p \
@@ -30,7 +31,6 @@ runs:
           "$CACHE_ROOT/bun" \
           "$CACHE_ROOT/native-deps" \
           "$PERSISTENT_TARGET" \
-          "$CACHE_ROOT/node_modules/$SCREENPIPE_RELEASE_TARGET" \
           "$CACHE_ROOT/tauri/$SCREENPIPE_RELEASE_TARGET"
 
         replace_with_symlink() {
@@ -49,9 +49,11 @@ runs:
         }
 
         replace_with_symlink "$WORKSPACE_TARGET" "$PERSISTENT_TARGET"
-        replace_with_symlink \
-          "$GITHUB_WORKSPACE/apps/screenpipe-app-tauri/node_modules" \
-          "$CACHE_ROOT/node_modules/$SCREENPIPE_RELEASE_TARGET"
+        # Bun can omit platform-specific optional packages when node_modules is
+        # installed through a persistent symlink. Keep its download cache, but
+        # materialize dependencies fresh for each job so native bindings match
+        # the EC2 Mac host.
+        rm -rf "$WORKSPACE_NODE_MODULES"
         replace_with_symlink \
           "$GITHUB_WORKSPACE/apps/screenpipe-app-tauri/.tauri" \
           "$CACHE_ROOT/tauri/$SCREENPIPE_RELEASE_TARGET"


### PR DESCRIPTION
## Summary

Keep the expensive Cargo, target, sccache, native dependency, and Bun download caches persistent, but materialize `node_modules` per job. Bun omitted Tauri native optional bindings when installing through the persistent symlink.

## Evidence

Before: both release workflows failed with `Cannot find module @tauri-apps/cli-darwin-arm64`.

After: Bun reuses its persistent package download cache while installing native bindings into a regular job-local directory.

## Local verification

- `git diff --check`
- Ruby YAML parse of `.github/actions/setup-persistent-macos-cache/action.yml`