### PR TITLE
fix(app): make pipe notification file links and chat buttons actually work

### DIFF
--- a/apps/screenpipe-app-tauri/lib/__tests__/notification-actions.test.ts
+++ b/apps/screenpipe-app-tauri/lib/__tests__/notification-actions.test.ts
@@ -13,8 +13,12 @@ vi.mock("@tauri-apps/api/event", () => ({
   emit: vi.fn(async () => undefined),
 }));
 
+const tauriCommandMocks = vi.hoisted(() => ({
+  openViewerWindow: vi.fn(async () => ({ status: "ok" as const, data: null })),
+}));
+
 vi.mock("@/lib/utils/tauri", () => ({
-  commands: {},
+  commands: tauriCommandMocks,
 }));
 
 vi.mock("@/lib/api", () => ({
@@ -151,5 +155,24 @@ describe("notification deeplink routing", () => {
       "deep-link-received",
       "screenpipe://timeline",
     );
+  });
+
+  it("sends file link actions to the in-app viewer, not the browser or Main", async () => {
+    tauriCommandMocks.openViewerWindow.mockClear();
+    const { emit } = await import("@tauri-apps/api/event");
+    vi.mocked(emit).mockClear();
+
+    // `commands.showWindowActivated` is deliberately absent from the mock —
+    // reaching the show-Main path would throw, so completing at all proves
+    // the timeline overlay was never shown over the viewer.
+    await executeNotificationAction({
+      type: "link",
+      url: "file:///Users/louis/.screenpipe/pipes/time-breakdown/output/2026-08-25.md",
+    });
+
+    expect(tauriCommandMocks.openViewerWindow).toHaveBeenCalledWith(
+      "/Users/louis/.screenpipe/pipes/time-breakdown/output/2026-08-25.md",
+    );
+    expect(emit).not.toHaveBeenCalled();
   });
 });

--- a/apps/screenpipe-app-tauri/lib/notifications/actions.test.ts
+++ b/apps/screenpipe-app-tauri/lib/notifications/actions.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   isActivityDeeplink,
   routeNotificationDeeplink,
+  viewerPathFromNotificationUrl,
   windowForDeeplink,
 } from "./actions";
 
@@ -33,5 +34,61 @@ describe("activity notification deeplinks", () => {
       "deep-link-received",
       "screenpipe://activity",
     );
+  });
+});
+
+describe("notification file links", () => {
+  it("extracts the local path from view deeplinks and file URLs", () => {
+    expect(
+      viewerPathFromNotificationUrl(
+        "screenpipe://view?path=%2FUsers%2Flouis%2F.screenpipe%2Fpipes%2Ftime-breakdown%2Foutput%2F2026-08-25.md",
+      ),
+    ).toBe("/Users/louis/.screenpipe/pipes/time-breakdown/output/2026-08-25.md");
+    expect(
+      viewerPathFromNotificationUrl("file:///Users/louis/report%20final.md"),
+    ).toBe("/Users/louis/report final.md");
+    // Windows drive letters lose the artificial leading slash.
+    expect(viewerPathFromNotificationUrl("file:///C:/Users/louis/report.md")).toBe(
+      "C:/Users/louis/report.md",
+    );
+    expect(viewerPathFromNotificationUrl("screenpipe://meeting/123")).toBeNull();
+    expect(viewerPathFromNotificationUrl("https://example.com/report.md")).toBeNull();
+  });
+
+  it("opens the viewer directly instead of showing the Main timeline", async () => {
+    const showWindowActivated = vi.fn().mockResolvedValue(undefined);
+    const emitEvent = vi.fn().mockResolvedValue(undefined);
+    const openViewerWindow = vi.fn().mockResolvedValue({ status: "ok" });
+
+    await routeNotificationDeeplink(
+      "screenpipe://view?path=%2FUsers%2Flouis%2Freport.md",
+      {
+        showWindowActivated,
+        emitEvent,
+        sleepMs: vi.fn().mockResolvedValue(undefined),
+        openViewerWindow,
+      },
+    );
+
+    expect(openViewerWindow).toHaveBeenCalledWith("/Users/louis/report.md");
+    // Showing Main would cover the viewer with the timeline overlay — the
+    // "clicked the report, got the timeline" bug.
+    expect(showWindowActivated).not.toHaveBeenCalled();
+    expect(emitEvent).not.toHaveBeenCalled();
+  });
+
+  it("surfaces viewer failures instead of pretending the click worked", async () => {
+    const openViewerWindow = vi
+      .fn()
+      .mockResolvedValue({ status: "error", error: "no such file" });
+
+    await expect(
+      routeNotificationDeeplink("file:///Users/louis/missing.md", {
+        showWindowActivated: vi.fn(),
+        emitEvent: vi.fn(),
+        sleepMs: vi.fn().mockResolvedValue(undefined),
+        openViewerWindow,
+      }),
+    ).rejects.toThrow("no such file");
   });
 });

