### PR TITLE
perf(ci): keep Windows frontend dependencies warm

### DIFF
--- a/.github/actions/setup-persistent-windows-cache/action.yml
+++ b/.github/actions/setup-persistent-windows-cache/action.yml
@@ -31,7 +31,6 @@ runs:
         $cacheRoot = 'S:\screenpipe-cache'
         $persistentTarget = "$cacheRoot\targets-v3\$env:SCREENPIPE_RELEASE_FLAVOR\$env:SCREENPIPE_RELEASE_TARGET"
         $workspaceTarget = "$env:GITHUB_WORKSPACE\apps\screenpipe-app-tauri\src-tauri\target"
-        $workspaceNodeModules = "$env:GITHUB_WORKSPACE\apps\screenpipe-app-tauri\node_modules"
         $workspaceTauri = "$env:GITHUB_WORKSPACE\apps\screenpipe-app-tauri\.tauri"
         $shortTarget = 'C:\t'
 
@@ -47,9 +46,6 @@ runs:
 
         # Bundle output is release-specific. Compiler outputs and downloads stay warm.
         Remove-Item "$persistentTarget\$env:SCREENPIPE_RELEASE_TARGET\release\bundle" -Recurse -Force -ErrorAction SilentlyContinue
-        # Match the Mac runners: materialize node_modules per job because Bun
-        # omits native optional packages when it installs through a junction.
-        Remove-Item $workspaceNodeModules -Recurse -Force -ErrorAction SilentlyContinue
 
         foreach ($path in @($workspaceTarget, $workspaceTauri, $shortTarget)) {
           if (-not (Test-Path $path)) { continue }

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -219,6 +219,14 @@ jobs:
           # check out different code (and re-runs pick up commits that were
           # never in the release). The published tag points at the bump commit.
           ref: ${{ needs.check_commit.outputs.release_sha }}
+          # The persistent Windows runners keep a regular node_modules tree on
+          # C:. Clean it explicitly below while retaining that one warm path.
+          clean: ${{ runner.environment != 'self-hosted' || matrix.os_type != 'windows' }}
+
+      - name: Clean persistent Windows workspace
+        if: runner.environment == 'self-hosted' && matrix.os_type == 'windows'
+        shell: pwsh
+        run: git clean -ffdx -e apps/screenpipe-app-tauri/node_modules/
 
       - name: Attach persistent EC2 Mac cache
         if: runner.environment == 'self-hosted' && matrix.os_type == 'macos'

--- a/.github/workflows/release-enterprise.yml
+++ b/.github/workflows/release-enterprise.yml
@@ -96,6 +96,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ needs.resolve-release.outputs.release_sha }}
+          # The persistent Windows runner keeps a regular node_modules tree on
+          # C:. Clean it explicitly below while retaining that one warm path.
+          clean: ${{ runner.environment != 'self-hosted' }}
+
+      - name: Clean persistent Windows workspace
+        if: runner.environment == 'self-hosted'
+        shell: pwsh
+        run: git clean -ffdx -e apps/screenpipe-app-tauri/node_modules/
 
       - name: Checkout persistent Windows cache action
         if: runner.environment == 'self-hosted'

--- a/infra/release-windows-runner/README.md
+++ b/infra/release-windows-runner/README.md
@@ -8,8 +8,9 @@ This stack provisions two always-on native Azure release runners: Windows Server
 2022 x64 for the x64 jobs in `Release App` and `Release Enterprise`, and Windows
 11 ARM64 Preview for the ARM64 job in `Release App`. Each default size has 16
 vCPUs and 64 GiB RAM. Each runner has a retained 2 TiB Premium SSD for Cargo,
-Rust, Bun, native dependency, compiler, and Tauri target caches; GitHub checkouts
-remain job-local.
+Rust, Bun, native dependency, compiler, and Tauri target caches. GitHub checkouts
+and job-local `node_modules` stay on the OS disk so Bun can materialize packages
+without the severe Windows non-system-drive penalty.
 
 Each VM has explicit NAT egress and no public IP or inbound network rule. The x64
 runner uses Trusted Launch and automatic platform patching. Azure's Windows 11

