### PR TITLE
fix(sidebar): keep archived automations out of pinned

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -19,14 +19,14 @@ results and `cargo llvm-cov` data on top when judging release confidence.
 ### Tauri E2E
 
 - Mapped specs: 124
-- Declared test blocks: 362
-- Weighted coverage points: 285.0
+- Declared test blocks: 363
+- Weighted coverage points: 286.0
 
 | Platform | Specs | Declared tests | Weighted points | Layers | Features | Critical score |
 | --- | --- | --- | --- | --- | --- | --- |
-| windows | 94 | 307 | 251.3 | 15 | 102 | 92% |
-| macos | 120 | 324 | 254.8 | 17 | 111 | 90% |
-| linux | 83 | 265 | 220.7 | 14 | 99 | 88% |
+| windows | 94 | 308 | 252.3 | 15 | 102 | 92% |
+| macos | 120 | 325 | 255.8 | 17 | 111 | 90% |
+| linux | 83 | 266 | 221.7 | 14 | 99 | 88% |
 
 ### Core Engine
 

--- a/apps/screenpipe-app-tauri/components/chat-sidebar.tsx
+++ b/apps/screenpipe-app-tauri/components/chat-sidebar.tsx
@@ -563,7 +563,7 @@ export function ChatSidebar({ className, onViewAll }: ChatSidebarProps) {
             useChatStore.getState().actions.patch(id, {
               hidden,
               unread: false,
-              ...(hidden ? { draft: false } : {}),
+              ...(hidden ? { draft: false, pinned: false } : {}),
             });
             return;
           }
