### PR TITLE
fix(app): randomize acquisition survey sources

### DIFF
--- a/apps/screenpipe-app-tauri/components/__tests__/announcement-survey.test.tsx
+++ b/apps/screenpipe-app-tauri/components/__tests__/announcement-survey.test.tsx
@@ -49,6 +49,34 @@ const ANNOUNCEMENT = parseAnnouncement({
 })!;
 
 describe("announcement survey", () => {
+  it("randomizes acquisition sources without reordering other questions", () => {
+    const random = vi.spyOn(Math, "random").mockReturnValue(0);
+
+    try {
+      render(<SurveyForm announcement={ANNOUNCEMENT} onSubmit={() => true} />);
+
+      expect(
+        screen
+          .getAllByRole("radio")
+          .map((choice) => choice.getAttribute("value")),
+      ).toEqual(["friend", "hn"]);
+      expect(
+        screen
+          .getAllByRole("checkbox")
+          .map((choice) => choice.getAttribute("value")),
+      ).toEqual(["memory", "automation"]);
+
+      fireEvent.click(screen.getByLabelText("A friend or colleague"));
+      expect(
+        screen
+          .getAllByRole("radio")
+          .map((choice) => choice.getAttribute("value")),
+      ).toEqual(["friend", "hn"]);
+    } finally {
+      random.mockRestore();
+    }
+  });
+
   it("requires configured answers and submits option ids only", () => {
     const onSubmit = vi.fn(() => true);
     render(<SurveyForm announcement={ANNOUNCEMENT} onSubmit={onSubmit} />);

--- a/apps/screenpipe-app-tauri/components/announcement-host.tsx
+++ b/apps/screenpipe-app-tauri/components/announcement-host.tsx
@@ -37,6 +37,35 @@ function useAutoDismiss(ms: number | undefined, onDismiss: () => void) {
   }, [ms, onDismiss]);
 }
 
+function shuffle<T>(items: readonly T[]) {
+  const shuffled = [...items];
+
+  for (let index = shuffled.length - 1; index > 0; index -= 1) {
+    const randomIndex = Math.floor(Math.random() * (index + 1));
+    [shuffled[index], shuffled[randomIndex]] = [
+      shuffled[randomIndex],
+      shuffled[index],
+    ];
+  }
+
+  return shuffled;
+}
+
+function createSurveyChoiceOrder(announcement: Announcement) {
+  const randomizeAcquisitionSource = announcement.id.startsWith(
+    "acquisition-survey-",
+  );
+
+  return new Map(
+    (announcement.survey?.questions ?? []).map((question) => [
+      question.id,
+      randomizeAcquisitionSource && question.type === "single-choice"
+        ? shuffle(question.choices)
+        : question.choices,
+    ]),
+  );
+}
+
 function AnnouncementModal({
   announcement,
   onDismiss,
@@ -83,7 +112,11 @@ function AnnouncementModal({
         </DialogDescription>
         <AnnouncementBody body={announcement.body} />
         {announcement.survey && (
-          <SurveyForm announcement={announcement} onSubmit={onSubmit} />
+          <SurveyForm
+            key={announcement.id}
+            announcement={announcement}
+            onSubmit={onSubmit}
+          />
         )}
         <DialogFooter className="mt-2 gap-2 sm:justify-start">
           {cta && (
@@ -117,6 +150,9 @@ export function SurveyForm({
   const survey = announcement.survey;
   const [answers, setAnswers] = useState<SurveyAnswers>({});
   const [attempted, setAttempted] = useState(false);
+  const [choicesByQuestion] = useState(() =>
+    createSurveyChoiceOrder(announcement),
+  );
   if (!survey) return null;
 
   const complete = survey.questions.every(
@@ -135,6 +171,7 @@ export function SurveyForm({
     >
       {survey.questions.map((question) => {
         const selected = answers[question.id] ?? [];
+        const choices = choicesByQuestion.get(question.id) ?? question.choices;
         return (
           <fieldset key={question.id} className="space-y-2">
             <legend className="text-sm font-medium text-foreground">
@@ -149,7 +186,7 @@ export function SurveyForm({
               </p>
             )}
             <div className="grid gap-1.5">
-              {question.choices.map((choice) => {
+              {choices.map((choice) => {
                 const checked = selected.includes(choice.id);
                 return (
                   <label


### PR DESCRIPTION
## Summary
- randomize the onboarding acquisition survey's single-choice source options with a Fisher-Yates shuffle
- keep that order stable while the user answers the survey
- preserve configured order for other survey questions and preserve every submitted option ID
- companion to screenpipe/website#841

## Before / after

```text
before: every respondent sees the configured source order
  ( ) Hacker News
  ( ) A friend or colleague

after: each survey presentation gets one stable randomized order
  presentation A                 presentation B
  ( ) A friend or colleague      ( ) Hacker News
  ( ) Hacker News                ( ) A friend or colleague
```

## Verification
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH bun run test:vitest -- components/__tests__/announcement-survey.test.tsx` (3 passed)
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH bun run typecheck`
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH bun x eslint components/announcement-host.tsx components/__tests__/announcement-survey.test.tsx`
