### PR TITLE
fix(auth): stabilize ChatGPT token reauthentication

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/chatgpt_oauth.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/chatgpt_oauth.rs
@@ -40,6 +40,8 @@ struct OAuthTokens {
     access_token: String,
     refresh_token: String,
     expires_at: Option<u64>,
+    #[serde(default)]
+    reauth_required: bool,
 }
 
 #[derive(Serialize, Deserialize, specta::Type)]
@@ -172,6 +174,11 @@ const MISSING_ACCOUNT_ID_MSG: &str = "This ChatGPT account can't be used for cha
     token has no ChatGPT account id. This usually means an Enterprise/Business workspace where \
     the admin hasn't enabled Codex local app access. Ask your workspace admin to enable it, or \
     sign in with a personal ChatGPT account.";
+const REAUTH_REQUIRED_MSG: &str =
+    "Your ChatGPT session expired. Sign in again to continue using ChatGPT in screenpipe.";
+const REFRESH_LEASE_SECONDS: u64 = 45;
+const REFRESH_LEASE_WAIT_ATTEMPTS: usize = 140;
+const REFRESH_LEASE_WAIT: std::time::Duration = std::time::Duration::from_millis(250);
 
 /// Extract the `chatgpt_account_id` claim from an access token JWT.
 /// Returns `None` for non-JWT strings (e.g. API keys) or tokens without
@@ -209,11 +216,104 @@ fn generate_pkce() -> (String, String) {
 
 // ── Token refresh ──────────────────────────────────────────────────────
 
-async fn do_refresh_token(refresh_token: &str) -> Result<OAuthTokens, String> {
+#[derive(Debug)]
+enum RefreshError {
+    ReauthRequired(String),
+    Transient(String),
+}
+
+impl std::fmt::Display for RefreshError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ReauthRequired(message) | Self::Transient(message) => f.write_str(message),
+        }
+    }
+}
+
+fn refresh_error(status: reqwest::StatusCode, body: &str) -> RefreshError {
+    let code = serde_json::from_str::<serde_json::Value>(body)
+        .ok()
+        .and_then(|value| value.pointer("/error/code")?.as_str().map(str::to_owned));
+    if matches!(
+        code.as_deref(),
+        Some("refresh_token_reused" | "invalid_grant")
+    ) {
+        RefreshError::ReauthRequired(REAUTH_REQUIRED_MSG.to_string())
+    } else {
+        RefreshError::Transient(format!("token refresh failed ({status}): {body}"))
+    }
+}
+
+async fn save_reauth_required(
+    store: &screenpipe_secrets::SecretStore,
+    tokens: &mut OAuthTokens,
+) -> Result<(), RefreshError> {
+    tokens.reauth_required = true;
+    let json = serde_json::to_vec(tokens).map_err(|e| {
+        RefreshError::Transient(format!("failed to serialize reauthentication state: {e}"))
+    })?;
+    store.set(SECRET_KEY, &json).await.map_err(|e| {
+        RefreshError::Transient(format!("failed to save reauthentication state: {e:#}"))
+    })
+}
+
+async fn do_refresh_token(refresh_token: &str) -> Result<OAuthTokens, RefreshError> {
+    let store = open_secret_store().await.map_err(RefreshError::Transient)?;
+    let lease_owner = uuid::Uuid::new_v4().simple().to_string();
+    let mut acquired = false;
+    for _ in 0..REFRESH_LEASE_WAIT_ATTEMPTS {
+        acquired = store
+            .try_acquire_refresh_lease(SECRET_KEY, &lease_owner, REFRESH_LEASE_SECONDS)
+            .await
+            .map_err(|error| {
+                RefreshError::Transient(format!("refresh coordination failed: {error:#}"))
+            })?;
+        if acquired {
+            break;
+        }
+        tokio::time::sleep(REFRESH_LEASE_WAIT).await;
+    }
+    if !acquired {
+        return Err(RefreshError::Transient(
+            "timed out waiting for another ChatGPT token refresh".to_string(),
+        ));
+    }
+
+    let result = do_refresh_token_as_owner(&store, refresh_token).await;
+    if let Err(error) = store.release_refresh_lease(SECRET_KEY, &lease_owner).await {
+        warn!("failed to release ChatGPT refresh lease: {error:#}");
+    }
+    result
+}
+
+async fn do_refresh_token_as_owner(
+    store: &screenpipe_secrets::SecretStore,
+    refresh_token: &str,
+) -> Result<OAuthTokens, RefreshError> {
+    let bytes = store
+        .get(SECRET_KEY)
+        .await
+        .map_err(|error| {
+            RefreshError::Transient(format!("failed to reread ChatGPT token: {error:#}"))
+        })?
+        .ok_or_else(|| RefreshError::ReauthRequired(REAUTH_REQUIRED_MSG.to_string()))?;
+    let mut current: OAuthTokens = serde_json::from_slice(&bytes).map_err(|error| {
+        RefreshError::Transient(format!("failed to parse stored ChatGPT token: {error}"))
+    })?;
+
+    if current.reauth_required {
+        return Err(RefreshError::ReauthRequired(
+            REAUTH_REQUIRED_MSG.to_string(),
+        ));
+    }
+    if current.refresh_token != refresh_token {
+        return Ok(current);
+    }
+
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(30))
         .build()
