### PR TITLE
fix(settings): accept scrubbed legacy user id

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/store.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/store.rs
@@ -3166,6 +3166,41 @@ mod tests {
         );
     }
 
+    /// Regression for DM/KE/KF: the auth-token migration intentionally scrubs
+    /// a JWT-shaped legacy `settings.userId` to JSON null. That compatibility
+    /// value must not make the entire persisted settings object unreadable and
+    /// turn an otherwise verified account into the recording gate's Unknown
+    /// state.
+    #[test]
+    fn scrubbed_legacy_user_id_keeps_verified_recording_access() {
+        let mut persisted = SettingsStore::default();
+        persisted.user.id = Some("user_free".to_string());
+        persisted.user.subscription_plan = Some("none".to_string());
+        persisted.user.entitlement = Some(json!({
+            "active": true,
+            "plan": "none",
+            "source": "free",
+            "checked_at": chrono::Utc::now().to_rfc3339(),
+            "features": { "app": true, "cloud": false }
+        }));
+        persisted.recording.audio_transcription_engine = "parakeet".to_string();
+
+        let mut settings_json = serde_json::to_value(&persisted).unwrap();
+        settings_json["userId"] = Value::Null;
+
+        let recovered: SettingsStore = serde_json::from_value(settings_json.clone())
+            .expect("a store with only the proven legacy userId null must deserialize");
+        assert_eq!(recovered.recording.user_id, "");
+        assert_eq!(recovered.recording.audio_transcription_engine, "parakeet");
+        assert_eq!(recovered.local_plan_policy(), LocalPlanPolicy::VerifiedFree);
+
+        settings_json["userId"] = json!({ "unexpected": true });
+        assert!(
+            serde_json::from_value::<SettingsStore>(settings_json).is_err(),
+            "malformed non-null userId must remain an error"
+        );
+    }
+
     /// Regression for the Windows 2.6.20+ onboarding outage: a torn `store.bin`
     /// must be recovered, not converted into a permanent recording lockout.
     ///

--- a/crates/screenpipe-config/src/recording.rs
+++ b/crates/screenpipe-config/src/recording.rs
@@ -6,6 +6,16 @@
 
 use serde::{Deserialize, Deserializer, Serialize};
 
+/// The auth-token migration scrubs a JWT-shaped legacy `userId` by persisting
+/// JSON `null`. Keep the historical empty-string sentinel when that store is
+/// read back without accepting nulls for unrelated recording settings.
+fn deserialize_null_user_id_as_default<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(Option::<String>::deserialize(deserializer)?.unwrap_or_default())
+}
+
 /// Older desktop builds persisted a single selected monitor as a string, while
 /// current builds persist an array. Accept both shapes so an upgrade preserves
 /// the user's selection instead of rejecting the entire settings store.
@@ -712,7 +722,10 @@ pub struct RecordingSettings {
     // ── Cloud / Auth ───────────────────────────────────────────────────
     /// Screenpipe cloud user ID. Empty string means not logged in.
     /// Kept as String (not Option) to match existing store.bin schema.
-    #[serde(rename = "userId")]
+    #[serde(
+        rename = "userId",
+        deserialize_with = "deserialize_null_user_id_as_default"
+    )]
     pub user_id: String,
 
     /// Display name for speaker identification.
