### PR TITLE
fix(chat): explain opaque custom provider 400s

### DIFF
--- a/apps/screenpipe-app-tauri/lib/chat/__tests__/provider-errors.test.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/__tests__/provider-errors.test.ts
@@ -219,6 +219,23 @@ describe("provider error copy", () => {
     expect(msg).toContain("Test Connection");
   });
 
+  it("maps the opaque custom-provider 400 to safe preset guidance", () => {
+    expect(
+      buildProviderErrorMessage("400 status code (no body)", {
+        provider: "custom",
+        model: "gemini-2.5-flash",
+      }),
+    ).toBe(
+      "The custom AI provider rejected the request. Verify the endpoint, model, and API key in Settings → AI.",
+    );
+    expect(
+      buildProviderErrorMessage("400 status code (no body)", {
+        provider: "screenpipe-cloud",
+        model: "auto",
+      }),
+    ).toBeNull();
+  });
+
   it("maps the ChatGPT missing-account-id error to reconnect guidance", () => {
     // exact string thrown by pi's openai-codex-responses provider when the
     // OAuth access token lacks the chatgpt_account_id claim (Enterprise/

--- a/apps/screenpipe-app-tauri/lib/chat/provider-errors.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/provider-errors.ts
@@ -317,6 +317,10 @@ function buildGenericProviderErrorMessage(
     return "The AI provider usage limit has been reached. Wait for it to reset, or switch your AI preset or provider.";
   }
 
+  if (provider === "custom" && errorStr === "400 status code (no body)") {
+    return "The custom AI provider rejected the request. Verify the endpoint, model, and API key in Settings → AI.";
+  }
+
   if (
     provider === "custom" &&
     (normalized.includes("401") ||


### PR DESCRIPTION
## Source feedback

- Feedback identity: Discord message `1543672008330453003` via trusted intake task `t_99121509`
- Reported environment: macOS 26.6.2, app 2.7.6
- Exact independently reviewed head: `6413f69ca7b1a4aa5a7a38a666734c35285f735f`

## Root cause

The shared chat provider-error classifier returned no actionable mapping for the exact opaque custom-provider response `400 status code (no body)`. Both chat call paths therefore fell through to displaying the unhelpful raw error.

## Fix and full-surface coverage

For provider `custom` only, the classifier maps that exact case- and whitespace-sensitive string to fixed guidance asking the user to verify the endpoint, model name, and API key in Settings → AI. Hosted providers, null providers, and prefixed, suffixed, or case-varied messages retain their existing behavior.

This covers the whole affected surface because both chat call paths use the shared classifier. The guidance is fixed copy: it does not interpolate the upstream error, endpoint, model, API key, or any credential value.

Prior context: draft PR #6378 carried the same patch but is now closed and unmerged. Current `main` does not contain that fix; this fresh app 2.7.6 report confirms the behavior persists. This PR does not modify or reopen #6378.

## Visual evidence

Deterministic text-only before/after evidence (no layout or interaction change):

```text
Before
custom + exact opaque 400 -> raw, non-actionable error fallback

After
custom + exact opaque 400 -> fixed endpoint/model/API-key guidance
hosted provider + same text -> unchanged
near-match text or null provider -> unchanged
```

A packaged-app screenshot is not required for this pure classifier change; the exact visible copy and all boundary cases are covered by deterministic tests.

## Verification

RED:

- With the implementation removed, the new focused assertion failed as expected: 45 passed, 1 failed, received `null`.

GREEN on the exact reviewed commit:

- Focused provider-error tests: 46/46 passed
- Related provider/agent/pipe/preset-switch tests: 89/89 passed
- Bun suite: 242/242 passed
- Changed-file ESLint: passed
- `git diff --check`: passed

Independent review reran the strict boundary matrix, focused tests (46/46), related tests (68/68), changed-file ESLint, scope/header/security checks, and patch-identity checks, then approved this exact SHA unconditionally.

Broad frontend Vitest/typecheck attempts were limited by an unrelated reused dependency cache missing current packages including `@xyflow/react`; the broad Vitest run still reached 4,857 passing tests before those unrelated failures. No focused, related, or changed-file check failed.

## Platform scope and risk

The report is from macOS, but this classifier is shared TypeScript logic and is platform-independent. Risk is low because the change requires both one provider value and one exact error string, with negative coverage for hosted providers and near matches.