### PR TITLE
fix(activity): persist timeline return navigation

### DIFF
--- a/apps/screenpipe-app-tauri/app/(main)/home/page.tsx
+++ b/apps/screenpipe-app-tauri/app/(main)/home/page.tsx
@@ -72,6 +72,7 @@ import Timeline from "@/components/rewind/timeline";
 import {
   NativeTimeline,
   NativeTimelineBridge,
+  shouldClearActivityReturn,
 } from "@/components/rewind/native-timeline";
 import { useQueryState } from "nuqs";
 import { listen } from "@tauri-apps/api/event";
@@ -170,32 +171,21 @@ function HomeContent() {
     serialize: (value) => value,
   });
   const [activityReturnVisible, setActivityReturnVisible] = useState(false);
-  const activityReturnButtonRef = useRef<HTMLButtonElement | null>(null);
+  const previousSectionRef = useRef(activeSection);
   const returnToActivity = useCallback(() => {
     setActivityReturnVisible(false);
     router.push("/home?section=activity");
   }, [router]);
-  const dismissActivityReturn = useCallback(() => {
-    setActivityReturnVisible(false);
-  }, []);
 
   useEffect(() => {
+    const previousSection = previousSectionRef.current;
+    previousSectionRef.current = activeSection;
     if (
-      !activityReturnVisible ||
-      (activeSection !== "meetings" && activeSection !== "timeline")
+      activityReturnVisible &&
+      shouldClearActivityReturn(previousSection, activeSection)
     ) {
-      return;
-    }
-    const dismiss = (event: PointerEvent) => {
-      if (
-        activityReturnButtonRef.current?.contains(event.target as Node)
-      ) {
-        return;
-      }
       setActivityReturnVisible(false);
-    };
-    document.addEventListener("pointerdown", dismiss, true);
-    return () => document.removeEventListener("pointerdown", dismiss, true);
+    }
   }, [activeSection, activityReturnVisible]);
   const [connectionFocusRequest, setConnectionFocusRequest] = useState<ConnectionFocusRequest | null>(null);
 
@@ -1206,10 +1196,7 @@ function HomeContent() {
           palette use teaches the direct key. Home window only: the settings
           page binds its own ⌘K for search focus while mounted. */}
       {/* Routes actions the native timeline window cannot perform itself. */}
-      <NativeTimelineBridge
-        onReturnToActivity={returnToActivity}
-        onDismissActivityReturn={dismissActivityReturn}
-      />
+      <NativeTimelineBridge onReturnToActivity={returnToActivity} />
 
       <CommandPalette
         open={commandPaletteOpen}
