### PR TITLE
fix(chat): keep pending follow-up below history

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat/standalone/chat-main-pane.test.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/chat-main-pane.test.tsx
@@ -140,4 +140,29 @@ describe("ChatMainPane", () => {
     render(<ChatMainPane {...paneProps("chat", [])} />);
     expect(screen.queryByTestId("first-run-banner")).not.toBeInTheDocument();
   });
+
+  it("renders a pending follow-up after durable chat history", () => {
+    const existingMessage: Message = {
+      id: "existing-message",
+      role: "user",
+      content: "existing durable message",
+      timestamp: Date.now(),
+    };
+
+    render(
+      <ChatMainPane
+        {...paneProps("chat", [existingMessage])}
+        pendingSend={{ text: "follow-up message" }}
+      />,
+    );
+
+    const messageList = screen.getByTestId("message-list");
+    const pendingBubble = screen.getByTestId("chat-pending-user-message");
+    expect(messageList).toHaveTextContent("1");
+    expect(pendingBubble).toHaveTextContent("follow-up message");
+    expect(
+      messageList.compareDocumentPosition(pendingBubble) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).not.toBe(0);
+  });
 });

--- a/apps/screenpipe-app-tauri/components/chat/standalone/chat-main-pane.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/standalone/chat-main-pane.tsx
@@ -251,6 +251,13 @@ export function ChatMainPane({
               <FirstRunLearningBanner fallback={homeStarter} />
             )}
             {!firstRunLearningEnabled && homeStarter}
+            {/* A conversation switch is a hard visual boundary. Remounting the
+                list prevents AnimatePresence from carrying an outgoing chat's
+                exit nodes into the new chat's empty state. */}
+            <ChatMessageList
+              key={conversationId ?? "blank-chat"}
+              {...messageListProps}
+            />
             {/* The message the user just sent, shown from the send frame until
                 the durable row replaces it. Same geometry as a real user row so
                 nothing moves when the swap happens. */}
@@ -268,13 +275,6 @@ export function ChatMainPane({
                 </div>
               </div>
             )}
-            {/* A conversation switch is a hard visual boundary. Remounting the
-                list prevents AnimatePresence from carrying an outgoing chat's
-                exit nodes into the new chat's empty state. */}
-            <ChatMessageList
-              key={conversationId ?? "blank-chat"}
-              {...messageListProps}
-            />
 
             <div ref={messagesEndRef} />
           </div>


### PR DESCRIPTION
## Source and root cause

Related to #6749 (Linear SCR-534). In the standalone desktop chat pane, the optimistic `pendingSend` bubble was rendered before `ChatMessageList`, so a follow-up briefly appeared above durable history during preflight before snapping to the bottom.

This is an order-only repair: the durable message list now renders first, the unchanged optimistic follow-up renders after it, and the existing end sentinel remains last. The standalone pane owns this optimistic bubble, so the fix covers the affected surface without changing transport, persistence, streaming, or scroll lifecycle behavior.

## Changed files

- `apps/screenpipe-app-tauri/components/chat/standalone/chat-main-pane.tsx`
- `apps/screenpipe-app-tauri/components/chat/standalone/chat-main-pane.test.tsx`

## Before / after

```text
BEFORE                           AFTER
optimistic follow-up             durable history
durable history                  optimistic follow-up
end sentinel                     end sentinel
```

Platform scope: standalone desktop chat React layout on all supported desktop platforms. No native/Tauri boundary changed; the behavior is covered by a DOM-order regression test and the broader standalone chat suite.

## Verification

- RED on reviewed base `bc2d014170e9cd8b81785ddf5fab6441c23d12f4`: focused suite failed 1/4 only at `renders a pending follow-up after durable chat history`, proving the DOM-order assertion catches the bug.
- GREEN on `2cb96cefdb3434621225d3df10a9826b5422cb6f`: focused regression suite passed 4/4.
- Standalone chat suite passed 286/286 (48 files).
- Broader implementation test run passed 472/472.
- Targeted ESLint passed with 0 warnings/errors; repository `bun run lint:effects` exited 0.
- Independent review recorded unconditional `REVIEW APPROVED` for exact commit `2cb96cefdb3434621225d3df10a9826b5422cb6f` against the reviewed base above.

## Typecheck limitation

Full `bun run typecheck` is not claimed green. The reviewed run is bounded by unrelated current-main/dependency-environment errors in `components/markdown/local-markdown-image.tsx` and borrowed dependency resolution for `@xyflow/react`/`live-view-canvas.tsx`. Those files and package/lock inputs are unchanged by this commit.
