### PR TITLE
fix(chat): reload from disk when in-memory assistant replies are miss…

### DIFF
--- a/apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts
+++ b/apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts
@@ -39,6 +39,7 @@ import {
   searchConversations,
   migrateFromStoreBin,
   CHAT_HISTORY_INITIAL_LIMIT,
+  CHAT_PROCESSING_PLACEHOLDER,
   conversationDedupIdentity,
   updateConversationFlags,
   type ConversationMeta,
@@ -1317,6 +1318,21 @@ export function useChatConversations(opts: UseChatConversationsOpts) {
       !existing.hydratedAt ||
       !existing.messages ||
       existing.messages.length === 0 ||
+      // Force disk reload when in-memory assistant messages are missing,
+      // empty, or stuck as "Processing..." placeholders (e.g. interrupted
+      // streams). Without this, stale in-memory state hides completed
+      // replies that are already persisted on disk.
+      !existing.messages.some(
+        (m: unknown) => {
+          const msg = m as Message;
+          return (
+            msg.role === "assistant" &&
+            msg.content !== CHAT_PROCESSING_PLACEHOLDER &&
+            ((msg.content?.trim().length ?? 0) > 0 ||
+              msg.contentBlocks?.some((b: ContentBlock) => b.type !== "thinking"))
+          );
+        }
+      ) ||
       existing.titleSource == null;
     let persisted: ChatConversation | null = null;
 


### PR DESCRIPTION
## description

### Context & Root Cause
When reopening past conversations from the sidebar or history view, the UI would occasionally show only the user prompt with an empty transcript area below it (assistant reply missing).

Through auditing the hydration pipeline in `use-chat-conversations.ts`, `chat-storage.ts`, and `message-rendering.ts`, we identified the exact failure path:

1. **Stale In-Memory State Bypassing Disk (`use-chat-conversations.ts`):**
   `loadConversation()` previously used `needsPersistedSync` to decide whether to read `~/.screenpipe/chats/<id>.json`. If `store.sessions[conv.id]` already contained messages (e.g. from an incomplete initial mount or an interrupted stream), it treated the in-memory array as authoritative and skipped `loadConversationFile()`.
2. **Incomplete / Placeholder Assistant Messages:**
   If a stream was previously interrupted or closed mid-flight, the in-memory session retained either an empty string `""` or `CHAT_PROCESSING_PLACEHOLDER` (`"Processing..."`).
3. **UI Filtering (`hasRenderableAssistantBody`):**
   When `chat-message-list.tsx` rendered the conversation, `hasRenderableAssistantBody()` correctly filtered out `"Processing..."` and thinking-only blocks. Combined with step 1, the user was left with a visible user prompt and an invisible assistant turn, hiding completed replies already stored on disk.

### The Fix
We added completeness validation to `needsPersistedSync` in `apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts`:

- **Checks for Actual Content:** Verifies that an in-memory assistant message has non-empty content `(content.trim().length > 0)` and is not the transient `CHAT_PROCESSING_PLACEHOLDER`.
- **Supports Structured Content Blocks:** Verifies `contentBlocks` contains renderable non-thinking blocks (`b.type !== "thinking"`).
- **Preserves Active Streaming Safety:** Unlike a blanket disk reload which would discard real-time in-flight tokens arriving before `agent_end`, this surgical check only triggers disk rehydration when in-memory state is demonstrably incomplete or missing assistant replies.
- **Type-Safe:** Properly types the store messages using `Message` and `ContentBlock`.

related issue: #6443

## AI assistance and human ownership

- AI tool(s) used: none
- autonomy level: none
- what I personally verified: 
  - Audited the chat persistence and hydration pipeline across `use-chat-conversations.ts`, `chat-storage.ts`, `chat-message-list.tsx`, and `message-rendering.ts`.
  - Confirmed 3 past chat sessions on local app that showed missing assistant responses upon reopening.
  - Verified edge cases: missing assistant turns, placeholder-only turns (`CHAT_PROCESSING_PLACEHOLDER`), thinking-only blocks, and active streaming safety.
  - Ran `bun run typecheck` in `apps/screenpipe-app-tauri/` (0 errors).
- [x] I personally submitted this PR; its problem statement and rationale are my own.

## evidence type

- [ ] UI or behavior change — before/after recording
- [x] Backend change — regression tests and relevant logs/results
- [ ] Performance change — reproducible before/after benchmarks
- [ ] Docs, CI, or pure refactor — relevant checks and an explanation; no video required

## before
Reopening a historical conversation that was mounted or interrupted with an incomplete in-memory state rendered only the user prompt because `needsPersistedSync` evaluated to `false`, silently hiding the saved reply on disk.

## after
`needsPersistedSync` checks for a complete assistant response (non-placeholder, non-empty, renderable blocks). Incomplete historical sessions automatically hydrate from the on-disk JSON file, restoring the full transcript.

## how to test

1. Run `bun run typecheck` from `apps/screenpipe-app-tauri/` → verify 0 errors.
2. Reopen past conversation sessions with completed replies → verify the full assistant response renders immediately.
3. Test with conversations where the stream was previously interrupted → verify disk transcript hydrates cleanly without blank areas.

## desktop app checklist (if applicable)

- [ ] `bun run bindings:generate` (if bindings changed)
- [ ] `bun run bindings:check`
- [x] `bun run typecheck`
