### PR TITLE
fix(chat): preserve unicode across context trimming

### DIFF
--- a/apps/screenpipe-app-tauri/lib/__tests__/context-pruning.test.ts
+++ b/apps/screenpipe-app-tauri/lib/__tests__/context-pruning.test.ts
@@ -122,6 +122,31 @@ describe("clampMessageText", () => {
     expect(out.endsWith("END")).toBe(true);
     expect(out).toContain("trimmed");
   });
+
+  it("never splits supplementary code points at history-tail or generic trim boundaries", () => {
+    const historyBefore = "<conversation_history>";
+    const historyAfter = "</conversation_history>\n\nquestion";
+    const historyMarker = "\n…[older history trimmed]\n";
+    const cases = [
+      {
+        text: `${historyBefore}${"old".repeat(30)}😀TAIL${historyAfter}`,
+        maxChars: historyBefore.length + historyMarker.length + 5 + historyAfter.length,
+      },
+      {
+        text: `abc😀${"MIDDLE".repeat(10)}😀xyz`,
+        maxChars: "\n…[trimmed]\n".length + 8,
+      },
+    ];
+
+    for (const { text, maxChars } of cases) {
+      const out = clampMessageText(text, maxChars);
+      expect(out.length).toBeLessThanOrEqual(maxChars);
+      expect([...out].some((char) => {
+        const codePoint = char.codePointAt(0)!;
+        return codePoint >= 0xD800 && codePoint <= 0xDFFF;
+      })).toBe(false);
+    }
+  });
 });
 
 // ── pure: boundOversizedMessages ─────────────────────────────────────────

--- a/crates/screenpipe-core/assets/extensions/context-pruning.ts
+++ b/crates/screenpipe-core/assets/extensions/context-pruning.ts
@@ -71,6 +71,16 @@ const CHARS_PER_TOKEN = 4;
 const HISTORY_OPEN = "<conversation_history>";
 const HISTORY_CLOSE = "</conversation_history>";
 
+function safeHead(text: string, end: number): string {
+  const last = text.charCodeAt(end - 1);
+  return text.slice(0, last >= 0xD800 && last <= 0xDBFF ? end - 1 : end);
+}
+
+function safeTail(text: string, start: number): string {
+  const first = text.charCodeAt(start);
+  return text.slice(first >= 0xDC00 && first <= 0xDFFF ? start + 1 : start);
+}
+
 /** Resolve the model's context window (tokens) from the extension context. */
 export function resolveContextWindowTokens(ctx: any): number {
   const fromModel = ctx?.model?.contextWindow;
@@ -112,7 +122,7 @@ export function clampMessageText(text: string, maxChars: number): string {
     const bodyBudget = maxChars - before.length - after.length - marker.length;
     if (bodyBudget > 0) {
       // Keep the TAIL of the history body (the most recent turns).
-      return before + marker + body.slice(body.length - bodyBudget) + after;
+      return before + marker + safeTail(body, body.length - bodyBudget) + after;
     }
     // The wrapper + real message already fills the budget: drop the whole
     // history body but keep the user's actual message intact.
@@ -122,7 +132,7 @@ export function clampMessageText(text: string, maxChars: number): string {
   // Generic oversized payload: keep head + tail so both ends survive.
   const marker = "\n…[trimmed]\n";
   const half = Math.max(0, Math.floor((maxChars - marker.length) / 2));
-  return text.slice(0, half) + marker + text.slice(text.length - half);
+  return safeHead(text, half) + marker + safeTail(text, text.length - half);
 }
 
 /**


### PR DESCRIPTION
## Summary

- prevent chat context trimming from splitting UTF-16 surrogate pairs
- cover both conversation-history tail retention and generic head/tail clamps
- preserve existing size budgets, newest-history retention, and the complete current question

## User impact

A Windows 10 user reported AI chat failing with `unexpected end of hex escape`. Long context trimming could cut an emoji or another supplementary Unicode character between its UTF-16 code units. `JSON.stringify` then emitted a lone `\uDxxx` surrogate, which Rust `serde_json` rejected before the request could be processed.

The boundary helpers now move an unsafe cut inward by one UTF-16 code unit. This covers the full trimming surface: the history-tail path and both generic head/tail slice boundaries. Output never grows, and no interface or dependency changes are involved.

Platform scope: the report came from Windows 10, but the fault is in shared JavaScript context-pruning logic and the fix applies consistently on every desktop platform.

Source feedback task: `t_2d959305`
Independent review: `t_cc4ce455` — unconditional approval for exact head `f2d8f537b5c37be268e89878fe12f34c1037826d`.

## Verification

- RED: restoring raw `slice` behavior made the supplementary-code-point regression fail with a detected lone surrogate
- GREEN: focused context-pruning suite passed, 30/30
- broad Vitest suite passed, 415 files / 4,334 tests
- TypeScript typecheck passed
- reviewer property checks passed across 139 deterministic boundaries
- independent Rust `serde_json` reproduction confirmed lone-surrogate rejection
- `git diff --check` passed; exact reviewed two-file commit remained clean

## Visual evidence

ASCII reproduction of the user-visible failure path:

```text
before: ... 😀 ... -- UTF-16 cut --> lone \uD83D --> unexpected end of hex escape
 after: ... 😀 ... -- safe cut  --> intact text  --> chat context parses normally
```

No issue-closing keyword is used because this originated from feedback intake rather than a GitHub issue.