--- a/apps/screenpipe-app-tauri/lib/notifications/actions.ts
+++ b/apps/screenpipe-app-tauri/lib/notifications/actions.ts
@@ -92,6 +92,44 @@ export function windowForDeeplink(url: string) {
   return "Main";
 }
 
+/**
+ * Local file a notification action points at, or null. Covers the two shapes
+ * producers use: `screenpipe://view?path=…` (what the /notify body rewriter
+ * emits) and raw `file://` URLs (what pipes tend to put in link actions).
+ *
+ * These must open the in-app viewer window directly. Routing them like a
+ * generic deeplink shows the Main timeline overlay first, which then covers
+ * the viewer — the user clicks "open report" and sees the timeline instead.
+ */
+export function viewerPathFromNotificationUrl(url: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  if (
+    parsed.protocol === "screenpipe:" &&
+    (parsed.host === "view" || parsed.pathname === "view")
+  ) {
+    return parsed.searchParams.get("path");
+  }
+  if (parsed.protocol === "file:") {
+    let path = parsed.pathname;
+    try {
+      path = decodeURIComponent(path);
+    } catch {
+      // keep the raw path when the URL contains malformed escapes
+    }
+    // file:///C:/… parses to /C:/… — strip the artificial leading slash.
+    if (/^\/[A-Za-z]:[\\/]/.test(path)) {
+      path = path.slice(1);
+    }
+    return path || null;
+  }
+  return null;
+}
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -102,12 +140,26 @@ export async function routeNotificationDeeplink(
     showWindowActivated?: typeof commands.showWindowActivated;
     emitEvent?: typeof emit;
     sleepMs?: (ms: number) => Promise<void>;
+    openViewerWindow?: typeof commands.openViewerWindow;
   } = {},
 ): Promise<void> {
   const showWindowActivated =
     deps.showWindowActivated ?? commands.showWindowActivated;
   const emitEvent = deps.emitEvent ?? emit;
   const sleepMs = deps.sleepMs ?? sleep;
+
+  // File links open the viewer window directly. Showing Main first would put
+  // the fullscreen timeline overlay on top of the viewer that's about to open.
+  const viewerPath = viewerPathFromNotificationUrl(url);
+  if (viewerPath) {
+    const openViewerWindow =
+      deps.openViewerWindow ?? commands.openViewerWindow;
+    const result = await openViewerWindow(viewerPath);
+    if (result.status === "error") {
+      throw new Error(result.error);
+    }
+    return;
+  }
 
   await showWindowActivated(windowForDeeplink(url));
 
@@ -259,7 +311,10 @@ export async function executeNotificationAction(
     case "link":
     case "deeplink": {
       if (action.url) {
-        if (action.url.startsWith("screenpipe://")) {
+        if (
+          action.url.startsWith("screenpipe://") ||
+          viewerPathFromNotificationUrl(action.url)
+        ) {
           await routeNotificationDeeplink(action.url);
         } else {
           // External URL — open in system browser.
@@ -289,7 +344,10 @@ export async function executeNotificationAction(
         action.deeplinkUrl ||
         ctx.sourceUrl;
       if (sourceUrl) {
-        if (sourceUrl.startsWith("screenpipe://")) {
+        if (
+          sourceUrl.startsWith("screenpipe://") ||
+          viewerPathFromNotificationUrl(sourceUrl)
+        ) {
           await routeNotificationDeeplink(sourceUrl);
         } else {
           const { open } = await import("@tauri-apps/plugin-shell");

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands/native_actions.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands/native_actions.rs
@@ -328,6 +328,214 @@ fn emit_timeline_daily_summary(app: &tauri::AppHandle, window_label: Option<&str
     }
 }
 
+/// Local file a notification URL points at, or `None`. Covers the two shapes
+/// producers use: `screenpipe://view?path=…` (what the /notify body rewriter
+/// emits) and raw `file://` URLs (what pipes tend to put in link actions).
+///
+/// These open the in-app viewer window directly. Routing them like a generic
+/// deeplink shows the Main timeline overlay first, which then covers the
+/// viewer — the user clicks "open report" and only sees the timeline.
+fn viewer_path_from_notification_url(url: &str) -> Option<String> {
+    if let Some(query) = url
+        .strip_prefix("screenpipe://view?")
+        .or_else(|| url.strip_prefix("screenpipe://view/?"))
+    {
+        return query.split('&').find_map(|part| {
+            let value = part.strip_prefix("path=")?;
+            let decoded = urlencoding::decode(value).ok()?.into_owned();
+            (!decoded.is_empty()).then_some(decoded)
+        });
+    }
+
+    let rest = url.strip_prefix("file://")?;
+    // Drop an optional localhost authority ("file://localhost/x").
+    let rest = rest.strip_prefix("localhost").unwrap_or(rest);
+    if !rest.starts_with('/') {
+        return None;
+    }
+    let decoded = urlencoding::decode(rest).ok()?.into_owned();
+    // file:///C:/… decodes to /C:/… — strip the artificial leading slash.
+    let bytes = decoded.as_bytes();
+    if bytes.len() > 3
+        && bytes[1].is_ascii_alphabetic()
+        && bytes[2] == b':'
+        && (bytes[3] == b'/' || bytes[3] == b'\\')
+    {
+        return Some(decoded[1..].to_string());
+    }
+    Some(decoded)
+}
+
+/// Open the in-app viewer for a notification file link. Activates the app
+/// first (a notification click is explicit user intent, mirroring
+/// `show_window_activated`) so the viewer doesn't open behind the frontmost
+/// app — and deliberately does NOT show the Main timeline overlay.
+fn open_viewer_from_notification(app: &tauri::AppHandle, path: String) {
+    #[cfg(target_os = "macos")]
+    {
+        let _ = app.run_on_main_thread(crate::window::activate_app_if_allowed);
+    }
+    let app = app.clone();
+    tauri::async_runtime::spawn(async move {
+        if let Err(e) = crate::viewer::open_viewer_window(app, path).await {
+            error!("failed to open viewer from notification action: {}", e);
+        }
+    });
+}
+
+/// Build the `chat-prefill` payload for a chat-opening notification action:
+/// `type=chat`, or `type=pipe` with `open_in_chat`. Mirrors
+/// `executeNotificationAction` in lib/notifications/actions.ts so a click on
+/// the native panel lands in chat exactly like a click on the webview toast.
+fn chat_prefill_payload_from_action(action: &serde_json::Value) -> Option<serde_json::Value> {
+    let action_type = action.get("type").and_then(|v| v.as_str())?;
+    let context = action.get("context").filter(|c| !c.is_null());
+    match action_type {
+        "chat" => {
+            let prompt = action.get("prompt").and_then(|v| v.as_str());
+            if prompt.is_none() && context.is_none() {
+                return None;
+            }
+            let context_str = context
+                .map(|c| {
+                    format!(
+                        "context:\n{}",
+                        serde_json::to_string_pretty(c).unwrap_or_default()
+                    )
+                })
+                .unwrap_or_default();
+            Some(serde_json::json!({
+                "context": context_str,
+                "prompt": prompt,
+                "displayLabel": action.get("label").and_then(|v| v.as_str()),
+                "autoSend": action
+                    .get("auto_send")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(true),
+                "source": "notification-native",
+                "targetWindow": "chat",
+            }))
+        }
+        "pipe" => {
+            if action.get("open_in_chat").and_then(|v| v.as_bool()) != Some(true) {
+                return None;
+            }
+            let pipe = action.get("pipe").and_then(|v| v.as_str())?;
+            let context_str = context
+                .map(|c| serde_json::to_string_pretty(c).unwrap_or_default())
+                .unwrap_or_default();
+            Some(serde_json::json!({
+                "context": format!("run pipe \"{pipe}\" with this context:\n{context_str}"),
+                "prompt": format!(
+                    "run the {pipe} pipe{}",
+                    if context.is_some() { " with the provided context" } else { "" }
+                ),
+                "autoSend": true,
+                "source": "notification-native",
+                "targetWindow": "chat",
+            }))
+        }
+        _ => None,
+    }
+}
+
+/// Show the Chat window and deliver a `chat-prefill` event once its webview is
+/// ready. Rust mirror of `showChatWithPrefill` (lib/chat-utils.ts): the chat
+/// component answers "chat-ping" with "chat-ready" once mounted, so we wait
+/// for that handshake instead of emitting into a webview that is still booting
+/// — the failure mode behind "open in chat does nothing".
+fn open_chat_with_prefill(app: tauri::AppHandle, prefill: serde_json::Value) {
+    std::thread::spawn(move || {
+        use tauri::Listener;
+
+        if let Err(e) = tauri::async_runtime::block_on(crate::commands::show_window_activated(
+            app.clone(),
+            ShowRewindWindow::Chat,
+        )) {
+            error!("failed to show chat window for notification action: {}", e);
+        }
+
+        let (tx, rx) = std::sync::mpsc::channel::<()>();
+        let listener = app.listen("chat-ready", move |event| {
+            let ready_window = serde_json::from_str::<serde_json::Value>(event.payload())
+                .ok()
+                .and_then(|v| {
+                    v.get("windowLabel")
+                        .and_then(|w| w.as_str())
+                        .map(str::to_string)
+                });
+            // A missing label counts as ready, matching waitForChatReady.
+            if ready_window.as_deref().map_or(true, |w| w == "chat") {
+                let _ = tx.send(());
+            }
+        });
+        let mut chat_ready = false;
+        for _ in 0..3 {
+            let _ = app.emit("chat-ping", serde_json::json!({ "targetWindow": "chat" }));
+            if rx
+                .recv_timeout(std::time::Duration::from_millis(2500))
+                .is_ok()
+            {
+                chat_ready = true;
+                break;
+            }
+        }
+        app.unlisten(listener);
+        if !chat_ready {
+            warn!("chat window never reported ready; sending notification prefill anyway");
+        }
+        if let Err(e) = app.emit("chat-prefill", prefill) {
+            error!("failed to deliver notification chat prefill: {}", e);
+        }
+    });
+}
+
+/// Run a pipe in the background from a notification click, then confirm (or
+/// report failure) through the same notification surface — a background run
+/// with zero feedback reads as a dead button.
+fn run_pipe_from_notification(
+    app: tauri::AppHandle,
+    pipe: String,
+    context: Option<serde_json::Value>,
+) {
+    std::thread::spawn(move || {
+        use crate::recording::local_api_context_from_app;
+        let api = local_api_context_from_app(&app);
+        let client = reqwest::blocking::Client::new();
+        let request = api.apply_auth_blocking(
+            client
+                .post(api.url(&format!("/pipes/{}/run", urlencoding::encode(&pipe))))
+                .header("Content-Type", "application/json")
+                .body(serde_json::json!({ "notification_context": context }).to_string()),
+        );
+        let outcome = match request.send() {
+            Ok(res) if res.status().is_success() => Ok(()),
+            Ok(res) => Err(format!("HTTP {}", res.status())),
+            Err(e) => Err(e.to_string()),
+        };
+        let confirmation = match &outcome {
+            Ok(()) => serde_json::json!({
+                "title": format!("{pipe} is running"),
+                "body": "started from your notification — results arrive as a new notification.",
+                // Toast-only: a "started" echo should not earn an inbox row.
+                "transient": true,
+            }),
+            Err(e) => {
+                error!("failed to run pipe '{}' from notification action: {}", pipe, e);
+                serde_json::json!({
+                    "title": format!("couldn't run {pipe}"),
+                    "body": format!("the run request failed: {e}"),
+                })
+            }
+        };
+        let _ = client
+            .post(api.url("/notify"))
+            .header("Content-Type", "application/json")
+            .body(confirmation.to_string())
+            .send();
+    });
+}
+
 fn notification_copy_value(action: &serde_json::Value) -> Option<String> {
     action
         .get("value")
@@ -576,6 +784,11 @@ pub(crate) fn dispatch_notification_action(json: String) {
             return;
         };
 
+        if let Some(path) = viewer_path_from_notification_url(&url) {
+            open_viewer_from_notification(app, path);
+            return;
+        }
+
         let is_in_app = url.starts_with("screenpipe://");
         let app_clone = app.clone();
         std::thread::spawn(move || {
@@ -683,6 +896,14 @@ pub(crate) fn dispatch_notification_action(json: String) {
             );
             return;
         };
+
+        // File links (screenpipe://view or file://) open the in-app viewer
+        // directly. Routing them through the generic path below would show the
+        // Main timeline overlay on top of the viewer that's about to open.
+        if let Some(path) = viewer_path_from_notification_url(&url) {
+            open_viewer_from_notification(app, path);
+            return;
+        }
 
         // Guard against senders putting a browser URL into "deeplink" or a
         // screenpipe:// URL into "link". We route on actual scheme, not on
@@ -798,9 +1019,48 @@ pub(crate) fn dispatch_notification_action(json: String) {
         return;
     }
 
-    // Everything else (pipe, mute, dismiss, auto_dismiss, legacy string
-    // actions) still goes to the JS handler. The overlay window owns those
-    // because they need access to posthog / localforage / chat prefill.
+    // Chat-opening actions ("chat", and "pipe" with open_in_chat) and
+    // background pipe runs are handled in Rust for the same reason as
+    // link/deeplink above: their JS listener lives in the Main overlay
+    // webview, which is usually not mounted when a native notification is
+    // clicked — the click silently did nothing ("open in chat does nothing").
+    if action_type == Some("chat") || action_type == Some("pipe") {
+        if let Some(action) = parsed.as_ref() {
+            // Mirrors the `notification_action` capture the JS handler did
+            // when it (sometimes) received these events.
+            let track = |app: &tauri::AppHandle| {
+                track_native_overlay_event(
+                    app,
+                    "notification_action",
+                    serde_json::json!({ "action_type": action_type }),
+                );
+            };
+            if let Some(prefill) = chat_prefill_payload_from_action(action) {
+                track(app);
+                open_chat_with_prefill(app.clone(), prefill);
+                return;
+            }
+            if action_type == Some("pipe")
+                && action.get("open_in_chat").and_then(|v| v.as_bool()) != Some(true)
+            {
+                if let Some(pipe) = action.get("pipe").and_then(|v| v.as_str()) {
+                    track(app);
+                    run_pipe_from_notification(
+                        app.clone(),
+                        pipe.to_string(),
+                        action.get("context").cloned(),
+                    );
+                    return;
+                }
+            }
+        }
+        // Unusable payload (e.g. a pipe action without a pipe name) — fall
+        // through to the JS handler like before.
+    }
+
+    // Everything else (mute, dismiss, auto_dismiss, legacy string actions)
+    // still goes to the JS handler. The overlay window owns those because
+    // they need access to posthog / localforage.
     let _ = app.emit("native-notification-action", &json);
 }
 
@@ -1187,11 +1447,127 @@ fn native_shortcut_action_callback_inner(action_ptr: *const std::os::raw::c_char
 #[cfg(test)]
 mod tests {
     use super::{
-        native_overlay_meeting_note_id, notification_copy_value, notification_source_url,
-        notification_deeplink_target, parse_meeting_deeplink, parse_overlay_anchor,
-        resolve_timeline_event_target, SHORTCUT_OVERLAY_ANCHORS,
+        chat_prefill_payload_from_action, native_overlay_meeting_note_id, notification_copy_value,
+        notification_deeplink_target, notification_source_url, parse_meeting_deeplink,
+        parse_overlay_anchor, resolve_timeline_event_target, viewer_path_from_notification_url,
+        SHORTCUT_OVERLAY_ANCHORS,
     };
     use serde_json::json;
+
+    #[test]
+    fn viewer_path_parses_view_deeplinks() {
+        assert_eq!(
+            viewer_path_from_notification_url(
+                "screenpipe://view?path=%2FUsers%2Flouis%2F.screenpipe%2Fpipes%2Ftime-breakdown%2Foutput%2F2026-08-25.md"
+            ),
+            Some("/Users/louis/.screenpipe/pipes/time-breakdown/output/2026-08-25.md".to_string())
+        );
+        assert_eq!(
+            viewer_path_from_notification_url("screenpipe://view?path="),
+            None
+        );
+        assert_eq!(viewer_path_from_notification_url("screenpipe://view"), None);
+    }
+
+    #[test]
+    fn viewer_path_parses_file_urls() {
+        assert_eq!(
+            viewer_path_from_notification_url("file:///Users/louis/report%20final.md"),
+            Some("/Users/louis/report final.md".to_string())
+        );
+        assert_eq!(
+            viewer_path_from_notification_url("file://localhost/Users/louis/report.md"),
+            Some("/Users/louis/report.md".to_string())
+        );
+        // Windows drive letters lose the artificial leading slash.
+        assert_eq!(
+            viewer_path_from_notification_url("file:///C:/Users/louis/report.md"),
+            Some("C:/Users/louis/report.md".to_string())
+        );
+    }
+
+    #[test]
+    fn viewer_path_ignores_other_urls() {
+        assert_eq!(
+            viewer_path_from_notification_url("screenpipe://meeting/123"),
+            None
+        );
+        assert_eq!(
+            viewer_path_from_notification_url("https://example.com/report.md"),
+            None
+        );
+        assert_eq!(viewer_path_from_notification_url("file://host/x.md"), None);
+    }
+
+    #[test]
+    fn chat_action_builds_prefill_with_auto_send_default_true() {
+        let prefill = chat_prefill_payload_from_action(&json!({
+            "type": "chat",
+            "label": "draft Razorpay email",
+            "prompt": "Draft a short email to Razorpay.",
+        }))
+        .expect("chat action should build a prefill");
+        assert_eq!(prefill["prompt"], "Draft a short email to Razorpay.");
+        assert_eq!(prefill["displayLabel"], "draft Razorpay email");
+        assert_eq!(prefill["autoSend"], true);
+        assert_eq!(prefill["targetWindow"], "chat");
+        assert_eq!(prefill["context"], "");
+    }
+
+    #[test]
+    fn chat_action_respects_auto_send_false_and_serializes_context() {
+        let prefill = chat_prefill_payload_from_action(&json!({
+            "type": "chat",
+            "prompt": "Review the failures.",
+            "auto_send": false,
+            "context": { "run_date": "2026-08-25" },
+        }))
+        .expect("chat action should build a prefill");
+        assert_eq!(prefill["autoSend"], false);
+        let context = prefill["context"].as_str().unwrap();
+        assert!(context.starts_with("context:\n"));
+        assert!(context.contains("2026-08-25"));
+    }
+
+    #[test]
+    fn chat_action_without_prompt_or_context_is_skipped() {
+        assert!(chat_prefill_payload_from_action(&json!({ "type": "chat" })).is_none());
+    }
+
+    #[test]
+    fn open_in_chat_pipe_action_builds_run_pipe_prefill() {
+        // The exact payload the "review in chat" buttons send today.
+        let prefill = chat_prefill_payload_from_action(&json!({
+            "type": "pipe",
+            "label": "review in chat",
+            "pipe": "meeting-summary",
+            "open_in_chat": true,
+            "context": { "meeting_id": 147 },
+        }))
+        .expect("open_in_chat pipe action should build a prefill");
+        assert_eq!(prefill["prompt"], "run the meeting-summary pipe with the provided context");
+        assert_eq!(prefill["autoSend"], true);
+        assert_eq!(prefill["targetWindow"], "chat");
+        assert!(prefill["context"]
+            .as_str()
+            .unwrap()
+            .starts_with("run pipe \"meeting-summary\" with this context:"));
+    }
+
+    #[test]
+    fn background_pipe_action_is_not_a_chat_prefill() {
+        assert!(chat_prefill_payload_from_action(&json!({
+            "type": "pipe",
+            "pipe": "meeting-summary",
+        }))
+        .is_none());
+        // open_in_chat without a pipe name has nothing to run.
+        assert!(chat_prefill_payload_from_action(&json!({
+            "type": "pipe",
+            "open_in_chat": true,
+        }))
+        .is_none());
+    }
 
     #[test]
     fn accepts_every_anchor_the_overlay_can_report() {


### PR DESCRIPTION
## Problem

Two classes of dead clicks on pipe notification actions, both reproduced from local app logs on 2026-08-25:

**1. "open report" file links opened the timeline instead of the report.**
A `screenpipe://view?path=…` (or `file://`) action was routed like a generic deeplink: show the Main window first, then emit `deep-link-received`. The logs show the viewer window *did* open — one second after the fullscreen timeline overlay was shown on top of it. The user sees only the timeline. Bonus noise: the broadcast reached every mounted webview, each racing to open the viewer (`a window with label viewer-… already exists` errors in the log).

**2. "review in chat" / chat action buttons did nothing.**
Native-panel clicks of `type=chat` and `type=pipe` actions were forwarded via `emit("native-notification-action")` to a JS listener that only lives in the Main overlay webview (`app/overlay/page.tsx`) — usually not mounted when a native notification is clicked. Logs show two such clicks with zero follow-up activity. Even when mounted, the JS listener had no `type=chat` branch at all.

## Before / after

```
BEFORE  click "open report" (screenpipe://view?path=…)
        └─ show Main (fullscreen timeline overlay)      ← user sees this
           └─ emit deep-link-received → every webview
              └─ viewer window opens BEHIND the overlay ← user never sees this

AFTER   click "open report"
        └─ activate app + open viewer window directly (no Main, one open call)

BEFORE  click "review in chat" (type=pipe, open_in_chat)
        └─ emit native-notification-action → overlay webview not mounted → nothing

AFTER   click "review in chat"
        └─ Rust: show Chat window → chat-ping/chat-ready handshake → chat-prefill
           (background pipe runs: POST /pipes/:name/run + /notify confirmation
            on success, error notification on failure — never a silent no-op)
```

## Changes

- `src-tauri/src/commands/native_actions.rs`
  - `viewer_path_from_notification_url`: recognizes `screenpipe://view?path=…` and `file://` URLs (incl. Windows drive letters); `link`/`deeplink`/`source` actions carrying one open the in-app viewer directly.
  - `chat_prefill_payload_from_action` + `open_chat_with_prefill`: Rust mirror of `showChatWithPrefill` — shows the Chat window via `show_window_activated`, waits for the `chat-ready` handshake (3×2.5s), then emits `chat-prefill`. Consumes `type=chat` and `type=pipe(open_in_chat)` natively.
  - `run_pipe_from_notification`: background pipe runs happen in Rust and confirm/report via `/notify`.
  - PostHog `notification_action` parity kept via `track_native_overlay_event`.
- `lib/notifications/actions.ts` (shared toast/bell executor)
  - `viewerPathFromNotificationUrl` + viewer short-circuit in `routeNotificationDeeplink`: view/file links open the viewer window instead of showing Main; `link`/`deeplink`/`source` actions with `file://` URLs go to the viewer instead of the OS default app.

## Tests

```
cd apps/screenpipe-app-tauri && bunx vitest run lib/notifications/actions.test.ts lib/__tests__/notification-actions.test.ts
# Test Files  2 passed (2) — Tests  10 passed (10)

cd apps/screenpipe-app-tauri && bun run test:tauri commands::native_actions
# 21 passed; 0 failed (7 new: viewer path parsing ×3, chat prefill payloads ×4)

cd apps/screenpipe-app-tauri && bun run typecheck
# clean
```

New coverage: view/file URL parsing (macOS + Windows shapes), viewer opens without showing Main, viewer failure surfaces instead of silently "working", chat prefill payloads for `type=chat` (auto_send default/false, context serialization) and `type=pipe(open_in_chat)`, background pipe actions excluded from the chat path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
