### PR TITLE
fix(activity): render persisted history without ledger rebuild

### DIFF
--- a/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
@@ -484,6 +484,7 @@ describe("activity history helpers", () => {
     expect(artifacts.pathname).toBe("/activity-ledger");
     expect(artifacts.searchParams.get("depth")).toBe("task");
     expect(artifacts.searchParams.get("include_artifacts")).toBe("true");
+    expect(artifacts.searchParams.get("refresh")).toBe("false");
   });
 
   it("requires more than 10 uncovered minutes before appending", () => {
@@ -921,7 +922,7 @@ describe("activity history helpers", () => {
     expect(within(previews[0]).getByText("github.com")).toBeVisible();
   });
 
-  it("shows the complete icon set together before preview loading starts", async () => {
+  it("shows persisted evidence before enriching the complete icon set", async () => {
     const persisted = parseActivityHistoryResponse(HISTORY_RESPONSE, {
       start: new Date("2026-08-17T16:00:00Z"),
       end: new Date("2026-08-17T20:00:00Z"),
@@ -961,10 +962,18 @@ describe("activity history helpers", () => {
       mocks.localFetch.mock.calls.filter(([path]) =>
         String(path).startsWith("/frames/preview-samples?"),
       );
-    await waitFor(() =>
-      expect(screen.getByTestId("activity-ledger-skeleton")).toBeVisible(),
-    );
-    expect(screen.queryByRole("link", { name: /Open Arc/ })).toBeNull();
+    expect(
+      await screen.findByRole("heading", {
+        name: "Fixed a capture reliability regression",
+      }),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("link", { name: /Open Arc .* in Timeline/ }),
+    ).toBeVisible();
+    expect(
+      screen.getByRole("link", { name: /Open Transcript .* in Timeline/ }),
+    ).toBeVisible();
+    expect(screen.queryByTestId("activity-ledger-skeleton")).toBeNull();
     expect(previewCalls()).toHaveLength(0);
 
     await act(async () => {
@@ -1745,15 +1754,7 @@ describe("ActivityLedger", () => {
   });
 
   it("loads a completed encrypted ledger without regenerating it", async () => {
-    mocks.localFetch.mockImplementation((path: string) =>
-      path.startsWith("/activity-ledger?")
-        ? Promise.resolve({
-            ok: true,
-            status: 200,
-            json: async () => LEDGER_ARTIFACTS_RESPONSE,
-          })
-        : new Promise(() => undefined),
-    );
+    mocks.localFetch.mockImplementation(() => new Promise(() => undefined));
     mocks.loadPersistedActivityHistory.mockImplementation(
       async (_producer: string, range: { start: Date; end: Date }) => ({
         entries: parseActivityHistoryResponse(HISTORY_RESPONSE, range).entries,
@@ -1767,6 +1768,20 @@ describe("ActivityLedger", () => {
     );
 
     render(<ActivityLedger />);
+
+    expect(
+      await screen.findByText("Fixed a capture reliability regression"),
+    ).toBeVisible();
+    expect(mocks.generateActivityHistory).not.toHaveBeenCalled();
+    expect(
+      mocks.localFetch.mock.calls.some(([path]) => {
+        const url = new URL(String(path), "http://localhost");
+        return (
+          url.pathname === "/activity-ledger" &&
+          url.searchParams.get("refresh") === "false"
+        );
+      }),
+    ).toBe(true);
 
     expect(
       await screen.findByRole("heading", {

--- a/apps/screenpipe-app-tauri/components/activity-ledger.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.tsx
@@ -296,6 +296,7 @@ export function buildActivityLedgerArtifactsPath(range: TimeRange): string {
     end_time: range.end.toISOString(),
     depth: "task",
     include_artifacts: "true",
+    refresh: "false",
   });
   return `/activity-ledger?${params.toString()}`;
 }
@@ -1090,10 +1091,12 @@ function ArtifactPreviewTooltip({
 function ActivityEntryArtifacts({
   entry,
   intervals,
+  artifactsLoading,
   openEvidence,
 }: {
   entry: ActivityHistoryEntry;
   intervals: ActivityLedgerArtifactInterval[];
+  artifactsLoading: boolean;
   openEvidence: (evidence: ActivityArtifact) => void;
 }) {
   const artifacts = useMemo(
@@ -1172,7 +1175,7 @@ function ActivityEntryArtifacts({
               key={artifactKey(evidence)}
               evidence={evidence}
               artifactName={artifactName}
-              artifactsLoading={false}
+              artifactsLoading={artifactsLoading}
               loadPreviewFrames={loadPreviewFrames}
               onPreviewLoaded={onPreviewLoaded}
             >
@@ -1988,7 +1991,7 @@ Re-query Screenpipe only inside the cited time range and use the cited frames an
                 </div>
               </div>
             )
-          ) : history && ledgerArtifactsReady ? (
+          ) : history ? (
             <section aria-label="Activity history">
               {groupedEntries.map(([day, entries]) => (
                 <div key={day} className="mb-12 last:mb-0">
@@ -2034,6 +2037,7 @@ Re-query Screenpipe only inside the cited time range and use the cited frames an
                           <ActivityEntryArtifacts
                             entry={entry}
                             intervals={ledgerIntervals}
+                            artifactsLoading={!ledgerArtifactsReady}
                             openEvidence={openEvidence}
                           />
                           <span aria-hidden="true">·</span>
@@ -2061,7 +2065,7 @@ Re-query Screenpipe only inside the cited time range and use the cited frames an
                 </div>
               ))}
             </section>
-          ) : !ledgerArtifactsReady || (loading && !summary) ? (
+          ) : loading && !summary ? (
             <ActivityLedgerSkeleton label="Reading your day…" />
           ) : error ? (
             <p className="text-sm text-muted-foreground">{error}</p>

--- a/crates/screenpipe-engine/src/routes/activity_ledger.rs
+++ b/crates/screenpipe-engine/src/routes/activity_ledger.rs
@@ -40,6 +40,15 @@ pub struct ActivityLedgerQuery {
     /// context they did not request.
     #[serde(default)]
     pub include_artifacts: bool,
+    /// Refresh the deterministic ledger before reading it. The desktop
+    /// Activities page disables this because generated history is already
+    /// persisted and artifact enrichment must not block first paint.
+    #[serde(default = "default_refresh")]
+    pub refresh: bool,
+}
+
+fn default_refresh() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Serialize, OaSchema)]
@@ -116,15 +125,17 @@ pub async fn get_activity_ledger(
     if query.end_time - query.start_time > Duration::days(31) {
         return Err(bad_request("activity ledger ranges are limited to 31 days"));
     }
-    crate::activity_ledger::reconcile_range(&state.db, query.start_time, query.end_time)
-        .await
-        .map_err(|error| {
-            error!(%error, "activity ledger generation failed");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                JsonResponse(json!({"error": "activity ledger generation failed"})),
-            )
-        })?;
+    if query.refresh {
+        crate::activity_ledger::reconcile_range(&state.db, query.start_time, query.end_time)
+            .await
+            .map_err(|error| {
+                error!(%error, "activity ledger generation failed");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    JsonResponse(json!({"error": "activity ledger generation failed"})),
+                )
+            })?;
+    }
     let include_actions = query.depth == ActivityLedgerDepth::Action;
     let include_evidence = include_actions || query.include_artifacts;
     let records = state


### PR DESCRIPTION
## Summary

- render persisted Activities as soon as the encrypted history read completes
- hydrate richer app/site artifacts afterward without blocking Activity text or actions
- let the desktop page read the cached deterministic ledger without reconciling the full selected range
- preserve `/activity-ledger` reconciliation by default for existing API callers

## Why

The Activities page gated already-persisted history on `/activity-ledger?include_artifacts=true`. On the live 5.4 GB database, that endpoint rebuilt the selected range before responding, so existing Activities remained behind a skeleton for 17.1 seconds.

The page now sends `refresh=false` for artifact enrichment and renders persisted evidence while that optional request is pending.

## Before / after

```text
before
open Activities
  -> persisted history ready
  -> wait for full ledger reconcile + artifact response (~17.1s)
  -> render Activities

after
open Activities
  -> persisted history ready
  -> render Activities immediately
  -> hydrate cached artifact metadata independently
```

## Real database benchmark

Measured through the live authenticated API against `~/.screenpipe/db.sqlite` (5.4 GB), using the same bounded interval and evidence reads as the cached ledger path over the last 24 hours. Seven measured runs after one warm-up:

- 1,384 intervals: 14.2 ms median
- 3,502 evidence rows: 24.9 ms median
- combined database read: about 39 ms
- previous reconcile-before-read endpoint: 17.1 s

The database timings isolate the read phase; the regression test separately proves that neither artifact nor summary network completion gates persisted Activity rendering.

## Historical intent

- inspected `9413bad03a` / PR #6402, which moved deterministic ledger work on demand to eliminate continuous idle CPU and I/O
- inspected `cfb52acca4` / PR #6511, which added lazy hover previews with stable initial icons and no preview requests while idle
- preserve both invariants: no always-running frontend worker, and previews remain lazy
- supersede only the accidental requirement that optional artifact enrichment finish before persisted Activity text can render; the old test encoded that coupling and now asserts progressive enrichment instead

## Validation

- `bun x vitest run components/activity-ledger.test.tsx` — 46 passed
- `bun run typecheck` — passed
- `bun run build:tauri:dev` — passed through the system queue using `debug-dev`
- `git diff --check upstream/main...HEAD` — passed