-        .map_err(|e| format!("failed to build HTTP client: {}", e))?;
+        .map_err(|e| RefreshError::Transient(format!("failed to build HTTP client: {e}")))?;
 
     let resp = client
         .post(TOKEN_URL)
@@ -226,23 +326,37 @@ async fn do_refresh_token(refresh_token: &str) -> Result<OAuthTokens, String> {
         }))
         .send()
         .await
-        .map_err(|e| format!("token refresh request failed: {}", e))?;
+        .map_err(|e| RefreshError::Transient(format!("token refresh request failed: {e}")))?;
 
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
-        return Err(format!("token refresh failed ({}): {}", status, body));
+        let error = refresh_error(status, &body);
+        if matches!(error, RefreshError::ReauthRequired(_)) {
+            save_reauth_required(store, &mut current).await?;
+        }
+        return Err(error);
     }
 
-    let v: serde_json::Value = resp
-        .json()
-        .await
-        .map_err(|e| format!("failed to parse refresh response: {}", e))?;
+    let v: serde_json::Value = match resp.json().await {
+        Ok(value) => value,
+        Err(error) => {
+            save_reauth_required(store, &mut current).await?;
+            return Err(RefreshError::ReauthRequired(format!(
+                "{REAUTH_REQUIRED_MSG} The refreshed credential could not be read: {error}"
+            )));
+        }
+    };
 
-    let new_access_token = v["access_token"]
-        .as_str()
-        .ok_or("no access_token in refresh response")?
-        .to_string();
+    let new_access_token = match v["access_token"].as_str() {
+        Some(token) => token.to_string(),
+        None => {
+            save_reauth_required(store, &mut current).await?;
+            return Err(RefreshError::ReauthRequired(
+                REAUTH_REQUIRED_MSG.to_string(),
+            ));
+        }
+    };
 
     let new_refresh_token = v["refresh_token"]
         .as_str()
@@ -256,16 +370,26 @@ async fn do_refresh_token(refresh_token: &str) -> Result<OAuthTokens, String> {
     // instead of overwriting a working credential.
     if extract_chatgpt_account_id(&new_access_token).is_none() {
         warn!("ChatGPT token refresh returned a token without chatgpt_account_id — not storing it");
-        return Err(MISSING_ACCOUNT_ID_MSG.to_string());
+        save_reauth_required(store, &mut current).await?;
+        return Err(RefreshError::ReauthRequired(
+            MISSING_ACCOUNT_ID_MSG.to_string(),
+        ));
     }
 
     let tokens = OAuthTokens {
         access_token: new_access_token,
         refresh_token: new_refresh_token,
         expires_at: Some(unix_now() + expires_in),
+        reauth_required: false,
     };
 
-    write_tokens_to_store(&tokens).await?;
+    if let Err(error) = write_tokens_to_store(&tokens).await {
+        warn!("refreshed ChatGPT token could not be persisted: {error}");
+        let _ = save_reauth_required(store, &mut current).await;
+        return Err(RefreshError::ReauthRequired(
+            REAUTH_REQUIRED_MSG.to_string(),
+        ));
+    }
     info!("ChatGPT token refreshed successfully");
     Ok(tokens)
 }