@@ -1303,7 +1303,7 @@ export function ChatSidebar({ className, onViewAll }: ChatSidebarProps) {
     // Stop any active session first to avoid immediate row resurrection
     // from trailing stream events.
     commands.piAbort(id).catch(() => {});
-    actions.patch(id, { hidden: true, unread: false });
+    actions.patch(id, { hidden: true, pinned: false, unread: false });
     // Archiving should tuck chats away immediately; users can reopen
     // the bucket manually when they want to review archived items.
     setArchivedCollapsed(true);
@@ -1328,7 +1328,7 @@ export function ChatSidebar({ className, onViewAll }: ChatSidebarProps) {
     }
     // Best-effort persistence for restart durability.
     try {
-      await updateConversationFlags(id, { hidden: true });
+      await updateConversationFlags(id, { hidden: true, pinned: false });
     } catch {
       // ignore
     }

--- a/apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts
+++ b/apps/screenpipe-app-tauri/components/hooks/use-chat-conversations.ts
@@ -1827,12 +1827,16 @@ export function useChatConversations(opts: UseChatConversationsOpts) {
   // Permanent deletion remains available from the sidebar row menu, where
   // the conversation being acted on is explicit and a confirmation follows.
   const archiveConversation = async (convId: string) => {
-    await updateConversationFlags(convId, { hidden: true });
+    await updateConversationFlags(convId, { hidden: true, pinned: false });
     commands.piAbort(convId).catch(() => {});
 
     const { useChatStore } = await import("@/lib/stores/chat-store");
     const store = useChatStore.getState();
-    store.actions.patch(convId, { hidden: true, unread: false });
+    store.actions.patch(convId, {
+      hidden: true,
+      pinned: false,
+      unread: false,
+    });
     await refreshFileConversations();
 
     try {

--- a/apps/screenpipe-app-tauri/e2e/COVERAGE.md
+++ b/apps/screenpipe-app-tauri/e2e/COVERAGE.md
@@ -7,8 +7,8 @@ and layer declared in the manifest, weighted by confidence and criticality.
 - Manifest: `e2e/coverage-map.json`
 - Specs directory: `e2e/specs`
 - Mapped specs: 124
-- Declared test blocks: 362
-- Weighted coverage points: 285.0
+- Declared test blocks: 363
+- Weighted coverage points: 286.0
 
 Confidence weights: strong=1.0, partial=0.7, conditional=0.4, smoke=0.3.
 Criticality weights: high=1.0, medium=0.7, low=0.4.
@@ -19,9 +19,9 @@ can execute more runtime cases than this number shows.
 
 | Platform | Specs | Declared tests | Weighted points | Layers | Features | Critical score |
 | --- | --- | --- | --- | --- | --- | --- |
-| windows | 94 | 307 | 251.3 | 15 | 102 | 92% |
-| macos | 120 | 324 | 254.8 | 17 | 111 | 90% |
-| linux | 83 | 265 | 220.7 | 14 | 99 | 88% |
+| windows | 94 | 308 | 252.3 | 15 | 102 | 92% |
+| macos | 120 | 325 | 255.8 | 17 | 111 | 90% |
+| linux | 83 | 266 | 221.7 | 14 | 99 | 88% |
 
 ## Runtime Results
 
@@ -37,15 +37,15 @@ pass/fail/skip counts.
 | auth | - | 1 specs / 1 tests / 1.0 pts | - |
 | billing | 4 specs / 6 tests / 5.7 pts | 4 specs / 6 tests / 5.7 pts | 4 specs / 6 tests / 5.7 pts |
 | capture-ocr | 2 specs / 16 tests / 6.4 pts | 8 specs / 12 tests / 4.8 pts | 1 specs / 3 tests / 1.2 pts |
-| chat-ai | 27 specs / 60 tests / 45.5 pts | 40 specs / 87 tests / 63.7 pts | 26 specs / 59 tests / 45.0 pts |
+| chat-ai | 27 specs / 61 tests / 46.5 pts | 40 specs / 88 tests / 64.7 pts | 26 specs / 60 tests / 46.0 pts |
 | entitlement | - | 1 specs / 1 tests / 1.0 pts | - |
 | local-api | 27 specs / 116 tests / 97.0 pts | 36 specs / 109 tests / 92.5 pts | 22 specs / 84 tests / 75.2 pts |
 | notifications | 4 specs / 26 tests / 17.3 pts | 3 specs / 5 tests / 3.4 pts | 2 specs / 4 tests / 3.1 pts |
 | onboarding | 9 specs / 38 tests / 33.8 pts | 11 specs / 42 tests / 37.2 pts | 9 specs / 38 tests / 33.8 pts |
 | os-integration | 7 specs / 32 tests / 26.9 pts | 14 specs / 29 tests / 17.4 pts | 2 specs / 15 tests / 10.8 pts |
 | performance | 3 specs / 45 tests / 45.0 pts | 5 specs / 35 tests / 31.5 pts | 2 specs / 30 tests / 30.0 pts |
-| pipes | 6 specs / 19 tests / 19.0 pts | 8 specs / 25 tests / 25.0 pts | 6 specs / 19 tests / 19.0 pts |
-| real-ui-e2e | 68 specs / 206 tests / 170.5 pts | 83 specs / 219 tests / 180.5 pts | 63 specs / 182 tests / 156.6 pts |
+| pipes | 6 specs / 20 tests / 20.0 pts | 8 specs / 26 tests / 26.0 pts | 6 specs / 20 tests / 20.0 pts |
+| real-ui-e2e | 68 specs / 207 tests / 171.5 pts | 83 specs / 220 tests / 181.5 pts | 63 specs / 183 tests / 157.6 pts |
 | settings | 14 specs / 40 tests / 37.0 pts | 16 specs / 34 tests / 29.7 pts | 13 specs / 31 tests / 28.0 pts |
 | storage-privacy | 9 specs / 42 tests / 33.3 pts | 9 specs / 27 tests / 26.1 pts | 6 specs / 20 tests / 19.1 pts |
 | tauri-command | 19 specs / 54 tests / 41.5 pts | 28 specs / 71 tests / 53.8 pts | 18 specs / 55 tests / 42.3 pts |
@@ -138,7 +138,7 @@ pass/fail/skip counts.
 | chat-settings-background-stream.spec.ts | windows, macos, linux | chat-ai, settings, real-ui-e2e | chat, chat-streaming, settings | high | strong | real-user-flow | 1 | Opening the standalone Settings route mid-stream must not abort the chat: a long synthetic stream keeps running while the user round-trips to Settings, remains live in Recents, and restores the full response (early + final tokens) after the row is clicked. |
 | chat-sidebar-groups.spec.ts | windows, macos, linux | chat-ai, real-ui-e2e | chat, chat-sidebar-groups | medium | strong | real-user-flow | 9 | Pipe auto-grouping (collapse, badge, expand/collapse, localStorage persistence) and manual sidebar groups (move-to-group, section headers, remove-from-group cleanup). 8 tests. |
 | chat-sidebar-navigation.spec.ts | windows, macos, linux | chat-ai, real-ui-e2e | chat, chat-navigation, chat-sidebar | high | strong | real-user-flow | 4 | Native Home WebView coverage for one active conversation, atomic sidebar-to-panel navigation, clean new-chat drafts, semantic unread state, removal of the duplicate tab strip, and a title-scoped Pin/Rename/Archive menu. |
-| chat-sidebar-pipe-inventory.spec.ts | windows, macos, linux | chat-ai, pipes, real-ui-e2e | chat, pipes, chat-sidebar-groups | high | strong | mixed | 1 | The long chat inventory scrolls independently; a collapsed Pipes section loads nothing, expanding it lists a compact execution-backed activity page, expanding a pipe lazily loads its newest 10 executions, and older runs paginate on demand. |
+| chat-sidebar-pipe-inventory.spec.ts | windows, macos, linux | chat-ai, pipes, real-ui-e2e | chat, pipes, chat-sidebar-groups | high | strong | mixed | 2 | The long chat inventory scrolls independently; a collapsed Automations section loads nothing, expanding it lists a compact execution-backed activity page, expanding an automation lazily loads its newest 10 executions, older runs paginate on demand, and a pinned automation remains archived after reload. |
 | chat-sidebar-repeated-prompt.spec.ts | windows, macos, linux | chat-ai, real-ui-e2e | chat, chat-sidebar-dedupe | high | strong | real-user-flow | 1 | Two distinct chats sent with the same opening prompt stay visible in the left sidebar. |
 | chat-sidebar-stub-dedup.spec.ts | windows, macos, linux | chat-ai | chat, chat-sidebar-dedupe | medium | partial | synthetic | 1 | Listener-order regression for metadata-only sidebar stubs gaining dedup keys. |
 | chat-source-file-preview.spec.ts | windows, macos, linux | chat-ai, real-ui-e2e | chat | medium | strong | real-user-flow | 1 | Clicking a chat file source opens it in the preview sidebar with rendered markdown + syntax-highlighted code. |

--- a/apps/screenpipe-app-tauri/e2e/coverage-map.json
+++ b/apps/screenpipe-app-tauri/e2e/coverage-map.json
@@ -1091,7 +1091,7 @@
       "criticality": "high",
       "confidence": "strong",
       "ux": "mixed",
-      "notes": "The long chat inventory scrolls independently; a collapsed Pipes section loads nothing, expanding it lists a compact execution-backed activity page, expanding a pipe lazily loads its newest 10 executions, and older runs paginate on demand."
+      "notes": "The long chat inventory scrolls independently; a collapsed Automations section loads nothing, expanding it lists a compact execution-backed activity page, expanding an automation lazily loads its newest 10 executions, older runs paginate on demand, and a pinned automation remains archived after reload."
     },
     {
       "spec": "chat-sidebar-repeated-prompt.spec.ts",

--- a/apps/screenpipe-app-tauri/e2e/specs/chat-sidebar-pipe-inventory.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/chat-sidebar-pipe-inventory.spec.ts
@@ -8,16 +8,18 @@
  * exposes 12 completed executions plus one running execution and verifies that:
  *
  * 1. the collapsed section loads neither inventory nor runs;
- * 2. opening Pipes loads the compact activity inventory;
+ * 2. opening Automations loads the compact activity inventory;
  * 3. expanding one pipe omits the running execution;
  * 4. the first page contains exactly 10 completed executions; and
  * 5. older executions paginate only when requested; and
- * 6. a newly completed Brain/background run invalidates an expanded group.
+ * 6. a newly completed Brain/background run invalidates an expanded group; and
+ * 7. pinning then archiving an automation stays archived after reload.
  */
 
 import { randomUUID } from "node:crypto";
 import {
   mkdirSync,
+  readFileSync,
   rmSync,
   utimesSync,
   writeFileSync,
@@ -31,9 +33,16 @@ import {
   waitForAppReady,
 } from "../helpers/test-utils.js";
 const PIPE_NAME = "e2e-sidebar-lazy-inventory";
+const ARCHIVE_PIPE_NAME = "e2e-sidebar-archive-state";
+const ARCHIVE_RUN_ID = 4242;
+const ARCHIVE_RUN_SESSION_ID = `pipe:${ARCHIVE_PIPE_NAME}:${ARCHIVE_RUN_ID}`;
 const PIPE_DIR = join(E2E_DATA_DIR, "pipes", PIPE_NAME);
 const CHATS_DIR = join(E2E_DATA_DIR, "chats");
 const GENERATED_RUN_CHAT = join(CHATS_DIR, `pipe_${PIPE_NAME}_12.json`);
+const ARCHIVE_RUN_CHAT = join(
+  CHATS_DIR,
+  `pipe_${ARCHIVE_PIPE_NAME}_${ARCHIVE_RUN_ID}.json`,
+);
 const E2E_ACCOUNT_USER_KEY = "screenpipe_e2e_account_user";
 const E2E_ACCOUNT_USER_EVENT = "screenpipe-e2e-seed-account-user";
 const createdChatFiles: string[] = [];
@@ -117,6 +126,39 @@ function writeConversation(
   createdChatFiles.push(file);
 }
 
+function writeArchiveRunConversation(updatedAt: number): void {
+  writeFileSync(ARCHIVE_RUN_CHAT, JSON.stringify({
+    id: ARCHIVE_RUN_SESSION_ID,
+    title: `${ARCHIVE_PIPE_NAME} #${ARCHIVE_RUN_ID}`,
+    titleSource: "user",
+    kind: "pipe-run",
+    pipeContext: {
+      pipeName: ARCHIVE_PIPE_NAME,
+      executionId: ARCHIVE_RUN_ID,
+    },
+    createdAt: updatedAt,
+    updatedAt,
+    lastUserMessageAt: updatedAt,
+    pinned: false,
+    hidden: false,
+    messages: [
+      {
+        id: `${ARCHIVE_RUN_SESSION_ID}-u`,
+        role: "user",
+        content: "archive fixture prompt",
+        timestamp: updatedAt,
+      },
+      {
+        id: `${ARCHIVE_RUN_SESSION_ID}-a`,
+        role: "assistant",
+        content: "archive fixture result",
+        timestamp: updatedAt + 1,
+      },
+    ],
+  }));
+  createdChatFiles.push(ARCHIVE_RUN_CHAT);
+}
+
 async function clickSection(title: string): Promise<void> {
   const clicked = await browser.execute((wanted: string) => {
     const sidebar = document.querySelector('[data-testid="chat-sidebar"]');
@@ -146,8 +188,53 @@ async function clickSection(title: string): Promise<void> {
   );
 }
 
+async function chooseRowAction(sessionId: string, action: string): Promise<void> {
+  // WebKit WebDriver neither applies Tailwind's group-hover visibility state
+  // nor sends pointerdown for element.click(). Open the real Radix trigger via
+  // its keyboard contract, which exercises the same controlled menu state.
+  const opened = await browser.execute((id: string) => {
+    const rowElement = document.querySelector(`[data-testid="chat-row-${id}"]`);
+    const button = rowElement?.querySelector<HTMLButtonElement>(
+      'button[aria-label="conversation actions"]',
+    );
+    if (!button) return false;
+    button.focus();
+    button.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "ArrowDown",
+      code: "ArrowDown",
+      bubbles: true,
+      cancelable: true,
+    }));
+    return true;
+  }, sessionId);
+  expect(opened).toBe(true);
+
+  await browser.waitUntil(
+    async () => await browser.execute((wanted: string) =>
+      Array.from(document.querySelectorAll<HTMLElement>('[role="menuitem"]'))
+        .some((item) => item.textContent?.trim().toLowerCase().includes(wanted)),
+    action.toLowerCase()),
+    {
+      timeout: t(5_000),
+      interval: 100,
+      timeoutMsg: `row action '${action}' did not open`,
+    },
+  );
+
+  const selected = await browser.execute((wanted: string) => {
+    const item = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+    ).find((candidate) =>
+      candidate.textContent?.trim().toLowerCase().includes(wanted),
+    );
+    item?.click();
+    return Boolean(item);
+  }, action.toLowerCase());
+  expect(selected).toBe(true);
+}
+
 async function mockPipeActivityApi(): Promise<void> {
-  await browser.execute((pipeName: string) => {
+  await browser.execute((pipeName: string, archivePipeName: string) => {
     const testWindow = window as typeof window & {
       __pipeActivityFetches?: number;
       __pipeExecutionFetches?: number;
@@ -206,13 +293,22 @@ async function mockPipeActivityApi(): Promise<void> {
         testWindow.__pipeActivityFetches = (testWindow.__pipeActivityFetches ?? 0) + 1;
         const latestCompletedId = testWindow.__pipeLatestCompletedId ?? 12;
         return Promise.resolve(new Response(JSON.stringify({
-          data: [{
-            pipe_name: pipeName,
-            execution_count: latestCompletedId,
-            latest_execution_id: latestCompletedId,
-            last_run_at: new Date().toISOString(),
-            status: "completed",
-          }],
+          data: [
+            {
+              pipe_name: pipeName,
+              execution_count: latestCompletedId,
+              latest_execution_id: latestCompletedId,
+              last_run_at: new Date().toISOString(),
+              status: "completed",
+            },
+            {
+              pipe_name: archivePipeName,
+              execution_count: 1,
+              latest_execution_id: 4242,
+              last_run_at: new Date(Date.now() - 1_000).toISOString(),
+              status: "completed",
+            },
+          ],
           has_more: false,
           next_before_id: null,
         }), { status: 200, headers: { "Content-Type": "application/json" } }));
@@ -257,7 +353,7 @@ async function mockPipeActivityApi(): Promise<void> {
       }
       return originalFetch(input, init);
     };
-  }, PIPE_NAME);
+  }, PIPE_NAME, ARCHIVE_PIPE_NAME);
 }
 
 describe("chat sidebar pipe inventory", function () {
@@ -277,14 +373,17 @@ describe("chat sidebar pipe inventory", function () {
     );
 
     const base = Date.now() - 120_000;
+    writeArchiveRunConversation(base + 5_000);
     for (let i = 0; i < 60; i += 1) {
       writeConversation(randomUUID(), base + 10_000 + i, "chat", base + 10_000 + i);
     }
 
-    await browser.execute((pipeName: string) => {
+    await browser.execute((pipeName: string, archivePipeName: string) => {
       localStorage.setItem("screenpipe:pipes-collapsed", "true");
+      localStorage.setItem("screenpipe:pinned-collapsed", "false");
       localStorage.removeItem(`screenpipe:group-expanded:pipe:${pipeName}`);
-    }, PIPE_NAME);
+      localStorage.removeItem(`screenpipe:group-expanded:pipe:${archivePipeName}`);
+    }, PIPE_NAME, ARCHIVE_PIPE_NAME);
     await reloadAndWaitForHome();
     // Apply the fake entitlement only after reload. Seeding it before reload
     // lets the normal account refresh reject the deliberately fake token and
@@ -329,7 +428,7 @@ describe("chat sidebar pipe inventory", function () {
     });
     expect(fetchesWhileCollapsed).toEqual([0, 0, 0]);
 
-    await clickSection("scheduled");
+    await clickSection("automations");
     const groupSelector = `[data-testid="pipe-group-pipe:${PIPE_NAME}"]`;
     await browser.waitUntil(
       async () => await browser.execute((selector: string) =>
@@ -354,7 +453,7 @@ describe("chat sidebar pipe inventory", function () {
       },
     );
 
-    // The conversation inventory must own its vertical scroll once Scheduled
+    // The conversation inventory must own its vertical scroll once Automations
     // is expanded at the minimum supported window height. It must never
     // stretch the app or push the fixed Settings footer out of reach.
     const devicePixelRatio = (await browser.execute(
@@ -456,5 +555,94 @@ describe("chat sidebar pipe inventory", function () {
         timeoutMsg: "new terminal execution did not refresh the expanded pipe history",
       },
     );
+  });
+
+  it("keeps a pinned automation archived after reload", async () => {
+    const groupSelector = `[data-testid="pipe-group-pipe:${ARCHIVE_PIPE_NAME}"]`;
+    await browser.waitUntil(
+      async () => await browser.execute((selector: string) =>
+        Boolean(document.querySelector(selector)), groupSelector),
+      {
+        timeout: t(15_000),
+        interval: 250,
+        timeoutMsg: "archive fixture automation group did not appear",
+      },
+    );
+
+    const groupExpanded = await browser.execute((selector: string) =>
+      document.querySelector(`${selector} > button`)?.getAttribute("aria-expanded") === "true",
+    groupSelector);
+    if (!groupExpanded) {
+      await $(`${groupSelector} > button`).click();
+    }
+    await browser.waitUntil(
+      async () => await browser.execute((id: string) =>
+        Boolean(document.querySelector(`[data-testid="chat-row-${id}"]`)),
+      ARCHIVE_RUN_SESSION_ID),
+      {
+        timeout: t(15_000),
+        interval: 250,
+        timeoutMsg: "archive fixture automation run did not appear",
+      },
+    );
+
+    await chooseRowAction(ARCHIVE_RUN_SESSION_ID, "pin");
+    await browser.waitUntil(
+      async () => await browser.execute((id: string) => {
+        const row = document.querySelector(`[data-testid="chat-row-${id}"]`);
+        const pinnedHeader = document.querySelector(
+          '[data-testid="sidebar-section-pinned"]',
+        );
+        const pinnedSection = pinnedHeader?.parentElement?.parentElement;
+        return row !== null && pinnedSection?.contains(row) === true;
+      }, ARCHIVE_RUN_SESSION_ID),
+      {
+        timeout: t(10_000),
+        interval: 100,
+        timeoutMsg: "automation did not move into Pinned",
+      },
+    );
+
+    await chooseRowAction(ARCHIVE_RUN_SESSION_ID, "archive");
+    await browser.waitUntil(
+      async () => await browser.execute((id: string) =>
+        !document.querySelector(`[data-testid="chat-row-${id}"]`),
+      ARCHIVE_RUN_SESSION_ID),
+      {
+        timeout: t(10_000),
+        interval: 100,
+        timeoutMsg: "archived automation stayed visible in the sidebar",
+      },
+    );
+
+    await browser.waitUntil(
+      async () => {
+        try {
+          const persisted = JSON.parse(readFileSync(ARCHIVE_RUN_CHAT, "utf8")) as {
+            hidden?: boolean;
+            pinned?: boolean;
+          };
+          return persisted.hidden === true && persisted.pinned === false;
+        } catch {
+          return false;
+        }
+      },
+      {
+        timeout: t(10_000),
+        interval: 100,
+        timeoutMsg: "archive flags were not persisted atomically",
+      },
+    );
+
+    await reloadAndWaitForHome();
+    await seedEntitledAccount();
+    const sidebar = await $('[data-testid="chat-sidebar"]');
+    await sidebar.waitForExist({ timeout: t(10_000) });
+    await browser.pause(1_000);
+
+    const resurrected = await browser.execute((id: string) =>
+      Boolean(document.querySelector(`[data-testid="chat-row-${id}"]`)),
+    ARCHIVE_RUN_SESSION_ID);
+    expect(resurrected).toBe(false);
   });
 });

--- a/apps/screenpipe-app-tauri/lib/__tests__/chat-store.test.ts
+++ b/apps/screenpipe-app-tauri/lib/__tests__/chat-store.test.ts
@@ -733,6 +733,31 @@ describe("chat-store: persisted empty chat cleanup", () => {
 
     expect(record.draft).toBeUndefined();
   });
+
+  it("keeps an archived pinned automation hidden during disk hydration", () => {
+    const record = sessionRecordFromMeta({
+      id: "pipe:photo-analyzer:7923",
+      title: "photo-analyzer #7923",
+      createdAt: 100,
+      updatedAt: 200,
+      messageCount: 2,
+      pinned: true,
+      hidden: true,
+      kind: "pipe-run",
+      pipeContext: {
+        pipeName: "photo-analyzer",
+        executionId: 7923,
+      },
+    });
+
+    useChatStore.getState().actions.hydrateFromDisk([record]);
+
+    expect(useChatStore.getState().sessions[record.id]).toMatchObject({
+      pinned: true,
+      hidden: true,
+      kind: "pipe-run",
+    });
+  });
 });
 
 describe("chat-store: isEmptyChatShell (derived backstop for missing draft flags)", () => {

--- a/apps/screenpipe-app-tauri/lib/stores/chat-store.ts
+++ b/apps/screenpipe-app-tauri/lib/stores/chat-store.ts
@@ -783,6 +783,7 @@ export function sessionRecordFromMeta(m: ConversationMeta): SessionRecord {
     createdAt: m.createdAt,
     updatedAt: m.updatedAt,
     pinned: m.pinned,
+    hidden: m.hidden,
     unread: false,
     // Empty persisted chat files are abandoned drafts, not durable history.
     // Mark them here so a restart cannot resurrect stray "untitled" rows.


### PR DESCRIPTION
## What changed

- preserve the persisted hidden flag when sidebar sessions hydrate from disk
- clear pinned atomically in both archive entry points and cross-window visibility sync
- add a store regression for hidden+pinned automation metadata
- extend the native sidebar E2E through pin, archive, disk verification, and full reload
- refresh the maintained E2E and unified coverage reports

## Root cause

Archived automation files could legitimately contain both hidden=true and pinned=true. sessionRecordFromMeta restored pinned but dropped hidden, so the next disk hydration classified the automation as visible and pinned. Two archive paths also preserved the stale pinned flag, making the contradictory state easy to create.

## Verification

- E2E-enabled macOS Tauri build completed successfully
- chat-sidebar-pipe-inventory native WebDriver spec: 2 passing, including pin -> archive -> reload
- post-rebase focused Vitest: 144 passing
- full app TypeScript check passed
- targeted ESLint passed
- E2E coverage and unified coverage freshness checks passed
- git diff --check passed

The final rebase onto current main was conflict-free. The native regression passed before that rebase; the post-rebase unit/static suite passed, and the current-base GitHub E2E lanes are running.