### PR TITLE
fix(macOS): pin libc before vm stats ABI expansion

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -6729,9 +6729,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.189"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libdbus-sys"

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
@@ -98,7 +98,10 @@ tracing-appender = "0.2.3"
 
 
 sha2 = "0.10"
-libc = "0.2"
+# 0.2.189 sizes vm_statistics64 for macOS 27. sysinfo 0.29 forwards that
+# 104-word size to macOS 26, whose libsystem maximum is 62, on every memory
+# refresh. Keep the pre-macOS-27 layout until the caller is version-aware.
+libc = "=0.2.186"
 anyhow = "1.0.71"
 arboard = "3.4"
 

--- a/apps/screenpipe-app-tauri/src-tauri/src/hardware.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/hardware.rs
@@ -47,3 +47,27 @@ pub fn detect_hardware_capability() -> HardwareCapability {
 pub fn get_hardware_capability() -> HardwareCapability {
     detect_hardware_capability()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn hardware_detection_uses_macos_26_compatible_vm_stats_count() {
+        const MACOS_26_MAX_HOST_VM_INFO64_COUNT: u32 = 62;
+
+        assert!(
+            libc::HOST_VM_INFO64_COUNT <= MACOS_26_MAX_HOST_VM_INFO64_COUNT,
+            "host_statistics64 count {} exceeds the macOS 26 maximum {}",
+            libc::HOST_VM_INFO64_COUNT,
+            MACOS_26_MAX_HOST_VM_INFO64_COUNT
+        );
+
+        for _ in 0..16 {
+            let capability = detect_hardware_capability();
+            assert!(capability.cpu_cores > 0);
+            assert!(capability.total_memory_gb > 0.0);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- pin the native app to the known-safe `libc 0.2.186`
- revert the macOS 27 `vm_statistics64` ABI expansion that makes `sysinfo 0.29` pass 104 words to macOS 26, whose maximum is 62
- add a regression that exercises repeated hardware memory detection and rejects an oversized count

Fixes the `host_statistics64() count is larger than expected` kernel-warning flood reported on ScreenPipe 2.6.91 and 2.7.1.

## Before / after

```text
before: libc 0.2.189 -> HOST_VM_INFO64_COUNT 104 -> macOS 26 warning (~4/sec)
after:  libc 0.2.186 -> HOST_VM_INFO64_COUNT <= 62 -> no warning
```

## Verification

Tested on Apple silicon, macOS 26.4:

```text
bun run test:tauri hardware_detection_uses_macos_26_compatible_vm_stats_count -- --nocapture
1 passed; 0 failed
```

The test performs 16 affected memory refreshes. Unified logging contained zero `host_statistics64` warnings during both the initial run and the exact post-rebase run.

## Historical intent

Inspected Dependabot PR #6180 / merge commit `4a2296c2ec`, which upgraded `libc` from 0.2.186 to 0.2.189 as part of a grouped patch update. The upgrade carried no ScreenPipe-specific behavior requirement. Upstream `libc` PR #5253 states that the expanded `vm_statistics64` definition is for macOS 27. This change preserves ScreenPipe’s existing CPU/memory detection while restoring the pre-macOS-27 ABI used by supported macOS 26 systems.