--- a/infra/release-windows-runner/configure-runner.ps1
+++ b/infra/release-windows-runner/configure-runner.ps1
@@ -12,12 +12,13 @@ param(
 
 $ErrorActionPreference = 'Stop'
 $runnerRoot = 'C:\actions-runner'
+$workRoot = 'C:\actions-runner-work'
 $hookRoot = 'C:\screenpipe-release-runner\hooks'
 $cacheRoot = 'S:\screenpipe-cache'
 $runnerName = if ($RunnerArchitecture -eq 'arm64') { 'screenpipe-release-windows-arm64' } else { 'screenpipe-release-windows' }
 $runnerLabel = $runnerName
 
-New-Item -ItemType Directory -Force -Path $hookRoot, "$cacheRoot\work" | Out-Null
+New-Item -ItemType Directory -Force -Path $hookRoot, $workRoot | Out-Null
 
 $allowedRefs = @("$Repository/.github/workflows/release-app.yml@refs/heads/main")
 if ($RunnerArchitecture -eq 'x64') {
@@ -97,8 +98,10 @@ if (Test-Path '.runner') {
 
 & icacls.exe $cacheRoot /grant 'NT AUTHORITY\NETWORK SERVICE:(OI)(CI)F' /Q
 if ($LASTEXITCODE -ne 0) { throw "cache ACL setup failed with exit code $LASTEXITCODE" }
+& icacls.exe $workRoot /grant 'NT AUTHORITY\NETWORK SERVICE:(OI)(CI)F' /Q
+if ($LASTEXITCODE -ne 0) { throw "work directory ACL setup failed with exit code $LASTEXITCODE" }
 
-& .\config.cmd --unattended --replace --url "https://github.com/$Repository" --token $RegistrationToken --name $runnerName --labels $runnerLabel --no-default-labels --work "$cacheRoot\work" --runasservice --windowslogonaccount 'NT AUTHORITY\NETWORK SERVICE'
+& .\config.cmd --unattended --replace --url "https://github.com/$Repository" --token $RegistrationToken --name $runnerName --labels $runnerLabel --no-default-labels --work $workRoot --runasservice --windowslogonaccount 'NT AUTHORITY\NETWORK SERVICE'
 if ($LASTEXITCODE -ne 0) { throw "runner configuration failed with exit code $LASTEXITCODE" }
 
 $service = Get-Service 'actions.runner.*' | Select-Object -First 1


### PR DESCRIPTION
## Summary
- move persistent Windows runner workspaces to the OS disk while retaining Cargo, Bun package, native dependency, Tauri, and Rust target caches on the retained S: disk
- preserve the regular C: `node_modules` directory across self-hosted Windows checkouts while explicitly cleaning every other untracked path
- stop deleting `node_modules` in the persistent cache action

## Benchmark
Same `package.json`, `bun.lock`, Bun 1.3.10, and warm `S:\screenpipe-cache\bun` cache on the native Azure runners:

| Runner | Materialize | First no-op | Second no-op |
|---|---:|---:|---:|
| Windows ARM64 | 44.494s | 0.498s | 0.484s |
| Windows x86 | 46.044s | 14.120s | 0.192s |

Bun reported `no changes` for every no-op. The prior ARM64 S: materialization measured 145.13s.

## Historical intent
- inspected `1f404d086f7`, which originally put the whole runner work directory on the retained S: disk for blanket persistence
- inspected `ff70ca84b5e`, which made frontend dependencies job-local because Bun omitted native optional packages when `node_modules` itself was a junction
- this change preserves that safety invariant: `node_modules` remains a normal directory, now on C:, and is retained without a junction

## Validation
- `actionlint -shellcheck= -pyflakes= .github/workflows/release-app.yml .github/workflows/release-enterprise.yml`
- `git diff --check`
- live ARM64 runner reconfigured with `C:\actions-runner-work`; service healthy, runner online, Network Service has FullControl
- controlled C:/S: and materialize/no-op benchmarks completed; temporary benchmark directories removed

CI is intentionally not awaited for this runner-only release acceleration change.