@@ -1298,6 +1311,33 @@ mod tests {
         assert!(settings.vocabulary.is_empty()); // default
         assert_eq!(settings.audio_capture_mode, "always"); // backward-compatible default
         assert!(!settings.enhanced_incognito_detection); // old stores stay permission-free
+    }
+
+    #[test]
+    fn scrubbed_legacy_user_id_null_uses_empty_string_sentinel() {
+        let settings: RecordingSettings = serde_json::from_str(
+            r#"{
+            "disableAudio": false,
+            "audioTranscriptionEngine": "whisper-large-v3-turbo",
+            "audioDevices": ["default"],
+            "monitorIds": ["default"],
+            "videoQuality": "balanced",
+            "userId": null
+        }"#,
+        )
+        .expect("the auth-token scrubbed store must remain readable");
+
+        assert_eq!(settings.user_id, "");
+        assert_eq!(
+            settings.audio_transcription_engine,
+            "whisper-large-v3-turbo"
+        );
+
+        let malformed = serde_json::from_str::<RecordingSettings>(r#"{"userId": 42}"#);
+        assert!(
+            malformed.is_err(),
+            "non-null malformed userId must still fail"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## description

Fixes the DM → KE → KF production settings-deserialization chain by accepting JSON `null` only for the proven legacy `settings.userId` field and mapping it back to that field's historical empty-string sentinel.

The auth-token migration intentionally replaces a JWT-shaped `userId` with `null` after persisting the token in the SecretStore. `RecordingSettings.user_id` still required a string, so both `store.bin` and its scrubbed `.last-good` snapshot could fail with `invalid type: null, expected a string`. Recovery then fell back to unattributed defaults, leaving the recording gate at `Unknown`.

This does not make settings broadly optional, default unrelated fields, weaken malformed-value errors, or log setting values.

Sentry scope from read-only triage on 2026-08-30:

- [DM](https://mediar.sentry.io/issues/7576820984/): 51 events in 7 days; 10 in 24 hours
- [KE](https://mediar.sentry.io/issues/7674273800/): 26 events in 7 days; 5 in 24 hours
- [KF](https://mediar.sentry.io/issues/7674273806/): 26 events in 7 days; 5 in 24 hours
- confirmed on 2.7.6/macOS and 2.6.91/Windows
- failure occurs before identity initialization, so affected-user counts are unavailable

## Historical intent

Inspected:

- `e8e93928ac`: introduced shared `RecordingSettings.user_id` as a `String` because the persisted schema uses `""` as the no-user sentinel.
- [PR #3986](https://github.com/screenpipe/screenpipe/pull/3986) / `363d9ed734`: moved long-lived cloud tokens out of plaintext settings and deliberately scrubbed JWT-shaped `settings.userId` to JSON `null` only after SecretStore persistence succeeds.
- [PR #6313](https://github.com/screenpipe/screenpipe/pull/6313) and [PR #6468](https://github.com/screenpipe/screenpipe/pull/6468): unmerged automated proposals to recursively strip nulls or default every scalar string; both were held for excessive/unclear migration scope.

Preserved invariants: the token remains scrubbed from plaintext; plain non-JWT IDs remain unchanged; missing/valid strings keep existing behavior; malformed non-null values still fail. The compatibility exception is defined once on `userId`.

## evidence type

- [ ] UI or behavior change — before/after recording
- [x] Backend change — regression tests and relevant logs/results
- [ ] Performance change
- [ ] Docs, CI, or pure refactor

## before

```text
JWT-shaped settings.userId
  -> SecretStore migration
  -> userId: null in store.bin + .last-good
  -> SettingsStore deserialization fails
  -> snapshot recovery also fails
  -> default store has LocalPlanPolicy::Unknown
  -> recording remains gated
```

## after

```text
userId: null from the proven legacy scrub
  -> deserialize as historical "" sentinel
  -> valid account/entitlement fields remain intact
  -> verified plan policy remains available
  -> recording gate is not closed by this compatibility value
```

## how to test

Exact commands run against `790341bc1ba09099ae8516b30a81b344c263434c` after rebasing on current `upstream/main`:

1. `cargo fmt --all -- --check` — passed.
2. `cargo test -p screenpipe-config recording::tests::` — 20 passed, 0 failed. Includes real persisted recording shape, null-only `userId`, valid-string preservation, and malformed-value rejection.
3. `cd apps/screenpipe-app-tauri && bun run test:tauri user_id` — 4 passed, 0 failed, 948 filtered. Covers JWT-shaped scrub, plain-ID preservation, SecretStore migration + scrub, and the real `SettingsStore` recording-gate regression.
4. `cd apps/screenpipe-app-tauri && bun run typecheck` — passed.

The canonical native script rewrote generated Tauri schemas; that generated noise was restored and is not part of this PR.

## desktop app checklist

- [ ] `bun run bindings:generate` — not needed; no exported type shape or command changed.
- [ ] `bun run bindings:check` — not needed; no exported type shape or command changed.
- [x] `bun run typecheck`

## AI assistance and human ownership

- AI tool(s) used: Codex
- autonomy level: agent
- what was verified: read-only Sentry chain/context, relevant Git/PR history, focused compatibility behavior, migration, malformed-value rejection, recording gate, formatting, and typecheck.

- [ ] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [ ] The problem statement, rationale, and replies to maintainers are my own.
