### PR TITLE
fix(chat): explain unsupported Ollama tools

### DIFF
--- a/apps/screenpipe-app-tauri/lib/chat/__tests__/provider-errors.test.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/__tests__/provider-errors.test.ts
@@ -84,6 +84,30 @@ describe("provider error copy", () => {
     expect(msg).toContain("ollama pull llama3.2");
   });
 
+  it("maps native Ollama tool-capability errors to actionable, non-retryable copy", () => {
+    const raw =
+      'Error: 400: {"message":"registry.ollama.ai/library/qwen2.5vl:3b does not support tools","type":"invalid_request_error","param":null,"code":null,"detail":"untrusted upstream suffix"}';
+
+    const presentation = buildProviderErrorPresentation(raw, {
+      provider: "native-ollama",
+      model: "qwen2.5vl:3b",
+    });
+
+    expect(presentation).toEqual({
+      kind: "provider",
+      message:
+        'Ollama model "qwen2.5vl:3b" does not support tools. Switch your AI preset to an Ollama model that supports tools.',
+      retryable: false,
+    });
+    expect(presentation?.message).not.toContain("untrusted upstream suffix");
+    expect(
+      buildProviderErrorPresentation(raw, {
+        provider: "custom",
+        model: "qwen2.5vl:3b",
+      }),
+    ).toBeNull();
+  });
+
   it("maps screenpipe cloud connection errors to a transient-outage message", () => {
     const msg = buildProviderErrorMessage("Connection error.", {
       provider: "screenpipe-cloud",

--- a/apps/screenpipe-app-tauri/lib/chat/provider-errors.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/provider-errors.ts
@@ -370,7 +370,21 @@ export function buildProviderErrorPresentation(
   }
 
   const message = buildGenericProviderErrorMessage(errorStr, preset);
-  return message ? { kind: "provider", message, retryable: true } : null;
+  if (message) return { kind: "provider", message, retryable: true };
+
+  if (
+    isNativeOllamaProvider(preset?.provider) &&
+    errorStr.toLowerCase().includes("does not support tools")
+  ) {
+    const model = preset?.model?.trim() || "the selected model";
+    return {
+      kind: "provider",
+      message: `Ollama model "${model}" does not support tools. Switch your AI preset to an Ollama model that supports tools.`,
+      retryable: false,
+    };
+  }
+
+  return null;
 }
 
 export function buildProviderErrorMessage(


### PR DESCRIPTION
## Source

Discord feedback message `1541546222500974613` reported a native Ollama HTTP 400 when the selected model did not support tools.

## Root cause

Ollama returns a model-specific `does not support tools` capability error, but chat presentation previously fell through to raw upstream JSON. That made a non-retryable model capability mismatch look like an opaque request failure.

## Fix

- Classify only native Ollama tool-capability failures.
- Present sanitized, model-specific guidance to select an Ollama model that supports tools.
- Mark the condition non-retryable and do not echo arbitrary upstream suffixes.
- Preserve non-Ollama behavior and existing connection, model, and context error handling.
- Cover the shared presentation helper used by both prompt dispatch and streamed foreground error events.

Scope is limited to:
- `apps/screenpipe-app-tauri/lib/chat/provider-errors.ts`
- `apps/screenpipe-app-tauri/lib/chat/__tests__/provider-errors.test.ts`

## Before / after

```text
Before: HTTP 400 -> raw provider JSON: {"message":"... does not support tools"}
After:  HTTP 400 -> selected Ollama model does not support tools; choose a tool-capable Ollama model
```

## Verification

- RED sabotage with the observed signature: expected failure, `1 failed / 43 passed` (received `null`).
- Focused provider-errors Vitest: `44/44` passed.
- Full frontend Vitest: `4,455/4,455` passed.
- Bun suites: `240/240` passed, 0 failures.
- `bun run typecheck`: passed.
- Focused ESLint for both changed files: passed.
- `git diff --check`: passed; reviewed worktree clean.
- Independent reviewer run `862`: unconditional approval for exact commit `05f874e08a97fe0549bff7080bc49903d27fdb3b` against `b272fbc0f73dbb77d9125a275bb6c2b49640342f`.

## Platform scope

Reported on Windows 10. The fix is in the platform-neutral TypeScript chat error-presentation path; it does not change native, persistence, protocol, or concurrency behavior.
