### PR TITLE
fix(chat): classify expired certificate failures

### DIFF
--- a/apps/screenpipe-app-tauri/lib/chat/__tests__/provider-errors.test.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/__tests__/provider-errors.test.ts
@@ -122,6 +122,18 @@ describe("provider error copy", () => {
     }
   });
 
+  it("maps an expired TLS certificate to retryable cloud connectivity copy", () => {
+    const presentation = buildProviderErrorPresentation(
+      "Error: certificate has expired",
+      { provider: "screenpipe-cloud", model: "auto" },
+    );
+
+    expect(presentation).toMatchObject({ kind: "provider", retryable: true });
+    expect(presentation?.message).toContain("screenpipe cloud");
+    expect(presentation?.message.toLowerCase()).toContain("try again");
+    expect(presentation?.message).not.toContain("certificate has expired");
+  });
+
   it("maps the daily free-chat wall to tomorrow-or-BYOK copy", () => {
     const msg = buildProviderErrorMessage(
       '{"error":"free_chat_limit_exceeded","limit":2}',

--- a/apps/screenpipe-app-tauri/lib/chat/provider-errors.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/provider-errors.ts
@@ -100,6 +100,7 @@ function isConnectionLikeError(errorStr: string): boolean {
     // 2026-06-18 outage: reqwest "error sending request" / "tls handshake eof".
     normalized.includes("error sending request") ||
     normalized.includes("tls handshake") ||
+    normalized === "error: certificate has expired" ||
     normalized.includes("unexpected eof") ||
     normalized.includes("unexpectedeof") ||
     normalized.includes("could not connect") ||


### PR DESCRIPTION
## Summary

- classify the exact normalized `Error: certificate has expired` provider failure as retryable connectivity
- route it through the existing provider-aware guidance instead of exposing raw certificate text
- add a regression test for the Screenpipe Cloud presentation

Source feedback: Discord feedback message `1542707228488892468` (Windows 10.0.26200, Screenpipe 2.6.91), tracked by automation task `t_2178edb7`.

## Root cause and coverage

The central provider error classifier already recognized connection, fetch, gateway send-request, and TLS-handshake failures, but it did not recognize the exact certificate-expiry string reported by the app. The classifier therefore returned no presentation and the raw provider error reached chat.

The fix adds a narrow, case-normalized equality check in that central classifier. This covers every caller that uses the shared provider presentation path while preserving the existing provider-aware result for Screenpipe Cloud, remote providers, and native Ollama. Broader substring matching is intentionally avoided so unrelated certificate text is not reclassified. This is an error-presentation change only; transport and TLS-validation code are untouched.

## Visual evidence

```text
Before
Chat error: Error: certificate has expired

After
Chat guidance: Can't reach screenpipe cloud right now — this is usually a brief
               outage on our end, not your setup. Wait a few seconds and try again.
```

## Verification

RED (before the fix):
- exact certificate-expiry regression returned `null` and failed as expected

GREEN and broad checks on the exact reviewed commit `39e3a75a829f55d845b96b8165cc1c6dfe83df6b`:
- `/home/ezra/.bun/bin/bun x vitest run --config vitest.config.ts lib/chat/__tests__/provider-errors.test.ts` — 1/1 file, 44/44 tests passed
- `PATH=/home/ezra/.bun/bin:$PATH bun run test:vitest` — 462/462 files, 4,832/4,832 tests passed
- `PATH=/home/ezra/.bun/bin:$PATH bun run typecheck` — `tsc --noEmit` passed
- `git diff --check origin/main...HEAD` — passed

## Platform scope

The reported environment is Windows. The change is platform-neutral TypeScript string classification in the shared chat provider-error path, so the same presentation behavior applies on Windows, macOS, and Linux.
