### PR TITLE
fix(chat): recover pre-acceptance prompt failures

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat/standalone/hooks/__tests__/pi-preset-switch.test.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/hooks/__tests__/pi-preset-switch.test.tsx
@@ -37,6 +37,8 @@ import {
   awaitPiStartInFlight,
   awaitPendingPiPresetSwitch,
   checkLivePiSession,
+  dispatchPiPromptWithRecovery,
+  isRecoverablePiPromptDispatchError,
 } from "../use-pi-send-transport";
 
 const runningInfo = {
@@ -184,6 +186,61 @@ describe("preset switch serialization", () => {
     expect(setPiInfo).toHaveBeenCalledWith(stoppedInfo);
     expect(runningConfigRef.current).toBeNull();
     unmount();
+  });
+});
+
+describe("prompt dispatch recovery", () => {
+  it.each([
+    "AI agent did not start responding within its startup grace period",
+    "Pi not initialized",
+    "Pi command queue dropped",
+    "stdin write failed: Broken pipe",
+    "Pi session restarted while preparing prompt",
+  ])("recognizes a pre-acceptance process failure: %s", (error) => {
+    expect(isRecoverablePiPromptDispatchError(error)).toBe(true);
+  });
+
+  it.each([
+    "429 rate limit exceeded",
+    "500 Internal server error",
+    "invalid API key",
+    "model_not_allowed",
+    "context_length_exceeded",
+    "upstream socket reported Broken pipe",
+  ])("does not recover an upstream provider failure: %s", (error) => {
+    expect(isRecoverablePiPromptDispatchError(error)).toBe(false);
+  });
+
+  it("replaces a silent process and redelivers the prompt exactly once", async () => {
+    const dispatch = vi.fn()
+      .mockResolvedValueOnce({
+        status: "error",
+        error: "AI agent did not start responding within its startup grace period",
+      })
+      .mockResolvedValueOnce({ status: "ok", data: "queue-2" });
+    const recover = vi.fn(async () => {});
+
+    await expect(dispatchPiPromptWithRecovery(dispatch, recover)).resolves.toEqual({
+      status: "ok",
+      data: "queue-2",
+    });
+    expect(recover).toHaveBeenCalledOnce();
+    expect(dispatch).toHaveBeenCalledTimes(2);
+  });
+
+  it("surfaces provider errors without restarting or redelivering", async () => {
+    const dispatch = vi.fn(async () => ({
+      status: "error" as const,
+      error: "500 Internal server error",
+    }));
+    const recover = vi.fn(async () => {});
+
+    await expect(dispatchPiPromptWithRecovery(dispatch, recover)).resolves.toEqual({
+      status: "error",
+      error: "500 Internal server error",
+    });
+    expect(recover).not.toHaveBeenCalled();
+    expect(dispatch).toHaveBeenCalledOnce();
   });
 });
 

