### PR TITLE
fix(overlay): restore readable macOS shortcut labels

### DIFF
--- a/apps/screenpipe-app-tauri/app/shortcut-reminder/format-shortcut.ts
+++ b/apps/screenpipe-app-tauri/app/shortcut-reminder/format-shortcut.ts
@@ -4,7 +4,7 @@
 
 export type ShortcutPlatform = "macos" | "windows" | "linux" | "unknown";
 
-/** Render saved shortcuts with familiar, platform-native modifier notation. */
+/** Render saved shortcuts with readable, platform-specific modifier notation. */
 export function formatShortcut(
   shortcut: string,
   platform: ShortcutPlatform,
@@ -24,29 +24,30 @@ export function formatShortcut(
     .filter(Boolean);
 
   if (platform === "macos") {
-    const macSymbols: Record<string, string> = {
-      super: "⌘",
-      command: "⌘",
-      cmd: "⌘",
-      meta: "⌘",
-      ctrl: "⌃",
-      control: "⌃",
-      alt: "⌥",
-      option: "⌥",
-      shift: "⇧",
+    const macLabels: Record<string, string> = {
+      super: "Cmd",
+      command: "Cmd",
+      cmd: "Cmd",
+      meta: "Cmd",
+      ctrl: "Ctrl",
+      control: "Ctrl",
+      alt: "Opt",
+      option: "Opt",
+      opt: "Opt",
+      shift: "Shift",
     };
-    const modifierOrder = ["⌘", "⌃", "⌥", "⇧"];
+    const modifierOrder = ["Cmd", "Ctrl", "Opt", "Shift"];
     const modifiers = new Set(
-      parts.flatMap((part) => macSymbols[part] ? [macSymbols[part]] : []),
+      parts.flatMap((part) => macLabels[part] ? [macLabels[part]] : []),
     );
     const keys = parts
-      .filter((part) => !macSymbols[part])
+      .filter((part) => !macLabels[part])
       .map((part) => part.toUpperCase());
-    return [...modifierOrder.filter((modifier) => modifiers.has(modifier)), ...keys].join("");
+    return [...modifierOrder.filter((modifier) => modifiers.has(modifier)), ...keys].join("+");
   }
 
-  // macOS has standard modifier glyphs. Windows and Linux conventionally keep
-  // Ctrl/Alt/Shift as words, with the OS modifier first in the chord.
+  // Windows and Linux conventionally keep Ctrl/Alt/Shift as words, with the OS
+  // modifier first in the chord.
   const systemModifier = platform === "windows" ? "⊞" : "Super";
   const otherLabels: Record<string, string> = {
     super: systemModifier,

--- a/apps/screenpipe-app-tauri/app/shortcut-reminder/page.test.tsx
+++ b/apps/screenpipe-app-tauri/app/shortcut-reminder/page.test.tsx
@@ -512,8 +512,12 @@ describe("recording health hover detail", () => {
 });
 
 describe("shortcut display ordering", () => {
-  it("renders familiar modifier notation in a stable platform order", () => {
-    expect(formatShortcut("Control+Super+s", "macos")).toBe("⌘⌃S");
+  it("renders readable modifier notation in a stable platform order", () => {
+    expect(formatShortcut("Control+Super+s", "macos")).toBe("Cmd+Ctrl+S");
+    expect(formatShortcut("⌘⌃S", "macos")).toBe("Cmd+Ctrl+S");
+    expect(formatShortcut("Shift+Option+Command+k", "macos")).toBe(
+      "Cmd+Opt+Shift+K",
+    );
     expect(formatShortcut("Control+Super+s", "windows")).toBe("⊞+Ctrl+S");
     expect(formatShortcut("Control+Super+s", "linux")).toBe("Super+Ctrl+S");
     expect(formatShortcut("Shift+Alt+Control+Super+k", "windows")).toBe(

--- a/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder.swift
+++ b/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder.swift
@@ -473,14 +473,14 @@ private let kRestingOpacity: Double = 0.50
 private let kAnimDur: Double = 0.2
 private let kDockControls = ["search", "chat", "timeline", "audio", "brand"]
 
-/// Convert configured shortcuts to one stable, compact macOS glyph order.
+/// Convert configured shortcuts to one stable, readable macOS order.
 /// Settings historically stored both `Super+Control+…` and
-/// `Control+Super+…`; the overlay should always read `⌘⌃…`.
+/// `Control+Super+…`; the overlay should always read `Cmd+Ctrl+…`.
 func prettifyShortcut(_ raw: String) -> String {
     let normalized = raw
-        .replacingOccurrences(of: "⌘", with: "Command+")
-        .replacingOccurrences(of: "⌃", with: "Control+")
-        .replacingOccurrences(of: "⌥", with: "Option+")
+        .replacingOccurrences(of: "⌘", with: "Cmd+")
+        .replacingOccurrences(of: "⌃", with: "Ctrl+")
+        .replacingOccurrences(of: "⌥", with: "Opt+")
         .replacingOccurrences(of: "⇧", with: "Shift+")
 
     var modifiers = Set<String>()
@@ -488,10 +488,10 @@ func prettifyShortcut(_ raw: String) -> String {
     for part in normalized.split(separator: "+", omittingEmptySubsequences: true) {
         let trimmed = part.trimmingCharacters(in: .whitespaces)
         switch trimmed.lowercased() {
-        case "super", "cmd", "command", "meta": modifiers.insert("⌘")
-        case "ctrl", "control": modifiers.insert("⌃")
-        case "alt", "option", "opt": modifiers.insert("⌥")
-        case "shift": modifiers.insert("⇧")
+        case "super", "cmd", "command", "meta": modifiers.insert("Cmd")
+        case "ctrl", "control": modifiers.insert("Ctrl")
+        case "alt", "option", "opt": modifiers.insert("Opt")
+        case "shift": modifiers.insert("Shift")
         default:
             if !trimmed.isEmpty {
                 keys.append(trimmed.uppercased())
@@ -499,8 +499,8 @@ func prettifyShortcut(_ raw: String) -> String {
         }
     }
 
-    let canonicalModifiers = ["⌘", "⌃", "⌥", "⇧"].filter(modifiers.contains)
-    return (canonicalModifiers + keys).joined()
+    let canonicalModifiers = ["Cmd", "Ctrl", "Opt", "Shift"].filter(modifiers.contains)
+    return (canonicalModifiers + keys).joined(separator: "+")
 }
 
 /// Which side of the panel the pill and its dock hug. The panel stays a fixed
@@ -1566,9 +1566,9 @@ class ShortcutReminderController: NSObject, NSWindowDelegate {
     private var hoverHideWorkItem: DispatchWorkItem?
     private var meetingStopTimeoutWorkItem: DispatchWorkItem?
 
-    private var overlayShortcut = "⌘⌃S"
-    private var chatShortcut = "⌘⌃L"
-    private var searchShortcut = "⌘⌃K"
+    private var overlayShortcut = "Cmd+Ctrl+S"
+    private var chatShortcut = "Cmd+Ctrl+L"
+    private var searchShortcut = "Cmd+Ctrl+K"
     private var metrics = OverlayMetrics()
     private var wsTask: URLSessionWebSocketTask?
     private var wsRetryTimer: Timer?

--- a/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder_tests.swift
+++ b/apps/screenpipe-app-tauri/src-tauri/swift/shortcut_reminder_tests.swift
@@ -390,20 +390,20 @@ private func testWireContract() {
     expect(actual == expected, "anchor raw values drifted: \(actual)")
 }
 
-/// The native overlay must use the same compact key notation as the webview
-/// fallback. Word labels made a two-modifier shortcut wider than its action.
-private func testShortcutGlyphs() {
+/// The native overlay and webview fallback must use the same readable macOS
+/// labels while preserving one stable modifier order.
+private func testShortcutLabels() {
     expect(
-        prettifyShortcut("Control+Super+s") == "⌘⌃S",
-        "shortcut should render Command and Control as glyphs"
+        prettifyShortcut("Control+Super+s") == "Cmd+Ctrl+S",
+        "shortcut should render readable Command and Control labels"
     )
     expect(
-        prettifyShortcut("Shift+Option+Command+k") == "⌘⌥⇧K",
-        "shortcut should keep a stable macOS glyph order"
+        prettifyShortcut("Shift+Option+Command+k") == "Cmd+Opt+Shift+K",
+        "shortcut should keep a stable macOS label order"
     )
     expect(
-        prettifyShortcut("⌘⌃S") == "⌘⌃S",
-        "shortcut glyph input should be idempotent"
+        prettifyShortcut("⌘⌃S") == "Cmd+Ctrl+S",
+        "shortcut glyph input should normalize to readable labels"
     )
 }
 
@@ -531,7 +531,7 @@ struct ShortcutReminderTests {
         testAttachmentStacking()
         testAttachmentStaysOnScreen()
         testWireContract()
-        testShortcutGlyphs()
+        testShortcutLabels()
         testClampLeavesOnScreenDragsAlone()
         testClampKeepsPillOnDesktop()
         testClampPicksNearestDisplay()


### PR DESCRIPTION
## Outcome

macOS shortcut hints use readable text labels again:

- `Cmd+Ctrl+S`
- `Cmd+Ctrl+L`
- `Cmd+Ctrl+K`

This changes display formatting only. Stored shortcuts and registered key combinations are unchanged. Windows and Linux notation is unchanged.

## Why

PostHog shows a directional advantage for text labels across two product-usage metrics.

### Metric 1: shortcut adoption

Percentage of new macOS users who saw the overlay and then used at least one displayed global shortcut (`show_search`, `show_chat`, or `show_screenpipe`) within 24 hours of first app start.

| Hint period | Exposed users | Shortcut users | Adoption |
| --- | ---: | ---: | ---: |
| Original symbols `⌘⌃` | 336 | 15 | 4.5% |
| Text `Cmd+Ctrl` | 186 | 12 | **6.5%** |
| Restored symbols `⌘⌃` | 53 | 3 | 5.7% |

### Metric 2: shortcut usage depth

Tracked shortcut presses per exposed user within the same 24-hour window.

| Hint period | Shortcut presses | Uses per exposed user |
| --- | ---: | ---: |
| Original symbols `⌘⌃` | 49 | 0.15 |
| Text `Cmd+Ctrl` | 103 | **0.55** |
| Restored symbols `⌘⌃` | 12 | 0.23 |

Text produced 3.7× the usage depth of the original-symbol period and 2.4× the restored-symbol period.

### Method

- New macOS users were assigned by their first observed `app_started` event and the published app version containing each treatment.
- Only users with `shortcut_reminder_shown` in their first 24 hours were included in the primary denominator.
- Shortcut use came from native `shortcut_used` events, not overlay button clicks.
- The configured localhost/test-account filter was applied.
- Every cohort used the same 24-hour observation window.

This was not a randomized experiment, and the number of adopting users is small, so the adoption differences are directional rather than statistically conclusive. Usage depth nevertheless favors text in both comparisons.

## Before / after

These are the real native Swift overlay captures from the original formatting PR, shown in reverse because this PR restores the previous text treatment.

| Before | After |
| --- | --- |
| ![Before: symbol shortcut labels](https://raw.githubusercontent.com/screenpipe/screenpipe/64c230368492b8540fff84b3fe1dd905876b9084/docs/pr-assets/shortcut-modifier-glyphs/after.png) | ![After: readable text shortcut labels](https://raw.githubusercontent.com/screenpipe/screenpipe/64c230368492b8540fff84b3fe1dd905876b9084/docs/pr-assets/shortcut-modifier-glyphs/before.png) |

## Historical intent

Inspected PR #6586 and commits `64c2303684` / `1559f909e0`. That change selected standardized platform-native glyphs and explicitly kept storage and shortcut registration unchanged. This PR intentionally supersedes the macOS glyph presentation based on the directional usage evidence while preserving stable modifier ordering and the display-only boundary.

## Validation

- `bun x vitest run app/shortcut-reminder/page.test.tsx` — 30 passed
- `bash scripts/test-shortcut-overlay.sh` — 172 checks passed
- `bun x tsc --noEmit` — passed
- `bun x eslint app/shortcut-reminder/format-shortcut.ts app/shortcut-reminder/page.test.tsx` — passed
- `git diff --check upstream/main...HEAD` — passed
