### PR TITLE
fix(macOS): gate SCK on live TCC permission

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/capture_session.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/capture_session.rs
@@ -87,9 +87,9 @@ impl CaptureSession {
         // On macOS 15+ SCShareableContent::current() (called by list_monitors inside
         // VisionManager::start) shows Apple's native TCC padlock dialog if the app has
         // not been granted Screen Recording access yet — even before onboarding runs.
-        // check_screen_recording_tauri() skips capture_probe on macOS 15+ (avoids the
-        // native TCC dialog CGWindowListCreateImage triggers). Skip vision entirely when not granted;
-        // spawn_screenpipe is called again from onboarding after the user grants access.
+        // The app-level check compares SkyLight's cached preflight with a direct
+        // TCC preflight. Skip vision unless both say this process may capture;
+        // spawn_screenpipe is called again after the user grants access.
         //
         // This gate deliberately does NOT consult
         // `permission_monitor::screen_enumeration_denied()`, unlike the UI-facing
@@ -102,7 +102,7 @@ impl CaptureSession {
         // and lifts the verdict, or re-confirms the loss within ~15s.
         #[cfg(target_os = "macos")]
         let screen_recording_permitted =
-            screenpipe_core::permissions::check_screen_recording_tauri().is_granted();
+            crate::permissions::screen_recording_permission_usable_in_process();
         #[cfg(not(target_os = "macos"))]
         let screen_recording_permitted = true;
 

--- a/apps/screenpipe-app-tauri/src-tauri/src/permissions.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/permissions.rs
@@ -85,37 +85,21 @@ pub fn screen_recording_permission_state() -> ScreenRecordingPermissionState {
 
 #[cfg(target_os = "macos")]
 fn direct_tcc_screen_recording_preflight() -> Result<bool, String> {
-    use std::ffi::c_void;
+    screenpipe_core::permissions::check_screen_recording_tcc().map(|status| status.is_granted())
+}
 
-    type TccAccessPreflight = unsafe extern "C" fn(*const c_void) -> u32;
+/// Whether this process can safely enter ScreenCaptureKit right now.
+///
+/// `GrantedNeedsRestart` and `RevokedButCached` are both unusable: only a
+/// matching cached + cache-bypassed TCC grant may start capture.
+#[cfg(target_os = "macos")]
+pub fn screen_recording_permission_usable_in_process() -> bool {
+    screen_recording_state_usable_in_process(screen_recording_permission_state())
+}
 
-    const TCC_FRAMEWORK: &[u8] = b"/System/Library/PrivateFrameworks/TCC.framework/TCC\0";
-    const PREFLIGHT_SYMBOL: &[u8] = b"TCCAccessPreflight\0";
-    const SCREEN_CAPTURE_SERVICE_SYMBOL: &[u8] = b"kTCCServiceScreenCapture\0";
-    const TCC_PREFLIGHT_GRANTED: u32 = 0;
-
-    unsafe {
-        let handle = libc::dlopen(
-            TCC_FRAMEWORK.as_ptr().cast(),
-            libc::RTLD_LAZY | libc::RTLD_LOCAL,
-        );
-        if handle.is_null() {
-            return Err("failed to load TCC.framework".to_string());
-        }
-
-        let preflight_symbol = libc::dlsym(handle, PREFLIGHT_SYMBOL.as_ptr().cast());
-        let service_symbol = libc::dlsym(handle, SCREEN_CAPTURE_SERVICE_SYMBOL.as_ptr().cast());
-        if preflight_symbol.is_null() || service_symbol.is_null() {
-            libc::dlclose(handle);
-            return Err("required TCC.framework symbols are unavailable".to_string());
-        }
-
-        let preflight: TccAccessPreflight = std::mem::transmute(preflight_symbol);
-        let service = *(service_symbol as *const *const c_void);
-        let result = preflight(service);
-        libc::dlclose(handle);
-        Ok(result == TCC_PREFLIGHT_GRANTED)
-    }
+#[cfg(any(target_os = "macos", test))]
+fn screen_recording_state_usable_in_process(state: ScreenRecordingPermissionState) -> bool {
+    matches!(state, ScreenRecordingPermissionState::Granted)
 }
 
 /// Restart only after the user explicitly clicks the in-app action. macOS's
@@ -1471,6 +1455,20 @@ mod screen_recording_state_tests {
             screen_recording_permission_state_from_checks(true, false),
             ScreenRecordingPermissionState::RevokedButCached
         );
+    }
+
+    #[test]
+    fn only_matching_grants_are_usable_for_capture() {
+        assert!(screen_recording_state_usable_in_process(
+            ScreenRecordingPermissionState::Granted
+        ));
+        for state in [
+            ScreenRecordingPermissionState::Denied,
+            ScreenRecordingPermissionState::GrantedNeedsRestart,
+            ScreenRecordingPermissionState::RevokedButCached,
+        ] {
+            assert!(!screen_recording_state_usable_in_process(state));
+        }
     }
 
     #[cfg(target_os = "macos")]

--- a/apps/screenpipe-app-tauri/src-tauri/src/recording.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/recording.rs
@@ -1140,7 +1140,7 @@ async fn spawn_screenpipe_inner(
 
     #[cfg(target_os = "macos")]
     let screen_recording_start_permitted =
-        screenpipe_core::permissions::check_screen_recording_tauri().is_granted();
+        crate::permissions::screen_recording_permission_usable_in_process();
     #[cfg(not(target_os = "macos"))]
     let screen_recording_start_permitted = true;
 

--- a/apps/screenpipe-app-tauri/src-tauri/src/tray_monitor_preview.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/tray_monitor_preview.rs
@@ -331,6 +331,9 @@ async fn bootstrap_sck_stream(monitor_id: u32) {
     if !preview_capture_expected() {
         return;
     }
+    if !crate::permissions::screen_recording_permission_usable_in_process() {
+        return;
+    }
     if user_disabled_monitor_ids().contains(&monitor_id) {
         return;
     }

--- a/crates/screenpipe-core/src/permissions.rs
+++ b/crates/screenpipe-core/src/permissions.rs
@@ -183,6 +183,40 @@ mod macos_screen_recording {
         unsafe { CGPreflightScreenCaptureAccess() }
     }
 
+    /// Read Screen Recording authorization directly from TCC, bypassing the
+    /// process-local SkyLight answer returned by `CGPreflightScreenCaptureAccess`.
+    pub fn tcc_preflight() -> Result<bool, String> {
+        type TccAccessPreflight = unsafe extern "C" fn(*const c_void) -> u32;
+
+        const TCC_FRAMEWORK: &[u8] = b"/System/Library/PrivateFrameworks/TCC.framework/TCC\0";
+        const PREFLIGHT_SYMBOL: &[u8] = b"TCCAccessPreflight\0";
+        const SCREEN_CAPTURE_SERVICE_SYMBOL: &[u8] = b"kTCCServiceScreenCapture\0";
+        const TCC_PREFLIGHT_GRANTED: u32 = 0;
+
+        unsafe {
+            let handle = libc::dlopen(
+                TCC_FRAMEWORK.as_ptr().cast(),
+                libc::RTLD_LAZY | libc::RTLD_LOCAL,
+            );
+            if handle.is_null() {
+                return Err("failed to load TCC.framework".to_string());
+            }
+
+            let preflight_symbol = libc::dlsym(handle, PREFLIGHT_SYMBOL.as_ptr().cast());
+            let service_symbol = libc::dlsym(handle, SCREEN_CAPTURE_SERVICE_SYMBOL.as_ptr().cast());
+            if preflight_symbol.is_null() || service_symbol.is_null() {
+                libc::dlclose(handle);
+                return Err("required TCC.framework symbols are unavailable".to_string());
+            }
+
+            let preflight: TccAccessPreflight = std::mem::transmute(preflight_symbol);
+            let service = *(service_symbol as *const *const c_void);
+            let result = preflight(service);
+            libc::dlclose(handle);
+            Ok(result == TCC_PREFLIGHT_GRANTED)
+        }
+    }
+
     /// True on macOS 15 (Sequoia) or later. Cached — spawns `sw_vers` once per process.
     pub fn is_sequoia_or_later() -> bool {
         use std::sync::OnceLock;
@@ -228,6 +262,27 @@ mod macos_screen_recording {
     }
 }
 
+/// Current Screen Recording authorization read directly from TCC.
+///
+/// Unlike `CGPreflightScreenCaptureAccess`, this bypasses SkyLight's
+/// process-local cache and therefore sees grants and revocations made while
+/// the process is running.
+#[cfg(target_os = "macos")]
+pub fn check_screen_recording_tcc() -> Result<PermissionStatus, String> {
+    macos_screen_recording::tcc_preflight().map(|granted| {
+        if granted {
+            PermissionStatus::Granted
+        } else {
+            PermissionStatus::Denied
+        }
+    })
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn check_screen_recording_tcc() -> Result<PermissionStatus, String> {
+    Ok(PermissionStatus::NotNeeded)
+}
+
 /// CLI: always uses `preflight() || capture_probe()` on every macOS version.
 #[cfg(target_os = "macos")]
 pub fn check_screen_recording() -> PermissionStatus {
@@ -245,10 +300,12 @@ pub fn check_screen_recording() -> PermissionStatus {
 /// and benefit from the full probe chain to avoid false-negative preflight stalls.
 #[cfg(target_os = "macos")]
 pub fn check_screen_recording_tauri() -> PermissionStatus {
+    let live = macos_screen_recording::tcc_preflight()
+        .unwrap_or_else(|_| macos_screen_recording::preflight());
     let ok = if macos_screen_recording::is_sequoia_or_later() && !cfg!(debug_assertions) {
-        macos_screen_recording::preflight()
+        live
     } else {
-        macos_screen_recording::preflight() || macos_screen_recording::capture_probe()
+        live || macos_screen_recording::capture_probe()
     };
     if ok {
         PermissionStatus::Granted

--- a/crates/screenpipe-engine/src/permission_monitor.rs
+++ b/crates/screenpipe-engine/src/permission_monitor.rs
@@ -12,9 +12,11 @@
 //! Detection comes from two sources that funnel through a single emission
 //! path (so events are deduped and dedup'd state is shared):
 //!
-//! 1. **Polling** (this task). Every 5s checks `check_permissions()` and
-//!    emits on transition. The only way to detect accessibility state
-//!    changes (no stream-failure signal for that permission).
+//! 1. **Polling** (this task). Every 5s checks `check_permissions_live()` and
+//!    emits on transition. On macOS the Screen Recording result comes directly
+//!    from TCC rather than SkyLight's process-local preflight cache. This is the
+//!    only way to detect accessibility state changes (no stream-failure signal
+//!    for that permission).
 //!
 //! 2. **Eager reports from capture modules**. Vision (`monitor_watcher`)
 //!    calls [`report_state`] when `SCStream` errors with `PermissionDenied`.
@@ -40,7 +42,10 @@ use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 use once_cell::sync::Lazy;
-use screenpipe_core::permissions::{check_permissions, PermissionStatus};
+use screenpipe_core::permissions::{
+    check_accessibility, check_microphone, check_screen_recording, PermissionStatus,
+    PermissionsCheck,
+};
 use screenpipe_events::{send_event, PermissionEvent, PermissionKind};
 use tokio::task::JoinHandle;
 use tracing::{debug, info};
@@ -112,6 +117,26 @@ static STATE: Lazy<Mutex<State>> = Lazy::new(|| {
     })
 });
 
+fn check_permissions_live() -> PermissionsCheck {
+    #[cfg(target_os = "macos")]
+    let screen_recording = screenpipe_core::permissions::check_screen_recording_tcc()
+        .unwrap_or_else(|error| {
+            debug!(
+                %error,
+                "direct Screen Recording TCC preflight failed; using fallback permission check"
+            );
+            check_screen_recording()
+        });
+    #[cfg(not(target_os = "macos"))]
+    let screen_recording = check_screen_recording();
+
+    PermissionsCheck {
+        screen_recording,
+        microphone: check_microphone(),
+        accessibility: check_accessibility(),
+    }
+}
+
 /// Start the monitor. Idempotent — calling twice returns early; the first
 /// call wins. Returns the join handle of the polling task (first call) or
 /// `None` on subsequent calls.
@@ -125,7 +150,7 @@ pub fn start() -> Option<JoinHandle<()>> {
         // Seed last-known with current state so the first poll tick doesn't
         // emit spurious events for permissions that were already denied at
         // process start.
-        let perms = check_permissions();
+        let perms = check_permissions_live();
         state.screen = LastKnown::new(perms.screen_recording.is_granted());
         state.mic = LastKnown::new(perms.microphone.is_granted());
         state.accessibility = LastKnown::new(perms.accessibility.is_granted());
@@ -287,7 +312,7 @@ async fn run() {
 
     loop {
         ticker.tick().await;
-        let perms = check_permissions();
+        let perms = check_permissions_live();
         // While vision enumeration says screen capture is broken, the
         // preflight's answer for ScreenRecording is known-stale (see
         // `report_screen_enumeration`) — don't let it flap us back.


### PR DESCRIPTION
## Summary
- centralize the cache-bypassed macOS Screen Recording TCC preflight in screenpipe-core
- require matching cached and live grants before capture startup or tray SCK preview bootstrap
- make the engine permission monitor poll live TCC state so permission recovery receives grant/revocation transitions

## Before / after

    before: cached grant -> SCK entry -> macOS system permission prompt
    after:  cached grant + live denial -> Screenpipe recovery; no SCK entry

## Validation
- `cd apps/screenpipe-app-tauri && bun run test:tauri screen_recording_state_tests` — 7 passed
- `cargo test -p screenpipe-core permissions` — 28 passed
- `git diff --check upstream/main...HEAD` — passed
