### PR TITLE
fix(app): disable trackpad history swipes

### DIFF
--- a/apps/screenpipe-app-tauri/app/(main)/layout.tsx
+++ b/apps/screenpipe-app-tauri/app/(main)/layout.tsx
@@ -15,25 +15,15 @@
 
 import { AppSidebarLayout, SidebarProvider } from "@/components/app-sidebar";
 import { CardAskProvider } from "@/components/card-ask-provider";
-import { HistorySwipeIndicator } from "@/components/history-swipe-indicator";
-import { useExperimentalFeaturesEnabled } from "@/lib/experimental-features";
 
 export default function MainLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const experimentalFeaturesEnabled = useExperimentalFeaturesEnabled();
-  const historySwipeIndicatorEnabled =
-    experimentalFeaturesEnabled ||
-    process.env.NEXT_PUBLIC_SCREENPIPE_E2E === "true";
-
   return (
     <SidebarProvider>
-      <AppSidebarLayout>
-        {children}
-        <HistorySwipeIndicator enabled={historySwipeIndicatorEnabled} />
-      </AppSidebarLayout>
+      <AppSidebarLayout>{children}</AppSidebarLayout>
       {/*
         Mounted here, not at "/" — the root route is a deliberate no-op so no
         window executes another window's code. This layout is the main window

--- a/apps/screenpipe-app-tauri/app/layout.tsx
+++ b/apps/screenpipe-app-tauri/app/layout.tsx
@@ -75,12 +75,10 @@ function RecentChatSwitcherMount() {
   );
 }
 
-function ExperimentalFeatureControls() {
-  const enabled = useExperimentalFeaturesEnabled();
-
+function WebviewGestureControls() {
   useEffect(() => {
-    void commands.setHistorySwipeNavigationEnabled(enabled).catch(() => {});
-  }, [enabled]);
+    void commands.setHistorySwipeNavigationEnabled(false).catch(() => {});
+  }, []);
 
   return null;
 }
@@ -316,7 +314,7 @@ export default function RootLayout({
           {!isOverlay && <ShortcutTracker />}
           {!isOverlay && <PipeInstallDialog />}
           {!isOverlay && <BrowserPairingDialog />}
-          <ExperimentalFeatureControls />
+          <WebviewGestureControls />
           <Suspense fallback={null}>
             <RecentChatSwitcherMount />
           </Suspense>


### PR DESCRIPTION
## description

Disable two-finger back/forward navigation in Screenpipe's Tauri webviews and remove the custom history-swipe arrow overlay from the main Home shell.

Normal in-app navigation, browser history state, Timeline scrolling, and pinch-to-zoom remain unchanged.

Related issue: none

## AI assistance and human ownership

- AI tool(s) used (`none` if not used): Codex
- autonomy level (`none`, `autocomplete`, `chat`, or `agent`): agent
- what I personally verified: The diff is limited to the two frontend activation/mount points. TypeScript typecheck and focused ESLint pass. I also inspected the native command path to confirm `false` disables `WKWebView.allowsBackForwardNavigationGestures` on macOS and WebView2 swipe navigation on Windows.

- [ ] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [ ] The problem statement, rationale, and replies to maintainers are my own.

## evidence type

- [x] UI or behavior change — before/after evidence below
- [ ] Backend change — regression tests and relevant logs/results
- [ ] Performance change — reproducible before/after benchmarks
- [ ] Docs, CI, or pure refactor — relevant checks and an explanation; no video required

## before

```text
two-finger horizontal swipe
        |
        v
native back/forward gesture + custom edge arrow
        |
        v
previous/next Home history entry
```

## after

```text
two-finger horizontal swipe
        |
        v
history navigation disabled; no edge arrow

ordinary sidebar clicks and Timeline gestures remain active
```

## historical intent

- Inspected commits `581480f961` / PR #6494 and `39d873d8c9` / PR #6536.
- The original feature deliberately gave Home native browser-style back/forward trackpad navigation, then added section-level history restoration and branded edge arrows.
- This PR intentionally supersedes that Home swipe-navigation choice following direct user feedback that horizontal trackpad swipes should not navigate backward or forward.
- It preserves the original protection for rewind and other horizontal interactions and does not change their handlers or ordinary route history.
- No test expectation is changed; the native gesture implementation remains available but production frontend activation is fail-closed.

## how to test

1. `bun install --frozen-lockfile` — passed.
2. `bun run typecheck` — passed.
3. `bun x eslint app/layout.tsx 'app/(main)/layout.tsx'` — passed.
4. `git diff --check` — passed.
5. Manual: open Home with experimental features enabled, navigate among Chat, Meetings, Timeline, and Activity, then swipe horizontally with two fingers. No back/forward edge arrow should appear and the current section should remain unchanged.

## desktop app checklist (if applicable)

This PR does not add or change a Tauri command or an exported Rust type.

- [ ] `bun run bindings:generate` (if bindings changed)
- [ ] `bun run bindings:check`
- [x] `bun run typecheck`
