### PR TITLE
fix(search): keep accessibility-frame metadata matches

### DIFF
--- a/apps/screenpipe-app-tauri/lib/hooks/__tests__/use-keyword-search-store.test.ts
+++ b/apps/screenpipe-app-tauri/lib/hooks/__tests__/use-keyword-search-store.test.ts
@@ -322,6 +322,43 @@ describe("useKeywordSearchStore search scheduling", () => {
 		expect(
 			requestedUrls.some((url) => url.includes("/text?persist=false")),
 		).toBe(false);
+		expect(mocks.capture).not.toHaveBeenCalledWith(
+			"search_ui_query_failed",
+			expect.anything(),
+		);
+	});
+
+	it("keeps metadata matches from accessibility-captured frames", async () => {
+		vi.mocked(localFetch).mockImplementation((input) => {
+			const url = String(input);
+			if (url.startsWith("/search/keyword?")) {
+				return Promise.resolve(jsonResponse(grouped([{
+					frame_id: 42,
+					timestamp: "2026-08-25T17:00:00.000Z",
+					text_positions: [{
+						text: "semantic button label",
+						confidence: 1,
+						bounds: { left: 0.1, top: 0.1, width: 0.2, height: 0.05 },
+					}],
+					app_name: "Google Chrome",
+					window_name: "screenpipe search",
+					confidence: 1,
+					text: "",
+					url: "https://screenpipe.com",
+					text_source: "accessibility",
+				}])));
+			}
+			if (url.startsWith("/search?")) {
+				return Promise.resolve(jsonResponse({ data: [] }));
+			}
+			throw new Error(`unexpected request: ${url}`);
+		});
+
+		await useKeywordSearchStore.getState().searchKeywords("chrome");
+
+		const [result] = useKeywordSearchStore.getState().searchResults;
+		expect(result.frame_id).toBe(42);
+		expect(result.text_positions).toEqual([]);
 	});
 
 	it("omits a semantic accessibility result with a coarse element box", async () => {

--- a/apps/screenpipe-app-tauri/lib/hooks/use-keyword-search-store.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-keyword-search-store.tsx
@@ -138,6 +138,13 @@ function textContainsToken(text: string, token: string): boolean {
 	).test(normalizedText);
 }
 
+function metadataMatchesQuery(result: SearchMatch, query: string): boolean {
+	const tokens = queryHighlightTokens(query);
+	return [result.app_name, result.window_name, result.url].some((value) =>
+		tokens.some((token) => textContainsToken(value, token)),
+	);
+}
+
 export function visibleMatchingPositions(
 	positions: SearchMatch["text_positions"],
 	query: string,
@@ -157,27 +164,33 @@ export function visibleMatchingPositions(
 /**
  * Narrow each result's highlight to the positions that match the query.
  *
- * The API remains authoritative and continues to return accessibility matches,
- * but the desktop search UI temporarily omits them. AX labels can describe icon
- * buttons or whole containers without rendering those words in the screenshot,
- * and their element bounds are not trustworthy pixel highlights. Screenshot OCR
- * is not run here because it shares the recorder's single OCR permit. Since
- * text_source is frame-level, this is a temporary UI cutoff rather than exact
- * per-query match provenance.
+ * The desktop search UI omits accessibility-only matches. AX labels can describe
+ * icon buttons or whole containers without rendering those words in the
+ * screenshot, and their element bounds are not trustworthy pixel highlights.
+ * `text_source` is frame-level rather than query provenance, though, so an
+ * accessibility-captured frame can still match visible app, window, or URL
+ * metadata. Keep those results without an AX highlight.
+ *
+ * Screenshot OCR is not run here because it shares the recorder's single OCR
+ * permit. Exact AX-only attribution still belongs in the API contract.
  */
 export function narrowSearchMatchHighlights(
 	results: SearchMatch[],
 	query: string,
 ): SearchMatch[] {
-	return results
-		.filter((result) => result.text_source !== "accessibility")
-		.map((result) => {
-			const matchingPositions = visibleMatchingPositions(
-				result.text_positions,
-				query,
-			);
-			return { ...result, text_positions: matchingPositions };
-		});
+	return results.flatMap((result) => {
+		const matchingPositions = visibleMatchingPositions(
+			result.text_positions,
+			query,
+		);
+		if (
+			result.text_source === "accessibility" &&
+			!metadataMatchesQuery(result, query)
+		) {
+			return [];
+		}
+		return [{ ...result, text_positions: matchingPositions }];
+	});
 }
 
 export const useKeywordSearchStore = create<KeywordSearchState>((set, get) => ({


### PR DESCRIPTION
## description

Desktop keyword search treated frame-level `text_source: accessibility` as query-level provenance. That dropped a backend-authoritative result even when the query matched visible app, window, or URL metadata, producing a false empty slate.

This keeps the existing AX-only semantic-label cutoff, but retains accessibility-captured frames when their visible metadata also matches the query. Those cards carry no AX highlight, so icon labels and coarse accessibility boxes remain suppressed.

The 14-day PostHog sample records only `error_type`, not the exception message or stack. Current code already safely removes filtered representatives with `flatMap`; the focused regression now also proves that an accessibility-only response settles without emitting `search_ui_query_failed`. The 19 prior-week versus 1 current-week TypeErrors are therefore consistent with an older deployed path, but the aggregate event cannot identify the exact exception.

## historical intent

- #5984 / `41dda9b29f`: stopped deleting primary accessibility results after expensive fallback OCR verification.
- #6009 / `1736578525`: made the backend discard hidden-only accessibility matches.
- #6272 / `4d6faffec3`: deliberately removed AX-only desktop cards because semantic labels and coarse bounds can point at icons or blank areas; it documented frame-level `text_source` as a temporary cutoff.

This change preserves #6272's AX-only suppression and its no-re-OCR invariant. It narrows the temporary cutoff so it no longer deletes a different match origin: visible frame metadata.

## AI assistance and human ownership

- AI tool(s) used (`none` if not used): Codex
- autonomy level (`none`, `autocomplete`, `chat`, or `agent`): agent
- what I personally verified: not claimed by the agent; automated verification is listed below for the submitter to review

- [ ] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [ ] The problem statement, rationale, and replies to maintainers are my own.

## evidence type

- [x] UI or behavior change — before/after ASCII evidence below
- [ ] Backend change — regression tests and relevant logs/results
- [ ] Performance change — reproducible before/after benchmarks
- [ ] Docs, CI, or pure refactor — relevant checks and an explanation; no video required

## before

```text
backend group: accessibility-captured frame + app_name="Google Chrome"
query: "chrome"
                         |
                         v
desktop filters text_source=accessibility
                         |
                         v
                    No results
```

The new regression fails on `main`: the returned result is `undefined` because the store deletes the group.

## after

```text
backend group: accessibility-captured frame + app_name="Google Chrome"
query: "chrome"
                         |
                         v
metadata matches --------+----> keep card, text_positions=[]
AX-only match ----------------> omit card
```

The regression returns frame `42` with no highlight positions. The existing semantic accessibility fixture remains omitted, and the filter path emits no query-failure event.

## how to test

From `apps/screenpipe-app-tauri`:

1. `bun x vitest run --config vitest.config.ts lib/hooks/__tests__/use-keyword-search-store.test.ts` — passed, 12/12 tests.
2. `bun run typecheck` — passed.
3. `git diff --check` — passed.

## desktop app checklist

No Tauri commands or exported Rust types changed.

- [ ] `bun run bindings:generate` (not applicable)
- [ ] `bun run bindings:check` (not applicable)
- [x] `bun run typecheck`
