### PR TITLE
fix(meetings): make meeting chat work on ACP presets

### DIFF
--- a/apps/screenpipe-app-tauri/components/meeting-notes/meeting-chat-prompt.test.ts
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/meeting-chat-prompt.test.ts
@@ -60,7 +60,12 @@ describe("buildMeetingChatPrompt", () => {
       [],
     );
     expect(prompt).toContain("broader screenpipe history");
-    expect(prompt).toContain("search-content");
+    // Deliberately not a tool id: the same tool is named `search-content`,
+    // `mcp__screenpipe__search-content`, or `keyword_search` depending on the
+    // backend, and naming one spelling told ACP agents to call a tool that does
+    // not exist for them.
+    expect(prompt).toContain("read-only screenpipe search and meeting tools");
+    expect(prompt).not.toContain("search-content");
     expect(prompt).toContain("smallest relevant time range");
     expect(prompt).toContain("Never imply broader evidence was part of this meeting");
   });

--- a/apps/screenpipe-app-tauri/components/meeting-notes/meeting-chat-stream.test.ts
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/meeting-chat-stream.test.ts
@@ -8,6 +8,7 @@ import {
   advanceMeetingChatStream,
   emptyStreamState,
   isAllowedMeetingChatTool,
+  normalizeMeetingChatToolName,
   stopMeetingChatStream,
   type MeetingChatStreamState,
 } from "./meeting-chat-stream";
@@ -152,6 +153,84 @@ describe("tool allowlist", () => {
     expect(isAllowedMeetingChatTool(undefined)).toBe(true);
     expect(isAllowedMeetingChatTool("search-content")).toBe(true);
     expect(isAllowedMeetingChatTool("bash")).toBe(false);
+  });
+
+  // The rail was dead on every ACP preset: those agents report MCP tools as
+  // `mcp__<server>__<tool>` and underscore the bundled server's names, so even
+  // the allowlisted tool failed the check and killed the turn on its first call.
+  it("recognizes an allowed tool under every backend's spelling", () => {
+    expect(normalizeMeetingChatToolName("search-content")).toBe("search-content");
+    expect(normalizeMeetingChatToolName("mcp__screenpipe__search-content")).toBe(
+      "search-content",
+    );
+    expect(
+      normalizeMeetingChatToolName("mcp__screenpipe-tools__frame_context"),
+    ).toBe("frame-context");
+
+    expect(isAllowedMeetingChatTool("mcp__screenpipe__search-content")).toBe(true);
+    expect(isAllowedMeetingChatTool("mcp__screenpipe-tools__get_meeting")).toBe(
+      true,
+    );
+    expect(isAllowedMeetingChatTool("mcp__screenpipe-tools__keyword_search")).toBe(
+      true,
+    );
+  });
+
+  it("a screenpipe tool outside the allowlist still kills the run", () => {
+    expect(isAllowedMeetingChatTool("mcp__screenpipe__update-memory")).toBe(false);
+    expect(isAllowedMeetingChatTool("mcp__screenpipe-tools__save_artifact")).toBe(
+      false,
+    );
+  });
+
+  it("another MCP server is the scope-widening case 65 exists to stop", () => {
+    expect(isAllowedMeetingChatTool("mcp__notion__search")).toBe(false);
+    expect(isAllowedMeetingChatTool("mcp__slack__post_message")).toBe(false);
+  });
+
+  // codex-acp reports an unreachable MCP server as a failed tool call on every
+  // turn. A user with one unauthenticated server would never get an answer.
+  it("an MCP startup diagnostic is not a tool the agent chose", () => {
+    expect(isAllowedMeetingChatTool("mcp__notion__startup")).toBe(true);
+    const state = fold([
+      { type: "tool_execution_start", toolName: "mcp__notion__startup" },
+      delta("answered anyway"),
+      { type: "agent_end" },
+    ]);
+    expect(state.stoppedReason).toBeNull();
+    expect(state.text).toBe("answered anyway");
+  });
+
+  // ACP harnesses always carry native tools and cannot be told to drop them.
+  // The runtime refuses the ones that need approval, so killing the turn on a
+  // read or a plan step only throws away an answer the user can use.
+  it("a read-only native agent step does not kill the run", () => {
+    expect(isAllowedMeetingChatTool("Read /a/b.ts", "read")).toBe(true);
+    expect(isAllowedMeetingChatTool("Grep", "search")).toBe(true);
+    expect(isAllowedMeetingChatTool("TodoWrite")).toBe(true);
+    expect(isAllowedMeetingChatTool("Skill")).toBe(true);
+  });
+
+  it("a native step that acts, runs, or fetches kills the run", () => {
+    expect(isAllowedMeetingChatTool("Edit /a/b.ts", "edit")).toBe(false);
+    expect(isAllowedMeetingChatTool("rm -rf /", "execute")).toBe(false);
+    expect(isAllowedMeetingChatTool("Fetch example.com", "fetch")).toBe(false);
+    // Raw Pi and adapters that send no `kind` are matched by name instead.
+    expect(isAllowedMeetingChatTool("bash")).toBe(false);
+    expect(isAllowedMeetingChatTool("write_file")).toBe(false);
+    expect(isAllowedMeetingChatTool("apply_patch")).toBe(false);
+  });
+
+  it("kills the run on an unsafe kind even when the name looks harmless", () => {
+    const state = fold([
+      delta("partial"),
+      { type: "tool_execution_start", toolName: "Run tests", kind: "execute" },
+    ]);
+    expect(state.done).toBe(true);
+    expect(state.stoppedReason).toBe("unexpected-tool");
+    // Case 65's copy is unchanged, and the partial answer is kept.
+    expect(state.error).toBe("stopped — unexpected tool");
+    expect(state.text).toBe("partial");
   });
 });
 

