### PR TITLE
fix(acp): preserve terminal assistant responses

### DIFF
--- a/crates/screenpipe-core/src/agents/acp/runtime.rs
+++ b/crates/screenpipe-core/src/agents/acp/runtime.rs
@@ -1846,7 +1846,11 @@ impl RuntimeState {
                 "isError": is_error
             }));
         }
+        // Foreground chat assembles text deltas, while headless consumers read
+        // the terminal payload. Preserve the same complete answer for both.
+        let mut terminal_message = None;
         if turn.message_open {
+            let mut terminal_text = turn.assistant_text.clone();
             if let Some(guidance) = model_access_guidance(&turn.assistant_text, &self.agent_id) {
                 self.output.send(json!({
                     "type": "message_update",
@@ -1860,15 +1864,36 @@ impl RuntimeState {
                     "agentId": self.agent_id,
                     "guidance": guidance
                 }));
+                if !terminal_text.trim().is_empty() {
+                    terminal_text.push_str("\n\n");
+                }
+                terminal_text.push_str(&guidance);
             }
+            let has_terminal_text = !terminal_text.trim().is_empty();
+            let content = if has_terminal_text {
+                json!([{ "type": "text", "text": terminal_text }])
+            } else {
+                json!([])
+            };
+            let message = json!({
+                "role": "assistant",
+                "content": content,
+                "stopReason": stop_reason
+            });
             self.output.send(json!({
                 "type": "message_end",
-                "message": { "role": "assistant", "stopReason": stop_reason }
+                "message": message.clone()
             }));
+            if has_terminal_text {
+                terminal_message = Some(message);
+            }
         }
         if turn.turn_open {
-            self.output
-                .send(json!({ "type": "agent_end", "authPending": auth_pending }));
+            let mut event = json!({ "type": "agent_end", "authPending": auth_pending });
+            if let Some(message) = terminal_message {
+                event["messages"] = json!([message]);
+            }
+            self.output.send(event);
         }
         turn.turn_open = false;
         turn.message_open = false;
@@ -6155,6 +6180,38 @@ mod tests {
                 && e["assistantMessageEvent"]["delta"] == json!("here is the summary")
         }));
         assert!(events_of_type(&events, "tool_execution_progress").is_empty());
+    }
+
+    #[test]
+    fn completed_turn_keeps_streamed_text_in_terminal_events() {
+        let output = ParentOutput::buffer();
+        let state = test_state(&output);
+        state.handle_update(json!({
+            "sessionUpdate": "agent_message_chunk",
+            "content": { "type": "text", "text": "{\"entries\":[" }
+        }));
+        state.handle_update(json!({
+            "sessionUpdate": "agent_message_chunk",
+            "content": { "type": "text", "text": "]}" }
+        }));
+        output.drain();
+
+        state.close_turn("end_turn");
+        let events = output.drain();
+        let message_end = events_of_type(&events, "message_end");
+        let agent_end = events_of_type(&events, "agent_end");
+
+        assert_eq!(message_end.len(), 1);
+        assert_eq!(
+            message_end[0]["message"]["content"][0]["text"],
+            json!("{\"entries\":[]}")
+        );
+        assert_eq!(agent_end.len(), 1);
+        assert_eq!(
+            agent_end[0]["messages"][0]["content"][0]["text"],
+            json!("{\"entries\":[]}")
+        );
+        assert_eq!(agent_end[0]["messages"][0]["stopReason"], json!("end_turn"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- preserve the assembled ACP assistant response in both `message_end` and `agent_end`
- give headless consumers the same complete answer that foreground chat receives from streamed deltas
- cover a response assembled from multiple ACP message chunks

## Root cause

Activity generation reads its final answer from `agent_end.messages`. The shared ACP runtime streamed assistant text through `message_update`, but its terminal events omitted that text. Foreground chat assembled the deltas successfully; headless Activity generation saw an empty terminal payload, retried once, then falsely reported an empty history.

## Before / after

```text
before: ACP text deltas -> message_end without content -> agent_end without messages
                                      -> Activity retries -> false empty-history error

after:  ACP text deltas -> message_end with content -> agent_end with messages
                                      -> Activity parses and persists the answer
```

Lifecycle ordering and empty/error behavior are unchanged. Only non-empty completed assistant output is attached to `agent_end.messages`.

## Validation

- `cargo test -p screenpipe-core --features acp --lib` — 616 passed, 1 ignored
- `bun run test:tauri activity_history::tests` — 26 passed
- `bun run coverage:all:check` — E2E, core, and unified reports current
- `rustfmt --edition 2021 --check crates/screenpipe-core/src/agents/acp/runtime.rs`
- `git diff origin/main...HEAD --check`
