### PR TITLE
fix(release): install Apple signing intermediates

### DIFF
--- a/infra/release-mac-runner/template.yml
+++ b/infra/release-mac-runner/template.yml
@@ -172,6 +172,17 @@ Resources:
             mkdir -p "$CACHE_ROOT" "$RUNNER_ROOT"
             chown -R ec2-user:staff "$CACHE_ROOT" "$RUNNER_ROOT"
 
+            APPLE_CERT_DIR=/var/tmp/screenpipe-apple-certs
+            mkdir -p "$APPLE_CERT_DIR"
+            curl -fsSL -o "$APPLE_CERT_DIR/DeveloperIDCA.cer" \
+              https://www.apple.com/certificateauthority/DeveloperIDCA.cer
+            curl -fsSL -o "$APPLE_CERT_DIR/DeveloperIDG2CA.cer" \
+              https://www.apple.com/certificateauthority/DeveloperIDG2CA.cer
+            security import "$APPLE_CERT_DIR/DeveloperIDCA.cer" \
+              -t cert -k /Library/Keychains/System.keychain || true
+            security import "$APPLE_CERT_DIR/DeveloperIDG2CA.cer" \
+              -t cert -k /Library/Keychains/System.keychain || true
+
             sudo -u ec2-user -H /bin/bash <<'BOOTSTRAP'
             set -euo pipefail
             eval "$(/opt/homebrew/bin/brew shellenv)"


### PR DESCRIPTION
## Summary

Install Apple Developer ID intermediate certificates into the persistent Mac system keychain during bootstrap. This lets headless codesign build the Developer ID chain without an interactive trust prompt.

## Evidence

Both App and Enterprise x86 builds compiled successfully, then failed with `unable to build chain to self-signed root` and `errSecInternalComponent`. The live runner now has both Developer ID CA generations in `/Library/Keychains/System.keychain`.

## Verification

- `aws cloudformation validate-template`
- live `security find-certificate` confirms both Developer ID intermediates