### PR TITLE
fix(acp): preserve verified result after late HTTP/2 cancel

### DIFF
--- a/crates/screenpipe-core/src/agents/acp/runtime.rs
+++ b/crates/screenpipe-core/src/agents/acp/runtime.rs
@@ -1266,6 +1266,14 @@ impl ParentOutput {
         }
     }
 
+    #[cfg(test)]
+    fn snapshot(&self) -> Vec<Value> {
+        match self {
+            Self::Buffer(events) => events.lock().unwrap().clone(),
+            Self::Stdout(_) => Vec::new(),
+        }
+    }
+
     fn send(&self, value: Value) {
         match self {
             Self::Stdout(stdout) => {
@@ -5182,6 +5190,8 @@ pub(super) async fn run_from_env_with_observer(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use agent_client_protocol::schema::v1::{AgentCapabilities, ContentChunk, SessionUpdate};
+    use agent_client_protocol::Channel;
     #[test]
     fn terminal_auth_meta_drives_a_cli_login() {
         // A standard advertised method (not the Terminal variant) that carries
@@ -6287,6 +6297,139 @@ mod tests {
             &observed_error.replace("[canceled]", "[cancelled]"),
             completed,
         ));
+    }
+
+    async fn protocol_events_after_late_http2_cancel(assistant_text: &str) -> Vec<Value> {
+        let (client_transport, agent_transport) = Channel::duplex();
+        let assistant_text = assistant_text.to_owned();
+        let agent = Agent
+            .builder()
+            .name("late-cancel-test-agent")
+            .on_receive_request(
+                async move |initialize: InitializeRequest, responder, _connection| {
+                    responder.respond(
+                        InitializeResponse::new(initialize.protocol_version)
+                            .agent_capabilities(AgentCapabilities::new()),
+                    )
+                },
+                agent_client_protocol::on_receive_request!(),
+            )
+            .on_receive_request(
+                async move |_request: NewSessionRequest, responder, _connection| {
+                    responder.respond(NewSessionResponse::new("provider-session"))
+                },
+                agent_client_protocol::on_receive_request!(),
+            )
+            .on_receive_request(
+                async move |_request: PromptRequest, responder, connection| {
+                    connection.send_notification(SessionNotification::new(
+                        "provider-session",
+                        SessionUpdate::AgentMessageChunk(ContentChunk::new(ContentBlock::Text(
+                            TextContent::new(assistant_text.clone()),
+                        ))),
+                    ))?;
+                    responder.respond_with_error(
+                        Error::internal_error().data(
+                            "RetriableError: [canceled] http/2 stream closed with error code CANCEL (0x8)",
+                        ),
+                    )
+                },
+                agent_client_protocol::on_receive_request!(),
+            );
+        let agent_task = tokio::spawn(async move { agent.connect_to(agent_transport).await });
+
+        let output = ParentOutput::buffer();
+        let state = Arc::new(test_state(&output));
+        let (command_tx, command_rx) = mpsc::unbounded_channel();
+        command_tx
+            .send(json!({
+                "type": "prompt",
+                "id": "prompt-1",
+                "message": "fix it",
+            }))
+            .unwrap();
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let mut config = runtime_config("test-agent");
+        config.project_dir = temp_dir.path().to_owned();
+        let close_commands_after_response = async {
+            loop {
+                if output
+                    .snapshot()
+                    .iter()
+                    .any(|event| event["type"] == "response" && event["id"] == "prompt-1")
+                {
+                    drop(command_tx);
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+        };
+        let protocol = async {
+            let (result, ()) = tokio::join!(
+                run_protocol(client_transport, config, state, command_rx),
+                close_commands_after_response,
+            );
+            result
+        };
+        tokio::time::timeout(std::time::Duration::from_secs(2), protocol)
+            .await
+            .expect("protocol should terminate")
+            .expect("prompt failure should not stop the ACP runtime");
+        agent_task.abort();
+        assert!(agent_task
+            .await
+            .expect_err("mock agent should stay available until disconnected")
+            .is_cancelled());
+
+        output.drain()
+    }
+
+    #[tokio::test]
+    async fn protocol_keeps_verified_result_when_prompt_ends_with_late_http2_cancel() {
+        let completed = concat!(
+            "Draft PR is up.\n\n",
+            "::screenpipe-result{kind=\"link\" state=\"created\" ",
+            "title=\"Fix\" url=\"https://github.com/screenpipe/screenpipe/pull/1\"}",
+        );
+        let events = protocol_events_after_late_http2_cancel(completed).await;
+
+        let agent_end = events_of_type(&events, "agent_end");
+        assert_eq!(agent_end.len(), 1);
+        assert_eq!(agent_end[0]["messages"][0]["stopReason"], json!("end_turn"));
+        assert!(agent_end[0]["messages"][0]["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("Draft PR is up."));
+
+        let prompt_response = events
+            .iter()
+            .find(|event| event["type"] == "response" && event["id"] == "prompt-1")
+            .expect("prompt response");
+        assert_eq!(prompt_response["success"], json!(true));
+        assert!(events_of_type(&events, "message_update")
+            .iter()
+            .all(|event| event["assistantMessageEvent"]["type"] != "error"));
+    }
+
+    #[tokio::test]
+    async fn protocol_keeps_late_http2_cancel_as_error_without_verified_result() {
+        let events = protocol_events_after_late_http2_cancel(
+            "I started the fix, but the connection closed before I finished.",
+        )
+        .await;
+
+        let agent_end = events_of_type(&events, "agent_end");
+        assert_eq!(agent_end.len(), 1);
+        assert_eq!(agent_end[0]["messages"][0]["stopReason"], json!("error"));
+        let prompt_response = events
+            .iter()
+            .find(|event| event["type"] == "response" && event["id"] == "prompt-1")
+            .expect("prompt response");
+        assert_eq!(prompt_response["success"], json!(false));
+        assert!(events_of_type(&events, "message_update")
+            .iter()
+            .any(|event| event["assistantMessageEvent"]["type"] == "error"));
     }
 
     #[test]

--- a/crates/screenpipe-core/src/agents/acp/runtime.rs
+++ b/crates/screenpipe-core/src/agents/acp/runtime.rs
@@ -2627,6 +2627,37 @@ fn parent_response(output: &ParentOutput, command: &str, id: &str, error: Option
     }));
 }
 
+/// Some ACP providers finish streaming a verified result, then close the
+/// underlying HTTP/2 request with `CANCEL` instead of returning clean trailers.
+/// Retrying an already-completed agent turn can duplicate durable side effects,
+/// while surfacing the late transport error overwrites the useful final answer.
+///
+/// Screenpipe's result directive is emitted only after the agent verifies a
+/// durable outcome. Accept that exact terminal boundary; partial text, pending
+/// results, and every other provider error keep their normal failure behavior.
+fn completed_result_survives_retriable_http2_cancel(error: &str, assistant_text: &str) -> bool {
+    let normalized_error = error.to_ascii_lowercase();
+    let is_retriable_cancel = normalized_error.contains("retriableerror")
+        && (normalized_error.contains("[canceled]") || normalized_error.contains("[cancelled]"))
+        && normalized_error.contains("http/2 stream closed")
+        && normalized_error.contains("cancel (0x8)");
+    if !is_retriable_cancel {
+        return false;
+    }
+
+    let Some(last_line) = assistant_text
+        .lines()
+        .rev()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+    else {
+        return false;
+    };
+    last_line.starts_with("::screenpipe-result{")
+        && last_line.ends_with('}')
+        && !last_line.contains("state=\"pending\"")
+}
+
 fn command_error(output: &ParentOutput, message: &str) {
     output.send(json!({
         "type": "message_update",
@@ -4771,10 +4802,20 @@ async fn run_protocol(
                         // desktop doesn't render an "LLM error" bubble or trigger an
                         // auth-invalidation restart (which would close the card).
                         let is_auth_error = !cancel_requested && matches!(&result, Err(e) if auth_error(e));
+                        let recovered_completed_result = !cancel_requested
+                            && matches!(&result, Err(error) if state
+                                .turn
+                                .lock()
+                                .ok()
+                                .is_some_and(|turn| completed_result_survives_retriable_http2_cancel(
+                                    &error.to_string(),
+                                    &turn.assistant_text,
+                                )));
                         let effective_reason = match &result {
                             Ok(reason) => serde_json::to_value(reason).ok().and_then(|value| value.as_str().map(str::to_owned)).unwrap_or_else(|| "end_turn".into()),
                             Err(_) if cancel_requested => "cancelled".into(),
                             Err(_) if is_auth_error => "cancelled".into(),
+                            Err(_) if recovered_completed_result => "end_turn".into(),
                             Err(_) => "error".into(),
                         };
                         state.close_turn_ex(&effective_reason, is_auth_error);
@@ -4788,6 +4829,13 @@ async fn run_protocol(
                         match result {
                             Ok(_) => parent_response(&state.output, &command_type, &command_id, None),
                             Err(_) if cancel_requested => parent_response(&state.output, &command_type, &command_id, None),
+                            Err(_) if recovered_completed_result => {
+                                eprintln!(
+                                    "[acp:{}] recovered a verified result after a retriable HTTP/2 cancellation",
+                                    config.agent_id
+                                );
+                                parent_response(&state.output, &command_type, &command_id, None);
+                            }
                             Err(ref error) if auth_error(error) => {
                                 // authenticate() drives the card + login and only
                                 // returns Err when the user cancels, which is not
@@ -6219,6 +6267,58 @@ mod tests {
             json!("{\"entries\":[]}")
         );
         assert_eq!(agent_end[0]["messages"][0]["stopReason"], json!("end_turn"));
+    }
+
+    #[test]
+    fn verified_result_survives_late_retriable_http2_cancel() {
+        let observed_error =
+            "RetriableError: [canceled] http/2 stream closed with error code CANCEL (0x8)";
+        let completed = concat!(
+            "Draft PR is up.\n\n",
+            "::screenpipe-result{kind=\"link\" state=\"created\" ",
+            "title=\"Fix\" url=\"https://github.com/screenpipe/screenpipe/pull/1\"}\n",
+        );
+
+        assert!(completed_result_survives_retriable_http2_cancel(
+            observed_error,
+            completed,
+        ));
+        assert!(completed_result_survives_retriable_http2_cancel(
+            &observed_error.replace("[canceled]", "[cancelled]"),
+            completed,
+        ));
+    }
+
+    #[test]
+    fn incomplete_or_unrelated_failures_remain_errors() {
+        let observed_error =
+            "RetriableError: [canceled] http/2 stream closed with error code CANCEL (0x8)";
+        let pending = concat!(
+            "Still working.\n",
+            "::screenpipe-result{kind=\"link\" state=\"pending\" ",
+            "title=\"Fix\" url=\"https://github.com/screenpipe/screenpipe/pull/1\"}",
+        );
+        let partial = concat!(
+            "Draft PR is up.\n",
+            "::screenpipe-result{kind=\"link\" state=\"created\" title=\"Fix\"",
+        );
+
+        assert!(!completed_result_survives_retriable_http2_cancel(
+            observed_error,
+            "I started the fix but did not finish it.",
+        ));
+        assert!(!completed_result_survives_retriable_http2_cancel(
+            observed_error,
+            pending,
+        ));
+        assert!(!completed_result_survives_retriable_http2_cancel(
+            observed_error,
+            partial,
+        ));
+        assert!(!completed_result_survives_retriable_http2_cancel(
+            "provider rejected the request",
+            "Done.\n::screenpipe-result{kind=\"link\" state=\"created\" title=\"Fix\"}",
+        ));
     }
 
     #[test]

--- a/crates/screenpipe-core/src/agents/acp/runtime.rs
+++ b/crates/screenpipe-core/src/agents/acp/runtime.rs
@@ -2641,8 +2641,9 @@ fn parent_response(output: &ParentOutput, command: &str, id: &str, error: Option
 /// while surfacing the late transport error overwrites the useful final answer.
 ///
 /// Screenpipe's result directive is emitted only after the agent verifies a
-/// durable outcome. Accept that exact terminal boundary; partial text, pending
-/// results, and every other provider error keep their normal failure behavior.
+/// durable outcome. Accept that exact terminal boundary; malformed directives,
+/// partial text, pending results, and every other provider error keep their
+/// normal failure behavior.
 fn completed_result_survives_retriable_http2_cancel(error: &str, assistant_text: &str) -> bool {
     let normalized_error = error.to_ascii_lowercase();
     let is_retriable_cancel = normalized_error.contains("retriableerror")
@@ -2661,9 +2662,156 @@ fn completed_result_survives_retriable_http2_cancel(error: &str, assistant_text:
     else {
         return false;
     };
-    last_line.starts_with("::screenpipe-result{")
-        && last_line.ends_with('}')
-        && !last_line.contains("state=\"pending\"")
+    valid_terminal_result_directive(last_line)
+}
+
+/// Mirror the desktop's durable-result contract closely enough that a random
+/// or malformed directive cannot turn a real transport failure into success.
+fn valid_terminal_result_directive(line: &str) -> bool {
+    let Some(attributes) = parse_result_attributes(line) else {
+        return false;
+    };
+    let Some(kind) = attributes.get("kind").map(String::as_str) else {
+        return false;
+    };
+    let Some(state) = attributes.get("state").map(String::as_str) else {
+        return false;
+    };
+    if !matches!(
+        kind,
+        "scheduled-task" | "artifact" | "chat" | "live-view" | "link"
+    ) || !matches!(
+        state,
+        "proposed"
+            | "created"
+            | "updated"
+            | "completed"
+            | "paused"
+            | "deleted"
+            | "missing"
+            | "error"
+    ) || attributes
+        .get("title")
+        .is_none_or(|title| title.trim().is_empty())
+    {
+        return false;
+    }
+
+    let target_optional = matches!(state, "deleted" | "missing" | "error");
+    target_optional
+        || match kind {
+            "scheduled-task" => attributes.get("id").is_some_and(|id| valid_pipe_name(id)),
+            "artifact" => attributes
+                .get("path")
+                .is_some_and(|path| valid_absolute_result_path(path)),
+            "chat" | "live-view" => attributes
+                .get("id")
+                .is_some_and(|id| valid_local_result_id(id)),
+            "link" => attributes.get("url").is_some_and(|url| {
+                url.len() <= 2_048
+                    && reqwest::Url::parse(url)
+                        .is_ok_and(|parsed| matches!(parsed.scheme(), "http" | "https"))
+            }),
+            _ => false,
+        }
+}
+
+fn parse_result_attributes(line: &str) -> Option<HashMap<String, String>> {
+    let source = line
+        .trim()
+        .strip_prefix("::screenpipe-result{")?
+        .strip_suffix('}')?;
+    let mut chars = source.chars().peekable();
+    let mut attributes = HashMap::new();
+
+    loop {
+        while chars
+            .peek()
+            .is_some_and(|character| character.is_whitespace() || *character == ',')
+        {
+            chars.next();
+        }
+        let Some(first) = chars.next() else {
+            break;
+        };
+        if !first.is_ascii_alphabetic() {
+            return None;
+        }
+        let mut name = String::from(first);
+        while chars.peek().is_some_and(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '_' | '-')
+        }) {
+            name.push(chars.next().expect("peeked attribute name character"));
+        }
+        if chars.next() != Some('=') || chars.next() != Some('"') {
+            return None;
+        }
+
+        let mut value = String::new();
+        let mut closed = false;
+        while let Some(character) = chars.next() {
+            match character {
+                '"' => {
+                    closed = true;
+                    break;
+                }
+                '\\' => match chars.next() {
+                    Some(escaped @ ('"' | '\\')) => value.push(escaped),
+                    Some(escaped) => {
+                        value.push('\\');
+                        value.push(escaped);
+                    }
+                    None => return None,
+                },
+                _ => value.push(character),
+            }
+        }
+        if !closed
+            || chars
+                .peek()
+                .is_some_and(|character| !character.is_whitespace() && *character != ',')
+        {
+            return None;
+        }
+        attributes.insert(name, value);
+    }
+
+    (!attributes.is_empty()).then_some(attributes)
+}
+
+fn valid_pipe_name(value: &str) -> bool {
+    value.len() <= 100
+        && value
+            .chars()
+            .next()
+            .is_some_and(|character| character.is_ascii_alphanumeric())
+        && value
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '_' | '-'))
+}
+
+fn valid_local_result_id(value: &str) -> bool {
+    value.len() <= 128
+        && value
+            .chars()
+            .next()
+            .is_some_and(|character| character.is_ascii_alphanumeric())
+        && value.chars().all(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '.' | '_' | ':' | '-')
+        })
+}
+
+fn valid_absolute_result_path(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 2_048
+        && !value.chars().any(char::is_control)
+        && (value.starts_with('/')
+            || (value.as_bytes().get(1) == Some(&b':')
+                && value
+                    .as_bytes()
+                    .first()
+                    .is_some_and(u8::is_ascii_alphabetic)
+                && matches!(value.as_bytes().get(2), Some(b'\\' | b'/'))))
 }
 
 fn command_error(output: &ParentOutput, message: &str) {
@@ -6299,9 +6447,51 @@ mod tests {
         ));
     }
 
-    async fn protocol_events_after_late_http2_cancel(assistant_text: &str) -> Vec<Value> {
+    #[test]
+    fn terminal_result_directive_requires_a_valid_kind_state_title_and_target() {
+        for directive in [
+            r#"::screenpipe-result{kind="scheduled-task" state="created" title="Daily recap" id="daily_recap"}"#,
+            r#"::screenpipe-result{kind="artifact" state="completed" title="Export" path="/tmp/export.json"}"#,
+            r#"::screenpipe-result{kind="artifact" state="completed" title="Export" path="C:\\tmp\\export.json"}"#,
+            r#"::screenpipe-result{kind="chat" state="created" title="Follow-up" id="chat:123"}"#,
+            r#"::screenpipe-result{kind="live-view" state="updated" title="Dashboard" id="focus.view"}"#,
+            r#"::screenpipe-result{kind="link" state="completed" title="Docs" url="https://screenpipe.com/docs"}"#,
+            r#"::screenpipe-result{kind="scheduled-task" state="error" title="Schedule failed"}"#,
+        ] {
+            assert!(
+                valid_terminal_result_directive(directive),
+                "expected valid directive: {directive}"
+            );
+        }
+
+        for directive in [
+            r#"::screenpipe-result{kind="link" state="pending" title="Docs" url="https://screenpipe.com/docs"}"#,
+            r#"::screenpipe-result{kind="unknown" state="created" title="Docs" url="https://screenpipe.com/docs"}"#,
+            r#"::screenpipe-result{kind="link" state="created" title="" url="https://screenpipe.com/docs"}"#,
+            r#"::screenpipe-result{kind="link" state="created" title="Docs" url="javascript:alert(1)"}"#,
+            r#"::screenpipe-result{kind="artifact" state="created" title="Export" path="relative/export.json"}"#,
+            r#"::screenpipe-result{kind="chat" state="created" title="Follow-up" id="../escape"}"#,
+            r#"::screenpipe-result{kind="scheduled-task" state="created" title="Daily recap"}"#,
+            r#"::screenpipe-result{this is not valid}"#,
+        ] {
+            assert!(
+                !valid_terminal_result_directive(directive),
+                "expected invalid directive: {directive}"
+            );
+        }
+    }
+
+    async fn protocol_events_after_late_http2_cancel(
+        assistant_chunks: &[&str],
+        abort_after_stream: bool,
+    ) -> Vec<Value> {
         let (client_transport, agent_transport) = Channel::duplex();
-        let assistant_text = assistant_text.to_owned();
+        let assistant_chunks: Vec<String> = assistant_chunks
+            .iter()
+            .map(|chunk| (*chunk).to_owned())
+            .collect();
+        let cancel_signal = Arc::new(tokio::sync::Semaphore::new(0));
+        let prompt_cancel_signal = cancel_signal.clone();
         let agent = Agent
             .builder()
             .name("late-cancel-test-agent")
@@ -6322,19 +6512,41 @@ mod tests {
             )
             .on_receive_request(
                 async move |_request: PromptRequest, responder, connection| {
-                    connection.send_notification(SessionNotification::new(
-                        "provider-session",
-                        SessionUpdate::AgentMessageChunk(ContentChunk::new(ContentBlock::Text(
-                            TextContent::new(assistant_text.clone()),
-                        ))),
-                    ))?;
-                    responder.respond_with_error(
-                        Error::internal_error().data(
-                            "RetriableError: [canceled] http/2 stream closed with error code CANCEL (0x8)",
-                        ),
-                    )
+                    let assistant_chunks = assistant_chunks.clone();
+                    let prompt_cancel_signal = prompt_cancel_signal.clone();
+                    let prompt_connection = connection.clone();
+                    connection.spawn(async move {
+                        for chunk in assistant_chunks {
+                            prompt_connection.send_notification(SessionNotification::new(
+                                "provider-session",
+                                SessionUpdate::AgentMessageChunk(ContentChunk::new(
+                                    ContentBlock::Text(TextContent::new(chunk)),
+                                )),
+                            ))?;
+                        }
+                        if abort_after_stream {
+                            prompt_cancel_signal
+                                .acquire()
+                                .await
+                                .map_err(Error::into_internal_error)?
+                                .forget();
+                        }
+                        responder.respond_with_error(
+                            Error::internal_error().data(
+                                "RetriableError: [canceled] http/2 stream closed with error code CANCEL (0x8)",
+                            ),
+                        )
+                    })?;
+                    Ok(())
                 },
                 agent_client_protocol::on_receive_request!(),
+            )
+            .on_receive_notification(
+                async move |_cancel: CancelNotification, _connection| {
+                    cancel_signal.add_permits(1);
+                    Ok(())
+                },
+                agent_client_protocol::on_receive_notification!(),
             );
         let agent_task = tokio::spawn(async move { agent.connect_to(agent_transport).await });
 
@@ -6348,27 +6560,51 @@ mod tests {
                 "message": "fix it",
             }))
             .unwrap();
+        let abort_tx = command_tx.clone();
 
         let temp_dir = tempfile::tempdir().unwrap();
         let mut config = runtime_config("test-agent");
         config.project_dir = temp_dir.path().to_owned();
         let close_commands_after_response = async {
             loop {
-                if output
-                    .snapshot()
+                let events = output.snapshot();
+                let prompt_finished = events
                     .iter()
-                    .any(|event| event["type"] == "response" && event["id"] == "prompt-1")
-                {
+                    .any(|event| event["type"] == "response" && event["id"] == "prompt-1");
+                let abort_finished = !abort_after_stream
+                    || events
+                        .iter()
+                        .any(|event| event["type"] == "response" && event["id"] == "abort-1");
+                if prompt_finished && abort_finished {
                     drop(command_tx);
                     return;
                 }
                 tokio::task::yield_now().await;
             }
         };
+        let abort_output = output.clone();
+        let abort_after_first_delta = async move {
+            if !abort_after_stream {
+                return;
+            }
+            loop {
+                if events_of_type(&abort_output.snapshot(), "message_update")
+                    .iter()
+                    .any(|event| event["assistantMessageEvent"]["type"] == "text_delta")
+                {
+                    abort_tx
+                        .send(json!({ "type": "abort", "id": "abort-1" }))
+                        .unwrap();
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+        };
         let protocol = async {
-            let (result, ()) = tokio::join!(
+            let (result, (), ()) = tokio::join!(
                 run_protocol(client_transport, config, state, command_rx),
                 close_commands_after_response,
+                abort_after_first_delta,
             );
             result
         };
@@ -6387,12 +6623,16 @@ mod tests {
 
     #[tokio::test]
     async fn protocol_keeps_verified_result_when_prompt_ends_with_late_http2_cancel() {
-        let completed = concat!(
-            "Draft PR is up.\n\n",
-            "::screenpipe-result{kind=\"link\" state=\"created\" ",
-            "title=\"Fix\" url=\"https://github.com/screenpipe/screenpipe/pull/1\"}",
-        );
-        let events = protocol_events_after_late_http2_cancel(completed).await;
+        let events = protocol_events_after_late_http2_cancel(
+            &[
+                "Draft PR is up.",
+                "\n\n::screenpipe-result{kind=\"link\" state=\"cre",
+                "ated\" title=\"Fix\" url=\"https://github.com/",
+                "screenpipe/screenpipe/pull/1\"}",
+            ],
+            false,
+        )
+        .await;
 
         let agent_end = events_of_type(&events, "agent_end");
         assert_eq!(agent_end.len(), 1);
@@ -6415,7 +6655,11 @@ mod tests {
     #[tokio::test]
     async fn protocol_keeps_late_http2_cancel_as_error_without_verified_result() {
         let events = protocol_events_after_late_http2_cancel(
-            "I started the fix, but the connection closed before I finished.",
+            &[
+                "I started the fix, ",
+                "but the connection closed before I finished.",
+            ],
+            false,
         )
         .await;
 
@@ -6432,6 +6676,61 @@ mod tests {
             .any(|event| event["assistantMessageEvent"]["type"] == "error"));
     }
 
+    #[tokio::test]
+    async fn protocol_rejects_pending_result_when_prompt_ends_with_late_http2_cancel() {
+        let events = protocol_events_after_late_http2_cancel(
+            &[
+                "Still working.\n",
+                "::screenpipe-result{kind=\"link\" state=\"pending\" ",
+                "title=\"Fix\" url=\"https://github.com/screenpipe/screenpipe/pull/1\"}",
+            ],
+            false,
+        )
+        .await;
+
+        let agent_end = events_of_type(&events, "agent_end");
+        assert_eq!(agent_end.len(), 1);
+        assert_eq!(agent_end[0]["messages"][0]["stopReason"], json!("error"));
+        let prompt_response = events
+            .iter()
+            .find(|event| event["type"] == "response" && event["id"] == "prompt-1")
+            .expect("prompt response");
+        assert_eq!(prompt_response["success"], json!(false));
+        assert!(events_of_type(&events, "message_update")
+            .iter()
+            .any(|event| event["assistantMessageEvent"]["type"] == "error"));
+    }
+
+    #[tokio::test]
+    async fn protocol_never_recovers_a_late_cancel_after_local_abort() {
+        let events = protocol_events_after_late_http2_cancel(
+            &[
+                "Draft PR is up.\n\n",
+                "::screenpipe-result{kind=\"link\" state=\"created\" ",
+                "title=\"Fix\" url=\"https://github.com/screenpipe/screenpipe/pull/1\"}",
+            ],
+            true,
+        )
+        .await;
+
+        let agent_end = events_of_type(&events, "agent_end");
+        assert_eq!(agent_end.len(), 1);
+        assert_eq!(
+            agent_end[0]["messages"][0]["stopReason"],
+            json!("cancelled")
+        );
+        for response_id in ["prompt-1", "abort-1"] {
+            let response = events
+                .iter()
+                .find(|event| event["type"] == "response" && event["id"] == response_id)
+                .unwrap_or_else(|| panic!("missing response for {response_id}"));
+            assert_eq!(response["success"], json!(true));
+        }
+        assert!(events_of_type(&events, "message_update")
+            .iter()
+            .all(|event| event["assistantMessageEvent"]["type"] != "error"));
+    }
+
     #[test]
     fn incomplete_or_unrelated_failures_remain_errors() {
         let observed_error =
@@ -6445,6 +6744,12 @@ mod tests {
             "Draft PR is up.\n",
             "::screenpipe-result{kind=\"link\" state=\"created\" title=\"Fix\"",
         );
+        let malformed = "Done.\n::screenpipe-result{this is not a valid result}";
+        let unsafe_link = concat!(
+            "Done.\n",
+            "::screenpipe-result{kind=\"link\" state=\"created\" ",
+            "title=\"Fix\" url=\"javascript:alert(1)\"}",
+        );
 
         assert!(!completed_result_survives_retriable_http2_cancel(
             observed_error,
@@ -6457,6 +6762,14 @@ mod tests {
         assert!(!completed_result_survives_retriable_http2_cancel(
             observed_error,
             partial,
+        ));
+        assert!(!completed_result_survives_retriable_http2_cancel(
+            observed_error,
+            malformed,
+        ));
+        assert!(!completed_result_survives_retriable_http2_cancel(
+            observed_error,
+            unsafe_link,
         ));
         assert!(!completed_result_survives_retriable_http2_cancel(
             "provider rejected the request",


### PR DESCRIPTION
## Summary

- preserve a verified ACP result when the provider closes its HTTP/2 stream with the observed retriable `CANCEL (0x8)` after the answer is complete
- acknowledge that prompt as successful instead of overwriting the completed task with a raw transport error or retrying its durable side effects
- require a desktop-valid result shape before recovery; malformed/unsafe cards, partial output, pending results, user cancellation, and unrelated provider failures keep their existing behavior

## Root cause

The ACP runtime can receive the complete final assistant output and its verified durable-result marker, then have the provider's prompt request resolve as `RetriableError: [canceled] http/2 stream closed with error code CANCEL (0x8)`. The runtime previously trusted only that late transport result, emitted an error lifecycle, and let the chat replace a completed task with the raw cancellation.

The completed result is the stronger task-outcome signal: Screenpipe asks agents to emit the directive only after verifying the durable action. This patch recognizes only an exact retriable HTTP/2 cancel when the final non-empty line satisfies the desktop's result-card contract: supported kind/state, non-empty title, and a safe target where required. The check is fail-closed.

## Before / after

```text
before
verified final answer + durable result
                  ↓
late HTTP/2 CANCEL (0x8)
                  ↓
agent_end(error) + response(false)
                  ↓
completed task appears failed / may be retried

now
verified final answer + durable result
                  ↓
late HTTP/2 CANCEL (0x8)
                  ↓
agent_end(end_turn) + response(true)
                  ↓
completed task stays completed

no verified result (malformed, unsafe, partial, or pending) + CANCEL
                  ↓
existing error path remains unchanged
```

## Regression coverage

The protocol tests use an in-memory ACP client/server pair. The mock agent streams fragmented assistant chunks and then returns the observed HTTP/2 cancellation, exercising the real `run_protocol` lifecycle rather than only the error classifier.

- completed durable result: emits `agent_end(end_turn)` and `response(true)`, retains the answer, and emits no assistant error
- incomplete output with the identical transport failure: emits `agent_end(error)`, `response(false)`, and the existing assistant error
- pending result with the identical transport failure stays on the full error path
- local abort after a completed result remains `cancelled`; the late provider cancel can never override the user's action
- validation matrix covers every supported result kind, terminal states, required IDs/paths/URLs, malformed attributes, unsafe targets, partial directives, and unrelated errors

## Validation

- `cargo test -p screenpipe-core --features acp --lib` — 648 passed, 0 failed, 1 ignored after rebasing on current `main`
- `cargo check -p screenpipe-core --no-default-features --features acp`
- strict Clippy for `screenpipe-core` with current-main baseline lint categories explicitly separated — no new warnings
- `bun run coverage:all:check` — E2E, core, and unified coverage dashboards current
- `rustfmt --edition 2021 --check crates/screenpipe-core/src/agents/acp/runtime.rs`
- `git diff --check origin/main...HEAD`

This is protocol-level coverage with the exact observed provider error. It does not depend on a live Cursor service reproducing a timing-sensitive cancellation.
