### PR TITLE
fix(meetings): render chat markdown and explain summary auth failures

### DIFF
--- a/apps/screenpipe-app-tauri/components/meeting-notes/meeting-chat-citations.ts
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/meeting-chat-citations.ts
@@ -41,6 +41,86 @@ export interface CitationWindow {
   endMs: number | null;
 }
 
+/** Internal Markdown link used to carry a parsed transcript timestamp. */
+export const MEETING_CITATION_HOST = "meeting-citation";
+
+interface MarkdownAstNode {
+  type: string;
+  value?: string;
+  url?: string;
+  children?: MarkdownAstNode[];
+}
+
+const CITATION_EXCLUDED_NODES = new Set([
+  "code",
+  "inlineCode",
+  "link",
+  "linkReference",
+]);
+
+function citationHref(at: number): string {
+  return `screenpipe://${MEETING_CITATION_HOST}?at=${at}`;
+}
+
+/** Read a timestamp only from links created by the meeting citation plugin. */
+export function meetingCitationAtFromHref(href?: string): number | null {
+  if (!href) return null;
+  try {
+    const url = new URL(href);
+    if (url.protocol !== "screenpipe:" || url.host !== MEETING_CITATION_HOST) {
+      return null;
+    }
+    const rawAt = url.searchParams.get("at");
+    if (!rawAt) return null;
+    const at = Number(rawAt);
+    return Number.isFinite(at) ? at : null;
+  } catch {
+    return null;
+  }
+}
+
+function linkMeetingCitations(
+  node: MarkdownAstNode,
+  window: CitationWindow | null,
+): void {
+  if (!node.children || CITATION_EXCLUDED_NODES.has(node.type)) return;
+
+  const next: MarkdownAstNode[] = [];
+  for (const child of node.children) {
+    if (child.type === "text" && typeof child.value === "string") {
+      for (const run of splitCitations(child.value, window)) {
+        next.push(
+          run.at === null
+            ? { type: "text", value: run.text }
+            : {
+                type: "link",
+                url: citationHref(run.at),
+                children: [{ type: "text", value: run.text }],
+              },
+        );
+      }
+      continue;
+    }
+
+    linkMeetingCitations(child, window);
+    next.push(child);
+  }
+  node.children = next;
+}
+
+/**
+ * Remark plugin that turns resolvable clock times into transcript controls.
+ *
+ * It runs after Markdown parsing, so emphasis such as `**11:25**` remains a
+ * strong element containing the citation instead of being split into literal
+ * asterisks around a button. Existing links and code stay untouched.
+ */
+export function createMeetingCitationPlugin(window: CitationWindow | null) {
+  return function meetingCitationPlugin() {
+    return (tree: MarkdownAstNode) => linkMeetingCitations(tree, window);
+  };
+}
+
 function windowEnd(window: CitationWindow): number {
   return window.endMs ?? Date.now();
 }

--- a/apps/screenpipe-app-tauri/components/meeting-notes/meeting-chat-panel.test.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/meeting-chat-panel.test.tsx
@@ -307,6 +307,43 @@ describe("meeting chat panel", () => {
     );
   });
 