@@ -1595,7 +1582,6 @@ function HomeContent() {
             {activityReturnVisible &&
               (activeSection === "meetings" || activeSection === "timeline") && (
                 <button
-                  ref={activityReturnButtonRef}
                   type="button"
                   onClick={returnToActivity}
                   aria-label="back to activity"

--- a/apps/screenpipe-app-tauri/components/rewind/native-timeline.test.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/native-timeline.test.tsx
@@ -10,6 +10,7 @@ import {
   nativeTimelineOcclusionMode,
   parseTimelineDailySummaryRequest,
   parseTimelineDay,
+  shouldClearActivityReturn,
 } from "./native-timeline";
 
 describe("native timeline bridge payloads", () => {
@@ -38,6 +39,12 @@ describe("native timeline bridge payloads", () => {
     expect(
       parseTimelineDailySummaryRequest("2026-08-16", "main")
     ).not.toBeNull();
+  });
+
+  it("keeps the Activity return for the Timeline visit and clears it on exit", () => {
+    expect(shouldClearActivityReturn("activity", "timeline")).toBe(false);
+    expect(shouldClearActivityReturn("timeline", "timeline")).toBe(false);
+    expect(shouldClearActivityReturn("timeline", "home")).toBe(true);
   });
 
   it("turns native selection context into the existing chat prefill shape", () => {

--- a/apps/screenpipe-app-tauri/components/rewind/native-timeline.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/native-timeline.tsx
@@ -134,6 +134,16 @@ export function parseTimelineDailySummaryRequest(
   return parseTimelineDay(payload.date);
 }
 
+export function shouldClearActivityReturn(
+  previousSection: string,
+  activeSection: string,
+): boolean {
+  return (
+    (previousSection === "meetings" || previousSection === "timeline") &&
+    activeSection !== previousSection
+  );
+}
+
 /**
  * Routes the actions the Swift window cannot perform on its own. Mount once,
  * high enough that it outlives navigation.
@@ -144,10 +154,8 @@ export function parseTimelineDailySummaryRequest(
  */
 export function NativeTimelineBridge({
   onReturnToActivity,
-  onDismissActivityReturn,
 }: {
   onReturnToActivity?: () => void;
-  onDismissActivityReturn?: () => void;
 } = {}) {
   const [dailySummaryRequest, setDailySummaryRequest] = useState<{
     date: Date;
@@ -165,9 +173,6 @@ export function NativeTimelineBridge({
       }),
       listen("timeline-return-to-activity", () => {
         onReturnToActivity?.();
-      }),
-      listen("timeline-dismiss-activity-return", () => {
-        onDismissActivityReturn?.();
       }),
       listen<string | NativeTimelineDailySummaryRequest>(
         "timeline-open-daily-summary",
@@ -264,7 +269,7 @@ export function NativeTimelineBridge({
         void subscription.then((unlisten) => unlisten());
       }
     };
-  }, [onDismissActivityReturn, onReturnToActivity]);
+  }, [onReturnToActivity]);
 
   if (!dailySummaryRequest) return null;
 

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands/native_actions.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands/native_actions.rs
@@ -206,14 +206,6 @@ fn native_timeline_action_callback_inner(action_ptr: *const std::os::raw::c_char
         TimelineAction::ReturnToActivity => {
             emit_timeline_event(&app, target.as_deref(), "timeline-return-to-activity", ());
         }
-        TimelineAction::DismissActivityReturn => {
-            emit_timeline_event(
-                &app,
-                target.as_deref(),
-                "timeline-dismiss-activity-return",
-                (),
-            );
-        }
         TimelineAction::OpenSearch => {
             emit_timeline_event(&app, target.as_deref(), "timeline-open-search", ());
         }

--- a/apps/screenpipe-app-tauri/src-tauri/src/native_timeline.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/native_timeline.rs
@@ -169,7 +169,6 @@ pub struct TimelineExportSelection {
 pub enum TimelineAction {
     CloseWindow,
     ReturnToActivity,
-    DismissActivityReturn,
     OpenSearch,
     OpenDailySummary { date: String },
     OpenChat,
@@ -228,7 +227,6 @@ impl TimelineAction {
         match (name, argument) {
             ("close_window", _) => Self::CloseWindow,
             ("return_to_activity", _) => Self::ReturnToActivity,
-            ("dismiss_activity_return", _) => Self::DismissActivityReturn,
             ("open_search", _) => Self::OpenSearch,
             ("open_daily_summary", Some(date)) => Self::OpenDailySummary {
                 date: date.to_string(),
@@ -504,10 +502,6 @@ mod tests {
         assert_eq!(
             TimelineAction::parse("return_to_activity"),
             TimelineAction::ReturnToActivity
-        );
-        assert_eq!(
-            TimelineAction::parse("dismiss_activity_return"),
-            TimelineAction::DismissActivityReturn
         );
         assert_eq!(TimelineAction::parse("open_search"), TimelineAction::OpenSearch);
         assert_eq!(TimelineAction::parse("open_chat"), TimelineAction::OpenChat);

--- a/apps/screenpipe-app-tauri/src-tauri/swift/timeline/TimelineWindow.swift
+++ b/apps/screenpipe-app-tauri/src-tauri/swift/timeline/TimelineWindow.swift
@@ -332,12 +332,6 @@ final class TimelineOriginChrome: ObservableObject {
         showsActivityReturn = false
         TimelineActionBridge.shared.emit("return_to_activity")
     }
-
-    func dismissActivityReturn() {
-        guard showsActivityReturn else { return }
-        showsActivityReturn = false
-        TimelineActionBridge.shared.emit("dismiss_activity_return")
-    }
 }
 
 @MainActor
@@ -385,13 +379,6 @@ struct TimelineHostView: View {
                     .padding(16)
                 }
             }
-            .simultaneousGesture(
-                TapGesture().onEnded {
-                    DispatchQueue.main.async {
-                        originChrome.dismissActivityReturn()
-                    }
-                }
-            )
     }
 }
 

--- a/apps/screenpipe-app-tauri/src-tauri/swift/timeline_interaction_tests.swift
+++ b/apps/screenpipe-app-tauri/src-tauri/swift/timeline_interaction_tests.swift
@@ -719,14 +719,6 @@ private func testActivityReturnChrome() {
         TimelineActionBridge.shared.drainEmitted().contains("return_to_activity"),
         "the Activity return must emit its routed navigation action"
     )
-
-    chrome.setActivityReturnVisible(true)
-    chrome.dismissActivityReturn()
-    expect(!chrome.showsActivityReturn, "an unrelated Timeline click must dismiss the return")
-    expect(
-        TimelineActionBridge.shared.drainEmitted().contains("dismiss_activity_return"),
-        "dismissal must clear the webview's Activity-origin state"
-    )
 }
 
 /// Deep links must drive the per-host controller used by the embedded app,


### PR DESCRIPTION
## Summary

- keep Back to Activities visible for the full Timeline visit
- clear the Activity origin only when returning or leaving Timeline
- remove the obsolete click-dismiss action from React, Rust, and Swift

## Before / after

    BEFORE: Activities -> Timeline -> click frame/control -> Back button disappears
    AFTER:  Activities -> Timeline -> click frame/control -> Back button remains
            Timeline -> another section                 -> Back state clears

## Historical intent

- inspected commit a657795889 / PR #6381, which introduced the Activity evidence drill-down and dismissed its return affordance on unrelated Timeline clicks
- preserve the original exact-evidence navigation and return action
- supersede only the unrelated-click dismissal with the current page-lifetime navigation contract

## Validation

- bun x vitest run --config vitest.config.ts components/rewind/native-timeline.test.tsx components/rewind/native-timeline-attach.test.tsx (8 passed)
- bun run typecheck (passed)
- bun run test:tauri native_timeline::tests::parses_plain_actions -- --nocapture (1 passed, 855 filtered out; actual Swift timeline library compiled)
- git diff --check (passed)