@@ -281,9 +405,14 @@ pub async fn get_valid_token() -> Result<String, String> {
         Err(e) => return Err(e),
     };
 
+    if tokens.reauth_required {
+        return Err(REAUTH_REQUIRED_MSG.to_string());
+    }
+
     if is_token_expired(&tokens) {
         match do_refresh_token(&tokens.refresh_token).await {
             Ok(refreshed) => return Ok(refreshed.access_token),
+            Err(RefreshError::ReauthRequired(message)) => return Err(message),
             Err(first_err) => {
                 warn!(
                     "ChatGPT token refresh failed, retrying in 1s: {}",
@@ -292,6 +421,7 @@ pub async fn get_valid_token() -> Result<String, String> {
                 tokio::time::sleep(std::time::Duration::from_secs(1)).await;
                 match do_refresh_token(&tokens.refresh_token).await {
                     Ok(refreshed) => return Ok(refreshed.access_token),
+                    Err(RefreshError::ReauthRequired(message)) => return Err(message),
                     Err(retry_err) => {
                         return Err(format!("token refresh failed after retry: {}", retry_err));
                     }
@@ -345,6 +475,10 @@ pub fn start_background_refresh() {
 
             match read_tokens_from_store().await {
                 Ok(Some(tokens)) => {
+                    if tokens.reauth_required {
+                        tokio::time::sleep(REFRESH_CHECK_INTERVAL).await;
+                        continue;
+                    }
                     let needs_refresh = match tokens.expires_at {
                         Some(exp) => {
                             let soon = unix_now().saturating_add(REFRESH_SOON_WINDOW.as_secs());
@@ -357,6 +491,10 @@ pub fn start_background_refresh() {
                         match do_refresh_token(&tokens.refresh_token).await {
                             Ok(_) => {
                                 info!("chatgpt background refresh: token refreshed proactively");
+                                consecutive_failures = 0;
+                            }
+                            Err(RefreshError::ReauthRequired(e)) => {
+                                warn!("chatgpt background refresh: reauthentication required: {e}");
                                 consecutive_failures = 0;
                             }
                             Err(e) => {
@@ -549,6 +687,7 @@ pub async fn chatgpt_oauth_login(
         access_token,
         refresh_token,
         expires_at: Some(unix_now() + expires_in),
+        reauth_required: false,
     };
 
     write_tokens_to_store(&tokens).await?;
@@ -564,12 +703,13 @@ pub async fn chatgpt_oauth_login(
 #[tauri::command]
 #[specta::specta]
 pub async fn chatgpt_oauth_status() -> Result<ChatGptOAuthStatus, String> {
-    // Only check token existence — no network refresh here.
+    // Check token existence and the persisted reauthentication marker — no
+    // network refresh here.
     // Refresh happens lazily in chatgpt_oauth_get_token when actually needed.
     // 3-second timeout guards against a locked/slow SQLite DB.
     match tokio::time::timeout(std::time::Duration::from_secs(3), read_tokens_from_store()).await {
-        Ok(Ok(Some(_))) => Ok(ChatGptOAuthStatus {
-            logged_in: true,
+        Ok(Ok(Some(tokens))) => Ok(ChatGptOAuthStatus {
+            logged_in: !tokens.reauth_required,
             error: None,
         }),
         Ok(Ok(None)) => Ok(ChatGptOAuthStatus {
@@ -714,5 +854,43 @@ mod tests {
             extract_chatgpt_account_id("head.%%%not-base64%%%.sig"),
             None
         );
+    }
+
+    #[test]
+    fn reused_refresh_token_requires_reauthentication() {
+        let error = refresh_error(
+            reqwest::StatusCode::UNAUTHORIZED,
+            r#"{"error":{"code":"refresh_token_reused"}}"#,
+        );
+        assert!(matches!(error, RefreshError::ReauthRequired(_)));
+    }
+
+    #[test]
+    fn invalid_grant_requires_reauthentication() {
+        let error = refresh_error(
+            reqwest::StatusCode::BAD_REQUEST,
+            r#"{"error":{"code":"invalid_grant"}}"#,
+        );
+        assert!(matches!(error, RefreshError::ReauthRequired(_)));
+    }
+
+    #[test]
+    fn server_failure_remains_retryable() {
+        let error = refresh_error(
+            reqwest::StatusCode::SERVICE_UNAVAILABLE,
+            r#"{"error":{"code":"temporarily_unavailable"}}"#,
+        );
+        assert!(matches!(error, RefreshError::Transient(_)));
+    }
+
+    #[test]
+    fn existing_tokens_default_to_no_reauthentication_required() {
+        let tokens: OAuthTokens = serde_json::from_value(serde_json::json!({
+            "access_token": "access",
+            "refresh_token": "refresh",
+            "expires_at": 123
+        }))
+        .unwrap();
+        assert!(!tokens.reauth_required);
     }
 }

--- a/crates/screenpipe-core/src/pipes/mod.rs
+++ b/crates/screenpipe-core/src/pipes/mod.rs
@@ -1547,10 +1547,19 @@ fn read_chatgpt_token_from_legacy_file() -> Option<String> {
         .unwrap_or(0);
 
     if now >= expires_at.saturating_sub(60) {
-        refresh_chatgpt_token(&mut token_data, now);
-        if let Ok(updated) = serde_json::to_string_pretty(&token_data) {
-            let _ = std::fs::write(&path, updated);
+        if refresh_chatgpt_token(&mut token_data, now) {
+            if let Ok(updated) = serde_json::to_string_pretty(&token_data) {
+                let _ = std::fs::write(&path, updated);
+            }
         }
+    }
+
+    if token_data
+        .get("reauth_required")
+        .and_then(|value| value.as_bool())
+        .unwrap_or(false)
+    {
+        return None;
     }
 
     token_data
@@ -1579,6 +1588,14 @@ fn read_chatgpt_token_from_secrets() -> Option<String> {
             let bytes = store.get("oauth:chatgpt").await.ok()??;
             let mut token_data: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
 
+            if token_data
+                .get("reauth_required")
+                .and_then(|value| value.as_bool())
+                .unwrap_or(false)
+            {
+                return None;
+            }
+
             let now = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap_or_default()
@@ -1589,12 +1606,69 @@ fn read_chatgpt_token_from_secrets() -> Option<String> {
                 .unwrap_or(0);
 
             if now >= expires_at.saturating_sub(60) {
-                refresh_chatgpt_token(&mut token_data, now);
-                // Write refreshed token back to secrets store
-                if let Ok(updated_bytes) = serde_json::to_vec(&token_data) {
-                    if let Err(e) = store.set("oauth:chatgpt", &updated_bytes).await {
-                        tracing::warn!("failed to write refreshed ChatGPT token to secrets: {}", e);
+                let lease_owner = uuid::Uuid::new_v4().simple().to_string();
+                let mut acquired = false;
+                for _ in 0..140 {
+                    acquired = store
+                        .try_acquire_refresh_lease("oauth:chatgpt", &lease_owner, 45)
+                        .await
+                        .ok()?;
+                    if acquired {
+                        break;
                     }
+                    tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+                }
+                if !acquired {
+                    tracing::warn!("timed out waiting for another ChatGPT token refresh");
+                    return None;
+                }
+
+                // The lease winner may have refreshed while we waited. Always
+                // reread before redeeming a rotating refresh token.
+                let refresh_result = async {
+                    let latest = store.get("oauth:chatgpt").await.ok()??;
+                    token_data = serde_json::from_slice(&latest).ok()?;
+                    if token_data
+                        .get("reauth_required")
+                        .and_then(|value| value.as_bool())
+                        .unwrap_or(false)
+                    {
+                        return None;
+                    }
+                    let latest_expires_at = token_data
+                        .get("expires_at")
+                        .and_then(|value| value.as_u64())
+                        .unwrap_or(0);
+                    if now >= latest_expires_at.saturating_sub(60) {
+                        if !refresh_chatgpt_token(&mut token_data, now) {
+                            return None;
+                        }
+                        let updated_bytes = serde_json::to_vec(&token_data).ok()?;
+                        if let Err(error) = store.set("oauth:chatgpt", &updated_bytes).await {
+                            tracing::warn!(
+                                "failed to write refreshed ChatGPT token to secrets: {error}"
+                            );
+                            return None;
+                        }
+                    }
+                    Some(())
+                }
+                .await;
+
+                if let Err(error) = store
+                    .release_refresh_lease("oauth:chatgpt", &lease_owner)
+                    .await
+                {
+                    tracing::warn!("failed to release ChatGPT refresh lease: {error}");
+                }
+                refresh_result?;
+
+                if token_data
+                    .get("reauth_required")
+                    .and_then(|value| value.as_bool())
+                    .unwrap_or(false)
+                {
+                    return None;
                 }
             }
 
@@ -1614,14 +1688,24 @@ fn read_chatgpt_token_from_secrets() -> Option<String> {
 
 /// Refresh an expired ChatGPT OAuth token using the refresh_token grant.
 /// Mutates `token_data` in place with the new access_token, refresh_token, and expires_at.
-fn refresh_chatgpt_token(token_data: &mut serde_json::Value, now: u64) {
+fn chatgpt_refresh_requires_reauth(body: &str) -> bool {
+    let code = serde_json::from_str::<serde_json::Value>(body)
+        .ok()
+        .and_then(|value| value.pointer("/error/code")?.as_str().map(str::to_owned));
+    matches!(
+        code.as_deref(),
+        Some("refresh_token_reused" | "invalid_grant")
+    )
+}
+
+fn refresh_chatgpt_token(token_data: &mut serde_json::Value, now: u64) -> bool {
     let refresh_token = match token_data
         .get("refresh_token")
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
     {
         Some(t) => t,
-        None => return,
+        None => return false,
     };
 
     tracing::info!("ChatGPT OAuth token expired, refreshing...");
@@ -1630,7 +1714,7 @@ fn refresh_chatgpt_token(token_data: &mut serde_json::Value, now: u64) {
         .build()
     {
         Ok(c) => c,
-        Err(_) => return,
+        Err(_) => return false,
     };
 
     let refresh_res = client
@@ -1646,28 +1730,48 @@ fn refresh_chatgpt_token(token_data: &mut serde_json::Value, now: u64) {
 
     match refresh_res {
         Ok(resp) if resp.status().is_success() => {
-            if let Ok(v) = resp.json::<serde_json::Value>() {
-                if let Some(new_token) = v.get("access_token").and_then(|t| t.as_str()) {
-                    let new_refresh = v
-                        .get("refresh_token")
-                        .and_then(|t| t.as_str())
-                        .unwrap_or(refresh_token.as_str());
-                    let new_expires_in =
-                        v.get("expires_in").and_then(|t| t.as_u64()).unwrap_or(3600);
+            let Ok(v) = resp.json::<serde_json::Value>() else {
+                token_data["reauth_required"] = serde_json::Value::Bool(true);
+                tracing::warn!(
+                    "ChatGPT refresh response could not be read; reauthentication required"
+                );
+                return true;
+            };
+            let Some(new_token) = v.get("access_token").and_then(|t| t.as_str()) else {
+                token_data["reauth_required"] = serde_json::Value::Bool(true);
+                tracing::warn!(
+                    "ChatGPT refresh response omitted the access token; reauthentication required"
+                );
+                return true;
+            };
+            let new_refresh = v
+                .get("refresh_token")
+                .and_then(|t| t.as_str())
+                .unwrap_or(refresh_token.as_str());
+            let new_expires_in = v.get("expires_in").and_then(|t| t.as_u64()).unwrap_or(3600);
 
-                    token_data["access_token"] = serde_json::Value::String(new_token.to_string());
-                    token_data["refresh_token"] =
-                        serde_json::Value::String(new_refresh.to_string());
-                    token_data["expires_at"] = serde_json::json!(now + new_expires_in);
-                    tracing::info!("ChatGPT token refreshed successfully");
-                }
-            }
+            token_data["access_token"] = serde_json::Value::String(new_token.to_string());
+            token_data["refresh_token"] = serde_json::Value::String(new_refresh.to_string());
+            token_data["expires_at"] = serde_json::json!(now + new_expires_in);
+            token_data["reauth_required"] = serde_json::Value::Bool(false);
+            tracing::info!("ChatGPT token refreshed successfully");
+            true
         }
         Ok(resp) => {
-            tracing::error!("ChatGPT token refresh failed ({})", resp.status());
+            let status = resp.status();
+            let body = resp.text().unwrap_or_default();
+            if chatgpt_refresh_requires_reauth(&body) {
+                token_data["reauth_required"] = serde_json::Value::Bool(true);
+                tracing::warn!("ChatGPT session requires reauthentication");
+                true
+            } else {
+                tracing::error!("ChatGPT token refresh failed ({status}): {body}");
+                false
+            }
         }
         Err(e) => {
             tracing::error!("ChatGPT token refresh request failed: {}", e);
+            false
         }
     }
 }
@@ -8508,6 +8612,19 @@ mod tests {
     use chrono::{TimeZone, Timelike};
     use std::path::Path;
     use std::sync::atomic::Ordering;
+
+    #[test]
+    fn rotating_chatgpt_token_errors_require_reauthentication() {
+        assert!(chatgpt_refresh_requires_reauth(
+            r#"{"error":{"code":"refresh_token_reused"}}"#
+        ));
+        assert!(chatgpt_refresh_requires_reauth(
+            r#"{"error":{"code":"invalid_grant"}}"#
+        ));
+        assert!(!chatgpt_refresh_requires_reauth(
+            r#"{"error":{"code":"temporarily_unavailable"}}"#
+        ));
+    }
 
     struct SequencedExecutor {
         outputs: std::sync::Mutex<VecDeque<AgentOutput>>,

--- a/crates/screenpipe-secrets/src/store.rs
+++ b/crates/screenpipe-secrets/src/store.rs
@@ -221,6 +221,20 @@ impl SecretStore {
         )
         .report_secret_store_integrity("initialize", None, Some(key.is_some()))
         .context("failed to create secrets table")?;
+        observe_database_result(
+            database_error_hook.as_ref(),
+            sqlx::query(
+                "CREATE TABLE IF NOT EXISTS credential_refresh_leases (
+                    key TEXT PRIMARY KEY,
+                    owner TEXT NOT NULL,
+                    expires_at INTEGER NOT NULL
+                )",
+            )
+            .execute(&pool)
+            .await,
+        )
+        .report_secret_store_integrity("initialize_refresh_leases", None, Some(key.is_some()))
+        .context("failed to create credential refresh lease table")?;
 
         Ok(Self {
             pool,
@@ -447,6 +461,60 @@ impl SecretStore {
         .report_secret_store_integrity("set", Some(key), Some(self.key.is_some()))
         .context("failed to set secret")?;
 
+        Ok(())
+    }
+
+    /// Try to become the sole refresh owner for a rotating credential.
+    ///
+    /// The lease is stored beside the credential so independent app, CLI, and
+    /// pipe processes cannot redeem the same one-time refresh token. A crashed
+    /// owner is recoverable after `lease_seconds`.
+    pub async fn try_acquire_refresh_lease(
+        &self,
+        key: &str,
+        owner: &str,
+        lease_seconds: u64,
+    ) -> Result<bool> {
+        let _write_permit = acquire_write_permit(&self.write_lock).await?;
+        let lease_seconds = i64::try_from(lease_seconds).unwrap_or(i64::MAX);
+        let result = self
+            .observe(
+                sqlx::query(
+                    "INSERT INTO credential_refresh_leases (key, owner, expires_at)
+                     VALUES (?, ?, unixepoch() + ?)
+                     ON CONFLICT(key) DO UPDATE SET
+                        owner = excluded.owner,
+                        expires_at = excluded.expires_at
+                     WHERE credential_refresh_leases.expires_at <= unixepoch()
+                        OR credential_refresh_leases.owner = excluded.owner",
+                )
+                .bind(key)
+                .bind(owner)
+                .bind(lease_seconds)
+                .execute(&self.pool)
+                .await,
+            )
+            .report_secret_store_integrity(
+                "try_acquire_refresh_lease",
+                Some(key),
+                Some(self.key.is_some()),
+            )
+            .context("failed to acquire credential refresh lease")?;
+        Ok(result.rows_affected() == 1)
+    }
+
+    /// Release a refresh lease without disturbing a newer owner.
+    pub async fn release_refresh_lease(&self, key: &str, owner: &str) -> Result<()> {
+        let _write_permit = acquire_write_permit(&self.write_lock).await?;
+        self.observe(
+            sqlx::query("DELETE FROM credential_refresh_leases WHERE key = ? AND owner = ?")
+                .bind(key)
+                .bind(owner)
+                .execute(&self.pool)
+                .await,
+        )
+        .report_secret_store_integrity("release_refresh_lease", Some(key), Some(self.key.is_some()))
+        .context("failed to release credential refresh lease")?;
         Ok(())
     }
 
@@ -739,6 +807,29 @@ mod tests {
         store.set("test:key", b"second").await.unwrap();
         let val = store.get("test:key").await.unwrap().unwrap();
         assert_eq!(val, b"second");
+    }
+
+    #[tokio::test]
+    async fn refresh_lease_allows_only_one_owner() {
+        let store = make_store(None).await;
+
+        assert!(store
+            .try_acquire_refresh_lease("oauth:chatgpt", "owner-a", 60)
+            .await
+            .unwrap());
+        assert!(!store
+            .try_acquire_refresh_lease("oauth:chatgpt", "owner-b", 60)
+            .await
+            .unwrap());
+
+        store
+            .release_refresh_lease("oauth:chatgpt", "owner-a")
+            .await
+            .unwrap();
+        assert!(store
+            .try_acquire_refresh_lease("oauth:chatgpt", "owner-b", 60)
+            .await
+            .unwrap());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- serialize ChatGPT refresh-token rotation across the desktop background refresher and headless pipe runner
- reread the encrypted credential after waiting so a second consumer uses the newly rotated token
- persist permanent OAuth failures such as refresh_token_reused and invalid_grant as reauthentication-required state
- keep transient refresh failures retryable and make abandoned refresh leases expire after 45 seconds

## Before / after

```text
Before
desktop refresh ---\
                    > same rotating refresh token -> one succeeds, one receives 401
pipe refresh -------/

After
desktop / pipe refresh -> SQLite lease -> one refresh -> persisted replacement
                                      -> waiter rereads replacement token
```

## Historical intent

- 8b50ea8655 moved pipe OAuth reads to the encrypted secrets store after the legacy JSON credential stopped being written.
- 2a3748c806 and #5063 added proactive desktop refresh to prevent ChatGPT tokens from silently expiring.
- This change preserves both behaviors and coordinates them through one refresh owner instead of removing either refresh path.

## Testing

- `cargo test -p screenpipe-secrets` — 41 passed, 0 failed, 1 ignored
- `cargo test -p screenpipe-core rotating_chatgpt_token_errors_require_reauthentication` — 1 passed
- `cd apps/screenpipe-app-tauri && bun run test:tauri chatgpt_oauth::tests` — 10 passed, 0 failed
