### PR TITLE
test: serialize shared secret-store auth cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8865,6 +8865,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "serial_test",
  "sha2 0.10.9",
  "socket2 0.5.10",
  "sqlx",

--- a/crates/screenpipe-engine/Cargo.toml
+++ b/crates/screenpipe-engine/Cargo.toml
@@ -146,6 +146,7 @@ tikv-jemallocator = { version = "0.6", optional = true }
 [dev-dependencies]
 chrono-tz = "0.10"
 env_logger = { workspace = true }
+serial_test = "3.2.0"
 tempfile = { workspace = true }
 tokio-tungstenite = { workspace = true }
 tower = { version = "0.4", features = ["util"] }

--- a/crates/screenpipe-engine/src/auth_key.rs
+++ b/crates/screenpipe-engine/src/auth_key.rs
@@ -347,8 +347,10 @@ pub async fn find_api_auth_key() -> Option<String> {
 #[cfg(test)]
 mod local_api_auth_tests {
     use super::*;
+    use serial_test::serial;
 
     #[tokio::test]
+    #[serial(secret_store)]
     async fn unreadable_encrypted_row_gets_stable_recovery_without_being_overwritten() {
         let dir = tempfile::tempdir().unwrap();
         let encryption_key = [7u8; 32];
@@ -556,11 +558,13 @@ fn cloud_token_from_store_json(data_dir: &Path) -> Option<String> {
 #[cfg(test)]
 mod cloud_token_tests {
     use super::*;
+    use serial_test::serial;
 
     const JWT: &str = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ0ZXN0In0.sig";
     const JWT_ALT: &str = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJvdGhlciJ9.sig";
 
     #[tokio::test]
+    #[serial(secret_store)]
     async fn resolve_cloud_token_reads_desktop_secret_store() {
         let dir = tempfile::tempdir().unwrap();
         let db_path = dir.path().join("db.sqlite");
@@ -587,6 +591,7 @@ mod cloud_token_tests {
     }
 
     #[tokio::test]
+    #[serial(secret_store)]
     async fn local_api_key_does_not_override_persisted_cloud_session() {
         let dir = tempfile::tempdir().unwrap();
         set_cloud_token(dir.path(), JWT).await.unwrap();
@@ -597,6 +602,7 @@ mod cloud_token_tests {
     }
 
     #[tokio::test]
+    #[serial(secret_store)]
     async fn cloud_session_round_trips_and_clears() {
         let dir = tempfile::tempdir().unwrap();
 


### PR DESCRIPTION
## Summary

- serialize auth tests that mutate the process-wide secret-store pool
- prevent the Linux-only race between pool teardown and cloud-token reads
- leave production auth and secret-store behavior unchanged

## Root cause

The local API recovery test calls `close_all_secret_pools()`, while cloud-token tests can concurrently read from the same process-wide pool cache. Linux CI scheduled those tests across the teardown boundary, producing the `resolve_cloud_token_reads_desktop_secret_store` failure.

## Validation

- `cargo test -p screenpipe-engine --lib --no-default-features auth_key:: -- --nocapture` (8 passed)
- 20 consecutive focused auth test runs passed
- post-rebase focused run passed (8 passed)
- `cargo metadata --no-deps --format-version 1`
- `git diff --check`

## CI incident

GitHub Actions currently has an acknowledged major outage, so new workflow runs may remain queued or report startup failures until GitHub resolves the incident: https://www.githubstatus.com/
