### PR TITLE
fix(release): isolate exact-SHA app dispatches

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -29,7 +29,7 @@ on:
         type: boolean
         default: false
 concurrency:
-  group: release-app-${{ github.event_name }}-${{ github.sha }}
+  group: release-app-${{ github.event_name }}-${{ github.event.inputs.commit_hash || github.sha }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
## Summary

Key Release App workflow-dispatch concurrency by the requested source SHA instead of the moving workflow revision. A release for another commit can no longer cancel an exact-SHA build already using the persistent Mac.

## Evidence

Dry run 32529373191 for `73bdb653` was canceled when another Release App dispatch started from the same workflow revision.

## Verification

- `actionlint .github/workflows/release-app.yml`
- `git diff --check`