--- a/apps/screenpipe-app-tauri/components/chat/standalone/hooks/use-pi-send-transport.ts
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/hooks/use-pi-send-transport.ts
@@ -60,6 +60,39 @@ export async function awaitPendingPiPresetSwitch(
 }
 
 /**
+ * Failures that happen before Pi accepts a prompt and are safe to redeliver
+ * after replacing the process. Provider/model errors are intentionally absent:
+ * retrying those would duplicate billing or hide an upstream failure.
+ */
+export function isRecoverablePiPromptDispatchError(error: string): boolean {
+  const normalized = error.toLowerCase();
+  return (
+    isPiPromptStartTimeout(error) ||
+    normalized.includes("pi not initialized") ||
+    normalized.includes("pi is not running") ||
+    normalized.includes("pi process has died") ||
+    normalized.includes("pi process died during") ||
+    normalized.includes("pi command queue dropped") ||
+    normalized.includes("pi command queue closed") ||
+    normalized.includes("stdin write failed") ||
+    normalized.includes("pi session restarted while preparing prompt")
+  );
+}
+
+export async function dispatchPiPromptWithRecovery<T>(
+  dispatch: () => Promise<Result<T, string>>,
+  recover: (error: string) => Promise<void>,
+): Promise<Result<T, string>> {
+  const first = await dispatch();
+  if (first.status !== "error" || !isRecoverablePiPromptDispatchError(first.error)) {
+    return first;
+  }
+
+  await recover(first.error);
+  return dispatch();
+}
+
+/**
  * Wait for a background start to finish before dispatching a prompt.
  *
  * ACP processes can report `running` before their initialize/auth handshake is
@@ -783,48 +816,54 @@ export function usePiSendTransport(options: PiSendTransportOptions) {
         return;
       }
 
-      // Send prompt — abort/new_session now await completion, so no retry needed
+      // Send prompt. If the process failed before accepting it, replace that
+      // exact session and redeliver once. The native prompt-start watchdog
+      // stops a silent process before returning its timeout, so this cannot
+      // overlap a still-running copy of the turn.
       const displayPreview = queuedPreviewForText(displayLabel ?? displayUserMessage);
-      let result = await commands.piPrompt(
-        turnSessionId,
-        promptMessage,
-        piImages.length > 0 ? piImages : null,
-        displayPreview,
-      );
-
-      // Race: user hit "+ NEW" before Pi finished registering the new session
-      // in the pool. Auto-spawn once and retry before surfacing the error.
-      if (result.status === "error" && result.error.includes("Pi not initialized")) {
-        console.log("[Pi] session not registered yet — auto-spawning and retrying");
-        try {
-          const dir = await piProjectDirForSession(turnSessionId);
-          const providerConfig = buildProviderConfig(attemptPreset);
-          const startRes = await commands.piStart(
-            turnSessionId,
-            dir,
-            settings.user?.token ?? null,
-            providerConfig,
-          );
-          if (startRes.status === "ok" && startRes.data.running) {
-            if (isAttemptForeground()) {
-              setPiInfo(startRes.data);
-              piSessionSyncedRef.current = false;
-              if (providerConfig) {
-                setRunningConfigFromProviderConfig(providerConfig);
-              }
-            }
-            syncThinkingLevelAfterStart(turnSessionId);
-            result = await commands.piPrompt(
-              turnSessionId,
-              promptMessage,
-              piImages.length > 0 ? piImages : null,
-              displayPreview,
-            );
-          }
-        } catch (e) {
-          console.error("[Pi] auto-spawn retry failed", e);
+      const dispatchPrompt = () =>
+        commands.piPrompt(
+          turnSessionId,
+          promptMessage,
+          piImages.length > 0 ? piImages : null,
+          displayPreview,
+        );
+      const result = await dispatchPiPromptWithRecovery(dispatchPrompt, async (error) => {
+        console.warn(
+          "[Pi] prompt was not accepted — replacing process and retrying once:",
+          error,
+        );
+        // `piStart` reuses an identical live process. Explicitly stop first so
+        // a queue whose drain task closed while the child stayed alive cannot
+        // be mistaken for a healthy reusable session.
+        const stopRes = await commands.piStop(turnSessionId);
+        if (stopRes.status === "error") {
+          throw new Error(stopRes.error);
         }
-      }
+        const dir = await piProjectDirForSession(turnSessionId);
+        const providerConfig = buildProviderConfig(attemptPreset);
+        const startRes = await commands.piStart(
+          turnSessionId,
+          dir,
+          settings.user?.token ?? null,
+          providerConfig,
+        );
+        if (startRes.status !== "ok" || !startRes.data.running) {
+          throw new Error(
+            startRes.status === "error"
+              ? startRes.error
+              : startRes.data.startupError ?? "AI assistant did not restart",
+          );
+        }
+        if (isAttemptForeground()) {
+          setPiInfo(startRes.data);
+          piSessionSyncedRef.current = false;
+          if (providerConfig) {
+            setRunningConfigFromProviderConfig(providerConfig);
+          }
+        }
+        syncThinkingLevelAfterStart(turnSessionId);
+      });
 
       if (result.status === "error") {
         if (timeoutId) clearTimeout(timeoutId);


### PR DESCRIPTION
## Summary

- replace the exact chat sidecar and redeliver once when a prompt fails before Pi accepts it
- cover the native prompt-start watchdog plus queue/process lifecycle races that were previously surfaced as `start_timeout` or `prompt_dispatch`
- keep provider, model, quota, context, and upstream network failures terminal; they are never auto-retried

This is limited to desktop Chat transport and its focused regression test. Activities are untouched.

## Root cause

The native queue already distinguishes acceptance from a long-running turn. PR #5563 added a 15-second prompt-start watchdog, stops a process that emits no acceptance signal, and returns a retryable error. The desktop transport then immediately settled the user's durable turn as failed. It only had automatic recovery for one literal race (`Pi not initialized`), so a stopped watchdog process, a dropped/closed queue, a dead process, a failed stdin write, or a concurrent process replacement all required the user to press Retry.

PR #5659 made these process/queue failures more explicit and request-correlated, but the send boundary still did not redeliver the already-durable user turn after a safe fresh-process recovery.

The fix classifies only errors emitted by Screenpipe before prompt acceptance, explicitly stops the exact session so `piStart` cannot reuse a live child with a closed drain queue, starts it with the send-time preset, and dispatches the same durable turn once more. A second failure follows the existing visible error path; there is no retry loop.

## Evidence

Live PostHog baseline for the 14 days ending 2026-08-25:

- 1,560 `chat_response_error` events / 458 users out of 19,025 `chat_message_sent` events
- current week: 7.7 errors per 100 messages
- Screenpipe Cloud: 624 `prompt_dispatch` events / 247 users and 455 `start_timeout` events / 214 users
- custom providers: 135 `prompt_dispatch` events / 25 users

Deterministic before/after acceptance flow:

```text
before
prompt durable -> dispatch -> no acceptance / internal queue race
               -> process stopped or unavailable
               -> visible failed turn -> user must press Retry

after
prompt durable -> dispatch -> no acceptance / internal queue race
               -> stop exact session -> fresh start -> redeliver once
               -> accepted: normal unlimited turn
               -> second failure: existing visible failed-turn path

provider/API/model error -> existing visible failed-turn path (no restart, no redelivery)
```

The regression suite asserts both boundaries: watchdog recovery dispatches exactly twice with one process replacement, while rate limits, 5xx, invalid keys, model restrictions, context overflow, and an upstream broken pipe dispatch exactly once and are returned unchanged.

## Historical intent

- `29689145de` / PR #5563: introduced the prompt-start watchdog to release silent hangs while preserving unlimited duration after a prompt is accepted. Preserved here; this change does not alter the watchdog or add a turn-duration timeout.
- `c1aacfcc97` / PR #5659: correlated queue lifecycle by request id and stopped draining follow-ups into a wedged process. Preserved here; retry happens only after the exact prompt was not accepted and the exact session is stopped.
- Existing provider-error behavior remains authoritative: upstream failures are shown with their actionable error presentation and are not hidden by automatic retry.

## Tests

Run after rebasing onto `upstream/main` (`845dc283e9`):

- `bun x vitest run --config vitest.config.ts components/chat/standalone/hooks/__tests__/pi-preset-switch.test.tsx` — 21 passed, 0 failed
- `bun x eslint components/chat/standalone/hooks/use-pi-send-transport.ts components/chat/standalone/hooks/__tests__/pi-preset-switch.test.tsx` — passed
- `bun x tsc --noEmit --pretty false` — passed
- `git diff --check upstream/main...HEAD` — passed
- `SEM_NO_TELEMETRY=1 sem diff upstream/main..HEAD --format plain --no-cosmetics` — 2 files; expected transport helper/send path and focused tests only
