### PR TITLE
fix(meetings): retry after UI detector insert failure

### DIFF
--- a/crates/screenpipe-engine/src/meeting_watcher/ui_scan/lifecycle.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/ui_scan/lifecycle.rs
@@ -293,6 +293,32 @@ pub(crate) async fn handle_no_apps_path(
 /// it with overlapping calendar data, replaces the placeholder meeting id in
 /// state, and emits detection telemetry. `EndMeeting` performs the natural
 /// grace-timeout end (end_reason left NULL so the merge window still applies).
+pub(crate) fn persist_started_meeting_state(state: &mut MeetingState, meeting_id: i64) -> bool {
+    if meeting_id < 0 {
+        *state = MeetingState::Idle;
+        return false;
+    }
+
+    // Update state with actual meeting ID (replace the placeholder -1).
+    if let MeetingState::Active {
+        app: ref a,
+        started_at,
+        last_seen,
+        is_browser,
+        ..
+    } = *state
+    {
+        *state = MeetingState::Active {
+            meeting_id,
+            app: a.clone(),
+            started_at,
+            last_seen,
+            is_browser,
+        };
+    }
+    true
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn apply_state_action(
     action: StateAction,
@@ -389,23 +415,23 @@ pub(crate) async fn apply_state_action(
                 }
             };
 
-            // Update state with actual meeting ID (replace the placeholder -1)
-            if let MeetingState::Active {
-                app: ref a,
-                started_at,
-                last_seen,
-                is_browser,
-                ..
-            } = *state
-            {
-                *state = MeetingState::Active {
-                    meeting_id,
-                    app: a.clone(),
-                    started_at,
-                    last_seen,
-                    is_browser,
-                };
+            // `insert_new_meeting` returns -1 on a persistence failure. Do not
+            // turn that sentinel into an Active state: doing so makes the
+            // detector believe the call is already tracked and prevents every
+            // subsequent scan from retrying the insert. This was particularly
+            // misleading in support logs because audio could continue while no
+            // meeting row was ever created.
+            if !persist_started_meeting_state(state, meeting_id) {
+                error!(
+                    app = %app,
+                    "meeting v2: detector observed a call but could not persist its meeting row; returning to idle so the next scan retries"
+                );
+                if let Ok(status) = resolve_meeting_status_from(db, manual_meeting).await {
+                    emit_meeting_status_changed(&status);
+                }
+                return;
             }
+
             if let Ok(status) = resolve_meeting_status_from(db, manual_meeting).await {
                 emit_meeting_status_changed(&status);
             }

--- a/crates/screenpipe-engine/src/meeting_watcher/ui_scan/tests.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/ui_scan/tests.rs
@@ -7,6 +7,21 @@
 use super::*;
 
 #[test]
+fn failed_meeting_insert_returns_detector_to_idle_for_retry() {
+    let now = std::time::Instant::now();
+    let mut state = MeetingState::Active {
+        meeting_id: -1,
+        app: "Zoom".to_string(),
+        started_at: chrono::Utc::now(),
+        last_seen: now,
+        is_browser: false,
+    };
+
+    assert!(!persist_started_meeting_state(&mut state, -1));
+    assert!(matches!(state, MeetingState::Idle));
+}
+
+#[test]
 fn output_audio_keepalive_requires_real_voice_not_just_a_chunk() {
     // The system-audio tap writes a recent (output) chunk continuously, even
     // during silence — that alone must NOT keep an ended call alive, or a


### PR DESCRIPTION
## description

When the UI detector found a call but failed to insert its meeting row, it kept the `-1` failure sentinel as the active meeting ID. From that point on, later scans assumed the meeting was already being tracked and never retried the insert. Audio could continue normally while the meeting stayed missing from the list.

This PR returns the detector to `Idle` when persistence fails, so the next confirmed scan can try again. It also logs the detector/database failure boundary and adds a regression test for the retry path.

Related issue: #6579

## AI assistance and human ownership

- AI tool(s) used: Codex
- autonomy level: agent
- verified: reviewed against current `main`, formatting passed, and the focused regression test passed locally
- [ ] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [ ] The problem statement, rationale, and replies to maintainers are my own.

## evidence type

- [ ] UI or behavior change — before/after recording
- [x] Backend change — regression tests and relevant logs/results
- [ ] Performance change — reproducible before/after benchmarks
- [ ] Docs, CI, or pure refactor — relevant checks and an explanation; no video required

## before

Not applicable — this is a backend state transition. A failed insert left the detector active with meeting ID `-1`, which blocked retries.

## after

Not applicable — no UI changed. Failed inserts now return the detector to `Idle`, produce a clear error in support logs, and are retried by later scans.

## how to test

1. `cargo fmt --check -p screenpipe-engine` — passed
2. `cargo test -p screenpipe-engine failed_meeting_insert_returns_detector_to_idle_for_retry --lib` — passed (1 passed, 0 failed)
3. `git diff --check upstream/main...HEAD` — passed

The Ubuntu full-suite failure is in the unrelated `auth_key::cloud_token_tests::resolve_cloud_token_reads_desktop_secret_store` test; the meeting-detector regression test passes.

## desktop app checklist

Not applicable — no Tauri commands or frontend-exported Rust types changed.