### PR TITLE
fix(analytics): classify desktop users as real

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/analytics.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/analytics.rs
@@ -210,7 +210,12 @@ impl AnalyticsManager {
                     "os_name": os_name,
                     "os_version": os_version,
                 },
-                "$set_once": {},
+                // A successful desktop launch is direct evidence that this is a
+                // real Screenpipe user. Set it once so a server-side fraud
+                // decision (`bot`) always remains authoritative.
+                "$set_once": {
+                    "screenpipe_user_type": "real",
+                },
             },
         });
 


### PR DESCRIPTION
## Summary

Set the PostHog person property `screenpipe_user_type=real` when the desktop app reports analytics.

The value uses `$set_once`, so a server-side fraud decision can later set `bot` and desktop telemetry will not overwrite it.

## Before / after

```text
before: desktop event -> PostHog request classifier says Automation
 after: desktop launch -> screenpipe_user_type = real
                       -> later server fraud verdict = bot (authoritative)
```

## Validation

- `cd apps/screenpipe-app-tauri && bun run test:tauri analytics::tests`
  - 5 passed, 0 failed
- `git diff --check`

## Historical intent

- `ca0dbcdd1d` / #4616 established the stable per-install identity so desktop events resolve to one durable PostHog person.
- `d57b2fb92d` / #5939 ensured telemetry opt-out and CI guards prevent identifying non-participating or automated runs.
- This change preserves both invariants: it adds one set-once property only to already-enabled desktop analytics and does not change identity or consent behavior.

## Visual evidence

Telemetry-only change; the before/after event flow is shown above. No application UI changes.
