### PR TITLE
fix(activity): classify no-data outcomes

### DIFF
--- a/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
@@ -1667,6 +1667,20 @@ describe("ActivityLedger", () => {
     );
     expect(mocks.runDailySummaryWithPi).not.toHaveBeenCalled();
     expect(screen.getByRole("button", { name: "Try again" })).toBeVisible();
+    expect(mocks.posthogCapture).toHaveBeenCalledWith(
+      "activity_generation_completed",
+      {
+        range: "today",
+        source: "empty_state",
+        outcome: "no_activity",
+        activity_count: 0,
+        data_status: "empty_but_recording",
+      },
+    );
+    expect(mocks.posthogCapture).not.toHaveBeenCalledWith(
+      "activity_generation_failed",
+      expect.anything(),
+    );
   });
 
   it("keeps a slow backend generation running past two minutes", async () => {

--- a/apps/screenpipe-app-tauri/components/activity-ledger.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.tsx
@@ -1641,11 +1641,21 @@ export function ActivityLedger({
                 ? quota.message
                 : "History could not be updated. Try again.",
         );
-        posthog.capture("activity_generation_failed", {
-          range: preset,
-          source,
-          error_kind: qualityFailure ? "quality_validation" : quota.kind,
-        });
+        if (noDataStatus) {
+          posthog.capture("activity_generation_completed", {
+            range: preset,
+            source,
+            outcome: "no_activity",
+            activity_count: 0,
+            data_status: noDataStatus,
+          });
+        } else {
+          posthog.capture("activity_generation_failed", {
+            range: preset,
+            source,
+            error_kind: qualityFailure ? "quality_validation" : quota.kind,
+          });
+        }
       } finally {
         if (historyAbortRef.current === controller) {
           historyLoadingRef.current = false;


### PR DESCRIPTION
## What changed

- record `activity_no_data:*` as `activity_generation_completed` with `outcome=no_activity` instead of an unclassified failure
- retain the existing user-facing empty-range message and retry control
- add a regression test that excludes expected no-data outcomes from `activity_generation_failed`

## Why

The Aug 17-23 PostHog review found 185 of 248 Activity failure events classified as `error_kind=none`. The native-generation migration returns expected empty ranges as `activity_no_data:*`, but the UI was sending those through the legacy failure event.

This PR intentionally does not change native generation, validation, persistence, coverage, scheduler retries, or AI usage.

@EzraEllette please review the Activity telemetry classification in particular.

## Behavior proof

```text
before
no recorded data -> activity_generation_failed(error_kind=none)

after
no recorded data -> activity_generation_completed(outcome=no_activity, data_status=...)
UI and native behavior -> unchanged
```

## Verification

- `PATH=/opt/homebrew/opt/node@22/bin:$PATH bun x vitest run --config vitest.config.ts components/activity-ledger.test.tsx` - 46 passed
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH bun run typecheck` - passed
- `git diff --check origin/main...HEAD` - passed

## Risk

Low and analytics-only. The event shape restores the pre-native `no_activity` classification; Activity generation and storage paths are untouched.
