### PR TITLE
fix(app): recover quarantined database in headless mode

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/db_recovery_notifications.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/db_recovery_notifications.rs
@@ -26,6 +26,18 @@ static RECOVERY_NOTICE_SHOWN: AtomicBool = AtomicBool::new(false);
 static RECOVERY_ACTIVE: AtomicBool = AtomicBool::new(false);
 static RECOVERY_QUIT_NOTICE_SHOWN: AtomicBool = AtomicBool::new(false);
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RecoveryInitiation {
+    UserAction,
+    HeadlessStartup,
+}
+
+impl RecoveryInitiation {
+    fn is_interactive(self) -> bool {
+        self == Self::UserAction
+    }
+}
+
 pub fn start(app: AppHandle) {
     let restart_app = app.clone();
     tauri::async_runtime::spawn(async move {
@@ -62,13 +74,7 @@ fn notify(app: &AppHandle, state: DbRecoveryState) {
         ),
     };
 
-    client::send_typed_with_priority(
-        title,
-        body,
-        "db_recovery",
-        None,
-        NotificationPriority::High,
-    );
+    client::send_typed_with_priority(title, body, "db_recovery", None, NotificationPriority::High);
 }
 
 fn recovery_action(label: &str) -> serde_json::Value {
@@ -119,41 +125,64 @@ pub fn notify_quarantined_database(data_dir: PathBuf) {
 /// immediately so the notification panel can close while work continues.
 pub fn start_quarantined_database_recovery(app: AppHandle) -> Result<(), String> {
     let data_dir = screenpipe_core::paths::default_screenpipe_data_dir();
+    start_quarantined_database_recovery_inner(app, data_dir, RecoveryInitiation::UserAction)
+}
+
+/// Headless launches have no UI in which to accept a recovery offer. Start the
+/// same protected offline recovery automatically and keep progress in logs.
+pub fn start_headless_quarantined_database_recovery(
+    app: AppHandle,
+    data_dir: PathBuf,
+) -> Result<(), String> {
+    start_quarantined_database_recovery_inner(app, data_dir, RecoveryInitiation::HeadlessStartup)
+}
+
+fn start_quarantined_database_recovery_inner(
+    app: AppHandle,
+    data_dir: PathBuf,
+    initiation: RecoveryInitiation,
+) -> Result<(), String> {
     let live = data_dir.join("db.sqlite");
     if !screenpipe_db::sqlite_quarantine_exists(&live) {
         return Err("the database no longer needs recovery".to_string());
     }
     if RECOVERY_ACTIVE.swap(true, Ordering::SeqCst) {
-        client::send_typed_with_priority(
-            "database repair already running",
-            "keep screenpipe open while it builds and verifies a fresh database.",
-            "db_recovery",
-            Some(8_000),
-            NotificationPriority::High,
-        );
+        if initiation.is_interactive() {
+            client::send_typed_with_priority(
+                "database repair already running",
+                "keep screenpipe open while it builds and verifies a fresh database.",
+                "db_recovery",
+                Some(8_000),
+                NotificationPriority::High,
+            );
+        }
         return Ok(());
     }
 
     RECOVERY_QUIT_NOTICE_SHOWN.store(false, Ordering::SeqCst);
-    client::send_typed_with_priority(
-        "repairing your database",
-        "your original data is protected. screenpipe is building and verifying a fresh copy. keep screenpipe open.",
-        "db_recovery",
-        Some(0),
-        NotificationPriority::High,
-    );
+    if initiation.is_interactive() {
+        client::send_typed_with_priority(
+            "repairing your database",
+            "your original data is protected. screenpipe is building and verifying a fresh copy. keep screenpipe open.",
+            "db_recovery",
+            Some(0),
+            NotificationPriority::High,
+        );
+    }
 
     tauri::async_runtime::spawn(async move {
         match screenpipe_engine::cli::db::recover_quarantined_database(&data_dir).await {
             Ok(()) => {
                 RECOVERY_ACTIVE.store(false, Ordering::SeqCst);
-                client::send_typed_with_priority(
-                    "database repaired",
-                    "your original database was preserved. screenpipe is reopening and checking recording.",
-                    "db_recovery",
-                    Some(0),
-                    NotificationPriority::High,
-                );
+                if initiation.is_interactive() {
+                    client::send_typed_with_priority(
+                        "database repaired",
+                        "your original database was preserved. screenpipe is reopening and checking recording.",
+                        "db_recovery",
+                        Some(0),
+                        NotificationPriority::High,
+                    );
+                }
                 crate::process_exit::request_app_relaunch(
                     app,
                     "database recovery complete",
@@ -163,19 +192,21 @@ pub fn start_quarantined_database_recovery(app: AppHandle) -> Result<(), String>
             Err(recovery_error) => {
                 RECOVERY_ACTIVE.store(false, Ordering::SeqCst);
                 error!("protected database recovery failed: {recovery_error:#}");
-                client::send_typed_with_actions_and_priority(
-                    "database repair paused",
-                    "your original data is still protected. screenpipe couldn't finish the repair. check free disk space, then retry. technical details were saved to the logs.",
-                    "db_recovery",
-                    Some(0),
-                    vec![recovery_action("retry repair"), dismiss_action()],
-                    NotificationPriority::High,
-                );
+                if initiation.is_interactive() {
+                    client::send_typed_with_actions_and_priority(
+                        "database repair paused",
+                        "your original data is still protected. screenpipe couldn't finish the repair. check free disk space, then retry. technical details were saved to the logs.",
+                        "db_recovery",
+                        Some(0),
+                        vec![recovery_action("retry repair"), dismiss_action()],
+                        NotificationPriority::High,
+                    );
+                }
             }
         }
     });
 
-    info!("protected database recovery requested from /notify");
+    info!(?initiation, "protected database recovery started");
     Ok(())
 }
 
@@ -230,5 +261,11 @@ mod tests {
         assert_eq!(action["type"], "dismiss");
         assert_eq!(action["label"], "not now");
         assert!(action.get("primary").is_none());
+    }
+
+    #[test]
+    fn headless_recovery_does_not_use_interactive_notifications() {
+        assert!(RecoveryInitiation::UserAction.is_interactive());
+        assert!(!RecoveryInitiation::HeadlessStartup.is_interactive());
     }
 }

--- a/apps/screenpipe-app-tauri/src-tauri/src/db_relaunch.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/db_relaunch.rs
@@ -91,7 +91,10 @@ pub async fn surface_manual_recovery(reason: &str) {
 /// Report a durable quarantine found at launch through the existing Sentry
 /// tracing layer. Only bounded marker metadata is attached: never its path,
 /// file identity, or free-form reason.
-pub async fn surface_quarantined_recovery_at_launch(database_path: &Path) {
+pub async fn surface_quarantined_recovery_at_launch(
+    database_path: &Path,
+    publish_recovery_event: bool,
+) {
     if GAVE_UP_NOTIFIED.swap(true, Ordering::SeqCst) {
         return;
     }
@@ -107,14 +110,20 @@ pub async fn surface_quarantined_recovery_at_launch(database_path: &Path) {
 
     error!(
         sqlite_quarantine_state = "active_at_launch",
-        sqlite_marker_metadata = if marker.is_some() { "readable" } else { "unreadable" },
+        sqlite_marker_metadata = if marker.is_some() {
+            "readable"
+        } else {
+            "unreadable"
+        },
         sqlite_extended_code = sqlite_code.unwrap_or(-1),
         sqlite_primary_code = sqlite_code.map(|code| code & 0xff).unwrap_or(-1),
         sqlite_marker_age = marker_age,
         "db recovery: durable SQLite quarantine was present at app launch"
     );
-    let evt = screenpipe_events::DbRecoveryEvent::needs_recovery();
-    let _ = screenpipe_events::send_event(evt.event_name(), evt);
+    if publish_recovery_event {
+        let evt = screenpipe_events::DbRecoveryEvent::needs_recovery();
+        let _ = screenpipe_events::send_event(evt.event_name(), evt);
+    }
 }
 
 fn quarantine_age_bucket(detected_at_unix_ms: u64) -> &'static str {

--- a/apps/screenpipe-app-tauri/src-tauri/src/db_self_heal.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/db_self_heal.rs
@@ -174,7 +174,11 @@ pub async fn try_resolve_quarantine(database_path: &Path) -> Result<(), SelfHeal
 ///
 /// Returns true when recording was resumed, so the caller can skip the
 /// recovery notification it would otherwise publish.
-pub async fn try_self_heal_at_launch(app: AppHandle, database_path: PathBuf) -> bool {
+pub async fn try_self_heal_at_launch(
+    app: AppHandle,
+    database_path: PathBuf,
+    notify_user: bool,
+) -> bool {
     match try_resolve_quarantine(&database_path).await {
         Ok(()) => {}
         Err(reason) => {
@@ -203,13 +207,15 @@ pub async fn try_self_heal_at_launch(app: AppHandle, database_path: PathBuf) -> 
         return false;
     }
 
-    client::send_typed_with_priority(
-        "recording resumed",
-        "screenpipe hit a temporary database error. your existing database passed a health check, so recording resumed without a rebuild.",
-        "db_recovery",
-        Some(10_000),
-        NotificationPriority::Normal,
-    );
+    if notify_user {
+        client::send_typed_with_priority(
+            "recording resumed",
+            "screenpipe hit a temporary database error. your existing database passed a health check, so recording resumed without a rebuild.",
+            "db_recovery",
+            Some(10_000),
+            NotificationPriority::Normal,
+        );
+    }
     true
 }
 

--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -2235,19 +2235,33 @@ async fn main() {
                 let self_heal_app = app_handle.clone();
                 let self_heal_db_path = launch_db_path.clone();
                 let notify_data_dir = data_dir.clone();
-                let surface_recovery = !app_ui_hidden && !headless_startup;
+                let recovery_app = app_handle.clone();
+                let automatic_recovery = headless_startup;
                 tauri::async_runtime::spawn(async move {
                     if crate::db_self_heal::try_self_heal_at_launch(
                         self_heal_app,
                         self_heal_db_path,
+                        !automatic_recovery,
                     )
                     .await
                     {
                         return;
                     }
-                    crate::db_relaunch::surface_quarantined_recovery_at_launch(&launch_db_path)
-                        .await;
-                    if surface_recovery {
+                    crate::db_relaunch::surface_quarantined_recovery_at_launch(
+                        &launch_db_path,
+                        !automatic_recovery,
+                    )
+                    .await;
+                    if automatic_recovery {
+                        let recovery = crate::db_recovery_notifications::
+                            start_headless_quarantined_database_recovery(
+                                recovery_app,
+                                notify_data_dir,
+                            );
+                        if let Err(error) = recovery {
+                            error!("failed to start automatic protected database recovery: {error}");
+                        }
+                    } else {
                         crate::db_recovery_notifications::notify_quarantined_database(
                             notify_data_dir,
                         );


### PR DESCRIPTION
## Root cause

Live Sentry API samples show [SCREENPIPE-APP-J2](https://mediar.sentry.io/issues/7648511751/) and [SCREENPIPE-APP-J9](https://mediar.sentry.io/issues/7654600283/) are the same durable state at two boundaries:

- J9: the quarantine marker is still installed at launch.
- J2: startup remains fail-closed because that marker was not resolved.

As of 2026-08-25, J2 had 330 events / 38 users and J9 had 175 events / 19 users. The launch path correctly refused to reopen a quarantined generation. Exact short-read code 522 can self-heal only after a read-only verification, but corruption and other hard faults require the protected replacement-generation recovery.

That recovery was only offered through UI. Actual headless launches deliberately have no recovery UI, so they could never accept the action and remained quarantined across every restart.

## Fix

- After launch-time self-heal declines, actual `headless_startup` automatically starts the existing offline recovery engine.
- Headless recovery suppresses recovery events and progress/completion notifications; progress remains in logs.
- Visible launches keep the existing explicit recovery offer and confirmation flow unchanged.
- Successful recovery still relaunches only after copy-first recovery installs and verifies a fresh generation.
- Failed recovery keeps the marker and original DB/WAL/SHM protected for the next launch.

## Before / after

```text
BEFORE
headless launch -> durable quarantine -> self-heal declines
                -> no UI allowed, no recovery can start
                -> next launch sees the same marker

AFTER
headless launch -> durable quarantine -> self-heal declines
                -> protected copy + recover + verify starts automatically
                -> success: relaunch with fresh verified generation
                -> failure: original generation and marker remain protected

VISIBLE LAUNCH (unchanged)
durable quarantine -> persistent recovery offer -> explicit user action
```

## Regression coverage

- `cd apps/screenpipe-app-tauri && bun run test:tauri db_recovery_notifications::tests -- --nocapture`
  - 3 passed, 0 failed, 883 filtered out.
- `cd apps/screenpipe-app-tauri && bun run test:tauri db_self_heal::tests::launch_path_refuses_every_unproven_io_error_code -- --nocapture`
  - 1 passed, 0 failed, 885 filtered out.
- `git diff --check upstream/main...HEAD`
  - passed.

The required repository-local Windows workflow skill file is absent from this checkout, so no ad hoc Windows runtime result is claimed. The native Tauri tests above ran through the required shared build queue and `debug-dev` profile.

## Historical intent

- PR #5758 / `1c0bd720`: durable quarantine must survive relaunch and recovery must preserve the exact source generation, install only a verified fresh file, and fail closed on errors. Preserved.
- `039551c`: moved interactive recovery from a native modal into the persistent notifications inbox. Preserved for visible launches; headless launches no longer depend on UI.
- PR #6149 / `2aadce408c`: only exact `SQLITE_IOERR_SHORT_READ` 522 may self-heal after a read-only check; other I/O errors, corruption, full disk, and NOTADB require verified replacement recovery. Preserved and re-tested.

## Scope

Four native recovery/lifecycle files only. No Activities changes. PR #6605 covers routine recording-control retries after quarantine; this PR is complementary and fixes recovery initiation during an actual headless launch.