+  it("renders assistant Markdown without breaking transcript citations", () => {
+    setup({
+      turns: [
+        {
+          id: "a",
+          role: "assistant",
+          text: "At **3:34**, this was *important*.\n\n- first point\n- second point",
+          done: true,
+        },
+      ],
+    });
+
+    expect(
+      screen.getByTestId("meeting-chat-citation").closest("strong"),
+    ).not.toBeNull();
+    expect(screen.getByText("important").closest("em")).not.toBeNull();
+    expect(screen.getByText("first point").closest("li")).not.toBeNull();
+    expect(screen.queryByText("**3:34**")).toBeNull();
+  });
+
+  it("keeps images out of the meeting thread", () => {
+    setup({
+      turns: [
+        {
+          id: "a",
+          role: "assistant",
+          text: "text before ![chart](https://example.com/chart.png) text after",
+          done: true,
+        },
+      ],
+    });
+
+    expect(
+      screen.getByTestId("meeting-chat-answer").querySelector("img"),
+    ).toBeNull();
+  });
+
   it("case 66: a finished empty turn says so rather than rendering blank", () => {
     setup({
       turns: [{ id: "a", role: "assistant", text: "", done: true }],

--- a/apps/screenpipe-app-tauri/components/meeting-notes/meeting-chat-panel.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/meeting-chat-panel.tsx
@@ -34,6 +34,8 @@ import React, {
   useState,
 } from "react";
 import { ArrowUp, Loader2, X } from "lucide-react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { AIPresetsSelector } from "@/components/rewind/ai-presets-selector";
@@ -41,9 +43,15 @@ import {
   AcpConfigSelector,
   type AcpConfigDefaultChange,
 } from "@/components/chat/standalone/acp-config-selector";
+import { createScreenpipeUrlTransform } from "@/components/markdown";
 import type { AIPreset } from "@/lib/utils/tauri";
 import { cn } from "@/lib/utils";
-import { splitCitations, type CitationWindow } from "./meeting-chat-citations";
+import {
+  createMeetingCitationPlugin,
+  meetingCitationAtFromHref,
+  MEETING_CITATION_HOST,
+  type CitationWindow,
+} from "./meeting-chat-citations";
 import {
   canSubmitTurn,
   clampPanelWidth,
@@ -427,28 +435,55 @@ function AnswerBody({
   window: CitationWindow | null;
   onCitationClick: (atMs: number) => void;
 }) {
-  const runs = useMemo(
-    () => splitCitations(text, citationWindow),
-    [text, citationWindow],
+  const citationPlugin = useMemo(
+    () => createMeetingCitationPlugin(citationWindow),
+    [citationWindow],
   );
+  const urlTransform = useMemo(
+    () => createScreenpipeUrlTransform([MEETING_CITATION_HOST]),
+    [],
+  );
+
   return (
-    <span className="[overflow-wrap:anywhere]">
-      {runs.map((run, index) =>
-        run.at === null ? (
-          <React.Fragment key={index}>{run.text}</React.Fragment>
-        ) : (
-          <button
-            key={index}
-            type="button"
-            data-testid="meeting-chat-citation"
-            data-at={run.at}
-            onClick={() => onCitationClick(run.at as number)}
-            className="border-b border-muted-foreground font-mono text-[11px] text-foreground transition-colors hover:border-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground"
-          >
-            {run.text}
-          </button>
-        ),
-      )}
-    </span>
+    <ReactMarkdown
+      className="prose prose-sm max-w-none [overflow-wrap:anywhere] dark:prose-invert prose-p:my-0 prose-p:text-[13px] prose-p:leading-relaxed prose-p:[&+p]:mt-2 prose-li:my-0 prose-li:text-[13px] prose-strong:text-foreground"
+      remarkPlugins={[remarkGfm, citationPlugin]}
+      urlTransform={urlTransform}
+      components={{
+        a({ href, children }) {
+          const at = meetingCitationAtFromHref(href);
+          if (at !== null) {
+            return (
+              <button
+                type="button"
+                data-testid="meeting-chat-citation"
+                data-at={at}
+                onClick={() => onCitationClick(at)}
+                className="border-b border-muted-foreground font-mono text-[11px] text-foreground transition-colors hover:border-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground"
+              >
+                {children}
+              </button>
+            );
+          }
+
+          return (
+            <a
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline underline-offset-2"
+            >
+              {children}
+            </a>
+          );
+        },
+        // Case 78: the meeting thread is text; media belongs in the note.
+        img() {
+          return null;
+        },
+      }}
+    >
+      {text}
+    </ReactMarkdown>
   );
 }

--- a/apps/screenpipe-app-tauri/components/meeting-notes/meeting-summary-lifecycle.test.ts
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/meeting-summary-lifecycle.test.ts
@@ -330,6 +330,17 @@ describe("meetingSummaryFailure", () => {
     expect(failure.copy.toLowerCase()).toContain("model");
   });
 
+  it("explains an AI provider authentication failure", () => {
+    const failure = meetingSummaryFailure(
+      failed("auth_failed", "authentication failed — check API key"),
+    );
+    expect(failure.kind).toBe("auth_failed");
+    expect(failure.retryable).toBe(false);
+    expect(failure.copy).toContain("AI provider");
+    expect(failure.copy).toContain("API key");
+    expect(failure.copy).toContain("meeting and transcript are safe");
+  });
+
   it("classifies from the error message when error_type is missing", () => {
     const failure = meetingSummaryFailure(
       failed(null, 'pipe failed: {"error":"credits_exhausted"}'),

--- a/apps/screenpipe-app-tauri/components/meeting-notes/meeting-summary-lifecycle.ts
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/meeting-summary-lifecycle.ts
@@ -171,7 +171,7 @@ export function latestSummaryInputAt(
 }
 
 export interface MeetingSummaryFailurePresentation {
-  kind: PipeErrorType;
+  kind: PipeErrorType | "auth_failed";
   copy: string;
   /** Validated plan-upgrade action when the gateway offered one. */
   upgrade: QuotaUpgradeAction | null;
@@ -192,8 +192,24 @@ export function meetingSummaryFailure(
   execution: MeetingSummaryExecution,
 ): MeetingSummaryFailurePresentation {
   const errorMessage = execution.error_message ?? "";
+  const normalizedErrorType = (execution.error_type ?? "")
+    .trim()
+    .toLowerCase();
+  const authFailed =
+    normalizedErrorType === "auth_failed" ||
+    /authentication failed|invalid api key|unauthorized/.test(
+      errorMessage.toLowerCase(),
+    );
+  if (authFailed) {
+    return {
+      kind: "auth_failed",
+      copy: "The summary couldn't authenticate with your AI provider. Check its API key or switch models, then retry. Your meeting and transcript are safe.",
+      upgrade: null,
+      retryable: false,
+    };
+  }
   const kind =
-    RUST_ERROR_TYPE_MAP[(execution.error_type ?? "").trim().toLowerCase()] ??
+    RUST_ERROR_TYPE_MAP[normalizedErrorType] ??
     parsePipeError(`${execution.error_type ?? ""} ${errorMessage}`.trim()).type;
   const upgrade = parseQuotaUpgradeAction(errorMessage);
 

--- a/docs/pr-assets/meeting-chat-markdown/before-after.svg
+++ b/docs/pr-assets/meeting-chat-markdown/before-after.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="820" viewBox="0 0 1440 820">
+  <rect width="1440" height="820" fill="#F2EFE6"/>
+  <text x="70" y="68" font-family="IBM Plex Mono, monospace" font-size="18" letter-spacing="3" fill="#78786F">MEETING CHAT · BEFORE / AFTER</text>
+
+  <g transform="translate(70 110)">
+    <rect width="620" height="620" fill="#050505"/>
+    <text x="34" y="42" font-family="IBM Plex Mono, monospace" font-size="15" letter-spacing="2" fill="#78786F">BEFORE · RAW MARKERS + VAGUE WARNING</text>
+    <rect x="362" y="72" width="224" height="48" fill="#252525"/>
+    <text x="384" y="103" font-family="Space Grotesk, sans-serif" font-size="20" fill="#F2EFE6">why did this fail?</text>
+    <text x="34" y="164" font-family="Space Grotesk, sans-serif" font-size="20" fill="#B8B8B0">The evidence shows a gap:</text>
+    <text x="34" y="208" font-family="Space Grotesk, sans-serif" font-size="20" fill="#B8B8B0">at **11:25**, Whitney wanted *tips*;</text>
+    <text x="34" y="244" font-family="Space Grotesk, sans-serif" font-size="20" fill="#B8B8B0">at **11:32**, usage was maybe **5%**.</text>
+    <line x1="0" y1="470" x2="620" y2="470" stroke="#383833"/>
+    <text x="34" y="518" font-family="Space Grotesk, sans-serif" font-size="22" fill="#F2EFE6">summary needs attention</text>
+    <text x="34" y="558" font-family="Space Grotesk, sans-serif" font-size="18" fill="#B8B8B0">Your meeting and transcript are safe.</text>
+    <text x="34" y="590" font-family="Space Grotesk, sans-serif" font-size="18" fill="#B8B8B0">Retry when you&apos;re ready.</text>
+  </g>
+
+  <g transform="translate(750 110)">
+    <rect width="620" height="620" fill="#050505"/>
+    <text x="34" y="42" font-family="IBM Plex Mono, monospace" font-size="15" letter-spacing="2" fill="#C7FF3E">AFTER · FORMATTED + ACTIONABLE</text>
+    <rect x="362" y="72" width="224" height="48" fill="#252525"/>
+    <text x="384" y="103" font-family="Space Grotesk, sans-serif" font-size="20" fill="#F2EFE6">why did this fail?</text>
+    <text x="34" y="164" font-family="Space Grotesk, sans-serif" font-size="20" fill="#B8B8B0">The evidence shows a gap:</text>
+    <circle cx="43" cy="204" r="3" fill="#78786F"/>
+    <text x="60" y="211" font-family="Space Grotesk, sans-serif" font-size="20" fill="#B8B8B0">at </text>
+    <text x="86" y="211" font-family="IBM Plex Mono, monospace" font-size="18" font-weight="700" text-decoration="underline" fill="#F2EFE6">11:25</text>
+    <text x="148" y="211" font-family="Space Grotesk, sans-serif" font-size="20" fill="#B8B8B0">, Whitney wanted </text>
+    <text x="306" y="211" font-family="Space Grotesk, sans-serif" font-size="20" font-style="italic" fill="#B8B8B0">tips</text>
+    <text x="340" y="211" font-family="Space Grotesk, sans-serif" font-size="20" fill="#B8B8B0">.</text>
+    <circle cx="43" cy="244" r="3" fill="#78786F"/>
+    <text x="60" y="251" font-family="Space Grotesk, sans-serif" font-size="20" fill="#B8B8B0">at </text>
+    <text x="86" y="251" font-family="IBM Plex Mono, monospace" font-size="18" font-weight="700" text-decoration="underline" fill="#F2EFE6">11:32</text>
+    <text x="148" y="251" font-family="Space Grotesk, sans-serif" font-size="20" fill="#B8B8B0">, usage was maybe </text>
+    <text x="328" y="251" font-family="Space Grotesk, sans-serif" font-size="20" font-weight="700" fill="#F2EFE6">5%</text>
+    <text x="360" y="251" font-family="Space Grotesk, sans-serif" font-size="20" fill="#B8B8B0">.</text>
+    <line x1="0" y1="470" x2="620" y2="470" stroke="#383833"/>
+    <text x="34" y="518" font-family="Space Grotesk, sans-serif" font-size="22" fill="#F2EFE6">summary needs attention</text>
+    <text x="34" y="558" font-family="Space Grotesk, sans-serif" font-size="18" fill="#B8B8B0">Couldn&apos;t authenticate with the AI provider.</text>
+    <text x="34" y="590" font-family="Space Grotesk, sans-serif" font-size="18" fill="#B8B8B0">Check its API key or switch models, then retry.</text>
+  </g>
+
+  <text x="70" y="775" font-family="IBM Plex Mono, monospace" font-size="16" fill="#78786F">TIMES REMAIN CLICKABLE TRANSCRIPT JUMPS · IMAGES STAY OUT OF THE THREAD</text>
+</svg>


### PR DESCRIPTION
## summary

- render meeting-chat assistant answers as GitHub-flavored Markdown
- preserve clock citations as keyboard-accessible transcript jump controls, including inside bold text
- explain `auth_failed` meeting summaries instead of showing the generic retry copy
- keep images out of the compact meeting thread

## root cause

The meeting chat split the raw answer into text and timestamp fragments before rendering. That preserved transcript jumps, but bypassed Markdown parsing, so markers such as `**11:25**` and `*why*` appeared literally.

Separately, the summary lifecycle did not classify the engine's sanitized `auth_failed` status, so a provider-key failure fell through to the vague unknown-error message.

## visual

Synthetic content only; no captured meeting data is included.

![meeting chat markdown and summary warning before/after](https://github.com/screenpipe/screenpipe/blob/codex/fix-meeting-chat-markdown-warning/docs/pr-assets/meeting-chat-markdown/before-after.svg?raw=1)

## verification

- `bun x vitest run components/meeting-notes/meeting-chat-panel.test.tsx components/meeting-notes/meeting-chat-citations.test.ts components/meeting-notes/meeting-summary-lifecycle.test.ts components/meeting-notes/meeting-chat-state.test.ts` — 107 passed
- `bun x tsc --noEmit`
- focused ESLint on all five changed TypeScript files
- `git diff --check`
- browser-rendered mock meeting panel inspected in dark mode

No meeting, transcript, provider credential, or runtime setting is changed by this patch.