--- a/apps/screenpipe-app-tauri/components/meeting-notes/meeting-chat-stream.ts
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/meeting-chat-stream.ts
@@ -42,19 +42,119 @@ function joinBlocks(blocks: Record<number, string>): string {
 /**
  * Tools this surface is allowed to call. Anything else kills the run, matching
  * the Live View editor's isolation (case 65).
+ *
+ * Both spellings of each tool are listed because the same logical tool arrives
+ * under different names depending on the backend: raw Pi and the stdio
+ * `screenpipe` MCP server use hyphens, while the bundled `screenpipe-tools`
+ * server that http-only ACP agents (Cursor, Copilot) talk to underscores them.
+ * `normalizeMeetingChatToolName` folds that away; the list stays in hyphen form.
+ * `keyword-search` is the `screenpipe-tools` equivalent of `search-content` —
+ * without it an ACP agent has no allowed way to search broader history at all.
  */
 export const MEETING_CHAT_ALLOWED_TOOLS = [
   "search-content",
+  "keyword-search",
   "get-meeting",
   "frame-context",
 ] as const;
 
 const ALLOWED = new Set<string>(MEETING_CHAT_ALLOWED_TOOLS);
 
-export function isAllowedMeetingChatTool(name: string | undefined): boolean {
-  if (!name) return true; // Unnamed internal steps are not tool calls.
-  return ALLOWED.has(name);
+/** `mcp__<server>__<tool>`, the shape every ACP agent reports MCP tools in. */
+const MCP_TOOL_RE = /^mcp__([a-z0-9_.-]+)__(.+)$/i;
+
+/**
+ * The bare tool name behind whatever the backend put on the wire, or `null`
+ * when this isn't an MCP tool call at all.
+ *
+ * ACP reports a tool's *human title* here — "Read /a/b.ts", "Grep" — falling
+ * back to the ACP `kind` category when there is no title. Only an MCP tool
+ * carries a machine name, so anything with whitespace is a native agent step
+ * and is classified separately.
+ */
+export function normalizeMeetingChatToolName(
+  name: string | undefined,
+): string | null {
+  const trimmed = name?.trim();
+  if (!trimmed) return null;
+  const bare = trimmed.match(MCP_TOOL_RE)?.[2]?.trim() ?? trimmed;
+  if (!bare || /\s/.test(bare)) return null;
+  return bare.toLowerCase().replace(/_/g, "-");
 }
+
+/** The MCP server a tool came from, lowercased, or `null` for a native step. */
+function mcpServerName(name: string | undefined): string | null {
+  return name?.trim().match(MCP_TOOL_RE)?.[1]?.toLowerCase() ?? null;
+}
+
+/** screenpipe's own read servers: the stdio `screenpipe` one and the bundled
+ *  `screenpipe-tools` one http-only agents get. */
+function isScreenpipeServer(server: string | null): boolean {
+  return server === "screenpipe" || server === "screenpipe-tools";
+}
+
+/**
+ * ACP `kind` categories that change something, run something, or reach the
+ * network. A native agent step in one of these is out of contract for a
+ * read-only surface and ends the run.
+ */
+const UNSAFE_TOOL_KINDS = new Set(["edit", "delete", "move", "execute", "fetch"]);
+
+/**
+ * Named native tools that act, for harnesses that send a bare tool name and no
+ * `kind`. Kinds cover the ACP path; this covers raw Pi and any adapter that
+ * omits the category.
+ */
+const NATIVE_ACTION_TOOLS = new Set([
+  "bash",
+  "shell",
+  "run",
+  "run-command",
+  "run-terminal-cmd",
+  "terminal",
+  "write",
+  "write-file",
+  "edit",
+  "edit-file",
+  "multiedit",
+  "apply-patch",
+  "notebookedit",
+  "delete",
+  "rm",
+  "webfetch",
+  "web-search",
+  "websearch",
+  "fetch",
+]);
+
+export function isAllowedMeetingChatTool(
+  name: string | undefined,
+  kind?: string | undefined,
+): boolean {
+  if (!name) return true; // Unnamed internal steps are not tool calls.
+
+  const server = mcpServerName(name);
+  if (server !== null) {
+    // A failed-startup diagnostic is emitted per unreachable MCP server on
+    // every turn — never a tool the agent chose to call.
+    if (normalizeMeetingChatToolName(name) === "startup") return true;
+    // Another server is another data source: exactly the silent scope-widening
+    // case 65 exists to stop.
+    if (!isScreenpipeServer(server)) return false;
+    const bare = normalizeMeetingChatToolName(name);
+    return bare !== null && ALLOWED.has(bare);
+  }
+
+  // A native agent step (ACP harnesses always carry a few, and unlike MCP tools
+  // they cannot be turned off). The runtime already refuses any of them that
+  // needs approval, so tearing the answer down on a read or a plan step just
+  // loses a good answer. Only the categories that act get killed.
+  if (kind && UNSAFE_TOOL_KINDS.has(kind.toLowerCase())) return false;
+  const bare = normalizeMeetingChatToolName(name);
+  if (bare === null) return true; // A human title with no kind: a benign step.
+  return !UNSAFE_TOOL_KINDS.has(bare) && !NATIVE_ACTION_TOOLS.has(bare);
+}
+
 
 /**
  * Apply one event. Returns a new state; never mutates the input.
@@ -73,7 +173,13 @@ export function advanceMeetingChatStream(
   const inner = event.assistantMessageEvent;
 
   // Case 65: an unexpected tool ends the run rather than silently succeeding.
-  if (type === "tool_execution_start" && !isAllowedMeetingChatTool(event.toolName)) {
+  if (
+    type === "tool_execution_start" &&
+    !isAllowedMeetingChatTool(
+      event.toolName,
+      typeof event.kind === "string" ? event.kind : undefined,
+    )
+  ) {
     return {
       ...state,
       done: true,

--- a/apps/screenpipe-app-tauri/components/meeting-notes/use-meeting-chat.ts
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/use-meeting-chat.ts
@@ -8,8 +8,15 @@
  *
  * Runs one private Pi session per turn, isolated the same way the Live View
  * editor is (`lib/live-views/generate-live-view-with-pi.ts`): its own project
- * dir, no Chat system prompt, and a tool allowlist enforced client-side so an
- * unrelated tool kills the run rather than quietly succeeding.
+ * dir, no Chat system prompt, and a tool allowlist.
+ *
+ * `allowedTools` is the enforcement boundary, not a hint. Raw Pi receives it as
+ * `--tools`; an ACP session receives it as `SCREENPIPE_ACP_TOOL_ALLOWLIST`,
+ * which also drops the user's own MCP servers and the shared screenpipe agent
+ * context, and makes the runtime refuse a non-allowlisted tool outright rather
+ * than wait on an approval card this panel cannot show. The client-side gate in
+ * `meeting-chat-stream.ts` is the second layer: it can only react once a tool
+ * has already started (case 65).
  *
  * One in-flight turn per meeting; there is no queue in v1 (case 38).
  */
@@ -111,7 +118,7 @@ export function buildMeetingChatPrompt(
 
 Rules:
 - Treat the meeting evidence below as the primary context. For ordinary questions about this meeting, answer only from it; if it does not contain the answer, say so plainly in one sentence.
-- If the user explicitly asks you to check, search, or compare their broader screenpipe history, use only the available read-only screenpipe tools (search-content, get-meeting, or frame-context). Keep the search bounded to the smallest relevant time range. Do not use unrelated tools.
+- If the user explicitly asks you to check, search, or compare their broader screenpipe history, use only the read-only screenpipe search and meeting tools you have been given. Keep the search bounded to the smallest relevant time range. Do not use any other tool, skill, file, or command: nothing else is available to you here, and reaching for one only costs the user their answer.
 - When broader history is used, label which claims came from this meeting and which came from broader screenpipe history. Never imply broader evidence was part of this meeting.
 - Cite the wall-clock time of meeting moments you rely on, written like 3:34, so the reader can jump to them in the transcript. Give broader results their captured date and time instead of turning them into meeting citations.
 - Be brief. Two or three sentences unless the question needs a list.

--- a/apps/screenpipe-app-tauri/lib/events/types.ts
+++ b/apps/screenpipe-app-tauri/lib/events/types.ts
@@ -56,6 +56,9 @@ export interface AgentInnerEvent {
   };
   toolCallId?: string;
   toolName?: string;
+  /** ACP tool category (read/edit/search/execute/fetch/...), forwarded by the
+   *  ACP runtime next to the name. Absent for raw Pi tool calls. */
+  kind?: string;
   args?: Record<string, unknown>;
   result?: { content?: Array<{ text?: string }> };
   isError?: boolean;

--- a/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
@@ -3084,11 +3084,37 @@ pub async fn pi_start_inner(
         {
             cmd.env("SCREENPIPE_ACP_SYSTEM_PROMPT", system_prompt);
         }
+        // A private surface (meeting chat) passes the exact read-only tools it
+        // needs. Raw Pi gets this as `--tools`; the ACP runtime uses it to scope
+        // the session — no third-party MCP servers, no shared agent context, and
+        // an out-of-contract tool refused instead of stranded on an approval
+        // card the surface cannot show.
+        cmd.env_remove(screenpipe_core::agents::acp::TOOL_ALLOWLIST_ENV);
+        let scoped_tools = provider_config
+            .as_ref()
+            .and_then(|config| config.allowed_tools.as_ref())
+            .map(|tools| {
+                tools
+                    .iter()
+                    .map(|tool| tool.trim())
+                    .filter(|tool| !tool.is_empty())
+                    .collect::<Vec<_>>()
+            });
+        if let Some(tools) = scoped_tools.as_ref() {
+            cmd.env(
+                screenpipe_core::agents::acp::TOOL_ALLOWLIST_ENV,
+                serde_json::to_string(tools).map_err(|e| e.to_string())?,
+            );
+        }
         // Forward the user's own MCP servers so the harness gets the same
-        // tool surface raw Pi gets from the mcp-bridge extension.
+        // tool surface raw Pi gets from the mcp-bridge extension. A scoped
+        // session never gets them (the runtime drops them too; not sending the
+        // resolved secret headers at all is the stronger boundary).
         cmd.env_remove("SCREENPIPE_ACP_USER_MCP_JSON");
-        if let Some(user_mcp) = resolve_user_mcp_servers_json().await {
-            cmd.env("SCREENPIPE_ACP_USER_MCP_JSON", user_mcp);
+        if scoped_tools.is_none() {
+            if let Some(user_mcp) = resolve_user_mcp_servers_json().await {
+                cmd.env("SCREENPIPE_ACP_USER_MCP_JSON", user_mcp);
+            }
         }
         // Reopen after the process was gone: reattach to the prior ACP
         // session instead of starting fresh with a glued transcript.

--- a/crates/screenpipe-core/src/agents/acp/mod.rs
+++ b/crates/screenpipe-core/src/agents/acp/mod.rs
@@ -24,7 +24,7 @@ pub use runtime::{
     agent_cloud_routing, agent_download_pending, agent_install_status, cloud_routing_env,
     install_agent, is_forbidden_acp_env, is_known_agent, is_process_guard_mode, is_runtime_mode,
     run_external_auth_login, run_process_guard, CloudRouting, ProviderSessionObserver,
-    CLOUD_API_KEY_ENV, RUNTIME_ARG, SCREENPIPE_MCP_PKG,
+    CLOUD_API_KEY_ENV, RUNTIME_ARG, SCREENPIPE_MCP_PKG, TOOL_ALLOWLIST_ENV,
 };
 
 use std::io::Write;

--- a/crates/screenpipe-core/src/agents/acp/runtime.rs
+++ b/crates/screenpipe-core/src/agents/acp/runtime.rs
@@ -3351,8 +3351,7 @@ fn normalized_tool_name(title: &str) -> Option<String> {
 /// name) are refused too: a scoped surface answers from the evidence in its own
 /// turn, so a file read or a skill load is out of contract by construction.
 fn scoped_tool_allowed(allowlist: &[String], title: Option<&str>) -> bool {
-    normalized_tool_name(title.unwrap_or(""))
-        .is_some_and(|name| allowlist.contains(&name))
+    normalized_tool_name(title.unwrap_or("")).is_some_and(|name| allowlist.contains(&name))
 }
 
 /// A short, readable heading for a permission prompt, from the tool's `kind`.
@@ -5130,7 +5129,10 @@ mod tests {
             &allowlist,
             Some("mcp__screenpipe__update-memory")
         ));
-        assert!(!scoped_tool_allowed(&allowlist, Some("mcp__notion__search")));
+        assert!(!scoped_tool_allowed(
+            &allowlist,
+            Some("mcp__notion__search")
+        ));
         assert!(!scoped_tool_allowed(&allowlist, Some("Skill")));
         assert!(!scoped_tool_allowed(&allowlist, None));
     }

--- a/crates/screenpipe-core/src/agents/acp/runtime.rs
+++ b/crates/screenpipe-core/src/agents/acp/runtime.rs
@@ -76,9 +76,18 @@ const RUNTIME_ONLY_ENV: &[&str] = &[
     "SCREENPIPE_ACP_ID",
     "SCREENPIPE_ACP_RESUME_SESSION_ID",
     "SCREENPIPE_ACP_UNATTENDED",
+    TOOL_ALLOWLIST_ENV,
     super::super::chat_control::CHAT_CONTROL_ADDR_ENV,
     super::super::chat_control::CHAT_CONTROL_TOKEN_ENV,
 ];
+
+/// A private, single-purpose surface (today: the meeting chat panel) passes the
+/// exact read-only tools it needs. When this is set the session is *scoped*:
+/// third-party MCP servers are not mounted, the shared screenpipe agent context
+/// is not injected, and a permission request for a tool outside the list is
+/// refused outright instead of waiting on an approval card the surface has no UI
+/// to show. Chat and scheduled tasks never set it and are unaffected.
+pub const TOOL_ALLOWLIST_ENV: &str = "SCREENPIPE_ACP_TOOL_ALLOWLIST";
 
 /// Strip every [`RUNTIME_ONLY_ENV`] var from a child command's inherited
 /// environment. Call at every spawn site so secrets can't leak into a
@@ -197,6 +206,18 @@ struct RuntimeConfig {
     /// cards. In this mode permissions use the task's preconfigured sandbox and
     /// authentication failures return immediately with recovery instructions.
     unattended: bool,
+    /// Set by a scoped surface (see [`TOOL_ALLOWLIST_ENV`]): the only tools this
+    /// session may use, as bare screenpipe tool names. `None` is an ordinary
+    /// full-surface session.
+    tool_allowlist: Option<Vec<String>>,
+}
+
+impl RuntimeConfig {
+    /// A scoped session gets no third-party MCP servers, no shared agent
+    /// context, and no approval cards.
+    fn is_scoped(&self) -> bool {
+        self.tool_allowlist.is_some()
+    }
 }
 
 /// A user-configured MCP server forwarded to the adapter. Header values and
@@ -311,6 +332,26 @@ impl RuntimeConfig {
         } else {
             load_self_improvement_context()
         };
+        // Normalized once here so every read site compares like with like.
+        let tool_allowlist = parse_json_env::<Vec<String>>(TOOL_ALLOWLIST_ENV)?.map(|tools| {
+            tools
+                .iter()
+                .filter_map(|tool| normalized_tool_name(tool))
+                .collect::<Vec<_>>()
+        });
+        // A scoped surface carries its whole contract in the turn it sends. The
+        // shared screenpipe agent context advertises skills and tools this
+        // session is not allowed to use, which is what made a scoped agent
+        // reach for a skill and get its run killed.
+        let system_context = if tool_allowlist.is_some() {
+            env_nonempty("SCREENPIPE_ACP_SYSTEM_PROMPT")
+        } else {
+            Some(build_first_turn_context(
+                load_screenpipe_agents_context(&data_dir),
+                self_improvement_context,
+                env_nonempty("SCREENPIPE_ACP_SYSTEM_PROMPT"),
+            ))
+        };
 
         Ok(Self {
             agent_id,
@@ -322,11 +363,7 @@ impl RuntimeConfig {
             project_dir,
             bun_path,
             preferred_auth_method: env_nonempty("SCREENPIPE_ACP_AUTH_METHOD"),
-            system_context: Some(build_first_turn_context(
-                load_screenpipe_agents_context(&data_dir),
-                self_improvement_context,
-                env_nonempty("SCREENPIPE_ACP_SYSTEM_PROMPT"),
-            )),
+            system_context,
             session_defaults: parse_json_env::<SessionDefaults>(
                 "SCREENPIPE_ACP_SESSION_CONFIG_JSON",
             )?
@@ -337,6 +374,7 @@ impl RuntimeConfig {
             resume_session_id: env_nonempty("SCREENPIPE_ACP_RESUME_SESSION_ID"),
             unattended: env_nonempty("SCREENPIPE_ACP_UNATTENDED")
                 .is_some_and(|value| value != "0" && !value.eq_ignore_ascii_case("false")),
+            tool_allowlist,
         })
     }
 }
@@ -2924,13 +2962,21 @@ fn mcp_servers(config: &RuntimeConfig) -> Vec<McpServer> {
         // pi-acp runs the same isolated Pi installation and loads the package
         // natively, so mounting its portable surface again would duplicate
         // tools. Every non-Pi ACP agent receives the middleware form.
-        if config.agent_id != "pi-acp" {
+        if config.agent_id != "pi-acp" && !config.is_scoped() {
             servers.extend(
                 config
                     .extension_middleware
                     .stdio_servers(&config.bun_path, &extension_mcp_env()),
             );
         }
+    }
+    // A scoped surface answers one question from screenpipe's own read tools.
+    // Mounting the user's Notion, Slack, or Postiz servers there would widen it
+    // into an unrelated data path, and each unauthenticated one also emits a
+    // failed `mcp__<server>__startup` tool call that the surface has to reason
+    // about.
+    if config.is_scoped() {
+        return servers;
     }
     // Forward the user's own registered MCP servers so every harness sees
     // the same tool surface the native Pi mcp-bridge extension gives raw Pi.
@@ -3271,6 +3317,42 @@ fn is_screenpipe_read_tool(tool_title: &str) -> bool {
             | "mcp__screenpipe-tools__get_meeting"
             | "mcp__screenpipe-tools__health_check"
     )
+}
+
+/// The bare screenpipe tool name behind whatever an adapter puts on the wire.
+///
+/// Tool identity reaches the desktop in three shapes and they must all compare
+/// equal: raw Pi sends the bare name (`search-content`), stdio ACP agents send
+/// `mcp__screenpipe__search-content`, and http-only agents (Cursor, Copilot)
+/// send the bundled server's underscored form,
+/// `mcp__screenpipe-tools__frame_context`. Returns `None` for a human title
+/// like "Read /a/b.ts", which is a native agent step and not an MCP tool.
+fn normalized_tool_name(title: &str) -> Option<String> {
+    let title = title.trim();
+    if title.is_empty() {
+        return None;
+    }
+    let bare = match title.split_once("__") {
+        // `mcp__<server>__<tool>`; the server name itself may contain no `__`.
+        Some(("mcp", rest)) => rest.split_once("__").map(|(_, tool)| tool)?,
+        Some(_) => return None,
+        None => title,
+    };
+    let bare = bare.trim();
+    // A tool name is a single identifier. Anything with whitespace is a human
+    // title ("Read /a/b.ts", "Searching the transcript"), never a tool id.
+    if bare.is_empty() || bare.chars().any(char::is_whitespace) {
+        return None;
+    }
+    Some(bare.to_ascii_lowercase().replace('_', "-"))
+}
+
+/// Whether a scoped session may use this tool. Native agent steps (no MCP tool
+/// name) are refused too: a scoped surface answers from the evidence in its own
+/// turn, so a file read or a skill load is out of contract by construction.
+fn scoped_tool_allowed(allowlist: &[String], title: Option<&str>) -> bool {
+    normalized_tool_name(title.unwrap_or(""))
+        .is_some_and(|name| allowlist.contains(&name))
 }
 
 /// A short, readable heading for a permission prompt, from the tool's `kind`.
@@ -3788,6 +3870,7 @@ async fn run_protocol(
     let kill_terminal_state = state.clone();
     let release_terminal_state = state.clone();
     let unattended = config.unattended;
+    let scoped_tools = config.tool_allowlist.clone();
 
     Client
         .builder()
@@ -3804,6 +3887,7 @@ async fn run_protocol(
         .on_receive_request(
             async move |request: RequestPermissionRequest, responder, connection| {
                 let state = permission_state.clone();
+                let scoped_tools = scoped_tools.clone();
                 connection.spawn(async move {
                     let serialized = serde_json::to_value(&request).unwrap_or_default();
                     let tool = serialized.get("toolCall").cloned().unwrap_or_default();
@@ -3814,6 +3898,26 @@ async fn run_protocol(
                         .filter(|value| !value.is_empty());
                     let kind = tool.get("kind").and_then(Value::as_str);
                     let options = serialized.get("options").cloned().unwrap_or_else(|| json!([]));
+                    // A scoped surface (meeting chat) has no approval card to
+                    // show, so it decides here and never blocks: an allowlisted
+                    // read tool is approved, anything else is refused. Refusing
+                    // is a normal tool result the agent can answer around —
+                    // unlike waiting on a UI that will never appear, which used
+                    // to strand the turn until its timeout.
+                    if let Some(allowlist) = scoped_tools.as_deref() {
+                        if scoped_tool_allowed(allowlist, title) {
+                            if let Some(option_id) = allow_option_id(&options) {
+                                return responder.respond(RequestPermissionResponse::new(
+                                    RequestPermissionOutcome::Selected(
+                                        SelectedPermissionOutcome::new(option_id),
+                                    ),
+                                ));
+                            }
+                        }
+                        return responder.respond(RequestPermissionResponse::new(
+                            RequestPermissionOutcome::Cancelled,
+                        ));
+                    }
                     // Chat auto-approves screenpipe's read tools plus every
                     // requested tool when the user explicitly selected Full
                     // access. A scheduled task has no foreground UI, so its
@@ -4966,7 +5070,98 @@ mod tests {
             user_mcp_servers: Vec::new(),
             resume_session_id: None,
             unattended: false,
+            tool_allowlist: None,
         }
+    }
+
+    fn server_names(servers: &[McpServer]) -> Vec<String> {
+        servers
+            .iter()
+            .map(|server| match server {
+                McpServer::Stdio(stdio) => stdio.name.clone(),
+                McpServer::Http(http) => http.name.clone(),
+                other => format!("{other:?}"),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn tool_names_normalize_across_every_wire_shape() {
+        // The same logical tool reaches us three ways: bare from raw Pi, stdio
+        // ACP's `mcp__screenpipe__`, and the bundled http server's underscored
+        // form. All three must compare equal or a scoped surface refuses the
+        // very tool it asked for.
+        assert_eq!(
+            normalized_tool_name("search-content").as_deref(),
+            Some("search-content")
+        );
+        assert_eq!(
+            normalized_tool_name("mcp__screenpipe__search-content").as_deref(),
+            Some("search-content")
+        );
+        assert_eq!(
+            normalized_tool_name("mcp__screenpipe-tools__frame_context").as_deref(),
+            Some("frame-context")
+        );
+
+        // Human titles are native agent steps, not MCP tools.
+        assert_eq!(normalized_tool_name("Read /a/b.ts"), None);
+        assert_eq!(normalized_tool_name("Searching the transcript"), None);
+        assert_eq!(normalized_tool_name(""), None);
+        assert_eq!(normalized_tool_name("   "), None);
+    }
+
+    #[test]
+    fn a_scoped_session_allows_only_its_own_read_tools() {
+        let allowlist = vec!["search-content".to_owned(), "get-meeting".to_owned()];
+
+        assert!(scoped_tool_allowed(
+            &allowlist,
+            Some("mcp__screenpipe__search-content")
+        ));
+        assert!(scoped_tool_allowed(
+            &allowlist,
+            Some("mcp__screenpipe-tools__get_meeting")
+        ));
+
+        // A screenpipe tool outside the list, another MCP server, a native step,
+        // and a title-less call are all refused.
+        assert!(!scoped_tool_allowed(
+            &allowlist,
+            Some("mcp__screenpipe__update-memory")
+        ));
+        assert!(!scoped_tool_allowed(&allowlist, Some("mcp__notion__search")));
+        assert!(!scoped_tool_allowed(&allowlist, Some("Skill")));
+        assert!(!scoped_tool_allowed(&allowlist, None));
+    }
+
+    #[test]
+    fn a_scoped_session_mounts_no_third_party_mcp_servers() {
+        let mut config = runtime_config("cursor");
+        config.user_mcp_servers = vec![UserMcpServer {
+            name: "notion".into(),
+            transport: "http".into(),
+            url: "https://mcp.notion.com/mcp".into(),
+            headers: Vec::new(),
+            command: None,
+            args: Vec::new(),
+            env: HashMap::new(),
+        }];
+
+        let unscoped = mcp_servers(&config);
+        assert!(
+            server_names(&unscoped).iter().any(|name| name == "notion"),
+            "ordinary chat still gets the user's own servers, got {:?}",
+            server_names(&unscoped)
+        );
+
+        config.tool_allowlist = Some(vec!["search-content".to_owned()]);
+        let scoped = mcp_servers(&config);
+        assert!(
+            !server_names(&scoped).iter().any(|name| name == "notion"),
+            "a scoped surface must not reach an unrelated data source, got {:?}",
+            server_names(&scoped)
+        );
     }
 
     #[test]

--- a/docs/MEETING_CHAT_RAIL_SPEC.md
+++ b/docs/MEETING_CHAT_RAIL_SPEC.md
@@ -159,7 +159,32 @@ Each is `case → decided behavior`. Numbers are stable; tests reference them.
 
 63. `piStart` fails → the turn fails immediately with the transport error, not a generic message.
 64. `piStart` succeeds but `piPrompt` fails → retry `piStart` once, mirroring `use-pi-send-transport`.
-65. The agent emits a tool call outside the read-only meeting allowlist → the run is killed, as in `generate-live-view-with-pi.ts`. The thread shows `stopped — unexpected tool`. An explicit request to check broader screenpipe history may use the allowlisted `search-content`, `get-meeting`, or `frame-context` tools; ordinary meeting questions never widen scope silently.
+65. The agent emits a tool call outside the read-only meeting allowlist → the run is killed, as in `generate-live-view-with-pi.ts`. The thread shows `stopped — unexpected tool`. An explicit request to check broader screenpipe history may use the allowlisted `search-content`/`keyword-search`, `get-meeting`, or `frame-context` tools; ordinary meeting questions never widen scope silently.
+
+    Tool identity is compared *normalized*, not literally. The same tool reaches
+    the panel under three spellings — bare (`search-content`) from raw Pi,
+    `mcp__screenpipe__search-content` from a stdio ACP agent, and
+    `mcp__screenpipe-tools__frame_context` from an http-only one (Cursor,
+    Copilot) — and matching only the bare form killed every ACP turn on its first
+    tool call, including calls to the allowlisted tool itself.
+
+    Two classes are deliberately **not** killed: an `mcp__<server>__startup`
+    diagnostic (emitted per unreachable MCP server on every turn, never a tool
+    the agent chose), and a read-only native agent step. ACP harnesses always
+    carry native tools and cannot be told to drop them, so a `read`/`search`
+    step must not cost the user an answer; native steps whose ACP `kind` is
+    `edit`, `delete`, `move`, `execute`, or `fetch` — and known action tools when
+    an adapter sends no kind — still kill the run.
+
+    Enforcement is layered, because the client gate only fires *after* a tool has
+    started. The session is spawned scoped: raw Pi gets `--tools`, and ACP gets
+    `SCREENPIPE_ACP_TOOL_ALLOWLIST`, under which the runtime mounts no
+    third-party MCP servers, injects no shared screenpipe agent context, and
+    answers a permission request for a non-allowlisted tool with a refusal
+    instead of waiting on an approval card this panel has no UI to show. Before
+    that scoping the panel inherited the user's own MCP servers and the shared
+    context that advertises skills, which is what made an agent reach for a skill
+    and lose its turn.
 66. The agent emits no text and terminates → `no answer` plus `retry`, never a blank turn.
 67. The agent streams `text_end` without `text_delta` → the renderer must fold both. Pipe agents emit `text_end` only; a delta-only reader shows nothing.
 68. Turn exceeds 90s → aborted with a timeout, matching `GENERATION_TIMEOUT_MS`.


### PR DESCRIPTION
## Why

Meeting chat is dead on every ACP preset. Ask anything and the turn ends with `stopped — unexpected tool`, usually mid-sentence.

The panel compared tool calls against bare names — `search-content`, `get-meeting`, `frame-context` — but **no ACP agent sends those**. ACP puts a tool's *human title* on the wire, in three shapes:

| backend | what arrives |
| --- | --- |
| raw Pi | `search-content` |
| stdio ACP (Claude Code, Codex) | `mcp__screenpipe__search-content` |
| http-only ACP (Cursor, Copilot) | `mcp__screenpipe-tools__keyword_search` |
| any ACP native step | `Read /a/b.ts`, `Grep`, `Skill` |

So the first tool call of any kind failed the check and killed the turn — including a call to an allowlisted tool. This was structural, not a strict-policy judgement call.

Two things fed it. `allowedTools` was applied only on the raw-Pi branch (`apply_pi_tool_allowlist`, `pi.rs:2941`); the ACP branch dropped it silently, so the panel inherited the full tool surface, the user's own MCP servers (Notion, Slack, …), and the shared screenpipe agent context that advertises skills — which is what made an agent reach for a skill and lose its turn. And had the client gate let a native tool through, the run would have stalled rather than answered: a non-allowlisted ACP tool raises a permission card this panel has no UI to answer, so the turn would sit until its 90s timeout.

From a local session, `~/.screenpipe/screenpipe-app.2026-08-25.log`:

```
Starting ACP agent from Rust ACP runtime in dir: .../pi-meeting-chat with provider: acp model: cursor
...
Stopping pi sidecar for session: __title:meeting-chat-147-…   (25s after prompt)
```

## Before / after

Same question, same Cursor preset. Fabricated meeting data.

| before | after |
| --- | --- |
| <img src="https://raw.githubusercontent.com/screenpipe/screenpipe/assets/meeting-chat-acp-tool-gate/before.png" width="470" alt="Before: the answer is cut off and replaced with stopped — unexpected tool and a retry button"> | <img src="https://raw.githubusercontent.com/screenpipe/screenpipe/assets/meeting-chat-acp-tool-gate/after.png" width="470" alt="After: the answer completes with a clock citation and labels which claim came from broader history"> |

## What changed

Enforcement moves to spawn time, where it can actually prevent a call; the client gate stays as a second layer, since it can only react once a tool has already started.

- **`acp/runtime.rs`** — new `SCREENPIPE_ACP_TOOL_ALLOWLIST`. A *scoped* session mounts no third-party MCP servers, injects no shared agent context, and answers a permission request for an out-of-list tool with a refusal instead of waiting on a card. `normalized_tool_name` folds all three wire spellings to one comparable name.
- **`pi.rs`** — plumbs `allowedTools` into the ACP spawn, and stops sending the user's resolved MCP secret headers to a scoped session at all (a stronger boundary than dropping them inside the runtime).
- **`meeting-chat-stream.ts`** — the gate normalizes names, adds `keyword-search` (the `screenpipe-tools` equivalent of `search-content`; without it an ACP agent has no allowed way to search broader history), ignores `mcp__<server>__startup` diagnostics, and no longer tears down a good answer over a read-only native step. It still kills on another MCP server, a non-allowlisted screenpipe tool, and any step whose ACP `kind` is `edit`/`delete`/`move`/`execute`/`fetch`.
- **prompt** — no longer names tool ids that do not exist on the active backend.
- **`MEETING_CHAT_RAIL_SPEC.md`** — case 65 records the normalized comparison, the two deliberately-not-killed classes, and the layered enforcement.

Chat and scheduled tasks never set the allowlist and are unaffected; `user_mcp_servers_are_forwarded_alongside_screenpipe` still passes unchanged.

## Evals

```bash
cargo test -p screenpipe-core --features acp --lib
```
`600 passed; 0 failed` — 3 new: `tool_names_normalize_across_every_wire_shape`, `a_scoped_session_allows_only_its_own_read_tools`, `a_scoped_session_mounts_no_third_party_mcp_servers`.

```bash
cd apps/screenpipe-app-tauri && bunx vitest run components/meeting-notes
```
`306 passed; 0 failed` — 7 new gate cases (every wire spelling, non-allowlisted screenpipe tool, other MCP server, startup diagnostic, read-only native step, acting native step, unsafe `kind` with a harmless-looking name).

```bash
cd apps/screenpipe-app-tauri && bun run test:tauri acp_tool_allowlist
```
`src-tauri` compiles clean (`debug-dev`, 7m53s); generated `gen/schemas/` churn restored.

```bash
cargo clippy -p screenpipe-core --features acp --lib
```
No new warnings.

Full frontend suite: `117 failed | 4393 passed`. Identical failures on the stashed base (`117 failed | 4386 passed`) — all the known `localStorage` baseline. Zero new failures, +7 passing.

**Not verified:** this has not been driven against a live app with a real Cursor preset. Both layers are covered by tests, but the end-to-end confirmation needs a dev build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
