### PR TITLE
fix(core): validate pipe names to prevent path traversal in PipeManager

### DIFF
--- a/crates/screenpipe-core/src/pipes/mod.rs
+++ b/crates/screenpipe-core/src/pipes/mod.rs
@@ -847,6 +847,22 @@ fn remove_tombstone(pipes_dir: &Path, name: &str) -> Result<()> {
     Ok(())
 }
 
+/// Validate that a pipe name is a safe, single directory component and does
+/// not attempt path traversal or contain directory separators.
+pub fn validate_pipe_name(name: &str) -> Result<()> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Err(anyhow!("pipe name cannot be empty"));
+    }
+    if trimmed.contains("..") || trimmed.contains('/') || trimmed.contains('\\') {
+        return Err(anyhow!(
+            "invalid pipe name '{}': path traversal sequences and separators are not allowed",
+            name
+        ));
+    }
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Local enabled overrides — per-device enabled state that never syncs.
 // Stored in `~/.screenpipe/pipes/.local-overrides.json`.
@@ -5014,6 +5030,7 @@ impl PipeManager {
         slug: &str,
         version: i64,
     ) -> Result<String> {
+        validate_pipe_name(slug)?;
         // Parse the source_md to get config + body
         let (mut config, body) = parse_frontmatter(source_md)?;
 
@@ -5047,6 +5064,8 @@ impl PipeManager {
         slug: &str,
         version: i64,
     ) -> Result<()> {
+        validate_pipe_name(name)?;
+        validate_pipe_name(slug)?;
         let dest_dir = self.pipes_dir.join(name);
         if !dest_dir.exists() {
             return Err(anyhow!("pipe '{}' not found", name));
@@ -5090,6 +5109,7 @@ impl PipeManager {
     /// Writes a tombstone so the pipe is not restored by builtin installation
     /// or cloud sync.
     pub async fn delete_pipe(&self, name: &str) -> Result<()> {
+        validate_pipe_name(name)?;
         let dir = self.pipes_dir.join(name);
         if !dir.exists() {
             return Err(self.pipe_not_found_error(name));
@@ -5151,6 +5171,7 @@ impl PipeManager {
 
     /// Clear a pipe's chat history by deleting its Pi session files.
     pub async fn clear_pipe_history(&self, name: &str) -> Result<()> {
+        validate_pipe_name(name)?;
         let pipe_dir = self.pipes_dir.join(name);
         if !pipe_dir.exists() {
             return Err(anyhow!("pipe '{}' not found", name));
@@ -8120,6 +8141,21 @@ impl Drop for PipeManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_validate_pipe_name_safety() {
+        assert!(validate_pipe_name("daily-summary").is_ok());
+        assert!(validate_pipe_name("sop_generator_1").is_ok());
+        assert!(validate_pipe_name("my-task-2026").is_ok());
+
+        assert!(validate_pipe_name("../../../etc/passwd").is_err());
+        assert!(validate_pipe_name("..\\..\\windows").is_err());
+        assert!(validate_pipe_name("foo/bar").is_err());
+        assert!(validate_pipe_name("foo\\bar").is_err());
+        assert!(validate_pipe_name("..").is_err());
+        assert!(validate_pipe_name("").is_err());
+        assert!(validate_pipe_name("   ").is_err());
+    }
     use chrono::{TimeZone, Timelike};
     use std::sync::atomic::Ordering;
 


### PR DESCRIPTION
## description

Adds input validation (`validate_pipe_name`) to `PipeManager` methods (`delete_pipe`, `install_pipe_from_store`, `update_pipe_from_store`, `clear_pipe_history`) in `crates/screenpipe-core/src/pipes/mod.rs`.

Previously, user-supplied pipe names/slugs were joined directly to `self.pipes_dir` without checking for `..` or path separators (`/`, `\`). Passing path traversal sequences allowed resolving outside `~/.screenpipe/pipes/` and executing recursive deletion on unrelated user directories.

This fix enforces that pipe names must be safe, single directory components, matching the maintainer note in `crates/screenpipe-core/src/pipes/trajectory.rs` (line 101) which noted that pipe names were expected to be validated upstream.

related issue: #6572 

## AI assistance and human ownership

read the [AI-assisted contribution policy](https://github.com/screenpipe/screenpipe/blob/main/CONTRIBUTING.md#ai-assisted-contributions).

- AI tool(s) used (`none` if not used): Antigravity
- autonomy level (`none`, `autocomplete`, `chat`, or `agent`): agent
- what I personally verified: Audited `crates/screenpipe-core/src/pipes/mod.rs` for path join locations, implemented `validate_pipe_name` helper, and ran `cargo test -p screenpipe-core test_validate_pipe_name_safety` (1 passed).

- [x] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [x] The problem statement, rationale, and replies to maintainers are my own.

## evidence type

check every category that applies and provide its required evidence below.

- [ ] UI or behavior change — before/after recording
- [x] Backend change — regression tests and relevant logs/results
- [ ] Performance change — reproducible before/after benchmarks
- [ ] Docs, CI, or pure refactor — relevant checks and an explanation; no video required

## before

Pipe names containing `..` or path separators were accepted, resolving paths outside `~/.screenpipe/pipes/` (e.g. `delete_pipe("../user_documents")` targeted `/user_documents`).

## after

Pipe names containing `..`, `/`, or `\` are rejected immediately with an error before any filesystem operations occur:

```rust
pub fn validate_pipe_name(name: &str) -> Result<()> {
    let trimmed = name.trim();
    if trimmed.is_empty() {
        return Err(anyhow!("pipe name cannot be empty"));
    }
    if trimmed.contains("..") || trimmed.contains('/') || trimmed.contains('\\') {
        return Err(anyhow!(
            "invalid pipe name '{}': path traversal sequences and separators are not allowed",
            name
        ));
    }
    Ok(())
}
```
## how to test

list the exact commands or manual steps you personally ran and their results.

1. `cargo test -p screenpipe-core test_validate_pipe_name_safety` -> finished with 1 passed, 0 failed.

## desktop app checklist (if applicable)

If this PR adds or changes `#[tauri::command]` handlers or Rust types exported to the frontend, from `apps/screenpipe-app-tauri/`:

- [ ] `bun run bindings:generate` (if bindings changed)
- [ ] `bun run bindings:check`
- [ ] `bun run typecheck`


Commands are auto-collected via the vendored `tauri-helper` crate — no manual handler list edits in `main.rs`.
