### PR TITLE
fix(app): disable devtools in release builds

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
@@ -34,7 +34,6 @@ tauri = { version = "=2.11.2", features = [
   "protocol-asset",
   "macos-private-api",
   "tray-icon",
-  "devtools",
   "image-png",
   "image-ico",
   # Embedded child webview (the agent-controlled browser sidebar) requires


### PR DESCRIPTION
## Summary

- remove the Tauri `devtools` feature from production builds
- keep devtools available in debug builds through Tauri/Wry `debug_assertions`
- remove release webview controls such as Inspect Element without affecting product context menus

## Historical intent

- inspected the feature history back to `01056bc8e5ed8dd02c65cafd8db5316f4e546d01` and `dc4c5dce40f85a78237f47f38dec5bae857decb1`
- the flag originated with the desktop app template and no product requirement for production devtools survives
- debug inspection remains supported; only release exposure is intentionally removed

## Validation

- `bun run build:tauri:dev` (passed; 4 existing dead-code warnings)
- `git diff --check` (passed)