### PR TITLE
feat(chat): make Ctrl+Tab cycle open chat tabs

### DIFF
--- a/apps/screenpipe-app-tauri/components/__tests__/shortcut-guide.test.tsx
+++ b/apps/screenpipe-app-tauri/components/__tests__/shortcut-guide.test.tsx
@@ -62,7 +62,7 @@ describe("ShortcutGuide", () => {
     expect(
       await screen.findByRole("dialog", { name: "keyboard shortcuts" }),
     ).toBeVisible();
-    expect(screen.getByText("switch recent chat")).toBeInTheDocument();
+    expect(screen.getByText("next chat tab")).toBeInTheDocument();
     expect(screen.getByText("close tab")).toBeInTheDocument();
     expect(screen.getByText("⌘W")).toBeInTheDocument();
     expect(screen.getByText("⌃Tab")).toBeInTheDocument();

--- a/apps/screenpipe-app-tauri/components/chat/recent-chat-switcher-controller.test.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/recent-chat-switcher-controller.test.tsx
@@ -52,6 +52,7 @@ function resetStore() {
     sessions: {},
     currentId: null,
     panelSessionId: null,
+    openChatIds: [],
     diskHydrated: false,
   });
 }
@@ -62,9 +63,6 @@ function seed(record: Partial<SessionRecord> & Pick<SessionRecord, "id">) {
     title: record.title ?? record.id,
     preview: "",
     status: "idle",
-    // Seeded rows stand in for real conversations. The switcher only lists
-    // chats that exist (isEmptyChatShell), so they need a message count —
-    // a zero-message row is an empty shell and is filtered out.
     messageCount: 2,
     createdAt: record.createdAt ?? 1_000,
     updatedAt: record.updatedAt ?? record.createdAt ?? 1_000,
@@ -72,6 +70,13 @@ function seed(record: Partial<SessionRecord> & Pick<SessionRecord, "id">) {
     unread: false,
     ...record,
   });
