### PR TITLE
fix(meetings): keep summary notifications local

### DIFF
--- a/apps/screenpipe-app-tauri/lib/utils/meeting-context.test.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/meeting-context.test.ts
@@ -43,6 +43,29 @@ describe("meeting summary pipe prompt", () => {
     expect(prompt).not.toContain("export the meeting");
     expect(prompt).not.toContain("ffmpeg-sample");
   });
+
+  it("keeps automatic summary follow-up local", () => {
+    const meeting: MeetingRecord = {
+      id: 42,
+      meeting_start: "2026-06-04T15:00:00.000Z",
+      meeting_end: "2026-06-04T15:30:00.000Z",
+      meeting_app: "zoom",
+      title: "Design review",
+      attendees: null,
+      note: null,
+      detection_source: "manual",
+      created_at: "2026-06-04T15:00:00.000Z",
+    };
+    const prompt = buildEnrichedSummarizePrompt({
+      meeting,
+      context: { activity: null, clipboardCount: 0, ok: false },
+      transcript: [],
+    });
+
+    expect(prompt).not.toContain("connected apps");
+    expect(prompt).not.toContain("/connections");
+    expect(prompt).not.toContain("push the summary");
+  });
 });
 
 describe("meeting-context image notes", () => {

--- a/apps/screenpipe-app-tauri/lib/utils/meeting-context.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/meeting-context.ts
@@ -525,7 +525,7 @@ export function buildEnrichedSummarizePrompt({
   // the id already).
   const directive = directiveOverride
     ? `the meeting you should summarize has id: ${meeting.id}. you can skip any "find which meeting ended" step.\n\n${directiveOverride}`
-    : buildMeetingSummarizeInstructions(meeting.id, { followUpAsk: true });
+    : buildMeetingSummarizeInstructions(meeting.id);
 
   return `${directive}\n\n${sections.join("\n\n")}`;
 }
@@ -570,7 +570,7 @@ function markdownImageDataUrlRegex(): RegExp {
  * Static instructions for "summarize this meeting and save it back onto the
  * record". Used by:
  *   - the in-app "summarize with AI" button (chat path) — passes the known
- *     meeting id and asks for the speaker/connector follow-up
+ *     meeting id and asks for speaker naming
  *   - the bundled meeting-summary pipe (background event-triggered path) —
  *     keep the wording in sync with crates/screenpipe-core/assets/pipes/meeting-summary/pipe.md
  *
@@ -580,7 +580,6 @@ function markdownImageDataUrlRegex(): RegExp {
  */
 export function buildMeetingSummarizeInstructions(
   meetingId: number | string,
-  options?: { followUpAsk?: boolean },
 ): string {
   const lines = [
     `search screenpipe for what happened during this meeting and summarize it: key topics, decisions, action items.`,
@@ -599,13 +598,6 @@ export function buildMeetingSummarizeInstructions(
     `    -d '{"title": "<NEW_TITLE_OR_OMIT>", "note": "<EXISTING_NOTE>\\n\\n## Summary\\n<YOUR_SUMMARY>"}'`,
     `replace <EXISTING_NOTE> with the meeting's current notes (shown above as "notes:" — empty string if none) so you don't overwrite the user's work; just append your summary under a "## Summary" heading. for the title: if the current "title:" is missing, generic ("untitled", "meeting", just the app name) or doesn't capture what actually happened, replace it with a 5-8 word plain-english title (no quotes, no "meeting about…" prefix) — otherwise omit the field so a user-set title is left alone. if there's nothing useful to summarize (empty transcript, irrelevant audio), say so out loud and skip the PUT — don't write a placeholder.`,
   ];
-
-  if (options?.followUpAsk) {
-    lines.push(
-      ``,
-      `after the PUT, offer to push the summary into one of the user's *connected* apps — ask first, never push on your own. don't guess at the integration list: GET http://localhost:3030/connections and keep only the ones with "connected": true, then ask in one short message which of those (if any) to push to. rank them by relevance — an app used during the meeting (see "apps used during meeting" / "tabs/docs visited") comes first. if nothing is connected, say so in one line (connecting Notion/Slack/Telegram/… would let you push next time) and stop. when they pick one, push via that connection's endpoint (POST /connections/<id>/send for slack/telegram/discord, POST /connections/<id>/proxy/... for notion/linear/etc.) and confirm specifics (channel, parent page) before anything leaves the machine.`,
-    );
-  }
 
   return lines.join("\n");
 }

--- a/crates/screenpipe-core/assets/pipes/meeting-summary/pipe.md
+++ b/crates/screenpipe-core/assets/pipes/meeting-summary/pipe.md
@@ -40,7 +40,6 @@ these are the exact response shapes. do not probe for them:
   - audio `content`: `transcription`, `speaker`, `timestamp` (`text` duplicates `transcription`)
   - ocr `content`: `text`, `frame_id`, `app_name`, `window_name`, `timestamp`
 - `GET /speakers/unnamed?limit=20&offset=0` → a bare **array** of `{"id", "name", …}`. `offset` is required; omitting it is a 400.
-- `GET /connections` → `{"data": [{"id", "name", "connected", "description", …}]}` — filter on `connected == true`
 
 step 1 — pull everything the summary needs in ONE command. the scheduler names the meeting in `./.trigger-context.json`; prefer that id, because "most recent" picks the wrong meeting when two end close together:
 
@@ -49,13 +48,12 @@ step 1 — pull everything the summary needs in ONE command. the scheduler names
   [ -z "$ID" ] && ID=$(curl -s -H "$A" "http://localhost:3030/meetings?limit=1" | jq -r '.data[0].id')
   curl -s -H "$A" "http://localhost:3030/meetings/$ID" -o /tmp/m.json
   S=$(jq -r .meeting_start /tmp/m.json); E=$(jq -r .meeting_end /tmp/m.json)
-  # the four fetches below are independent — run them in parallel, not one per turn
+  # the three fetches below are independent — run them in parallel, not one per turn
   curl -s -G -H "$A" --data-urlencode "start_time=$S" --data-urlencode "end_time=$E" \
     -d content_type=audio -d limit=500 "http://localhost:3030/search" -o /tmp/audio.json &
   curl -s -G -H "$A" --data-urlencode "start_time=$S" --data-urlencode "end_time=$E" \
     -d content_type=ocr -d limit=150 "http://localhost:3030/search" -o /tmp/ocr.json &
   curl -s -H "$A" "http://localhost:3030/speakers/unnamed?limit=20&offset=0" -o /tmp/spk.json &
-  curl -s -H "$A" "http://localhost:3030/connections" -o /tmp/conn.json &
   wait
   tail -40 ./memory.md 2>/dev/null
 
@@ -85,7 +83,7 @@ only rename when the on-screen evidence is unambiguous — never guess from voic
 
 step 3 — write the summary out as your own message, before you save it. this message must contain no tool call; end the turn after it. start a line with exactly `## Summary` and put the finished summary markdown after that heading. the meeting UI streams this section live while you write it — it is the only way the user sees anything before the run ends — and it is the same markdown you pass as `<YOUR_SUMMARY>` in step 3b.
 
-this step is not optional and it is not the closing report. "meeting 112 was summarized and saved to its record" is a report; it does not satisfy this step. saving a summary you never printed means the user watched a placeholder for the entire run and then got nothing to read, so treat that as a failed run. keep planning, tool narration, and save confirmations out of the section after the heading — those belong in your closing message in step 4.
+this step is not optional and it is not the closing report. "meeting 112 was summarized and saved to its record" is a report; it does not satisfy this step. saving a summary you never printed means the user watched a placeholder for the entire run and then got nothing to read, so treat that as a failed run. keep planning, tool narration, and save confirmations out of the section after the heading — those belong in your closing message after saving.
 
 step 3b — now save it. if your summary is worth saving, append it to the meeting note (and refresh the title in the same call) via:
 
@@ -96,18 +94,11 @@ step 3b — now save it. if your summary is worth saving, append it to the meeti
 
 replace `<EXISTING_NOTE>` with the meeting's current `note` field (empty string if none) so you don't overwrite the user's work; just append your summary under a `## Summary` heading. for the title: if the current title is missing, generic ("untitled", "meeting", just the app name) or doesn't capture what actually happened, replace it with a 5-8 word plain-english title (no quotes, no "meeting about…" prefix) — otherwise omit the field so a user-set title is left alone. if there's nothing useful to summarize (empty transcript, irrelevant audio), say so out loud and skip the PUT — don't write a placeholder.
 
-step 4 — offer to push the summary into one of the user's connected apps (ask, never push on your own). list what's actually connected, then let them pick with one click:
-
-  jq -r '.data[] | select(.connected == true) | "\(.id)\t\(.name)"' /tmp/conn.json   # already fetched in step 1
-
-rank the connected targets by relevance — an app used during the meeting first (Notion, Slack, Linear, …). then post a desktop notification whose action buttons are those targets, so the ask renders as buttons in the UI:
+step 4 — notify the user that the summary is ready, keeping the automatic result local. never suggest or create outbound push/send actions here; sharing happens only when the user explicitly chooses it from the meeting view.
 
   curl -s -X POST "http://localhost:11435/notify" \
     -H "Content-Type: application/json" \
-    -d '{"title": "<TITLE> summarized", "body": "<one-line recap> — push it somewhere?", "priority": "high", "actions": [
-          {"label": "push to notion", "type": "api", "method": "POST", "url": "http://localhost:3030/connections/notion/proxy/v1/pages", "body": { /* page payload built from the summary */ }},
-          {"label": "review in chat", "type": "pipe", "pipe": "meeting-summary", "open_in_chat": true, "context": {"meeting_id": <ID>}},
+    -d '{"title": "<TITLE> summarized", "body": "<one-line recap>", "priority": "high", "actions": [
+          {"label": "open summary", "type": "deeplink", "url": "screenpipe://meeting/<ID>"},
           {"label": "dismiss", "type": "dismiss"}
         ]}'
-
-each button maps to a connection's endpoint from its `/connections` `description` (`POST /connections/<id>/send` for slack/telegram/discord, `POST /connections/<id>/proxy/...` for notion/linear/etc.). when a target needs a destination you can't infer (a Notion parent page, a Slack channel), make that button `"review in chat"` so the user confirms specifics before anything leaves the machine. if nothing is connected, skip the notification and just say that connecting an app would let you push summaries next time.

--- a/crates/screenpipe-core/src/pipes/builtin_migrations.rs
+++ b/crates/screenpipe-core/src/pipes/builtin_migrations.rs
@@ -33,6 +33,18 @@ struct FragmentSwap {
     new: &'static str,
 }
 
+/// One anchored section swap applied to an installed builtin prompt.
+struct SectionSwap {
+    /// Why this swap exists. Logged when it fires.
+    why: &'static str,
+    /// Start of the obsolete section.
+    start: &'static str,
+    /// End of the obsolete section, included in the replaced span.
+    end: &'static str,
+    /// Replacement derived from the bundled prompt.
+    new: &'static str,
+}
+
 /// The shipped prompt for a builtin pipe.
 fn bundled_prompt(name: &str) -> Option<&'static str> {
     BUNDLED_BUILTIN_PIPES
@@ -51,6 +63,29 @@ fn section_between(text: &'static str, start: &str, end: &str) -> Option<&'stati
     Some(text[from..to].trim_end())
 }
 
+/// Slice a shipped prompt from `start` through the end of the file.
+fn section_from(text: &'static str, start: &str) -> Option<&'static str> {
+    let from = text.find(start)?;
+    Some(text[from..].trim_end())
+}
+
+/// Replace an anchored section while preserving any user-authored suffix.
+fn replace_section_through(
+    text: &str,
+    start: &str,
+    end: &str,
+    replacement: &str,
+) -> Option<String> {
+    let from = text.find(start)?;
+    let end_start = from + text[from..].find(end)?;
+    let to = end_start + end.len();
+    let mut updated = String::with_capacity(text.len() - (to - from) + replacement.len());
+    updated.push_str(&text[..from]);
+    updated.push_str(replacement);
+    updated.push_str(&text[to..]);
+    (updated != text).then_some(updated)
+}
+
 /// Anchors around the latency preamble (budget + verified response shapes) in
 /// the shipped `meeting-summary` prompt.
 const FAST_PATH_START: &str = "the user is staring at a spinner";
@@ -63,6 +98,12 @@ const FAST_PATH_ANCHOR: &str =
 /// The previous bundled frontmatter before meeting-summary appended the
 /// configured-preset wildcard to its existing fallback chain.
 const PRESET_CHAIN_ANCHOR: &str = "preset:\n  - screenpipe-cloud\ntimeout: 600";
+
+/// Anchors around the obsolete outbound-sharing completion step.
+const OUTBOUND_COMPLETION_START: &str =
+    "step 4 — offer to push the summary into one of the user's connected apps";
+const OUTBOUND_COMPLETION_END: &str = "connecting an app would let you push summaries next time.";
+const LOCAL_COMPLETION_START: &str = "step 4 — notify the user that the summary is ready";
 
 /// Swaps for `meeting-summary`, oldest defect first.
 fn meeting_summary_swaps() -> Vec<FragmentSwap> {
@@ -117,6 +158,25 @@ fn meeting_summary_swaps() -> Vec<FragmentSwap> {
             old: "\"http://localhost:3030/speakers/unnamed?limit=20\"",
             new: "\"http://localhost:3030/speakers/unnamed?limit=20&offset=0\"",
         },
+        FragmentSwap {
+            why: "automatic meeting summaries stay local until the user explicitly \
+                  chooses to share from the meeting view, so connection discovery is \
+                  unnecessary",
+            old: "- `GET /connections` → `{\"data\": [{\"id\", \"name\", \"connected\", \"description\", …}]}` — filter on `connected == true`\n",
+            new: "",
+        },
+        FragmentSwap {
+            why: "automatic meeting summaries no longer fetch connections, leaving \
+                  three independent meeting-data requests",
+            old: "  # the four fetches below are independent — run them in parallel, not one per turn",
+            new: "  # the three fetches below are independent — run them in parallel, not one per turn",
+        },
+        FragmentSwap {
+            why: "automatic meeting summaries stay local, so do not query configured \
+                  outbound destinations",
+            old: "  curl -s -H \"$A\" \"http://localhost:3030/connections\" -o /tmp/conn.json &\n",
+            new: "",
+        },
     ];
 
     // Latency: the shipped prompt sent the agent off to read skill files and
@@ -145,6 +205,23 @@ fn meeting_summary_swaps() -> Vec<FragmentSwap> {
     swaps
 }
 
+/// Anchored swaps for `meeting-summary`, kept separate from exact fragments so
+/// small historical edits inside the obsolete sharing example still migrate.
+fn meeting_summary_section_swaps() -> Vec<SectionSwap> {
+    meeting_summary_local_completion_step()
+        .map(|new| {
+            vec![SectionSwap {
+                why: "automatic meeting summaries suggested direct Telegram, Slack, \
+                      and other outbound sends after every call; keep completion local \
+                      and let the user open the saved summary instead",
+                start: OUTBOUND_COMPLETION_START,
+                end: OUTBOUND_COMPLETION_END,
+                new,
+            }]
+        })
+        .unwrap_or_default()
+}
+
 /// The latency preamble as it appears in the shipped prompt.
 fn meeting_summary_fast_path() -> Option<&'static str> {
     section_between(
@@ -158,6 +235,11 @@ fn meeting_summary_fast_path() -> Option<&'static str> {
 /// `trigger`, preserving any installed trigger customization outside the span.
 fn meeting_summary_preset_chain() -> Option<&'static str> {
     section_between(bundled_prompt("meeting-summary")?, "preset:", "trigger:")
+}
+
+/// The local-only completion step as it appears in the shipped prompt.
+fn meeting_summary_local_completion_step() -> Option<&'static str> {
+    section_from(bundled_prompt("meeting-summary")?, LOCAL_COMPLETION_START)
 }
 
 /// Apply every known repair for `name` to an installed prompt.
@@ -187,6 +269,13 @@ pub(super) fn migrate_builtin_pipe_text(name: &str, original: &str) -> Option<St
         }
         tracing::debug!(pipe = name, why = swap.why, "repairing installed pipe.md");
         updated = updated.replace(swap.old, swap.new);
+    }
+    for swap in meeting_summary_section_swaps() {
+        let Some(next) = replace_section_through(&updated, swap.start, swap.end, swap.new) else {
+            continue;
+        };
+        tracing::debug!(pipe = name, why = swap.why, "repairing installed pipe.md");
+        updated = next;
     }
 
     (updated != original).then_some(updated)
@@ -235,6 +324,16 @@ mod tests {
         assert_eq!(section_between(text, "START", "END"), Some("START body"));
         assert_eq!(section_between(text, "START", "MISSING"), None);
         assert_eq!(section_between(text, "MISSING", "END"), None);
+    }
+
+    #[test]
+    fn replace_section_through_preserves_user_suffix() {
+        let text = "before\nSTART obsolete END\nmy own instruction\n";
+        let fixed = replace_section_through(text, "START", "END", "replacement")
+            .expect("anchored section should be replaced");
+
+        assert_eq!(fixed, "before\nreplacement\nmy own instruction\n");
+        assert!(replace_section_through(&fixed, "START", "END", "replacement").is_none());
     }
 
     /// The migration must quote the shipped prompt, not a copy of it, so the two
@@ -349,6 +448,54 @@ mod tests {
         assert!(migrate_builtin_pipe_text("meeting-summary", &fixed).is_none());
     }
 
+    #[test]
+    fn migrate_builtin_pipe_replaces_outbound_summary_actions() {
+        let stale = concat!(
+            "step 3b — save the summary.\n\n",
+            "step 4 — offer to push the summary into one of the user's connected apps ",
+            "(ask, never push on your own).\n\n",
+            "  curl -s http://localhost:3030/connections -o /tmp/conn.json\n",
+            "  push to telegram\n",
+            "  push to slack\n\n",
+            "if nothing is connected, skip the notification and just say that ",
+            "connecting an app would let you push summaries next time.\n\n",
+            "my own instruction stays here.\n",
+        );
+
+        let fixed = migrate_builtin_pipe_text("meeting-summary", stale)
+            .expect("outbound completion step should migrate");
+        let local_step = meeting_summary_local_completion_step()
+            .expect("bundled prompt should carry the local completion step");
+
+        assert!(fixed.contains(local_step));
+        assert!(fixed.contains("screenpipe://meeting/<ID>"));
+        assert!(fixed.contains("my own instruction stays here."));
+        assert!(!fixed.contains("push to telegram"));
+        assert!(!fixed.contains("push to slack"));
+        assert!(!fixed.contains("/connections"));
+        assert!(migrate_builtin_pipe_text("meeting-summary", &fixed).is_none());
+    }
+
+    #[test]
+    fn migrate_builtin_pipe_removes_connection_discovery() {
+        let stale = concat!(
+            "- `GET /connections` → `{\"data\": [{\"id\", \"name\", \"connected\", ",
+            "\"description\", …}]}` — filter on `connected == true`\n",
+            "  # the four fetches below are independent — run them in parallel, not one per turn\n",
+            "  curl -s -H \"$A\" \"http://localhost:3030/connections\" -o /tmp/conn.json &\n",
+            "  wait\n",
+        );
+
+        let fixed = migrate_builtin_pipe_text("meeting-summary", stale)
+            .expect("connection discovery should be removed");
+
+        assert!(!fixed.contains("/connections"));
+        assert!(!fixed.contains("/tmp/conn.json"));
+        assert!(fixed.contains("the three fetches below"));
+        assert!(fixed.ends_with("  wait\n"));
+        assert!(migrate_builtin_pipe_text("meeting-summary", &fixed).is_none());
+    }
+
     /// Latency: the shipped prompt sent the agent to read skill files and left it
     /// to probe endpoint shapes, which cost roughly eight of eighteen turns on a
     /// real 7-minute meeting while the user watched a spinner.
@@ -373,7 +520,7 @@ mod tests {
         assert!(fixed.contains("6 tool calls or fewer"));
         assert!(fixed.contains("these are the exact response shapes"));
         assert!(fixed.contains("`offset` is required"));
-        assert!(fixed.contains("filter on `connected == true`"));
+        assert!(!fixed.contains("/connections"));
 
         // the user's own edits and the surrounding steps survive.
         assert!(fixed.starts_with("a meeting just ended.\n"));
@@ -414,7 +561,7 @@ mod tests {
 
         // the endpoints reused from that batch are not re-fetched later.
         assert!(body.contains("already fetched to /tmp/spk.json in step 1"));
-        assert!(body.contains("/tmp/conn.json"));
+        assert!(!body.contains("/tmp/conn.json"));
 
         // and the discovery loop stays gone.
         assert!(!body.contains("read the screenpipe skill first"));
@@ -422,6 +569,14 @@ mod tests {
 
         // the streaming contract the UI depends on is preserved.
         assert!(body.contains("## Summary"));
+
+        // Automatic completion stays local. Sharing remains an explicit action
+        // from the meeting view rather than a generated send button.
+        assert!(body.contains("screenpipe://meeting/<ID>"));
+        assert!(body.contains("open summary"));
+        assert!(!body.contains("push to"));
+        assert!(!body.contains("\"type\": \"api\""));
+        assert!(!body.contains("/connections"));
     }
 
     #[test]


### PR DESCRIPTION
## why

Automatic meeting summaries queried every configured connection and generated one-click outbound actions such as `push to telegram` and `push to slack`. That makes a local completion notification feel like a sharing prompt even when the user only asked for a summary.

## what changed

- keep the bundled meeting-summary completion notification local: `open summary` and `dismiss`
- open the saved meeting directly with `screenpipe://meeting/<ID>` instead of rerunning the pipe in chat
- stop querying `/connections` during automatic meeting summarization
- remove the same connected-app follow-up from the in-app manual summarize prompt
- migrate already-installed built-in prompts while preserving user-authored content after the replaced section

## before / after

```text
before  [push to telegram] [push to slack] [review in chat] [dismiss]
after   [open summary] [dismiss]
```

## verification

- `cargo test -p screenpipe-core builtin_migrations --lib` — 15 passed
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH bun run test:vitest -- lib/utils/meeting-context.test.ts` — 10 passed
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH bun run typecheck` — passed
- `PATH=/opt/homebrew/opt/node@22/bin:$PATH bun run coverage:all:check` — all reports current
- `cargo fmt --check -p screenpipe-core` — passed
- `git diff --check origin/main...HEAD` — passed
