### PR TITLE
fix(release): install cmake on persistent Mac

### DIFF
--- a/infra/release-mac-runner/template.yml
+++ b/infra/release-mac-runner/template.yml
@@ -176,7 +176,7 @@ Resources:
             set -euo pipefail
             eval "$(/opt/homebrew/bin/brew shellenv)"
             brew update
-            brew install aria2 bun ffmpeg gh git-lfs jq node sccache wget
+            brew install aria2 bun cmake ffmpeg gh git-lfs jq node sccache wget
             brew install xcodesorg/made/xcodes
 
             if [[ ! -x "$HOME/.cargo/bin/rustup" ]]; then


### PR DESCRIPTION
## Summary

Install CMake during persistent EC2 Mac bootstrap. Native release dependencies such as `whisper-rs-sys` require it.

## Evidence

The first real ARM build reached `whisper-rs-sys`, then failed with `is cmake not installed?`.

## Verification

- `git diff --check`
- `aws cloudformation validate-template`