+}
+
+function seedOpenTab(
+  record: Partial<SessionRecord> & Pick<SessionRecord, "id">,
+) {
+  seed(record);
+  useChatStore.getState().actions.openChat(record.id);
 }
 
 describe("RecentChatSwitcherController", () => {
@@ -87,17 +92,23 @@ describe("RecentChatSwitcherController", () => {
     vi.restoreAllMocks();
   });
 
-  it("cycles forward with Ctrl+Tab and commits on Control release", async () => {
-    seed({ id: "chat-a", lastViewedAt: 300, createdAt: 300, updatedAt: 300 });
-    seed({ id: "chat-b", lastViewedAt: 200, createdAt: 200, updatedAt: 200 });
-    seed({ id: "chat-c", lastViewedAt: 100, createdAt: 100, updatedAt: 100 });
+  it("cycles open tabs with Ctrl+Tab and commits on Control release", async () => {
+    seedOpenTab({ id: "chat-a", title: "first tab" });
+    seedOpenTab({ id: "chat-b", title: "second tab" });
+    seedOpenTab({ id: "chat-c", title: "third tab" });
+    seed({
+      id: "closed-recent",
+      title: "closed recent",
+      lastViewedAt: 9_000,
+    });
     useChatStore.setState({ currentId: "chat-a" });
     const onActivateConversation = vi.fn(async () => {});
 
     render(<RecentChatSwitcherController onActivateConversation={onActivateConversation} />);
 
     fireEvent.keyDown(window, { key: "Tab", ctrlKey: true });
-    expect(screen.getByText("Recently viewed")).toBeInTheDocument();
+    expect(screen.getByText("Open chats")).toBeInTheDocument();
+    expect(screen.queryByText("closed recent")).not.toBeInTheDocument();
     let buttons = screen.getAllByRole("button");
     expect(buttons[1]).toHaveClass("bg-muted/55");
 
@@ -114,9 +125,9 @@ describe("RecentChatSwitcherController", () => {
   });
 
   it("cycles backward with Ctrl+Shift+Tab", async () => {
-    seed({ id: "chat-a", lastViewedAt: 300, createdAt: 300, updatedAt: 300 });
-    seed({ id: "chat-b", lastViewedAt: 200, createdAt: 200, updatedAt: 200 });
-    seed({ id: "chat-c", lastViewedAt: 100, createdAt: 100, updatedAt: 100 });
+    seedOpenTab({ id: "chat-a", title: "first tab" });
+    seedOpenTab({ id: "chat-b", title: "second tab" });
+    seedOpenTab({ id: "chat-c", title: "third tab" });
     useChatStore.setState({ currentId: "chat-b" });
     const onActivateConversation = vi.fn(async () => {});
 
@@ -134,9 +145,42 @@ describe("RecentChatSwitcherController", () => {
     expect(onActivateConversation).toHaveBeenCalledWith("chat-a");
   });
 
+  it("includes an empty worktree tab in the cycle", async () => {
+    seedOpenTab({
+      id: "chat-a",
+      title: "primary",
+      lastViewedAt: 300,
+    });
+    seedOpenTab({
+      id: "worktree-chat",
+      title: "isolated fix",
+      draft: true,
+      messageCount: 0,
+      lastViewedAt: undefined,
+      codingWorkspace: {
+        repoName: "screenpipe",
+        branch: "screenpipe/chat-worktree-chat",
+        worktreePath: "/worktrees/worktree-chat",
+      },
+    });
+    useChatStore.setState({ currentId: "chat-a" });
+    const onActivateConversation = vi.fn(async () => {});
+
+    render(<RecentChatSwitcherController onActivateConversation={onActivateConversation} />);
+
+    fireEvent.keyDown(window, { key: "Tab", ctrlKey: true });
+    expect(screen.getByText("isolated fix")).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.keyUp(window, { key: "Control" });
+    });
+
+    expect(onActivateConversation).toHaveBeenCalledWith("worktree-chat");
+  });
+
   it("ignores Cmd+Tab so the app does not steal OS window switching", () => {
-    seed({ id: "chat-a", lastViewedAt: 200, createdAt: 200, updatedAt: 200 });
-    seed({ id: "chat-b", lastViewedAt: 100, createdAt: 100, updatedAt: 100 });
+    seedOpenTab({ id: "chat-a" });
+    seedOpenTab({ id: "chat-b" });
     useChatStore.setState({ currentId: "chat-a" });
     const onActivateConversation = vi.fn(async () => {});
 
@@ -145,13 +189,13 @@ describe("RecentChatSwitcherController", () => {
     fireEvent.keyDown(window, { key: "Tab", ctrlKey: true, metaKey: true });
     fireEvent.keyUp(window, { key: "Control" });
 
-    expect(screen.queryByText("Recently viewed")).not.toBeInTheDocument();
+    expect(screen.queryByText("Open chats")).not.toBeInTheDocument();
     expect(onActivateConversation).not.toHaveBeenCalled();
   });
 
   it("opens from a chat-origin search handoff and commits on Control release", async () => {
-    seed({ id: "chat-a", lastViewedAt: 300, createdAt: 300, updatedAt: 300 });
-    seed({ id: "chat-b", lastViewedAt: 200, createdAt: 200, updatedAt: 200 });
+    seedOpenTab({ id: "chat-a" });
+    seedOpenTab({ id: "chat-b" });
     useChatStore.setState({ currentId: "chat-a" });
     const onActivateConversation = vi.fn(async () => {});
 
@@ -163,7 +207,7 @@ describe("RecentChatSwitcherController", () => {
       });
     });
 
-    expect(screen.getByText("Recently viewed")).toBeInTheDocument();
+    expect(screen.getByText("Open chats")).toBeInTheDocument();
     const buttons = screen.getAllByRole("button");
     expect(buttons[1]).toHaveClass("bg-muted/55");
 
@@ -174,9 +218,9 @@ describe("RecentChatSwitcherController", () => {
     expect(onActivateConversation).toHaveBeenCalledWith("chat-b");
   });
 
-  it("commits a command-menu recent-chat action without waiting for Control", async () => {
-    seed({ id: "chat-a", lastViewedAt: 300, createdAt: 300, updatedAt: 300 });
-    seed({ id: "chat-b", lastViewedAt: 200, createdAt: 200, updatedAt: 200 });
+  it("commits a command-menu chat-tab action without waiting for Control", async () => {
+    seedOpenTab({ id: "chat-a" });
+    seedOpenTab({ id: "chat-b" });
     useChatStore.setState({ currentId: "chat-a" });
     const onActivateConversation = vi.fn(async () => {});
 
@@ -191,33 +235,28 @@ describe("RecentChatSwitcherController", () => {
       await Promise.resolve();
     });
     expect(onActivateConversation).toHaveBeenCalledWith("chat-b");
-    expect(screen.queryByText("Recently viewed")).not.toBeInTheDocument();
+    expect(screen.queryByText("Open chats")).not.toBeInTheDocument();
   });
 
-  it("opens an empty state when no sessions are available", () => {
+  it("does nothing when fewer than two chat tabs are open", async () => {
     const onActivateConversation = vi.fn(async () => {});
 
     render(<RecentChatSwitcherController onActivateConversation={onActivateConversation} />);
 
     fireEvent.keyDown(window, { key: "Tab", ctrlKey: true });
-    expect(screen.queryByText("Recently viewed")).not.toBeInTheDocument();
-    expect(screen.getByText("No recently viewed chats")).toBeInTheDocument();
-  });
+    expect(screen.queryByText("Open chats")).not.toBeInTheDocument();
+    expect(screen.queryByText("No open chats")).not.toBeInTheDocument();
 
-  it("opens even when only one session exists (and does not re-activate current on release)", async () => {
-    seed({ id: "chat-a", lastViewedAt: 200, createdAt: 200, updatedAt: 200 });
-    useChatStore.setState({ currentId: "chat-a" });
-    const onActivateConversation = vi.fn(async () => {});
-
-    render(<RecentChatSwitcherController onActivateConversation={onActivateConversation} />);
-
+    await act(async () => {
+      seedOpenTab({ id: "chat-a" });
+      useChatStore.setState({ currentId: "chat-a" });
+    });
     fireEvent.keyDown(window, { key: "Tab", ctrlKey: true });
-    expect(screen.getByText("Recently viewed")).toBeInTheDocument();
-
     await act(async () => {
       fireEvent.keyUp(window, { key: "Control" });
     });
 
+    expect(screen.queryByText("Open chats")).not.toBeInTheDocument();
     expect(onActivateConversation).not.toHaveBeenCalled();
   });
 });

--- a/apps/screenpipe-app-tauri/components/chat/recent-chat-switcher-controller.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/recent-chat-switcher-controller.tsx
@@ -8,7 +8,8 @@ import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
   useChatStore,
-  selectRecentSwitcherSessions,
+  nextOpenChatTabId,
+  selectVisibleOpenChatTabs,
 } from "@/lib/stores/chat-store";
 import {
   RECENT_CHAT_SEARCH_HANDOFF_EVENT,
@@ -29,11 +30,12 @@ export function RecentChatSwitcherController({
   onActivateConversation,
 }: RecentChatSwitcherControllerProps) {
   const sessionsMap = useChatStore((s) => s.sessions);
+  const openChatIds = useChatStore((s) => s.openChatIds);
   const currentId = useChatStore((s) => s.currentId);
   const panelSessionId = useChatStore((s) => s.panelSessionId);
-  const recentSwitcherSessions = useMemo(
-    () => selectRecentSwitcherSessions({ sessions: sessionsMap }),
-    [sessionsMap]
+  const openTabs = useMemo(
+    () => selectVisibleOpenChatTabs({ sessions: sessionsMap, openChatIds }),
+    [openChatIds, sessionsMap],
   );
   const [open, setOpen] = useState(false);
   const [selectedId, setSelectedIdRaw] = useState<string | null>(null);
@@ -53,53 +55,43 @@ export function RecentChatSwitcherController({
   }, [setSelectedId]);
 
   const moveSelection = useCallback((direction: 1 | -1) => {
-    if (recentSwitcherSessions.length === 0) {
-      openRef.current = true;
-      setOpen(true);
-      setSelectedId(null);
-      return;
-    }
-    const ids = recentSwitcherSessions.map((session) => session.id);
+    if (openTabs.length < 2) return;
+    const ids = openTabs.map((session) => session.id);
     const baseId = openRef.current
       ? selectedIdRef.current
       : currentId ?? panelSessionId;
-    const currentIndex = baseId ? ids.indexOf(baseId) : -1;
-    const nextIndex =
-      currentIndex >= 0
-        ? (currentIndex + direction + ids.length) % ids.length
-        : direction === 1
-          ? 0
-          : ids.length - 1;
+    const nextId = nextOpenChatTabId(ids, baseId, direction);
+    if (!nextId) return;
     openRef.current = true;
     setOpen(true);
     hoverLockUntilRef.current = Date.now() + 120;
-    setSelectedId(ids[nextIndex]);
-  }, [currentId, panelSessionId, recentSwitcherSessions, setSelectedId]);
+    setSelectedId(nextId);
+  }, [currentId, openTabs, panelSessionId, setSelectedId]);
 
   const commitConversationById = useCallback(async (id: string | null) => {
     const selected = id
-      ? recentSwitcherSessions.find((session) => session.id === id) ?? null
+      ? openTabs.find((session) => session.id === id) ?? null
       : null;
     closeSwitcher();
     if (!selected) return;
     if (selected.id === (currentId ?? panelSessionId)) return;
     await onActivateConversation(selected.id);
-  }, [closeSwitcher, currentId, onActivateConversation, panelSessionId, recentSwitcherSessions]);
+  }, [closeSwitcher, currentId, onActivateConversation, openTabs, panelSessionId]);
 
   useEffect(() => {
     if (!open) return;
-    if (recentSwitcherSessions.length === 0) {
-      setSelectedId(null);
+    if (openTabs.length < 2) {
+      closeSwitcher();
       return;
     }
     if (
       selectedIdRef.current &&
-      recentSwitcherSessions.some((session) => session.id === selectedIdRef.current)
+      openTabs.some((session) => session.id === selectedIdRef.current)
     ) {
       return;
     }
-    setSelectedId(recentSwitcherSessions[0]?.id ?? null);
-  }, [open, closeSwitcher, recentSwitcherSessions, setSelectedId]);
+    setSelectedId(openTabs[0]?.id ?? null);
+  }, [open, closeSwitcher, openTabs, setSelectedId]);
 
   useEffect(() => {
     const handleEscape = (event: KeyboardEvent) => {
@@ -172,7 +164,7 @@ export function RecentChatSwitcherController({
   return (
     <RecentChatSwitcher
       open={open}
-      sessions={recentSwitcherSessions}
+      sessions={openTabs}
       selectedId={selectedId}
       onHoverSelect={(id) => {
         if (Date.now() < hoverLockUntilRef.current) return;

--- a/apps/screenpipe-app-tauri/components/chat/recent-chat-switcher.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/recent-chat-switcher.tsx
@@ -79,11 +79,11 @@ export function RecentChatSwitcher({
           >
             {hasSessions ? (
               <div className="px-4 pb-1.5 pt-3 text-[12px] font-normal text-muted-foreground/70">
-                Recently viewed
+                Open chats
               </div>
             ) : (
               <div className="px-4 pb-1.5 pt-3 text-[12px] font-normal text-muted-foreground/70">
-                No recently viewed chats
+                No open chats
               </div>
             )}
             <div

--- a/apps/screenpipe-app-tauri/components/command-palette.tsx
+++ b/apps/screenpipe-app-tauri/components/command-palette.tsx
@@ -169,8 +169,8 @@ export function buildPaletteEntries(
       ? [
           {
             id: "next_recent_chat" as const,
-            label: "switch recent chat",
-            keywords: "conversation previous recent mru cycle",
+            label: "next chat tab",
+            keywords: "conversation previous recent mru cycle tab worktree",
             group: "navigation" as const,
             hint: inAppShortcutLabel("next_recent_chat", isMac),
             icon: History,
@@ -178,8 +178,8 @@ export function buildPaletteEntries(
           },
           {
             id: "previous_recent_chat" as const,
-            label: "switch recent chat backward",
-            keywords: "conversation previous recent mru reverse",
+            label: "previous chat tab",
+            keywords: "conversation previous recent mru reverse tab worktree",
             group: "navigation" as const,
             hint: inAppShortcutLabel("previous_recent_chat", isMac),
             icon: History,

--- a/apps/screenpipe-app-tauri/components/settings/__tests__/shortcut-section.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/shortcut-section.test.tsx
@@ -57,7 +57,7 @@ describe("ShortcutSection experimental rollout", () => {
 
     expect(screen.getByText("Keyboard shortcuts and hotkeys")).toBeVisible();
     expect(screen.queryByText("in app")).toBeNull();
-    expect(screen.queryByText("switch recent chat")).toBeNull();
+    expect(screen.queryByText("next chat tab")).toBeNull();
     expect(screen.getByText("toggle screenpipe overlay")).toBeVisible();
   });
 
@@ -67,6 +67,6 @@ describe("ShortcutSection experimental rollout", () => {
 
     expect(screen.getByText("in-app commands and global hotkeys")).toBeVisible();
     expect(screen.getByText("in app")).toBeVisible();
-    expect(screen.getByText("switch recent chat")).toBeVisible();
+    expect(screen.getByText("next chat tab")).toBeVisible();
   });
 });

--- a/apps/screenpipe-app-tauri/lib/__tests__/chat-store.test.ts
+++ b/apps/screenpipe-app-tauri/lib/__tests__/chat-store.test.ts
@@ -13,6 +13,8 @@ import {
   useChatStore,
   selectOrderedSessions,
   selectRecentSwitcherSessions,
+  selectVisibleOpenChatTabs,
+  nextOpenChatTabId,
   getOrCreateEmptyChatId,
   isReusableBlankChatSession,
   isEmptyChatShell,
@@ -70,6 +72,34 @@ describe("chat-store: tab and split working set", () => {
     actions.drop("B");
     expect(useChatStore.getState().splitChatId).toBeNull();
     expect(useChatStore.getState().openChatIds).toEqual(["A"]);
+  });
+
+  it("lists open tabs in strip order, including empty worktree chats", () => {
+    const actions = useChatStore.getState().actions;
+    actions.upsert(baseRecord({ id: "closed", lastViewedAt: 90 }));
+    actions.upsert(baseRecord({ id: "A", lastViewedAt: 10 }));
+    actions.upsert(
+      baseRecord({
+        id: "worktree",
+        draft: true,
+        messageCount: 0,
+        lastViewedAt: undefined,
+        codingWorkspace: {
+          repoName: "screenpipe",
+          branch: "screenpipe/chat-worktree",
+          worktreePath: "/worktrees/worktree",
+        },
+      }),
+    );
+    actions.openChat("A");
+    actions.openChat("worktree");
+
+    expect(
+      selectVisibleOpenChatTabs(useChatStore.getState()).map((session) => session.id),
+    ).toEqual(["A", "worktree"]);
+    expect(nextOpenChatTabId(["A", "worktree"], "A", 1)).toBe("worktree");
+    expect(nextOpenChatTabId(["A", "worktree"], "worktree", 1)).toBe("A");
+    expect(nextOpenChatTabId(["A"], "A", 1)).toBeNull();
   });
 });
 

--- a/apps/screenpipe-app-tauri/lib/shortcuts.ts
+++ b/apps/screenpipe-app-tauri/lib/shortcuts.ts
@@ -39,14 +39,14 @@ export const IN_APP_SHORTCUTS: readonly InAppShortcutDefinition[] = [
   {
     id: "next_recent_chat",
     section: "chat",
-    label: "switch recent chat",
-    description: "hold control, cycle, then release",
+    label: "next chat tab",
+    description: "hold control, cycle open tabs, then release",
   },
   {
     id: "previous_recent_chat",
     section: "chat",
-    label: "switch recent chat backward",
-    description: "reverse the recent-chat switcher",
+    label: "previous chat tab",
+    description: "cycle open chat tabs backward",
   },
   {
     id: "toggle_sidebar",

--- a/apps/screenpipe-app-tauri/lib/stores/chat-store.ts
+++ b/apps/screenpipe-app-tauri/lib/stores/chat-store.ts
@@ -1288,6 +1288,31 @@ export function selectRecentSwitcherSessions(
     .sort((a, b) => (b.lastViewedAt ?? 0) - (a.lastViewedAt ?? 0));
 }
 
+/** Visible chat-tab strip order, including empty or worktree-backed tabs. */
+export function selectVisibleOpenChatTabs(state: {
+  sessions: Record<string, SessionRecord>;
+  openChatIds: string[];
+}): SessionRecord[] {
+  return state.openChatIds
+    .map((id) => state.sessions[id])
+    .filter((session): session is SessionRecord =>
+      Boolean(session && !session.hidden),
+    );
+}
+
+export function nextOpenChatTabId(
+  tabIds: string[],
+  currentId: string | null,
+  direction: 1 | -1,
+): string | null {
+  if (tabIds.length < 2) return null;
+  const currentIndex = currentId ? tabIds.indexOf(currentId) : -1;
+  if (currentIndex < 0) {
+    return direction === 1 ? tabIds[0] : tabIds[tabIds.length - 1];
+  }
+  return tabIds[(currentIndex + direction + tabIds.length) % tabIds.length];
+}
+
 /**
  * Stable hook returning the ordered session list. Subscribes to the raw
  * `sessions` map (referentially stable across no-op updates) and memoizes


### PR DESCRIPTION
## Summary
- Ctrl+Tab / Ctrl+Shift+Tab now cycle the visible chat tab strip, not every recently viewed conversation.
- Empty and worktree-backed tabs stay in the cycle, matching the strip (including isolated coding worktrees).
- Closed recents stay out of the overlay. Hold Control, tap Tab, release to switch.

```
before: Ctrl+Tab → recently viewed chats (skips empty worktree tabs)
after:  Ctrl+Tab → open tab 1 → tab 2 (worktree) → tab 3 → …
```

## Test plan
- [x] `bun x vitest run` on switcher, chat-store, shortcuts, command palette, shortcut guide, shortcut section (116 tests)
- [ ] Open 3 chat tabs, including one with a worktree, and cycle with Ctrl+Tab / Ctrl+Shift+Tab
- [ ] Confirm a closed recent chat does not appear in the overlay
- [ ] Confirm Cmd+Tab still belongs to the OS
- [ ] Confirm ⌘W still closes the current tab


Made with [Cursor](https://cursor.com)