### PR TITLE
fix(ai-presets): preserve local-only configurations

### DIFF
--- a/apps/screenpipe-app-tauri/components/rewind/ai-presets-selector.test.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/ai-presets-selector.test.tsx
@@ -432,3 +432,50 @@ describe("AIPresetsSelector agent presets", () => {
     );
   });
 });
+
+describe("AIPresetsSelector preset deletion", () => {
+  const localPreset: AIPreset = {
+    ...originalPreset,
+    id: "local",
+    provider: "native-ollama",
+    model: "qwen3",
+    url: "http://localhost:11434",
+    defaultPreset: false,
+  };
+
+  beforeEach(() => {
+    mocks.settings.listeners.clear();
+    mocks.updateSettings.mockClear();
+    mocks.controlledSelect.mockClear();
+    mocks.acpEnabled.current = false;
+  });
+
+  it("deletes the cloud preset when a local preset remains", () => {
+    mocks.settings.current = {
+      aiPresets: [originalPreset, localPreset],
+      user: { token: "test-token", cloud_subscribed: true },
+    };
+    render(<AIPresetsSelector compact showModelOnly />);
+
+    fireEvent.click(screen.getByRole("combobox"));
+    fireEvent.click(screen.getByRole("button", { name: "Delete original" }));
+
+    expect(mocks.updateSettings).toHaveBeenCalledWith({
+      aiPresets: [{ ...localPreset, defaultPreset: true }],
+    });
+  });
+
+  it("does not offer deletion for the sole remaining preset", () => {
+    mocks.settings.current = {
+      aiPresets: [originalPreset],
+      user: { token: "test-token", cloud_subscribed: true },
+    };
+    render(<AIPresetsSelector compact showModelOnly />);
+
+    fireEvent.click(screen.getByRole("combobox"));
+
+    expect(
+      screen.queryByRole("button", { name: "Delete original" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/screenpipe-app-tauri/components/rewind/ai-presets-selector.tsx
+++ b/apps/screenpipe-app-tauri/components/rewind/ai-presets-selector.tsx
@@ -1778,12 +1778,11 @@ export const AIPresetsSelector = ({
       return;
     }
 
-    // Safety net: prevent deletion of the last screenpipe-cloud preset for subscribers
-    if (preset.provider === "screenpipe-cloud" && settings.user?.cloud_subscribed) {
-      const cloudPresets = settings.aiPresets.filter((p) => p.provider === "screenpipe-cloud");
-      if (cloudPresets.length <= 1) {
-        return;
-      }
+    if (settings.aiPresets.length <= 1) {
+      toast.error("Cannot delete preset", {
+        description: "At least one AI preset is required",
+      });
+      return;
     }
 
     let updatedPresets = settings.aiPresets.filter((p) => p.id !== preset.id);
@@ -1801,13 +1800,7 @@ export const AIPresetsSelector = ({
     });
   };
 
-  // Hide delete button on the last remaining screenpipe-cloud preset for subscribers
-  const cloudPresetCount = useMemo(
-    () => (settings?.aiPresets || []).filter((p) => p.provider === "screenpipe-cloud").length,
-    [settings?.aiPresets]
-  );
-  const isLastCloudPreset = (preset: AIPreset) =>
-    preset.provider === "screenpipe-cloud" && settings.user?.cloud_subscribed && cloudPresetCount <= 1;
+  const isOnlyPreset = (settings?.aiPresets || []).length <= 1;
   const selectedProviderName =
     selectedPresetData?.provider === "acp"
       ? acpAdapterInfo(selectedPresetData.acpAgent?.id).name
@@ -2217,10 +2210,11 @@ export const AIPresetsSelector = ({
                                 <Star className="h-3.5 w-3.5" />
                               </Button>
                             )}
-                            {canManageEmployeePresets && !isEnterpriseManagedPreset(preset) && !isLastCloudPreset(preset) && (
+                            {canManageEmployeePresets && !isEnterpriseManagedPreset(preset) && !isOnlyPreset && (
                               <Button
                                 variant="ghost"
                                 size="icon"
+                                aria-label={`Delete ${preset.id}`}
                                 className="h-6 w-6 shrink-0"
                                 onClick={(e) => {
                                   e.stopPropagation();

--- a/apps/screenpipe-app-tauri/components/settings/ai-presets.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/ai-presets.tsx
@@ -2149,7 +2149,14 @@ function SortablePresetCard({
             </TooltipProvider>
           )}
           {!readOnly && onDelete && (
-            <Button variant="ghost" size="sm" className="text-[11px] h-6 px-2 text-destructive hover:text-destructive ml-auto" onClick={(e) => { e.stopPropagation(); onDelete(); }} disabled={isLoading}>
+            <Button
+              aria-label={`Delete ${preset.id}`}
+              variant="ghost"
+              size="sm"
+              className="text-[11px] h-6 px-2 text-destructive hover:text-destructive ml-auto"
+              onClick={(e) => { e.stopPropagation(); onDelete(); }}
+              disabled={isLoading}
+            >
               <Trash2 className="w-3 h-3" />
             </Button>
           )}
@@ -2248,7 +2255,6 @@ useEffect(() => {
   const removePreset = async (id: string) => {
     setIsLoading(true);
     try {
-      // Prevent deletion of screenpipe-cloud preset for Pro subscribers
       const presetToRemove = settings.aiPresets.find((preset) => preset.id === id);
       if (
         isManagedDeployment &&
@@ -2261,16 +2267,13 @@ useEffect(() => {
         });
         return;
       }
-      if (presetToRemove?.provider === "screenpipe-cloud" && settings.user?.cloud_subscribed) {
-        const cloudPresets = settings.aiPresets.filter((p) => p.provider === "screenpipe-cloud");
-        if (cloudPresets.length <= 1) {
-          toast({
-            title: "Cannot delete cloud preset",
-            description: "This preset is included with your Business subscription",
-            variant: "destructive",
-          });
-          return;
-        }
+      if (settings.aiPresets.length <= 1) {
+        toast({
+          title: "Cannot delete preset",
+          description: "At least one AI preset is required",
+          variant: "destructive",
+        });
+        return;
       }
 
       const wasDefault = settings.aiPresets.find(
@@ -2470,13 +2473,11 @@ useEffect(() => {
         >
           <div className="w-full grid grid-cols-1 md:grid-cols-2 gap-3">
             {(() => {
-              const cloudPresetCount = (settings.aiPresets || []).filter((p) => p.provider === "screenpipe-cloud").length;
+              const isOnlyPreset = settings.aiPresets.length <= 1;
               return visiblePresets.map((preset) => {
                 const readOnly =
                   isManagedDeployment &&
                   (!aiPresetPolicy.allow_employee_custom_presets || isEnterpriseManagedPreset(preset));
-                const isLastCloudPreset =
-                  preset.provider === "screenpipe-cloud" && settings.user?.cloud_subscribed && cloudPresetCount <= 1;
                 return (
                   <SortablePresetCard
                     key={preset.id}
@@ -2493,7 +2494,7 @@ useEffect(() => {
                     }}
                     onDuplicate={() => duplicatePreset(preset.id)}
                     onSetDefault={() => setPresetToSetDefault(preset.id)}
-                    onDelete={isLastCloudPreset ? undefined : () => setPresetToDelete(preset.id)}
+                    onDelete={isOnlyPreset ? undefined : () => setPresetToDelete(preset.id)}
                     onShareToTeam={isTeamAdmin ? () => sharePresetToTeam(preset) : undefined}
                     isLoading={isLoading}
                     isTeamAdmin={isTeamAdmin}

--- a/apps/screenpipe-app-tauri/lib/hooks/__tests__/settings-collection-normalization.test.ts
+++ b/apps/screenpipe-app-tauri/lib/hooks/__tests__/settings-collection-normalization.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  assertValidAiPresetUpdate,
   createDefaultSettingsObject,
   normalizeSettingsArrays,
   type Settings,
@@ -35,5 +36,116 @@ describe("normalizeSettingsArrays", () => {
     expect(normalizeSettingsArrays(settings)).toBe(false);
     expect(settings.audioDevices).toEqual(["Studio Mic"]);
     expect(settings.languages).toEqual(["en", "fr"]);
+  });
+
+  it.each([
+    [false, "screenpipe"],
+    [true, "chat"],
+  ])(
+    "recovers an empty legacy preset list to one default when subscribed=%s",
+    (cloudSubscribed, expectedId) => {
+      const settings = {
+        ...createDefaultSettingsObject(),
+        aiPresets: [],
+        user: { cloud_subscribed: cloudSubscribed },
+      } as Settings;
+
+      expect(normalizeSettingsArrays(settings)).toBe(true);
+      expect(settings.aiPresets).toEqual([
+        expect.objectContaining({
+          id: expectedId,
+          provider: "screenpipe-cloud",
+          defaultPreset: true,
+        }),
+      ]);
+      expect(normalizeSettingsArrays(settings)).toBe(false);
+      expect(settings.aiPresets).toHaveLength(1);
+    },
+  );
+
+  it("preserves a local-only preset list across account refreshes", () => {
+    const localPreset = {
+      id: "local",
+      provider: "native-ollama",
+      model: "qwen3",
+      url: "http://localhost:11434",
+      defaultPreset: true,
+      prompt: "",
+      maxContextChars: 128000,
+    };
+    const settings = {
+      ...createDefaultSettingsObject(),
+      aiPresets: [localPreset],
+      user: null,
+    } as Settings;
+
+    expect(normalizeSettingsArrays(settings)).toBe(false);
+    settings.user = { token: "token", cloud_subscribed: true } as Settings["user"];
+    expect(normalizeSettingsArrays(settings)).toBe(false);
+    settings.user = {
+      ...settings.user,
+      cloud_subscribed: false,
+    } as Settings["user"];
+    expect(normalizeSettingsArrays(settings)).toBe(false);
+    expect(settings.aiPresets).toEqual([localPreset]);
+  });
+
+  it("does not duplicate or change valid cloud preset configurations", () => {
+    const settings = {
+      ...createDefaultSettingsObject(),
+      aiPresets: [
+        {
+          id: "cloud",
+          provider: "screenpipe-cloud",
+          model: "auto",
+          url: "",
+          defaultPreset: true,
+          prompt: "",
+          maxContextChars: 200000,
+        },
+        {
+          id: "pipes",
+          provider: "screenpipe-cloud",
+          model: "gpt-5.6-luna",
+          url: "",
+          defaultPreset: false,
+          prompt: "",
+          maxContextChars: 200000,
+        },
+      ],
+    } as Settings;
+    const original = structuredClone(settings.aiPresets);
+
+    expect(normalizeSettingsArrays(settings)).toBe(false);
+    expect(settings.aiPresets).toEqual(original);
+  });
+});
+
+describe("assertValidAiPresetUpdate", () => {
+  it("rejects an empty preset list at the shared mutation boundary", () => {
+    expect(() => assertValidAiPresetUpdate({ aiPresets: [] })).toThrow(
+      "At least one AI preset is required",
+    );
+  });
+
+  it("accepts non-preset updates and non-empty preset lists", () => {
+    expect(() =>
+      assertValidAiPresetUpdate({ analyticsEnabled: false }),
+    ).not.toThrow();
+    expect(() =>
+      assertValidAiPresetUpdate({
+        aiPresets: [
+          {
+            id: "local",
+            provider: "native-ollama",
+            model: "qwen3",
+            url: "http://localhost:11434",
+            defaultPreset: true,
+            prompt: "",
+            maxContextChars: 128000,
+          },
+        ],
+      }),
+    ).not.toThrow();
   });
 });

--- a/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -667,10 +667,6 @@ export function makeDefaultPresets(isPro: boolean): AIPreset[] {
 	];
 }
 
-// Seed value — module load can't know pro status yet, so fall back to non-pro.
-// ensureDefaultPreset() re-seeds with pro status once settings.user is loaded.
-const DEFAULT_CLOUD_PRESET: AIPreset = makeDefaultPresets(false)[0];
-
 const DEFAULT_AUDIO_ENGINE = "whisper-large-v3-turbo-quantized";
 
 // "Paid" = any active app entitlement (Basic / Business / Enterprise / Lifetime)
@@ -892,14 +888,29 @@ export function normalizeSettingsArrays(settings: Settings): boolean {
 		aiPresets: makeDefaultPresets(settings.user?.cloud_subscribed === true),
 	};
 	let changed = false;
+	const presets = settings.aiPresets;
+	if (!Array.isArray(presets) || presets.length === 0) {
+		settings.aiPresets = [defaults.aiPresets[0]] as any;
+		changed = true;
+	}
 
 	for (const [key, fallback] of Object.entries(defaults)) {
+		if (key === "aiPresets") continue;
 		if (!Array.isArray(fallback) || Array.isArray(settings[key])) continue;
 		settings[key] = [...fallback];
 		changed = true;
 	}
 
 	return changed;
+}
+
+export function assertValidAiPresetUpdate(value: Partial<Settings>): void {
+	if (
+		"aiPresets" in value &&
+		(!Array.isArray(value.aiPresets) || value.aiPresets.length === 0)
+	) {
+		throw new Error("At least one AI preset is required");
+	}
 }
 
 // Store singleton
@@ -1204,13 +1215,6 @@ function createSettingsStore() {
 		// installs default to "meetings-only" (via createDefaultSettingsObject, which
 		// get() returns directly when there are no stored settings).
 
-		// Migration: Add default presets if user has none
-		if (!Array.isArray(settings.aiPresets) || settings.aiPresets.length === 0) {
-			const isPro = settings.user?.cloud_subscribed === true;
-			settings.aiPresets = makeDefaultPresets(isPro) as any;
-			needsUpdate = true;
-		}
-
 		// b2 seed: the first time we see a logged-in user, replace the anonymous
 		// "screenpipe" placeholder with the pro pair (chat + pipes) IF they're pro.
 		// Anonymous users keep the placeholder forever (which is correct — non-pro
@@ -1243,18 +1247,6 @@ function createSettingsStore() {
 			settings.aiPresets = settings.aiPresets.map((p: any) =>
 				p.id === "pi-agent" ? { ...p, id: "screenpipe-cloud" } : p
 			);
-			needsUpdate = true;
-		}
-
-		// Migration: Add screenpipe-cloud preset for existing users (without touching their existing presets)
-		const hasCloudPreset = settings.aiPresets?.some(
-			(p: any) => p.id === "screenpipe-cloud" || p.provider === "screenpipe-cloud"
-		);
-		if (settings.aiPresets && settings.aiPresets.length > 0 && !hasCloudPreset) {
-			// Only set as default if no other preset is already default
-			const hasDefault = settings.aiPresets.some((p: any) => p.defaultPreset);
-			const cloudPreset = { ...DEFAULT_CLOUD_PRESET, defaultPreset: !hasDefault };
-			settings.aiPresets = [cloudPreset as any, ...settings.aiPresets];
 			needsUpdate = true;
 		}
 
@@ -1429,6 +1421,7 @@ function createSettingsStore() {
 
 	const set = (value: Partial<Settings>) =>
 		enqueueSettingsStoreWrite(async () => {
+			assertValidAiPresetUpdate(value);
 			const store = await getStore();
 			const current = await get();
 			const managedValues = await activeManagedValues(current);
@@ -1791,6 +1784,7 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
 	}, [settings.fontSize]);
 
 	const updateSettings = async (updates: Partial<Settings>) => {
+		assertValidAiPresetUpdate(updates);
 		const updateGeneration = ++settingsUpdateGenerationRef.current;
 		const settingsBeforeUpdate = settingsRef.current;
 


### PR DESCRIPTION
## Summary

- allow deleting Screenpipe Cloud whenever another AI preset remains
- preserve valid local-only preset lists across settings loads and account or entitlement refreshes
- reject empty preset writes at the shared mutation and persistence boundary
- recover legacy empty state to exactly one existing tier-appropriate default

The invariant is provider-neutral: every user has at least one AI preset, but no provider is mandatory. This does not add an AI-disabled mode or change provider execution or entitlements.

## Before / after

Before:

<pre>Screenpipe Cloud + local preset
├─ Screenpipe Cloud: delete unavailable
└─ settings reload: missing cloud preset prepended again</pre>

After: Screenpipe Cloud has a delete action because the local Ollama preset remains. Deleting it promotes the remaining local preset if needed, and later reloads leave the local-only list unchanged.

![Screenpipe Cloud delete action available beside a local Ollama preset](https://raw.githubusercontent.com/EzraEllette/screenpipe/7b6cea9af1ad2793b36463b1ad952a932b1aedff/ai-preset-cloud-delete-available.png)

## Historical intent

- 46420fd83ce introduced Pi as the default chat preset and injected it for existing users so the new default path was available.
- 54836e84c89 protected the hosted preset for subscribed users as part of defaulting subscribers to cloud transcription.
- PR #4110 relaxed that protection only for duplicate cloud presets while retaining the final cloud preset.
- 87fe0832c66 established the current tier-specific seeds and explicitly limited account-time replacement to the untouched anonymous placeholder.
- Issue #5348 and empty PR #5357 proposed delete-all AI mode; this change intentionally does not adopt that contract. The current product decision supersedes provider-specific retention while preserving the non-empty safety invariant.

## Implementation

- remove the unconditional add-cloud migration for valid non-empty lists
- normalize missing or empty legacy lists to the first existing tier default only, idempotently
- reject explicit empty-list mutations before optimistic UI and inside the serialized settings-store write
- base delete visibility and handler guards on total preset count, not cloud count or subscription state
- preserve default promotion when deleting the active preset

## Tests

- PASS: bun x vitest run --config vitest.config.ts lib/hooks/__tests__/settings-collection-normalization.test.ts components/rewind/ai-presets-selector.test.tsx (19 tests)
- PASS: bun run typecheck
- PASS: git diff --check upstream/main...HEAD

Browser-mock evidence used bun run dev:web at /settings?section=ai. No Tauri build was run because the change does not cross a native boundary.