### PR TITLE
fix(health): treat clamshell mic as unavailable

### DIFF
--- a/crates/screenpipe-core/src/display_topology.rs
+++ b/crates/screenpipe-core/src/display_topology.rs
@@ -166,6 +166,86 @@ pub fn capture_ready_display_ids() -> Option<BTreeSet<u32>> {
     None
 }
 
+/// Whether this Mac is currently running with its built-in display inactive
+/// (clamshell mode).
+///
+/// CoreGraphics omits the built-in panel from both its active and online lists
+/// on some MacBooks after the lid closes, so display enumeration cannot answer
+/// this reliably. The IOPM root domain's `AppleClamshellState` is the system's
+/// direct lid-state signal. `false` on read failure and non-macOS platforms:
+/// unknown state must never suppress a real capture failure.
+#[cfg(target_os = "macos")]
+pub fn is_clamshell_mode() -> bool {
+    use std::ffi::{c_char, c_void};
+
+    type IoObject = u32;
+    type MachPort = u32;
+
+    #[link(name = "IOKit", kind = "framework")]
+    extern "C" {
+        fn IOServiceMatching(name: *const c_char) -> *mut c_void;
+        fn IOServiceGetMatchingService(main_port: MachPort, matching: *mut c_void) -> IoObject;
+        fn IORegistryEntryCreateCFProperty(
+            entry: IoObject,
+            key: *const c_void,
+            allocator: *const c_void,
+            options: u32,
+        ) -> *const c_void;
+        fn IOObjectRelease(object: IoObject) -> i32;
+    }
+    #[link(name = "CoreFoundation", kind = "framework")]
+    extern "C" {
+        fn CFStringCreateWithCString(
+            allocator: *const c_void,
+            value: *const c_char,
+            encoding: u32,
+        ) -> *const c_void;
+        fn CFGetTypeID(value: *const c_void) -> usize;
+        fn CFBooleanGetTypeID() -> usize;
+        fn CFBooleanGetValue(value: *const c_void) -> u8;
+        fn CFRelease(value: *const c_void);
+    }
+
+    const UTF8: u32 = 0x0800_0100;
+    unsafe {
+        let matching = IOServiceMatching(b"IOPMrootDomain\0".as_ptr().cast());
+        if matching.is_null() {
+            return false;
+        }
+        // kIOMainPortDefault is MACH_PORT_NULL (0). The matching dictionary is
+        // consumed by IOServiceGetMatchingService.
+        let root_domain = IOServiceGetMatchingService(0, matching);
+        if root_domain == 0 {
+            return false;
+        }
+
+        let key = CFStringCreateWithCString(
+            std::ptr::null(),
+            b"AppleClamshellState\0".as_ptr().cast(),
+            UTF8,
+        );
+        if key.is_null() {
+            let _ = IOObjectRelease(root_domain);
+            return false;
+        }
+        let value = IORegistryEntryCreateCFProperty(root_domain, key, std::ptr::null(), 0);
+        CFRelease(key);
+        let _ = IOObjectRelease(root_domain);
+        if value.is_null() {
+            return false;
+        }
+
+        let is_closed = CFGetTypeID(value) == CFBooleanGetTypeID() && CFBooleanGetValue(value) != 0;
+        CFRelease(value);
+        is_closed
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn is_clamshell_mode() -> bool {
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/screenpipe-engine/src/routes/health.rs
+++ b/crates/screenpipe-engine/src/routes/health.rs
@@ -448,6 +448,25 @@ fn meetings_only_audio_idle_state(
     }
 }
 
+/// macOS continues to enumerate the built-in MacBook microphone after the lid
+/// closes even though it can only deliver zero-filled buffers. For health
+/// purposes that device is unavailable in clamshell mode. External microphones
+/// remain real inputs and must still surface capture failures normally.
+fn input_device_is_available(device_name: &str, clamshell_mode: bool) -> bool {
+    if !device_name.contains("(input)") {
+        return false;
+    }
+    if !clamshell_mode {
+        return true;
+    }
+
+    let lower = device_name.to_ascii_lowercase();
+    let built_in_laptop_mic = (lower.contains("macbook") && lower.contains("microphone"))
+        || lower.contains("built-in microphone")
+        || lower.contains("internal microphone");
+    !built_in_laptop_mic
+}
+
 /// Classify the raw audio capture status from health signals. Pure so it can be
 /// unit-tested in isolation. `stream_timeout_recent` must mean a recent timeout
 /// that the same current device has not recovered from, NOT a cumulative count
@@ -478,11 +497,12 @@ fn classify_audio_status(
         "meeting_detector_unavailable"
     } else if audio_waiting_for_meeting {
         "waiting_for_meeting"
-    } else if audio_never_captured && !has_input_device {
+    } else if !has_input_device {
         // Audio is on but there is no microphone to capture from — expected
         // idle, not a failure. Distinct from "not_started" so /health stays 200
-        // and the desktop stall notification (which keys off "not_started")
-        // does not false-fire on machines without a mic.
+        // and the desktop stall notification does not false-fire on machines
+        // without a mic. This also covers a previously-used built-in MacBook
+        // mic becoming unavailable when the lid closes in clamshell mode.
         "no_input_device"
     } else if audio_never_captured {
         "not_started"
@@ -1493,9 +1513,10 @@ async fn health_check_inner(state: &Arc<AppState>) -> HealthCheckResponse {
     // 503 degraded, nor trip the desktop "mic not capturing" stall notification.
     // Input devices are tagged "(input)" in the device list (output-only devices
     // like "Remote Audio (output)" are not microphones).
+    let clamshell_mode = screenpipe_core::display_topology::is_clamshell_mode();
     let has_input_device = audio_devices
         .iter()
-        .any(|device| device.to_string().contains("(input)"));
+        .any(|device| input_device_is_available(&device.to_string(), clamshell_mode));
 
     // Detect "active_no_data": the device appears active (selected and in the
     // device list) but the zero-fill watchdog has fired *recently*, indicating
@@ -3106,6 +3127,14 @@ mod tests {
             ),
             "no_input_device"
         );
+        // previously captured + mic later unavailable (for example clamshell)
+        // remains the same benign state instead of degrading to stale.
+        assert_eq!(
+            classify_audio_status(
+                false, false, false, false, false, false, true, false, 1000, 2000, 60
+            ),
+            "no_input_device"
+        );
         // never captured but a mic exists -> not_started
         assert_eq!(
             classify_audio_status(
@@ -3189,5 +3218,24 @@ mod tests {
             audio_is_degraded(status_broken),
             "a present-but-silent mic must still surface as degraded"
         );
+    }
+
+    #[test]
+    fn clamshell_ignores_only_the_builtin_laptop_microphone() {
+        assert!(input_device_is_available(
+            "MacBook Pro Microphone (input)",
+            false
+        ));
+        assert!(!input_device_is_available(
+            "MacBook Pro Microphone (input)",
+            true
+        ));
+        assert!(!input_device_is_available(
+            "Built-in Microphone (input)",
+            true
+        ));
+        assert!(input_device_is_available("USB Microphone (input)", true));
+        assert!(input_device_is_available("AirPods Pro (input)", true));
+        assert!(!input_device_is_available("System Audio (output)", true));
     }
 }


### PR DESCRIPTION
## Summary

- read macOS's direct `AppleClamshellState` signal because CoreGraphics can omit the closed built-in panel entirely
- treat the built-in MacBook microphone as unavailable while the lid is closed, reusing the existing benign `no_input_device` health state
- keep attached USB/Bluetooth microphones in the normal health path so genuine capture failures remain visible
- do not add a new notification in this change; this only stops the false restart/error treatment

## Incident evidence

The live app logs showed the failure beginning with the clamshell display transition:

- display-change recovery repeatedly reopened `MacBook Pro Microphone`
- VoiceProcessingIO initialized successfully, but the device then delivered only zero-filled buffers and repeatedly hit the 30-second watchdog
- `/health` reported `audio_status: stale`, `status_code: 503`, with the built-in mic listed inactive
- after 90 seconds, the desktop logged `audio capture stalled ... showing restart notification` and put the overlay into its failure state

macOS still listed the built-in microphone even though the closed lid made it unusable, so the old presence check incorrectly treated expected absence as recorder failure.

## Before / after

```text
Before
lid closes -> CoreAudio still lists built-in mic -> zero-fill/stale
           -> health 503 -> restart notification + failure overlay

After
lid closes -> IOPM says clamshell + only built-in mic remains
           -> no_input_device -> health remains benign, no restart error

external mic attached -> remains an available input -> real failures still surface
```

## Historical intent

- PR #4357 introduced `no_input_device` because a machine with no usable microphone is expected idle, not a 503 audio failure.
- PR #4537 preserved recent, unrecovered stream timeouts as real failures while allowing recovered devices to return to healthy.
- This change preserves both invariants: clamshell makes only the built-in laptop mic unavailable; any external mic remains eligible for timeout/stale failure classification.

## Tests

- `cargo test -p screenpipe-core display_topology` — 1 passed
- `cargo test -p screenpipe-engine --lib routes::health::tests` — 30 passed
- `git diff --check upstream/main...HEAD` — clean
- live read-only macOS probe while the lid was closed: `AppleClamshellState = Yes`; the IOPM CoreFoundation property read returned true
