### PR TITLE
fix(live-views): repair dashboard replacement handoff

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/__tests__/brain-overview.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/__tests__/brain-overview.test.tsx
@@ -1663,6 +1663,54 @@ describe("BrainOverview", () => {
     );
   });
 
+  it("hands an explicit template replacement to the generator as a replacement", async () => {
+    mocks.listBrainViewTemplateKits.mockResolvedValue({
+      status: "ok",
+      data: [dailyMemoryTemplate],
+    });
+    mocks.listBrainViews.mockResolvedValue({
+      status: "ok",
+      data: [populatedView],
+    });
+    mocks.generateLiveViewWithPi.mockResolvedValue({
+      title: "Daily memory, personalized",
+      timeRange: "today",
+      periodPolicy: populatedView.periodPolicy,
+      note: "Replaced the dashboard.",
+      blocks: [
+        {
+          id: "today-in-brief",
+          title: "Today in brief",
+          intent: "Summarize today's source-backed work.",
+          component: "markdown.v1",
+          width: 12,
+          pipeName: "daily-summary",
+        },
+      ],
+    });
+    render(<BrainOverview />);
+
+    await openDashboardMenu();
+    fireEvent.click(await screen.findByTestId("overview-templates"));
+    fireEvent.click(
+      await screen.findByTestId("preview-live-view-template-daily-memory"),
+    );
+    fireEvent.click(await screen.findByTestId("overview-destination-replace"));
+    fireEvent.click(screen.getByTestId("overview-apply-template"));
+    fireEvent.click(await screen.findByTestId("overview-confirm-replace"));
+
+    await waitFor(() =>
+      expect(mocks.generateLiveViewWithPi).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scope: "dashboard",
+          currentViewRef: { id: "my-overview", revision: 3 },
+          replaceExisting: true,
+        }),
+      ),
+    );
+    expect(await screen.findByTestId("live-view-ai-review")).toBeTruthy();
+  });
+
   it("edits the real dashboard, reorders with the keyboard, and resizes without losing its Pipe", async () => {
     const secondSlot = {
       ...populatedView.slots[0],

--- a/apps/screenpipe-app-tauri/components/settings/brain-overview.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/brain-overview.tsx
@@ -1763,6 +1763,8 @@ export function BrainOverview({
           ? { id: reference.id, revision: reference.revision }
           : null,
         targetBlockId: target.scope === "block" ? target.block.id : null,
+        replaceExisting:
+          target.scope === "dashboard" && target.operation === "replace",
         signal: controller.signal,
         onPhase: (phase) =>
           setBuilderFeedback({

--- a/apps/screenpipe-app-tauri/lib/live-views/__tests__/generate-live-view-with-pi.test.ts
+++ b/apps/screenpipe-app-tauri/lib/live-views/__tests__/generate-live-view-with-pi.test.ts
@@ -347,6 +347,51 @@ describe("parseGeneratedLiveView", () => {
       ),
     ).toThrow("targeted Live View changes");
   });
+
+  it("accepts a complete Block list for an explicit replacement", () => {
+    const result = parseGeneratedLiveView(
+      {
+        title: "Replacement",
+        timeRange: "7d",
+        blocks: [
+          {
+            id: "new-focus",
+            title: "New focus",
+            intent: "Show the replacement focus view.",
+            component: "table.v1",
+            width: 12,
+          },
+        ],
+        note: "Replaces the dashboard with a focused table.",
+      },
+      [],
+      "dashboard",
+      {
+        title: "Existing",
+        timeRange: "today",
+        blocks: [
+          {
+            id: "old-focus",
+            title: "Old focus",
+            intent: "Show the old focus view.",
+            component: "metric.v1",
+            width: 6,
+            pipeName: null,
+          },
+        ],
+      },
+      null,
+      true,
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        title: "Replacement",
+        timeRange: "7d",
+        blocks: [expect.objectContaining({ id: "new-focus" })],
+      }),
+    );
+  });
 });
 
 describe("buildLiveViewGenerationPrompt", () => {
@@ -369,6 +414,23 @@ describe("buildLiveViewGenerationPrompt", () => {
     expect(prompt).not.toContain("Current Live View:\n{");
     // The reference is an id and revision, never the view's Block list.
     expect(prompt).not.toContain('"blocks":[');
+  });
+
+  it("asks for a complete Block list when replacing a dashboard", () => {
+    const prompt = buildLiveViewGenerationPrompt({
+      prompt: "replace this with a weekly review",
+      scope: "dashboard",
+      preset: {} as any,
+      userToken: null,
+      pipes: [],
+      currentViewRef: { id: "daily", revision: 7 },
+      replaceExisting: true,
+    });
+
+    expect(prompt).toContain("complete replacement Live View");
+    expect(prompt).toContain("complete new Block list in blocks, not operations");
+    expect(prompt).not.toContain("Do not restate, remove, or update unrelated Blocks");
+    expect(prompt).not.toContain("action=values");
   });
 
   it("looks installed scheduled tasks up on demand instead of injecting them", () => {

--- a/apps/screenpipe-app-tauri/lib/live-views/generate-live-view-with-pi.ts
+++ b/apps/screenpipe-app-tauri/lib/live-views/generate-live-view-with-pi.ts
@@ -79,6 +79,7 @@ type GenerateLiveViewOptions = {
     revision: number;
   } | null;
   targetBlockId?: string | null;
+  replaceExisting?: boolean;
   signal?: AbortSignal;
   onPhase?: (phase: "starting" | "working" | "reviewing") => void;
 };
@@ -139,6 +140,7 @@ export function parseGeneratedLiveView(
   scope: LiveViewGenerationScope,
   currentView: GenerateLiveViewOptions["currentView"] = null,
   targetBlockId: string | null = null,
+  replaceExisting = false,
 ): GeneratedLiveView {
   const parsed = asRecord(proposal);
   if (!parsed) throw new Error("AI returned an invalid Live View proposal");
@@ -180,7 +182,7 @@ export function parseGeneratedLiveView(
 
   let blocks: GeneratedLiveViewBlock[];
   let operationCount = 0;
-  if (currentView) {
+  if (currentView && !replaceExisting) {
     if (!Array.isArray(parsed.operations)) {
       throw new Error("AI did not return targeted Live View changes");
     }
@@ -304,11 +306,14 @@ export function buildLiveViewGenerationPrompt(
   options: GenerateLiveViewOptions,
 ): string {
   const editing = Boolean(options.currentViewRef);
+  const replacing = editing && options.replaceExisting === true;
   const scopeInstruction =
     options.scope === "block"
       ? options.currentViewRef
         ? `Propose exactly one update operation for Block id ${JSON.stringify(options.targetBlockId)}. Do not add, remove, or change any other Block.`
         : "Create exactly one new section to add to the existing Live View."
+      : replacing
+        ? "Create a complete replacement Live View with 4 to 7 useful, visually varied sections. Submit the complete new Block list in blocks, not operations; the app will show the replacement as reversible changes for review."
       : options.currentViewRef
         ? "Edit the referenced Live View with the smallest explicit operation set. Do not restate, remove, or update unrelated Blocks."
         : "Create a complete Live View with 4 to 7 useful, visually varied sections.";
@@ -334,14 +339,14 @@ Find scheduled tasks with screenpipe_live_view action=pipes and a short query. B
 ${scopeInstruction}
 
 Work in this order:
-1. ${editing ? `Call screenpipe_live_view action=values for ${JSON.stringify(options.currentViewRef?.id ?? "")} to see what the Blocks currently render. A Block shows its bound task's last payload, so an intent-only edit changes nothing the user can see.` : "Decide the outcomes the user wants to see."}
+1. ${editing && !replacing ? `Call screenpipe_live_view action=values for ${JSON.stringify(options.currentViewRef?.id ?? "")} to see what the Blocks currently render. A Block shows its bound task's last payload, so an intent-only edit changes nothing the user can see.` : "Decide the outcomes the user wants to see."}
 2. ${options.pipeAvailability === "store" ? "Choose from the installable tasks listed below." : "Look up scheduled tasks only if a section needs one."}
 3. Call screenpipe_live_view_propose once with the finished change. Fix and retry if it reports problems.
 
 Each Block needs a precise, source-backed intent covering the selected period and how missing evidence is handled. Avoid duplicate Blocks. Reuse the id of every Block you edit.
 ${storeCandidates}
 
-${editing ? EDIT_EXAMPLES : ""}
+${editing && !replacing ? EDIT_EXAMPLES : ""}
 
 User request:
 ${options.prompt.trim()}
@@ -553,6 +558,7 @@ export async function generateLiveViewWithPi(
     options.scope,
     options.currentView,
     options.targetBlockId ?? null,
+    options.replaceExisting ?? false,
   );
   const selectedPipes = new Set(
     generated.blocks

--- a/apps/screenpipe-app-tauri/src-tauri/assets/extensions/live-views.ts
+++ b/apps/screenpipe-app-tauri/src-tauri/assets/extensions/live-views.ts
@@ -413,19 +413,22 @@ const proposeParameters = {
       description:
         "One sentence telling the user what visibly changes and why. Do not claim a change the operations do not make.",
     },
-    title: { type: "string", description: "New dashboard title. Create only." },
+    title: {
+      type: "string",
+      description: "New dashboard title. Create or whole-dashboard replacement only.",
+    },
     timeRange: { type: "string", enum: TIME_RANGES },
     timeRangeBehavior: { type: "string", enum: ["selectable", "fixed"] },
     blocks: {
       type: "array",
       description:
-        "Complete Block list. Use only when creating a new dashboard.",
+        "Complete Block list. Use when creating a new dashboard or when the prompt explicitly asks for a whole-dashboard replacement.",
       items: blockSchema,
     },
     operations: {
       type: "array",
       description:
-        "Targeted changes to an existing dashboard. Use instead of blocks whenever a current view was supplied.",
+        "Targeted changes to an existing dashboard. Use instead of blocks for edits that preserve unrelated Blocks; do not use for an explicit whole-dashboard replacement.",
       items: {
         type: "object",
         properties: {


### PR DESCRIPTION
## Summary

- carry the user-selected whole-dashboard replacement intent into the inline Live View generator
- ask replacement runs for a complete Block list and accept that list for reversible proposal review
- keep targeted operation safeguards unchanged for normal dashboard and Block edits
- align the proposal tool descriptions with the replacement contract

## Regression

On app v2.7.6, the replace path had no completed handoffs in the observed production attempts. The UI requested a whole-dashboard replacement, but the generator saw an existing dashboard and instructed the model to preserve unrelated Blocks through targeted operations. That contradicted the replacement request and the proposal schema's creation-only description for complete Block lists.

## Before / after

    before: Replace current -> targeted-edit prompt -> proposal rejected or no usable proposal
    after:  Replace current -> complete replacement prompt -> reversible Block proposals for review

The existing confirmation dialog and Undo path remain the user-visible safety boundary.

## Historical intent

Inspected commits 98753a419b and 869014f923. The targeted-operation contract was introduced to keep ordinary AI edits safe, preserve unrelated Blocks, and make accepted changes reversible; the later flow also avoided asking for redundant confirmation on requested targeted edits. This change preserves those invariants for create/edit/Block operations and only selects complete-list parsing after the user explicitly chooses and confirms whole-dashboard replacement.

## Tests

- bun x vitest run lib/live-views/__tests__/generate-live-view-with-pi.test.ts lib/live-views/__tests__/generate-live-view-proposal.test.ts lib/live-views/__tests__/onboarding-live-view.test.ts src-tauri/assets/extensions/__tests__/live-views.test.ts components/settings/__tests__/brain-overview.test.tsx — 114 passed
- bun run typecheck — passed
