### PR TITLE
fix(activity): keep artifact icons stable on settings refresh

### DIFF
--- a/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
@@ -1370,6 +1370,43 @@ describe("activity history helpers", () => {
 });
 
 describe("ActivityLedger", () => {
+  it("keeps artifact icons mounted across unrelated settings refreshes", async () => {
+    const originalUser = mocks.settings.user;
+    const { rerender } = render(<ActivityLedger />);
+    await generateActivities();
+
+    const appArtifact = await screen.findByRole("link", {
+      name: /Open Arc at .* in Timeline/,
+    });
+    await waitFor(() =>
+      expect(appArtifact.querySelector("img")).toHaveAttribute(
+        "src",
+        "http://localhost:11535/app-icon?name=Arc",
+      ),
+    );
+    const appIcon = appArtifact.querySelector("img");
+    const artifactRequestCount = mocks.localFetch.mock.calls.filter(([path]) =>
+      String(path).startsWith("/activity-ledger?"),
+    ).length;
+
+    try {
+      mocks.settings.user = {
+        ...originalUser,
+        entitlement: { ...originalUser.entitlement },
+      };
+      rerender(<ActivityLedger />);
+
+      expect(appArtifact.querySelector("img")).toBe(appIcon);
+      expect(
+        mocks.localFetch.mock.calls.filter(([path]) =>
+          String(path).startsWith("/activity-ledger?"),
+        ),
+      ).toHaveLength(artifactRequestCount);
+    } finally {
+      mocks.settings.user = originalUser;
+    }
+  });
+
   it("shows a completed backend run without refreshing the page", async () => {
     render(<ActivityLedger />);
 

--- a/apps/screenpipe-app-tauri/components/activity-ledger.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.tsx
@@ -306,11 +306,19 @@ export function effectiveActivityRange(
   now: Date,
   isEnterpriseBuild = false,
 ): TimeRange | null {
-  if (
-    !range ||
-    isEnterpriseBuild ||
-    !isFreeOrUnattributedUser(user)
-  ) {
+  return effectiveActivityRangeForAccess(
+    range,
+    !isEnterpriseBuild && isFreeOrUnattributedUser(user),
+    now,
+  );
+}
+
+function effectiveActivityRangeForAccess(
+  range: TimeRange | null,
+  historyAccessRestricted: boolean,
+  now: Date,
+): TimeRange | null {
+  if (!range || !historyAccessRestricted) {
     return range;
   }
   const start = new Date(
@@ -1444,20 +1452,12 @@ export function ActivityLedger({
 
   const range = useMemo(
     () =>
-      effectiveActivityRange(
+      effectiveActivityRangeForAccess(
         rangeForPreset(preset, anchor, customStart, customEnd),
-        settings.user as AppUser | null | undefined,
+        activityHistoryRestricted,
         anchor,
-        enterpriseBuild.isEnterprise,
       ),
-    [
-      anchor,
-      customEnd,
-      customStart,
-      enterpriseBuild.isEnterprise,
-      preset,
-      settings.user,
-    ],
+    [activityHistoryRestricted, anchor, customEnd, customStart, preset],
   );
   const invalidRange = !range || range.start >= range.end;
   const reviewPresets = useMemo(


### PR DESCRIPTION
## Summary

- keep the memoized Activity range stable when settings refresh with an equivalent user object
- depend on the derived history-access policy instead of the reconstructed settings.user object
- add a regression test proving artifact data is not refetched and the existing icon DOM node remains mounted

## Root cause

The native scheduler updates settings such as activitiesNextRunAt. Settings hydration reconstructs settings.user, so the Activity range memo saw a new object and produced a new range even when access policy was unchanged. The range effect then cleared and refetched artifact intervals, making every icon disappear and reload.

## Before / after

    Before: unrelated settings update -> new user object -> new range -> artifact refetch -> icons flash
    After:  unrelated settings update -> same access policy -> stable range -> icons stay mounted

## Historical intent

- Inspected d950d9226b / PR #6630: free and unattributed history access must update live when the account policy changes. This remains intact because the memo depends on the derived restricted/unrestricted Boolean.
- Inspected e0f61dc7acc / PR #6480: transient icon failures use bounded retries. The retry behavior is unchanged.
- Preserved a7b7c739cd / PR #6622 progressive rendering: persisted history still renders before optional artifact hydration; only irrelevant refetches are removed.

## Tests

- bun run test:vitest components/activity-ledger.test.tsx — 53 passed
- bun run typecheck — passed
- git diff upstream/main..HEAD --check — passed