### PR TITLE
fix(timeline): recover daily summary runtime starts

### DIFF
--- a/apps/screenpipe-app-tauri/components/rewind/timeline/daily-summary.test.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/timeline/daily-summary.test.tsx
@@ -327,6 +327,7 @@ describe("TimelineDailySummary", () => {
 				preset: PIPE_PRESET,
 				userToken: "test-token",
 				signal: expect.any(AbortSignal),
+				recoverTransientRuntimeStart: true,
 			}),
 		);
 		expect(
@@ -340,6 +341,39 @@ describe("TimelineDailySummary", () => {
 				format_valid: true,
 			}),
 		);
+	});
+
+	it("records an explicit terminal event when generation is cancelled", async () => {
+		mocks.settings.enhancedAI = true;
+		mocks.runDailySummaryWithPi.mockImplementation(
+			({ signal }: { signal: AbortSignal }) =>
+				new Promise((_resolve, reject) => {
+					signal.addEventListener(
+						"abort",
+						() => {
+							const error = new Error("daily summary generation aborted");
+							error.name = "AbortError";
+							reject(error);
+						},
+						{ once: true },
+					);
+				}),
+		);
+		render(<TimelineDailySummary currentDate={new Date(2026, 6, 25)} />);
+
+		fireEvent.click(screen.getByTestId("timeline-daily-summary-trigger"));
+		fireEvent.click(
+			await screen.findByRole("button", {
+				name: "Stop and close daily summary",
+			}),
+		);
+
+		await waitFor(() => {
+			expect(mocks.posthogCapture).toHaveBeenCalledWith(
+				"timeline_daily_summary_cancelled",
+				expect.objectContaining({ reason: "panel_closed" }),
+			);
+		});
 	});
 
 	it("offers a plan upgrade instead of a bare retry when the usage limit is hit", async () => {

--- a/apps/screenpipe-app-tauri/components/rewind/timeline/daily-summary.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/timeline/daily-summary.tsx
@@ -172,7 +172,7 @@ export function TimelineDailySummary({
 	);
 
 	useEffect(() => {
-		abortRef.current?.abort();
+		abortRef.current?.abort("selection_changed_or_unmounted");
 		const cached = readCachedSummary(currentDate);
 		setSummary(cached);
 		setStatus(cached ? "complete" : "idle");
@@ -181,7 +181,8 @@ export function TimelineDailySummary({
 		setCopied(false);
 		setPanelOpen(false);
 
-		return () => abortRef.current?.abort();
+		return () =>
+			abortRef.current?.abort("selection_changed_or_unmounted");
 		// `dateId` deliberately represents the selected local calendar day.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [dateId]);
@@ -200,7 +201,7 @@ export function TimelineDailySummary({
 				return;
 			}
 
-			abortRef.current?.abort();
+			abortRef.current?.abort("superseded");
 			const controller = new AbortController();
 			abortRef.current = controller;
 			const requestedDate = new Date(currentDate);
@@ -226,6 +227,7 @@ export function TimelineDailySummary({
 					preset: dailySummaryPreset,
 					userToken: token,
 					signal: controller.signal,
+					recoverTransientRuntimeStart: true,
 				});
 				const formatFailures = evaluateDailySummaryFormat(completedSummary);
 
@@ -247,6 +249,14 @@ export function TimelineDailySummary({
 					generationError instanceof Error &&
 					generationError.name === "AbortError"
 				) {
+					posthog.capture("timeline_daily_summary_cancelled", {
+						selected_date: dateId,
+						duration_ms: Math.round(performance.now() - startedAt),
+						reason:
+							typeof controller.signal.reason === "string"
+								? controller.signal.reason
+								: "aborted",
+					});
 					return;
 				}
 				console.error("daily summary generation failed", generationError);
@@ -348,7 +358,7 @@ export function TimelineDailySummary({
 
 	const closePanel = useCallback(() => {
 		if (isGenerating) {
-			abortRef.current?.abort();
+			abortRef.current?.abort("panel_closed");
 			setStatus("idle");
 			setSummary("");
 		}

--- a/apps/screenpipe-app-tauri/lib/daily-summary-pi.test.ts
+++ b/apps/screenpipe-app-tauri/lib/daily-summary-pi.test.ts
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
   registerForeground: vi.fn(),
   mountAgentEventBus: vi.fn(),
   piStart: vi.fn(),
+  piStartAndPrompt: vi.fn(),
   piPrompt: vi.fn(),
   piStop: vi.fn(),
   homeDir: vi.fn(),
@@ -42,6 +43,7 @@ vi.mock("@tauri-apps/api/path", () => ({
 vi.mock("@/lib/utils/tauri", () => ({
   commands: {
     piStart: mocks.piStart,
+    piStartAndPrompt: mocks.piStartAndPrompt,
     piPrompt: mocks.piPrompt,
     piStop: mocks.piStop,
   },
@@ -57,6 +59,7 @@ describe("runDailySummaryWithPi", () => {
       status: "ok",
       data: { running: true },
     });
+    mocks.piStartAndPrompt.mockResolvedValue({ status: "ok", data: "accepted" });
     mocks.piStop.mockResolvedValue({ status: "ok", data: { running: false } });
   });
 
@@ -82,7 +85,7 @@ describe("runDailySummaryWithPi", () => {
       handler = nextHandler;
       return unregister;
     });
-    mocks.piPrompt.mockImplementation(async () => {
+    mocks.piStartAndPrompt.mockImplementation(async () => {
       queueMicrotask(() => {
         handler?.({
           event: {
@@ -107,10 +110,11 @@ describe("runDailySummaryWithPi", () => {
       },
       preset: PRESET,
       userToken: "user-token",
+      recoverTransientRuntimeStart: true,
     });
 
     expect(result).toBe("Final daily summary");
-    expect(mocks.piStart).toHaveBeenCalledWith(
+    expect(mocks.piStartAndPrompt).toHaveBeenCalledWith(
       expect.stringContaining("daily-summary"),
       "/Users/test/.screenpipe/pi-daily-summary",
       "user-token",
@@ -121,13 +125,9 @@ describe("runDailySummaryWithPi", () => {
           "private Timeline daily-summary agent",
         ),
       }),
-    );
-    expect(mocks.piPrompt).toHaveBeenCalledWith(
-      expect.stringContaining("daily-summary"),
       expect.stringContaining("start_time: 2026-07-25T07:00:00.000Z"),
-      null,
-      null,
     );
+    expect(mocks.piPrompt).not.toHaveBeenCalled();
     expect(unregister).toHaveBeenCalledOnce();
     expect(mocks.piStop).toHaveBeenCalledOnce();
   });
@@ -182,37 +182,36 @@ describe("runDailySummaryWithPi", () => {
       handler = nextHandler;
       return vi.fn();
     });
-    mocks.piPrompt
-      .mockImplementationOnce(async () => {
-        queueMicrotask(() => {
-          handler?.({
-            event: {
-              type: "agent_end",
-              messages: [
-                { role: "assistant", content: [{ type: "toolCall" }] },
-                { role: "toolResult", content: "source evidence" },
-              ],
-            },
-          });
+    mocks.piStartAndPrompt.mockImplementation(async () => {
+      queueMicrotask(() => {
+        handler?.({
+          event: {
+            type: "agent_end",
+            messages: [
+              { role: "assistant", content: [{ type: "toolCall" }] },
+              { role: "toolResult", content: "source evidence" },
+            ],
+          },
         });
-        return { status: "ok", data: null };
-      })
-      .mockImplementationOnce(async () => {
-        queueMicrotask(() => {
-          handler?.({
-            event: {
-              type: "agent_end",
-              messages: [
-                {
-                  role: "assistant",
-                  content: [{ type: "text", text: "Recovered summary" }],
-                },
-              ],
-            },
-          });
-        });
-        return { status: "ok", data: null };
       });
+      return { status: "ok", data: "accepted" };
+    });
+    mocks.piPrompt.mockImplementation(async () => {
+      queueMicrotask(() => {
+        handler?.({
+          event: {
+            type: "agent_end",
+            messages: [
+              {
+                role: "assistant",
+                content: [{ type: "text", text: "Recovered summary" }],
+              },
+            ],
+          },
+        });
+      });
+      return { status: "ok", data: null };
+    });
 
     await expect(
       runDailySummaryWithPi({
@@ -220,10 +219,11 @@ describe("runDailySummaryWithPi", () => {
         range: { start: "start", end: "end" },
         preset: PRESET,
         userToken: "user-token",
+        recoverTransientRuntimeStart: true,
       }),
     ).resolves.toBe("Recovered summary");
 
-    expect(mocks.piPrompt).toHaveBeenCalledTimes(2);
+    expect(mocks.piPrompt).toHaveBeenCalledOnce();
     expect(mocks.piPrompt).toHaveBeenLastCalledWith(
       expect.stringContaining("daily-summary"),
       expect.stringContaining("without a final response"),
@@ -238,6 +238,10 @@ describe("runDailySummaryWithPi", () => {
       handler = nextHandler;
       return vi.fn();
     });
+    mocks.piStartAndPrompt.mockImplementation(async () => {
+      queueMicrotask(() => handler?.({ event: { type: "agent_end" } }));
+      return { status: "ok", data: "accepted" };
+    });
     mocks.piPrompt.mockImplementation(async () => {
       queueMicrotask(() => handler?.({ event: { type: "agent_end" } }));
       return { status: "ok", data: null };
@@ -249,9 +253,50 @@ describe("runDailySummaryWithPi", () => {
         range: { start: "start", end: "end" },
         preset: PRESET,
         userToken: "user-token",
+        recoverTransientRuntimeStart: true,
       }),
     ).rejects.toThrow("AI returned an empty daily summary");
-    expect(mocks.piPrompt).toHaveBeenCalledTimes(2);
+    expect(mocks.piPrompt).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    "Pi command queue dropped",
+    "AI agent did not start responding within its startup grace period",
+  ])("restarts once after a transient runtime start failure: %s", async (reason) => {
+    let handler: ((envelope: any) => void) | null = null;
+    mocks.registerForeground.mockImplementation((_sessionId, nextHandler) => {
+      handler = nextHandler;
+      return vi.fn();
+    });
+    mocks.piStartAndPrompt
+      .mockResolvedValueOnce({ status: "error", error: reason })
+      .mockImplementationOnce(async () => {
+        queueMicrotask(() => {
+          handler?.({
+            event: {
+              type: "agent_end",
+              messages: [{ role: "assistant", content: "Recovered summary" }],
+            },
+          });
+        });
+        return { status: "ok", data: "accepted" };
+      });
+
+    await expect(
+      runDailySummaryWithPi({
+        date: new Date(2026, 7, 18),
+        range: { start: "start", end: "end" },
+        preset: PRESET,
+        userToken: "user-token",
+        recoverTransientRuntimeStart: true,
+      }),
+    ).resolves.toBe("Recovered summary");
+
+    expect(mocks.piStartAndPrompt).toHaveBeenCalledTimes(2);
+    expect(mocks.piStartAndPrompt.mock.calls[0]?.[0]).not.toBe(
+      mocks.piStartAndPrompt.mock.calls[1]?.[0],
+    );
+    expect(mocks.piStop).toHaveBeenCalledTimes(2);
   });
 
   it("preserves a terminal provider error from message_end", async () => {
@@ -260,7 +305,7 @@ describe("runDailySummaryWithPi", () => {
       handler = nextHandler;
       return vi.fn();
     });
-    mocks.piPrompt.mockImplementation(async () => {
+    mocks.piStartAndPrompt.mockImplementation(async () => {
       queueMicrotask(() => {
         handler?.({
           event: {
@@ -275,7 +320,7 @@ describe("runDailySummaryWithPi", () => {
           },
         });
       });
-      return { status: "ok", data: null };
+      return { status: "ok", data: "accepted" };
     });
 
     await expect(
@@ -284,9 +329,10 @@ describe("runDailySummaryWithPi", () => {
         range: { start: "start", end: "end" },
         preset: PRESET,
         userToken: "user-token",
+        recoverTransientRuntimeStart: true,
       }),
     ).rejects.toThrow("hosted_ai_allowance_exceeded");
-    expect(mocks.piPrompt).toHaveBeenCalledOnce();
+    expect(mocks.piStartAndPrompt).toHaveBeenCalledOnce();
   });
 
   it("preserves a terminal provider error carried only by agent_end", async () => {
@@ -295,7 +341,7 @@ describe("runDailySummaryWithPi", () => {
       handler = nextHandler;
       return vi.fn();
     });
-    mocks.piPrompt.mockImplementation(async () => {
+    mocks.piStartAndPrompt.mockImplementation(async () => {
       queueMicrotask(() => {
         handler?.({
           event: {
@@ -311,7 +357,7 @@ describe("runDailySummaryWithPi", () => {
           },
         });
       });
-      return { status: "ok", data: null };
+      return { status: "ok", data: "accepted" };
     });
 
     await expect(
@@ -320,14 +366,18 @@ describe("runDailySummaryWithPi", () => {
         range: { start: "start", end: "end" },
         preset: PRESET,
         userToken: "user-token",
+        recoverTransientRuntimeStart: true,
       }),
     ).rejects.toThrow("rate_limit_exceeded");
-    expect(mocks.piPrompt).toHaveBeenCalledOnce();
+    expect(mocks.piStartAndPrompt).toHaveBeenCalledOnce();
   });
 
   it("stops the Pi session when the request is aborted", async () => {
     mocks.registerForeground.mockReturnValue(vi.fn());
-    mocks.piPrompt.mockResolvedValue({ status: "ok", data: null });
+    mocks.piStartAndPrompt.mockResolvedValue({
+      status: "ok",
+      data: "accepted",
+    });
     const controller = new AbortController();
     const running = runDailySummaryWithPi({
       date: new Date(2026, 6, 25),
@@ -335,9 +385,12 @@ describe("runDailySummaryWithPi", () => {
       preset: PRESET,
       userToken: "user-token",
       signal: controller.signal,
+      recoverTransientRuntimeStart: true,
     });
 
-    await vi.waitFor(() => expect(mocks.piPrompt).toHaveBeenCalledOnce());
+    await vi.waitFor(() =>
+      expect(mocks.piStartAndPrompt).toHaveBeenCalledOnce(),
+    );
     controller.abort();
 
     await expect(running).rejects.toMatchObject({ name: "AbortError" });

--- a/apps/screenpipe-app-tauri/lib/daily-summary-pi.ts
+++ b/apps/screenpipe-app-tauri/lib/daily-summary-pi.ts
@@ -23,6 +23,8 @@ import { applyResolvedModelLimits } from "@/lib/model-metadata";
 const DAILY_SUMMARY_PROJECT_DIR = "pi-daily-summary";
 const EMPTY_COMPLETION_PROMPT =
   "Your previous turn ended after tool execution without a final response. Using the tool results already in this session, return the requested final response now. Do not call tools again.";
+const RETRYABLE_RUNTIME_START_ERROR =
+  /Pi command queue (?:dropped|closed)|did not start responding within|Pi command queue not initialized|Pi not initialized|not running|has died|broken pipe/i;
 
 export type RunDailySummaryOptions = {
   date: Date;
@@ -33,6 +35,7 @@ export type RunDailySummaryOptions = {
   prompt?: string;
   systemPrompt?: string;
   sessionPrefix?: string;
+  recoverTransientRuntimeStart?: boolean;
 };
 
 export function buildDailySummaryProviderConfig(
@@ -118,19 +121,12 @@ function abortError(): Error {
   return error;
 }
 
-/** Run one isolated Pi turn and return only its final assistant response. */
-export async function runDailySummaryWithPi(
+async function runDailySummaryAttempt(
   options: RunDailySummaryOptions,
+  projectDir: string,
 ): Promise<string> {
-  if (options.signal?.aborted) throw abortError();
-  if (!options.preset.model?.trim())
-    throw new Error("No AI model is configured");
-
   const sessionPrefix = options.sessionPrefix?.trim() || "daily-summary";
   const sessionId = `${INTERNAL_TITLE_PREFIX}${sessionPrefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-  await mountAgentEventBus();
-  const home = await homeDir();
-  const projectDir = await join(home, ".screenpipe", DAILY_SUMMARY_PROJECT_DIR);
 
   let settled = false;
   let lastAssistant = "";
@@ -141,6 +137,9 @@ export async function runDailySummaryWithPi(
     resolveResponse = resolve;
     rejectResponse = reject;
   });
+  // Abort or dispatch failure can settle this while native startup is still in
+  // flight. Observe it immediately; the awaited return below still propagates it.
+  void response.catch(() => {});
 
   const settle = (value: string) => {
     if (settled) return;
@@ -207,35 +206,76 @@ export async function runDailySummaryWithPi(
   const unregister = registerForeground(sessionId, handler);
 
   try {
-    const started = await commands.piStart(
-      sessionId,
-      projectDir,
-      options.userToken,
-      buildDailySummaryProviderConfig(
-        options.preset,
-        options.systemPrompt ?? DAILY_SUMMARY_AGENT_SYSTEM_PROMPT,
-      ),
+    const providerConfig = buildDailySummaryProviderConfig(
+      options.preset,
+      options.systemPrompt ?? DAILY_SUMMARY_AGENT_SYSTEM_PROMPT,
     );
-    if (started.status !== "ok" || !started.data.running) {
-      throw new Error(
-        started.status === "error" ? started.error : "AI did not start",
-      );
-    }
-    if (options.signal?.aborted) return await response;
-
-    const prompted = await commands.piPrompt(
-      sessionId,
-      options.prompt ??
-        buildDailySummaryAgentPrompt(options.date, options.range),
-      null,
-      null,
-    );
-    if (prompted.status !== "ok") throw new Error(prompted.error);
+    const prompt =
+      options.prompt ?? buildDailySummaryAgentPrompt(options.date, options.range);
+    const accepted = options.recoverTransientRuntimeStart
+      ? commands.piStartAndPrompt(
+          sessionId,
+          projectDir,
+          options.userToken,
+          providerConfig,
+          prompt,
+        )
+      : (async () => {
+          const started = await commands.piStart(
+            sessionId,
+            projectDir,
+            options.userToken,
+            providerConfig,
+          );
+          if (started.status !== "ok" || !started.data.running) {
+            return started.status === "error"
+              ? started
+              : ({ status: "error", error: "AI did not start" } as const);
+          }
+          return await commands.piPrompt(sessionId, prompt, null, null);
+        })();
+    void accepted
+      .then((result) => {
+        if (result.status === "error") fail(new Error(result.error));
+      })
+      .catch((reason: unknown) => {
+        fail(reason instanceof Error ? reason : new Error(String(reason)));
+      });
 
     return await response;
   } finally {
     options.signal?.removeEventListener("abort", handleAbort);
     unregister();
     void commands.piStop(sessionId);
+  }
+}
+
+/** Run one isolated Pi turn and return only its final assistant response. */
+export async function runDailySummaryWithPi(
+  options: RunDailySummaryOptions,
+): Promise<string> {
+  if (options.signal?.aborted) throw abortError();
+  if (!options.preset.model?.trim())
+    throw new Error("No AI model is configured");
+
+  await mountAgentEventBus();
+  const home = await homeDir();
+  const projectDir = await join(home, ".screenpipe", DAILY_SUMMARY_PROJECT_DIR);
+
+  try {
+    return await runDailySummaryAttempt(options, projectDir);
+  } catch (error) {
+    if (
+      options.signal?.aborted ||
+      !options.recoverTransientRuntimeStart ||
+      !(error instanceof Error) ||
+      !RETRYABLE_RUNTIME_START_ERROR.test(error.message)
+    ) {
+      throw error;
+    }
+    // The native prompt-start watchdog has already stopped a silent runtime.
+    // A dropped/closed queue likewise cannot accept more work. Use a fresh
+    // private session once instead of making the user manually retry.
+    return await runDailySummaryAttempt(options, projectDir);
   }
 }


### PR DESCRIPTION
## Summary

- dispatch Timeline daily-summary startup and its first prompt atomically through the existing native command
- retry once with a fresh private session after a dropped/closed Pi queue, prompt-start grace timeout, dead runtime, or broken pipe
- emit a terminal cancellation event with its reason so aborted starts no longer disappear from telemetry
- keep the recovery opt-in Timeline-only; Activity generation retains its existing runtime path

## Evidence

Live PostHog baseline for the 14 days ending 2026-08-25:

- 201 generation starts
- 40 successful generations
- 72 failures across 39 users
- top failures: Pi command queue dropped (32), empty daily summary (12), prompt-start grace timeout (12), generation timeout (10)
- current-week generation rate 23.7%; failure rate 32.2%; many starts had no terminal event

Lifecycle before:

```text
Timeline -> pi_start -> WebView round trip -> pi_prompt
                                      \-> queue/start failure -> user retry
AbortError -> no terminal telemetry
```

Lifecycle after:

```text
Timeline -> pi_start_and_prompt
             | transient queue/start failure
             -> stop attempt -> fresh private session -> retry once
AbortError -> timeline_daily_summary_cancelled(reason)
```

The shared runner already performs one continuation when a turn ends empty after tool execution; focused coverage preserves the final empty-output failure after that recovery is exhausted. The earlier flat generation deadline is not reintroduced.

## Historical intent

- f009ad3e918 / #5471 introduced isolated, explicit, on-demand Timeline summaries. This PR preserves the private session, selected-day boundary, local cache, and explicit stop behavior.
- 222fa009bf introduced pi_start_and_prompt specifically so foreground event consumers do not round-trip between readiness and first-prompt acceptance. Timeline now uses that existing invariant.
- 20b0254f07 / #6391 removed the shared client-side generation deadline; this PR preserves the no-flat-deadline behavior.
- ad1375c7a1 / #6400 added one empty-completion continuation; its expectation remains unchanged.

## Validation

- `bun run test:daily-summary-prompt-evals` — 3 files passed, 27 tests passed
- `bun x tsc --noEmit` — passed
- `bun x eslint components/rewind/timeline/daily-summary.tsx components/rewind/timeline/daily-summary.test.tsx lib/daily-summary-pi.ts lib/daily-summary-pi.test.ts` — passed
- `git diff --check` — passed

No native build was run: this uses an existing generated Tauri command and the changed behavior is fully at the TypeScript orchestration boundary.
