### PR TITLE
ci: retain macOS app artifacts in dry runs

### DIFF
--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -1626,6 +1626,18 @@ jobs:
             echo "✅ ${APP_NAME} stapled, tarball rebuilt and re-signed"
           done
 
+      - name: Upload macOS dry-run artifacts
+        if: matrix.os_type == 'macos' && github.event.inputs.dry_run == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: consumer-macos-${{ matrix.target }}
+          path: |
+            apps/screenpipe-app-tauri/src-tauri/target/${{ matrix.target }}/release/bundle/dmg/*.dmg
+            apps/screenpipe-app-tauri/src-tauri/target/${{ matrix.target }}/release/bundle/macos/*.app.tar.gz
+            apps/screenpipe-app-tauri/src-tauri/target/${{ matrix.target }}/release/bundle/macos/*.app.tar.gz.sig
+          if-no-files-found: error
+          compression-level: 0
+
       - name: Upload to Cloudflare R2 (macOS)
         if: matrix.os_type == 'macos' && github.event.inputs.dry_run != 'true'
         shell: bash


### PR DESCRIPTION
Release App dry runs intentionally skip R2, but that left no retained artifacts to verify. Upload the notarized DMG and rebuilt/signed updater tarball to GitHub Actions only when `dry_run=true`. Real release upload behavior is unchanged.

Verification: workflow parses as YAML; current exact-SHA run already proves both Mac builds/signing/notarization paths.

No publication or R2 write is performed.