### PR TITLE
ci: select the installed Metal toolchain

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -1289,6 +1289,12 @@ jobs:
           # 10.13 to the Metal compiler. This breaks both MSL 3.0+ and std::filesystem.
           # Fix: wrap cc/c++/xcrun to replace all -mmacosx-version-min flags with 14.0.
           if [[ "${{ matrix.target }}" == "aarch64-apple-darwin" ]]; then
+            TOOLCHAINS=$(xcodebuild -showComponent MetalToolchain | sed -n 's/^Toolchain Identifier: //p')
+            if [[ -z "$TOOLCHAINS" ]]; then
+              echo "Metal Toolchain is installed but its identifier could not be resolved" >&2
+              exit 1
+            fi
+            export TOOLCHAINS
             xcrun metal --version
             WRAPPER_DIR="$(pwd)/.compiler-wrapper"
             mkdir -p "$WRAPPER_DIR"

--- a/.github/workflows/release-enterprise.yml
+++ b/.github/workflows/release-enterprise.yml
@@ -839,6 +839,12 @@ jobs:
 
           # Compiler wrapper is only needed for ARM64 MLX Metal kernels.
           if [[ "$TARGET" == "aarch64-apple-darwin" ]]; then
+            TOOLCHAINS=$(xcodebuild -showComponent MetalToolchain | sed -n 's/^Toolchain Identifier: //p')
+            if [[ -z "$TOOLCHAINS" ]]; then
+              echo "Metal Toolchain is installed but its identifier could not be resolved" >&2
+              exit 1
+            fi
+            export TOOLCHAINS
             xcrun metal --version
             WRAPPER_DIR="$(pwd)/.compiler-wrapper"
             mkdir -p "$WRAPPER_DIR"


### PR DESCRIPTION
The EC2 Mac has the Xcode 26 Metal component installed, but `xcrun -sdk macosx metal` does not select a separately downloaded toolchain by default. Resolve the installed identifier with `xcodebuild -showComponent MetalToolchain`, export it through `TOOLCHAINS`, and keep the existing ARM deployment-target wrappers.

Verified directly on the runner:
- default `xcrun -sdk macosx metal --version` fails
- `TOOLCHAINS=com.apple.dt.toolchain.Metal.32023.883 xcrun -sdk macosx metal --version` succeeds
- both edited workflow files parse as YAML

No publication is performed.