### PR TITLE
fix(updater): stop failed macOS restart loops

### DIFF
--- a/apps/screenpipe-app-tauri/e2e/mock-updates/updater-harness.ts
+++ b/apps/screenpipe-app-tauri/e2e/mock-updates/updater-harness.ts
@@ -24,6 +24,7 @@ import path from 'node:path';
 const SIGNING_PASSWORD = 'screenpipe-local-updater-e2e';
 const CARGO_PROFILE    = 'release-local';
 const PORT             = 8765;
+const TAURI_CLI        = ['bunx', '--bun', '@tauri-apps/cli@2.11.2'];
 
 // ── Paths ──────────────────────────────────────────────────────────────────────
 
@@ -76,7 +77,7 @@ function ensureSigning(): void {
   if (!existsSync(PRIVATE_KEY)) {
     console.info('[updater-local] generating dev minisign keypair…');
     const gen = Bun.spawnSync(
-      ['bun', 'x', 'tauri', 'signer', 'generate', '-w', PRIVATE_KEY, '--ci', '--password', SIGNING_PASSWORD],
+      [...TAURI_CLI, 'signer', 'generate', '-w', PRIVATE_KEY, '--ci', '--password', SIGNING_PASSWORD],
       { cwd: APP_ROOT, stdin: 'ignore', stderr: 'inherit', stdout: 'inherit' },
     );
     if (gen.exitCode !== 0) throw new Error('tauri signer generate failed (exit ' + gen.exitCode + ')');
@@ -123,7 +124,7 @@ function cmdBuild(argv: string[]): void {
 
   const features = ['official-build', ...extraFeatures].join(',');
   let env: Record<string, string | undefined> = { ...process.env };
-  let tauriArgs = ['bun', 'x', 'tauri', 'build', '--features', features, '--config', cfgE2e];
+  let tauriArgs = [...TAURI_CLI, 'build', '--features', features, '--config', cfgE2e];
 
   if (appVersion) {
     if (!/^\d+\.\d+\.\d+$/.test(appVersion)) {

--- a/apps/screenpipe-app-tauri/src-tauri/src/updates.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/updates.rs
@@ -11,6 +11,8 @@ use dark_light::Mode;
 use log::{debug, error, info, warn};
 use semver::Version;
 use serde_json;
+#[cfg(any(target_os = "macos", test))]
+use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -257,7 +259,8 @@ const BANNER_GATE_TIMEOUT_SECS: u64 = 60;
 /// inflated the `app_downloaded` metric ~12x. While a version is in cooldown
 /// we still hit the cheap CHECK endpoint but skip the binary download until
 /// the window elapses, a newer version ships, or the user retries manually
-/// (which passes `force=true`). In-memory only — a restart re-attempts once.
+/// (which passes `force=true`). A durable failed-install marker carries the
+/// cooldown across the relaunch that discovered the failure.
 const UPDATE_FAILURE_COOLDOWN: Duration = Duration::from_secs(6 * 60 * 60);
 
 /// Wait for boot to reach a settled state, with timeout. Logs the
@@ -599,6 +602,27 @@ fn failed_version_in_cooldown(
     matches!(last_failed, Some((v, elapsed)) if v == version && elapsed < cooldown)
 }
 
+/// Carry a failed exit-path install into the existing per-version cooldown.
+/// Without this bridge, the durable marker added in #6147 reports the failure
+/// but the boot check immediately downloads, restarts, and fails again.
+fn cooldown_from_failed_attempt(
+    failed_attempt: Option<&UpdateAttempt>,
+) -> Option<(String, std::time::Instant)> {
+    failed_attempt.map(|attempt| (attempt.to_version.clone(), std::time::Instant::now()))
+}
+
+/// The Tauri updater replaces the bundle containing its configured executable.
+/// Gatekeeper App Translocation and mounted disk images are read-only launch
+/// locations, so attempting an in-place update there can only relaunch the old
+/// version. macOS requires the user to move the app to an install location.
+#[cfg(any(target_os = "macos", test))]
+fn macos_update_location_is_protected(executable: &Path) -> bool {
+    executable
+        .components()
+        .any(|component| component.as_os_str() == "AppTranslocation")
+        || executable.starts_with("/Volumes")
+}
+
 /// Whether `candidate` is a strictly higher semantic version than `current`.
 /// On parse failure of either string this returns `false` (falls back to the
 /// exact-string semantics of `failed_version_in_cooldown`), so a malformed
@@ -804,6 +828,7 @@ impl UpdatesManager {
 
         // Did the previous process quit to apply an update that never landed?
         let failed_attempt = consume_update_attempt_marker(app);
+        let last_failed_update = cooldown_from_failed_attempt(failed_attempt.as_ref());
 
         let update_menu_item = if is_enterprise_build(app) {
             None
@@ -832,7 +857,7 @@ impl UpdatesManager {
             app: app.clone(),
             update_menu_item,
             is_checking: AtomicBool::new(false),
-            last_failed_update: Arc::new(Mutex::new(None)),
+            last_failed_update: Arc::new(Mutex::new(last_failed_update)),
         })
     }
 
@@ -889,6 +914,31 @@ impl UpdatesManager {
         if cfg!(debug_assertions) {
             info!("dev mode is enabled, skipping update check");
             return Result::Ok(false);
+        }
+
+        #[cfg(target_os = "macos")]
+        if let Ok(executable) = std::env::current_exe() {
+            if macos_update_location_is_protected(&executable) {
+                warn!(
+                    "updater disabled: app is running from protected macOS location {}",
+                    executable.display()
+                );
+                if let Some(ref item) = self.update_menu_item {
+                    item.set_enabled(true)?;
+                    item.set_text("Move screenpipe to Applications to update")?;
+                }
+                if show_dialog {
+                    self.app
+                        .dialog()
+                        .message(
+                            "Quit screenpipe, move screenpipe.app to Applications, then reopen it. macOS prevents apps launched from Downloads or a disk image from updating themselves.",
+                        )
+                        .title("Move screenpipe to Applications")
+                        .buttons(MessageDialogButtons::Ok)
+                        .show(|_| {});
+                }
+                return Result::Ok(false);
+            }
         }
 
         if let Err(err) = self.app.emit("update-all-pipes", ()) {
@@ -1798,6 +1848,43 @@ mod tests {
             "2.5.57",
             UPDATE_FAILURE_COOLDOWN
         ));
+    }
+
+    #[test]
+    fn failed_install_marker_arms_the_existing_cooldown_on_boot() {
+        let attempt = UpdateAttempt {
+            from_version: "2.6.77".into(),
+            to_version: "2.6.81".into(),
+            ts_epoch_secs: 0,
+        };
+        let cooldown = cooldown_from_failed_attempt(Some(&attempt));
+        assert!(failed_version_in_cooldown(
+            cooldown
+                .as_ref()
+                .map(|(version, started)| (version.as_str(), started.elapsed())),
+            "2.6.81",
+            UPDATE_FAILURE_COOLDOWN,
+        ));
+    }
+
+    #[test]
+    fn protected_macos_launch_locations_cannot_self_update() {
+        assert!(macos_update_location_is_protected(Path::new(
+            "/private/var/folders/xx/T/AppTranslocation/UUID/d/screenpipe.app/Contents/MacOS/screenpipe-app"
+        )));
+        assert!(macos_update_location_is_protected(Path::new(
+            "/Volumes/screenpipe/screenpipe.app/Contents/MacOS/screenpipe-app"
+        )));
+    }
+
+    #[test]
+    fn installed_macos_launch_locations_remain_updateable() {
+        assert!(!macos_update_location_is_protected(Path::new(
+            "/Applications/screenpipe.app/Contents/MacOS/screenpipe-app"
+        )));
+        assert!(!macos_update_location_is_protected(Path::new(
+            "/Users/ezra/Applications/screenpipe.app/Contents/MacOS/screenpipe-app"
+        )));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- stop macOS auto-update from attempting an in-place install when the app is running from Gatekeeper App Translocation or a mounted disk image; the tray now tells the user to move `screenpipe.app` to Applications
- carry a durable failed-install marker into the existing six-hour per-version cooldown so boot cannot immediately download, restart, and fail again
- pin the packaged updater harness to the repository's Tauri CLI version instead of resolving an obsolete unpinned CLI

No release, tag, updater pointer, publication action, or Activities code is touched.

## Live evidence / root cause

Sentry `SCREENPIPE-APP-K7` currently has 7,169 events across 47 users. The dominant user accounts for 47% of events and repeatedly reports `2.6.77 → 2.6.81` failures about every 38 seconds.

The recommended live event proves that process is running from:

```text
/private/var/.../AppTranslocation/.../screenpipe.app/Contents/MacOS/...
```

The Tauri updater derives its replacement bundle from the current executable. App Translocation and mounted DMGs are protected/read-only locations, so the install cannot replace that bundle and the old version relaunches.

The event storm is a separate regression in the same failure path: `consume_update_attempt_marker()` detects the failed install, but `UpdatesManager::new()` discarded the returned target version and initialized `last_failed_update` to `None`. The boot check therefore bypassed #4510's cooldown, downloaded the same target, waited 30 seconds, restarted, and failed again.

The live issue groups multiple install failures. App Translocation is proven for the dominant 47% user; the exact underlying cause for every other user is not claimed. Carrying the marker into the existing cooldown bounds every failed-install cause.

## Before / after evidence

```text
BEFORE
protected/translocated app → download + stage → restart → install cannot replace bundle
                                                  ↓
old version boots → marker reports failure → cooldown state is empty
                                                  ↓
boot check downloads same target → restart again (~38-second loop)

AFTER
protected/translocated app → no download/restart; tray says move to Applications

other failed install → old version boots → marker arms target-version cooldown
                                      ↓
cheap checks continue; same binary is not downloaded/restarted for 6 hours
(user retry and newer versions remain allowed)
```

## Historical intent

- `7e24c9e187` / #4510 introduced the six-hour per-version cooldown after a few Macs created unbounded updater download loops. This change restores that invariant across the later durable marker.
- `391d1e3789` / #6147 added failed-install detection and actionable tray feedback, but did not connect the consumed marker to `last_failed_update`. The new marker test closes that gap without changing its classification contract.
- `631b65b76a` / #5389 and `ead27f067b` / #6553 require macOS installs to stay deferred until exit and use the verified Tauri installer to preserve TCC grants. Those invariants remain unchanged.

## Validation

Passed:

- `cd apps/screenpipe-app-tauri && bun run test:tauri updates::tests`
  - 44 passed, 0 failed, 841 filtered out
- `git diff --check`
- `SEM_NO_TELEMETRY=1 sem diff --format plain --no-cosmetics`
- `bunx --bun @tauri-apps/cli@2.11.2 --version`
  - `tauri-cli 2.11.2`

Packaged updater E2E:

- `bun run test:e2e:packaged-updater:macos` is blocked before updater scenarios execute.
- The first attempt exposed the harness's unpinned `bun x tauri` resolving an obsolete `sharp` dependency; this PR pins the CLI and key generation then succeeds.
- After dependencies were installed with `bun install --frozen-lockfile`, the native build reported the shared `sccache` server had shut down and was falling back to local compilation, so it was stopped as required by repository policy.
- One retry after the cache recovered reached the generated release-local target but aborted in `mp3lame-sys` (`cd: mpglib: No such file or directory`) left by the interrupted build. No updater assertion failed or ran.
