### PR TITLE
fix(vision): restart capture task started with stale display-mode dimensions

### DIFF
--- a/crates/screenpipe-engine/src/vision_manager/manager.rs
+++ b/crates/screenpipe-engine/src/vision_manager/manager.rs
@@ -119,6 +119,13 @@ pub struct VisionManager {
     /// to upgrade the running task after SCK recovers.
     #[cfg(target_os = "macos")]
     monitor_sck_backends: Arc<DashMap<u32, bool>>,
+    /// Dimensions the active capture task was started with. A monitor handle
+    /// enumerated mid lock/display-layout transition can carry a stale display
+    /// mode (issue #6650: e.g. 1920x1080 on a 3008x1692 display) and the
+    /// stream then keeps that size forever. The watcher compares this against
+    /// fresh enumerations to restart the task once the real mode is visible.
+    #[cfg(target_os = "macos")]
+    monitor_started_dimensions: Arc<DashMap<u32, (u32, u32)>>,
     /// Per-monitor pipeline heartbeat. Aggregate metrics remain in `config` for
     /// `/health`; these independent clocks are exclusively the recovery source
     /// so partial multi-display stalls are observable.
@@ -229,6 +236,8 @@ impl VisionManager {
             recording_tasks: Arc::new(DashMap::new()),
             #[cfg(target_os = "macos")]
             monitor_sck_backends: Arc::new(DashMap::new()),
+            #[cfg(target_os = "macos")]
+            monitor_started_dimensions: Arc::new(DashMap::new()),
             monitor_liveness: Arc::new(DashMap::new()),
             hd_recording_tasks: Arc::new(DashMap::new()),
             trigger_tx,
@@ -573,6 +582,8 @@ impl VisionManager {
 
         #[cfg(target_os = "macos")]
         let uses_sck_backend = monitor.uses_sck_backend();
+        #[cfg(target_os = "macos")]
+        let started_dimensions = monitor.dimensions();
         let liveness = Arc::new(PipelineMetrics::new());
         let handle = self
             .start_event_driven_monitor(monitor_id, monitor, liveness.clone())
@@ -582,6 +593,9 @@ impl VisionManager {
         #[cfg(target_os = "macos")]
         self.monitor_sck_backends
             .insert(monitor_id, uses_sck_backend);
+        #[cfg(target_os = "macos")]
+        self.monitor_started_dimensions
+            .insert(monitor_id, started_dimensions);
         self.recording_tasks.insert(monitor_id, handle);
 
         Ok(())
@@ -788,6 +802,8 @@ impl VisionManager {
         self.monitor_liveness.remove(&monitor_id);
         #[cfg(target_os = "macos")]
         self.monitor_sck_backends.remove(&monitor_id);
+        #[cfg(target_os = "macos")]
+        self.monitor_started_dimensions.remove(&monitor_id);
         // Stop the HD recorder first. Aborting drops its ffmpeg stdin, which
         // sends EOF so ffmpeg finalizes the .mp4 (moov atom) on its own.
         if let Some((_, hd_handle)) = self.hd_recording_tasks.remove(&monitor_id) {
@@ -839,6 +855,8 @@ impl VisionManager {
             self.monitor_liveness.remove(id);
             #[cfg(target_os = "macos")]
             self.monitor_sck_backends.remove(id);
+            #[cfg(target_os = "macos")]
+            self.monitor_started_dimensions.remove(id);
             if let Some((_, handle)) = self.recording_tasks.remove(id) {
                 // Await to clean up the JoinHandle and capture exit reason
                 match handle.await {
@@ -871,6 +889,18 @@ impl VisionManager {
     #[cfg(target_os = "macos")]
     pub(crate) fn active_monitor_uses_sck(&self, monitor_id: u32) -> Option<bool> {
         self.monitor_sck_backends
+            .get(&monitor_id)
+            .map(|entry| *entry.value())
+    }
+
+    /// Return the dimensions the active capture task for a macOS monitor was
+    /// started with, so the watcher can detect a stale display mode (#6650).
+    #[cfg(target_os = "macos")]
+    pub(crate) fn active_monitor_started_dimensions(
+        &self,
+        monitor_id: u32,
+    ) -> Option<(u32, u32)> {
+        self.monitor_started_dimensions
             .get(&monitor_id)
             .map(|entry| *entry.value())
     }

--- a/crates/screenpipe-engine/src/vision_manager/monitor_watcher.rs
+++ b/crates/screenpipe-engine/src/vision_manager/monitor_watcher.rs
@@ -185,6 +185,45 @@ fn vision_capture_wedged(
     )
 }
 
+
+/// Pure decision: is the active capture task for a monitor stale relative to a
+/// fresh enumeration of the same display? Two shapes (both macOS):
+/// - **backend**: the task still holds the bounded CoreGraphics fallback while
+///   ScreenCaptureKit has recovered (pre-existing upgrade path).
+/// - **dimensions** (#6650): the task was started from a monitor handle
+///   enumerated mid lock/display-layout transition, carrying a stale display
+///   mode (e.g. 1920x1080 on a 3008x1692 display, or a previous scaled mode
+///   such as 1728x1117 on a 2056x1329 built-in panel). The pinned size is
+///   never re-checked by the stream itself, so every frame stays downscaled
+///   and OCR quality collapses until the task is restarted.
+///
+/// `active_*` values are `None` when the monitor has no active task; that is
+/// never stale — the regular hot-plug path handles starting it.
+/// Clock-free for unit testing, mirroring [`vision_capture_wedged`].
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn stale_capture_task_reason(
+    active_uses_sck: Option<bool>,
+    fresh_uses_sck: bool,
+    active_dimensions: Option<(u32, u32)>,
+    fresh_dimensions: (u32, u32),
+) -> Option<&'static str> {
+    if !fresh_uses_sck {
+        // Mid-transition enumerations can come from the bounded CoreGraphics
+        // recovery path with unreliable geometry; never chase dimensions (or
+        // restart at all) until a healthy SCK enumeration is available.
+        return None;
+    }
+    if active_uses_sck == Some(false) {
+        return Some("CoreGraphics fallback while ScreenCaptureKit recovered");
+    }
+    match active_dimensions {
+        Some(active) if active != fresh_dimensions => {
+            Some("started with stale display mode dimensions")
+        }
+        _ => None,
+    }
+}
+
 fn vision_capture_wedged_with(
     config: &VisionWatchdogConfig,
     uptime_secs: f64,
@@ -1102,28 +1141,35 @@ pub async fn start_monitor_watcher(
             // otherwise excluded-window capture keeps failing closed forever.
             #[cfg(target_os = "macos")]
             for monitor in &current_monitors {
-                if monitor.uses_sck_backend()
-                    && vision_manager.active_monitor_uses_sck(monitor.id()) == Some(false)
-                {
-                    info!(
-                        "ScreenCaptureKit recovered for monitor {}; replacing temporary CoreGraphics fallback",
-                        monitor.id()
+                let Some(reason) = stale_capture_task_reason(
+                    vision_manager.active_monitor_uses_sck(monitor.id()),
+                    monitor.uses_sck_backend(),
+                    vision_manager.active_monitor_started_dimensions(monitor.id()),
+                    monitor.dimensions(),
+                ) else {
+                    continue;
+                };
+                info!(
+                    "monitor {} capture task is stale ({}); restarting with fresh handle ({}x{})",
+                    monitor.id(),
+                    reason,
+                    monitor.width(),
+                    monitor.height()
+                );
+                if let Err(e) = vision_manager.stop_monitor(monitor.id()).await {
+                    warn!(
+                        "failed to stop stale capture task for monitor {}: {:?}",
+                        monitor.id(),
+                        e
                     );
-                    if let Err(e) = vision_manager.stop_monitor(monitor.id()).await {
-                        warn!(
-                            "failed to stop CoreGraphics fallback for monitor {}: {:?}",
-                            monitor.id(),
-                            e
-                        );
-                        continue;
-                    }
-                    if let Err(e) = vision_manager.start_monitor_handle(monitor.clone()).await {
-                        warn!(
-                            "failed to upgrade monitor {} back to ScreenCaptureKit: {:?}",
-                            monitor.id(),
-                            e
-                        );
-                    }
+                    continue;
+                }
+                if let Err(e) = vision_manager.start_monitor_handle(monitor.clone()).await {
+                    warn!(
+                        "failed to restart monitor {} with fresh handle: {:?}",
+                        monitor.id(),
+                        e
+                    );
                 }
             }
 
@@ -1818,4 +1864,51 @@ mod tests {
             "re-arrangement with unchanged ids must change the canonical json"
         );
     }
+
+    #[test]
+    fn stale_task_detects_fallback_display_mode_dimensions() {
+        // #6650: stream created mid lock/dock transition pinned 1920x1080
+        // while the display's real mode is 3008x1692.
+        assert_eq!(
+            stale_capture_task_reason(Some(true), true, Some((1920, 1080)), (3008, 1692)),
+            Some("started with stale display mode dimensions")
+        );
+        // Built-in panel variant: previous scaled mode 1728x1117 vs 2056x1329.
+        assert_eq!(
+            stale_capture_task_reason(Some(true), true, Some((1728, 1117)), (2056, 1329)),
+            Some("started with stale display mode dimensions")
+        );
+    }
+
+    #[test]
+    fn stale_task_ignores_matching_dimensions_and_inactive_monitors() {
+        // Matching dimensions: healthy, nothing to do.
+        assert_eq!(
+            stale_capture_task_reason(Some(true), true, Some((3008, 1692)), (3008, 1692)),
+            None
+        );
+        // No active task for this monitor: hot-plug path owns it, never stale.
+        assert_eq!(stale_capture_task_reason(None, true, None, (3008, 1692)), None);
+    }
+
+    #[test]
+    fn stale_task_still_detects_coregraphics_fallback_backend() {
+        // Pre-existing upgrade path keeps priority over the dimension check.
+        assert_eq!(
+            stale_capture_task_reason(Some(false), true, Some((3008, 1692)), (3008, 1692)),
+            Some("CoreGraphics fallback while ScreenCaptureKit recovered")
+        );
+        // Fresh handle itself still on CG fallback: no upgrade available yet,
+        // and dimension differences are ignored too — CG-recovery geometry is
+        // unreliable mid-transition, so no restart is chased until SCK is back.
+        assert_eq!(
+            stale_capture_task_reason(Some(false), false, Some((3008, 1692)), (3008, 1692)),
+            None
+        );
+        assert_eq!(
+            stale_capture_task_reason(Some(true), false, Some((1920, 1080)), (3008, 1692)),
+            None
+        );
+    }
+
 }


### PR DESCRIPTION
Fixes #6650.

## Problem

A monitor handle enumerated mid lock/display-layout transition can carry a stale display mode. The SCK stream created from it keeps that size forever — nothing re-checks the pinned dimensions after the layout settles. Observed on the reporting machine on every dock/undock cycle (twice per workday):

- external 3008×1692 display pinned at **1920×1080** (recurring across days: 6/1, 12/3, 7/2 wrong/right stream starts on Aug 21/24/25)
- built-in 2056×1329 panel pinned at **1728×1117** (a previous scaled mode — so this is not a hardcoded-1920×1080 issue but stale-mode enumeration)

Every frame from the affected display is captured downscaled; measured with Apple Vision on an affected frame, mean OCR confidence drops to 0.69 for glyphs <12 px (45% of all text lines), producing garbled search results.

## Fix

`monitor_watcher.rs` already has an upgrade block that restarts an active capture task holding a stale *backend* (bounded CoreGraphics fallback → SCK, via `uses_sck_backend()`). The dimension case is the exact analogue, so this PR:

- tracks the dimensions each capture task was started with (`monitor_started_dimensions`, mirroring the existing `monitor_sck_backends` generation signal, same insert/remove lifecycle);
- generalizes the upgrade block into one pure decision, `stale_capture_task_reason(...)`, covering both staleness shapes, and takes the existing stop/`start_monitor_handle` path on either;
- gates dimension chasing on a healthy SCK enumeration (`fresh_uses_sck`), so unreliable CoreGraphics-recovery geometry mid-transition never triggers restarts and the loop cannot flap between transient modes.

## Tests

- 3 clock-free unit tests in the existing `monitor_watcher` test style, using the real dimensions from the field logs (1920×1080 vs 3008×1692, 1728×1117 vs 2056×1329), plus the CG-gating and no-active-task cases.
- `cargo check -p screenpipe-engine` and `cargo test -p screenpipe-engine --lib stale_task` green.

## Real-device validation

The bug reproduces deterministically on this machine (M3 Max, 2× EIZO EV2740S + rotated EV2785, dock/undock twice per workday). I'm running this branch locally and will report the before/after log lines on the next dock cycles; the interim log-watchdog described in #6650 doubles as an independent verifier — with this fix it should observe zero mispins left to correct.