### PR TITLE
feat(ui): add opt-out toggle for importing external claude/codex chats

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat-sidebar.tsx
+++ b/apps/screenpipe-app-tauri/components/chat-sidebar.tsx
@@ -64,6 +64,7 @@ import {
   sessionRecordFromMeta,
   type SessionRecord,
 } from "@/lib/stores/chat-store";
+import { useSettings } from "@/lib/hooks/use-settings";
 import {
   conversationMetaFromJson,
   deleteConversationFile,
@@ -292,8 +293,8 @@ export function hiddenRecentSourcesFromStoredValue(
     return new Set(
       Array.isArray(parsed)
         ? parsed.filter((source): source is RecentSource =>
-            source === "screenpipe" || source === "codex" || source === "claude-code",
-          )
+          source === "screenpipe" || source === "codex" || source === "claude-code",
+        )
         : [],
     );
   } catch {
@@ -530,19 +531,19 @@ export function ChatSidebar({ className, onViewAll }: ChatSidebarProps) {
               : {}),
             ...(hasContentAt
               ? {
-                  lastContentAt: Math.max(
-                    existing.lastContentAt ?? 0,
-                    meta.lastContentAt ?? 0,
-                  ),
-                }
+                lastContentAt: Math.max(
+                  existing.lastContentAt ?? 0,
+                  meta.lastContentAt ?? 0,
+                ),
+              }
               : {}),
             ...(hasViewedAt
               ? {
-                  lastViewedAt: Math.max(
-                    existing.lastViewedAt ?? 0,
-                    meta.lastViewedAt ?? 0,
-                  ),
-                }
+                lastViewedAt: Math.max(
+                  existing.lastViewedAt ?? 0,
+                  meta.lastViewedAt ?? 0,
+                ),
+              }
               : {}),
             updatedAt: Math.max(existing.updatedAt, meta.updatedAt),
             kind: meta.kind,
@@ -673,6 +674,8 @@ export function ChatSidebar({ className, onViewAll }: ChatSidebarProps) {
   // Local Codex and Claude histories are part of the chat index, not a
   // separate import workflow. Watch their native transcripts while the app is
   // open; a bounded focus reconciliation recovers any events the OS dropped.
+  const { settings } = useSettings();
+  const importExternalChatsEnabled = settings.importExternalChatsEnabled ?? true;
   useEffect(() => {
     let cancelled = false;
     let controller: ExternalChatSyncController | null = null;
@@ -682,7 +685,9 @@ export function ChatSidebar({ className, onViewAll }: ChatSidebarProps) {
     };
     const start = async () => {
       try {
-        const nextController = await startExternalChatSync();
+        const nextController = await startExternalChatSync({
+          enabled: importExternalChatsEnabled,
+        });
         if (cancelled) {
           nextController.stop();
           return;
@@ -706,7 +711,7 @@ export function ChatSidebar({ className, onViewAll }: ChatSidebarProps) {
       controller?.stop();
       window.removeEventListener("focus", onFocus);
     };
-  }, [actions]);
+  }, [actions, importExternalChatsEnabled]);
 
   const { pinned, recents, pipes, archived } = useVisibleChatSections();
   const [hiddenRecentSources, setHiddenRecentSources] = useState<Set<RecentSource>>(
@@ -752,28 +757,28 @@ export function ChatSidebar({ className, onViewAll }: ChatSidebarProps) {
   const groupedSections = useMemo(
     () => recentLayout === "source"
       ? RECENT_SOURCE_OPTIONS.flatMap(({ source, label }) => {
-          const sessions = visibleRecents.filter((session) => recentSource(session) === source);
-          return sessions.length === 0
-            ? []
-            : [{
-                key: `source:${source}`,
-                title: label,
-                items: buildGroupedRecents(
-                  sessions,
-                  Number.POSITIVE_INFINITY,
-                  () => null,
-                ),
-              }];
-        })
+        const sessions = visibleRecents.filter((session) => recentSource(session) === source);
+        return sessions.length === 0
+          ? []
+          : [{
+            key: `source:${source}`,
+            title: label,
+            items: buildGroupedRecents(
+              sessions,
+              Number.POSITIVE_INFINITY,
+              () => null,
+            ),
+          }];
+      })
       : [{
-          key: "all-recents",
-          title: "",
-          items: buildGroupedRecents(
-            visibleRecents,
-            Number.POSITIVE_INFINITY,
-            () => null,
-          ),
-        }],
+        key: "all-recents",
+        title: "",
+        items: buildGroupedRecents(
+          visibleRecents,
+          Number.POSITIVE_INFINITY,
+          () => null,
+        ),
+      }],
     [recentLayout, visibleRecents],
   );
 
@@ -1368,7 +1373,7 @@ export function ChatSidebar({ className, onViewAll }: ChatSidebarProps) {
     }
     // Stop any active session first to avoid immediate row resurrection
     // from trailing stream events.
-    commands.piAbort(id).catch(() => {});
+    commands.piAbort(id).catch(() => { });
     actions.patch(id, { hidden: true, pinned: false, unread: false });
     // Archiving should tuck chats away immediately; users can reopen
     // the bucket manually when they want to review archived items.
@@ -1800,8 +1805,8 @@ export function ChatSidebar({ className, onViewAll }: ChatSidebarProps) {
                   {recents.length > 0
                     ? "no chats match filters"
                     : pinned.length === 0 && pipes.length === 0
-                    ? "no chats yet — click + to start"
-                    : "no recent chats"}
+                      ? "no chats yet — click + to start"
+                      : "no recent chats"}
                 </div>
               ) : (
                 <RecentsBody
@@ -1830,63 +1835,63 @@ export function ChatSidebar({ className, onViewAll }: ChatSidebarProps) {
           </div>
 
           <div className="group/pipes min-h-0 flex flex-col shrink-0">
-              <Section
-                title="automations"
-                collapsed={pipesCollapsed}
-                onCollapsedChange={updatePipesCollapsed}
-                headerAction={
-                  <Timer className="h-3 w-3 sidebar-text-tertiary" aria-hidden />
-                }
-                bodyClassName=""
-              >
-                {!pipeInventoryLoaded && pipeItems.length === 0 ? (
-                  <div className="px-2.5 py-2 space-y-1.5">
-                    {Array.from({ length: 3 }).map((_, i) => (
-                      <Skeleton key={i} className="h-6 w-full rounded-md" />
-                    ))}
-                  </div>
-                ) : pipeItems.length === 0 ? (
-                  <div className="px-2.5 py-2 text-xs sidebar-text-secondary italic">
-                    no automation runs yet
-                  </div>
-                ) : pipeItems.map((item) => (
-                    <PipeGroupRow
-                      key={item.key}
-                      item={item}
-                      lastRun={pipeLastRuns[item.title]}
-                      runsLoading={loadingPipeRuns.has(item.title)}
-                      runsLoaded={loadedPipeRuns[item.title] != null}
-                      hasMoreRuns={pipeRunsHaveMore[item.title] === true}
-                      expanded={expandedGroups.has(item.key)}
-                      onToggleExpand={() => toggleGroupExpanded(item.key)}
-                      onLoadMore={() => void loadPipeRuns(item.title, true)}
-                      currentId={currentId}
-                      queueDepths={queueDepths}
-                      onSelect={handleSelect}
-                      onArchive={handleArchive}
-                      onUnarchive={handleUnarchive}
-                      onDeleteRequest={setDeletingSessionId}
-                      onTogglePin={handleTogglePin}
-                      onRenameRequest={handleRenameRequest}
-                      onBranch={handleBranch}
-                      onMoveToGroup={handleMoveToGroup}
-                      onNewGroupRequest={setNewGroupSessionId}
-                      existingGroups={existingGroups}
-                      openConversationMenuId={openConversationMenuId}
-                      setOpenConversationMenuId={setOpenConversationMenuId}
-                    />
-                ))}
-                {pipeInventoryHasMore && (
-                  <button
-                    type="button"
-                    className="w-full px-2.5 py-1.5 text-left text-[10px] uppercase tracking-wider sidebar-text-secondary hover:text-foreground transition-colors"
-                    onClick={() => void fetchPipeInventory(true)}
-                    disabled={pipeInventoryLoadingMore}
-                  >
-                    {pipeInventoryLoadingMore ? "loading…" : "show more automation runs"}
-                  </button>
-                )}
-              </Section>
+            <Section
+              title="automations"
+              collapsed={pipesCollapsed}
+              onCollapsedChange={updatePipesCollapsed}
+              headerAction={
+                <Timer className="h-3 w-3 sidebar-text-tertiary" aria-hidden />
+              }
+              bodyClassName=""
+            >
+              {!pipeInventoryLoaded && pipeItems.length === 0 ? (
+                <div className="px-2.5 py-2 space-y-1.5">
+                  {Array.from({ length: 3 }).map((_, i) => (
+                    <Skeleton key={i} className="h-6 w-full rounded-md" />
+                  ))}
+                </div>
+              ) : pipeItems.length === 0 ? (
+                <div className="px-2.5 py-2 text-xs sidebar-text-secondary italic">
+                  no automation runs yet
+                </div>
+              ) : pipeItems.map((item) => (
+                <PipeGroupRow
+                  key={item.key}
+                  item={item}
+                  lastRun={pipeLastRuns[item.title]}
+                  runsLoading={loadingPipeRuns.has(item.title)}
+                  runsLoaded={loadedPipeRuns[item.title] != null}
+                  hasMoreRuns={pipeRunsHaveMore[item.title] === true}
+                  expanded={expandedGroups.has(item.key)}
+                  onToggleExpand={() => toggleGroupExpanded(item.key)}
+                  onLoadMore={() => void loadPipeRuns(item.title, true)}
+                  currentId={currentId}
+                  queueDepths={queueDepths}
+                  onSelect={handleSelect}
+                  onArchive={handleArchive}
+                  onUnarchive={handleUnarchive}
+                  onDeleteRequest={setDeletingSessionId}
+                  onTogglePin={handleTogglePin}
+                  onRenameRequest={handleRenameRequest}
+                  onBranch={handleBranch}
+                  onMoveToGroup={handleMoveToGroup}
+                  onNewGroupRequest={setNewGroupSessionId}
+                  existingGroups={existingGroups}
+                  openConversationMenuId={openConversationMenuId}
+                  setOpenConversationMenuId={setOpenConversationMenuId}
+                />
+              ))}
+              {pipeInventoryHasMore && (
+                <button
+                  type="button"
+                  className="w-full px-2.5 py-1.5 text-left text-[10px] uppercase tracking-wider sidebar-text-secondary hover:text-foreground transition-colors"
+                  onClick={() => void fetchPipeInventory(true)}
+                  disabled={pipeInventoryLoadingMore}
+                >
+                  {pipeInventoryLoadingMore ? "loading…" : "show more automation runs"}
+                </button>
+              )}
+            </Section>
           </div>
         </div>
       </div>
@@ -2216,11 +2221,11 @@ function CompactDrawerList({
             isCurrent={session.id === currentId}
             queuedCount={0}
             onSelect={onSelect}
-            onArchive={() => {}}
-            onUnarchive={() => {}}
-            onDeleteRequest={() => {}}
-            onTogglePin={() => {}}
-            onRenameRequest={() => {}}
+            onArchive={() => { }}
+            onUnarchive={() => { }}
+            onDeleteRequest={() => { }}
+            onTogglePin={() => { }}
+            onRenameRequest={() => { }}
             showActions={false}
           />
         ))}
@@ -3006,141 +3011,141 @@ export function SidebarChatRow({
       }}
     >
       <ContextMenuTrigger asChild disabled={!canShowActions}>
-    <div
-      className={cn(
-        "group relative flex items-center gap-2 border-l-2 px-2.5 py-1 rounded-md select-none",
-        "transition-colors",
-        isCurrent
-          ? "border-foreground bg-foreground/[0.08] text-foreground"
-          : disableHover
-            ? tone === "subtle"
-              ? "border-transparent sidebar-text-tertiary"
-              : "border-transparent sidebar-text-secondary"
-            : tone === "subtle"
-              ? "border-transparent sidebar-text-tertiary hover:bg-muted/12"
-              : "border-transparent sidebar-text-secondary hover:bg-muted/20"
-      )}
-      data-testid={`chat-row-${session.id}`}
-      data-current={isCurrent ? "true" : undefined}
-      title={isError && session.lastError ? session.lastError : undefined}
-    >
-      <button
-        type="button"
-        className="min-w-0 flex-1 flex items-center gap-2 text-left"
-        aria-current={isCurrent ? "page" : undefined}
-        onClick={() => {
-          setOpenConversationMenuId?.(null);
-          onSelect(session.id);
-        }}
-      >
-        <span
-          className="flex h-5 w-5 shrink-0 items-center justify-center"
-          aria-label={harnessLabel ? `${harnessLabel} harness` : `${sourceLabel} source`}
-          title={harnessLabel ? `${harnessLabel}${sourceLabel ? ` · ${sourceLabel}` : ""}` : sourceLabel ?? undefined}
-        >
-          {harnessIcon ? (
-            <Image
-              src={harnessIcon}
-              alt=""
-              width={17}
-              height={17}
-              className="h-[17px] w-[17px] rounded-sm object-contain"
-              unoptimized
-            />
-          ) : (
-            <Terminal className="h-4 w-4 sidebar-text-tertiary" aria-hidden />
-          )}
-        </span>
-        {!insideGroup && (session.kind === "pipe-run" || session.kind === "pipe-watch") && (
-          <Timer className="h-3 w-3 shrink-0 sidebar-text-tertiary" aria-hidden />
-        )}
-        <span className="min-w-0 flex-1">
-          <span
-            className={cn(
-            "block truncate text-xs font-normal",
-            isUnread
-              ? "font-medium text-foreground"
-              : isCurrent
-                ? "font-medium text-foreground"
+        <div
+          className={cn(
+            "group relative flex items-center gap-2 border-l-2 px-2.5 py-1 rounded-md select-none",
+            "transition-colors",
+            isCurrent
+              ? "border-foreground bg-foreground/[0.08] text-foreground"
+              : disableHover
+                ? tone === "subtle"
+                  ? "border-transparent sidebar-text-tertiary"
+                  : "border-transparent sidebar-text-secondary"
                 : tone === "subtle"
-                  ? "sidebar-text-tertiary"
-                : "sidebar-text-secondary"
+                  ? "border-transparent sidebar-text-tertiary hover:bg-muted/12"
+                  : "border-transparent sidebar-text-secondary hover:bg-muted/20"
           )}
-          >
-            {session.streamingTitle || (isInjectedTitle(session.title) ? undefined : session.title) || "untitled"}
-          </span>
-        </span>
-        <span className="ml-1 h-4 w-10 shrink-0 relative flex items-center justify-end">
-          <span
-            className={cn(
-              "absolute inset-y-0 right-0 flex items-center justify-end transition-opacity duration-150",
-              canShowActions && "group-hover:opacity-0",
-              menuOpen && "opacity-0"
-            )}
-          >
-            {showCurrentLabel ? (
-              <span className="text-[9px] font-medium uppercase tracking-[0.08em] text-foreground/70">
-                current
-              </span>
-            ) : (
-              <RowRightSignal
-                isLive={isLive}
-                isError={isError}
-                isUnread={isUnread}
-                queuedCount={queuedCount}
-                status={session.status}
-                age={age}
-              />
-            )}
-          </span>
-        </span>
-      </button>
-
-      {canShowActions && (
-        // Absolute so the menu overlays the age slot instead of reserving
-        // its own column. Without this, recents rows sit ~28px further from
-        // the right edge than scheduled rows (gap-2 + w-5) and read as
-        // misaligned even when the menu is invisible.
-        <div className="absolute right-2.5 top-1/2 -translate-y-1/2 h-5 w-5 flex items-center justify-end">
-          <DropdownMenu
-            open={menuOpen}
-            onOpenChange={(open) => {
-              setOpenConversationMenuId?.(open ? session.id : null);
+          data-testid={`chat-row-${session.id}`}
+          data-current={isCurrent ? "true" : undefined}
+          title={isError && session.lastError ? session.lastError : undefined}
+        >
+          <button
+            type="button"
+            className="min-w-0 flex-1 flex items-center gap-2 text-left"
+            aria-current={isCurrent ? "page" : undefined}
+            onClick={() => {
+              setOpenConversationMenuId?.(null);
+              onSelect(session.id);
             }}
           >
-            <DropdownMenuTrigger asChild>
-              <button
-                type="button"
-                onPointerDown={(e) => e.stopPropagation()}
-                onClick={(e) => e.stopPropagation()}
-                className={cn(
-                  "p-0.5 rounded hover:bg-muted transition-opacity duration-150 inline-flex items-center justify-center",
-                  menuOpen
-                    ? "opacity-100 visible"
-                    : "opacity-0 invisible group-hover:opacity-100 group-hover:visible"
-                )}
-                aria-label="conversation actions"
-              >
-                <MoreVertical className="h-3.5 w-3.5 text-muted-foreground" />
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              align="end"
-              alignOffset={2}
-              side="bottom"
-              sideOffset={4}
-              collisionPadding={8}
-              className="w-[156px] p-1 rounded-none border border-border bg-background shadow-none"
-              onClick={(e) => e.stopPropagation()}
-              onPointerDown={(e) => e.stopPropagation()}
-              onKeyDown={handleRowMenuShortcut}
+            <span
+              className="flex h-5 w-5 shrink-0 items-center justify-center"
+              aria-label={harnessLabel ? `${harnessLabel} harness` : `${sourceLabel} source`}
+              title={harnessLabel ? `${harnessLabel}${sourceLabel ? ` · ${sourceLabel}` : ""}` : sourceLabel ?? undefined}
             >
-              <RowMenuItems variant="dropdown" session={session} {...rowMenuActions} />
-            </DropdownMenuContent>
-          </DropdownMenu>
+              {harnessIcon ? (
+                <Image
+                  src={harnessIcon}
+                  alt=""
+                  width={17}
+                  height={17}
+                  className="h-[17px] w-[17px] rounded-sm object-contain"
+                  unoptimized
+                />
+              ) : (
+                <Terminal className="h-4 w-4 sidebar-text-tertiary" aria-hidden />
+              )}
+            </span>
+            {!insideGroup && (session.kind === "pipe-run" || session.kind === "pipe-watch") && (
+              <Timer className="h-3 w-3 shrink-0 sidebar-text-tertiary" aria-hidden />
+            )}
+            <span className="min-w-0 flex-1">
+              <span
+                className={cn(
+                  "block truncate text-xs font-normal",
+                  isUnread
+                    ? "font-medium text-foreground"
+                    : isCurrent
+                      ? "font-medium text-foreground"
+                      : tone === "subtle"
+                        ? "sidebar-text-tertiary"
+                        : "sidebar-text-secondary"
+                )}
+              >
+                {session.streamingTitle || (isInjectedTitle(session.title) ? undefined : session.title) || "untitled"}
+              </span>
+            </span>
+            <span className="ml-1 h-4 w-10 shrink-0 relative flex items-center justify-end">
+              <span
+                className={cn(
+                  "absolute inset-y-0 right-0 flex items-center justify-end transition-opacity duration-150",
+                  canShowActions && "group-hover:opacity-0",
+                  menuOpen && "opacity-0"
+                )}
+              >
+                {showCurrentLabel ? (
+                  <span className="text-[9px] font-medium uppercase tracking-[0.08em] text-foreground/70">
+                    current
+                  </span>
+                ) : (
+                  <RowRightSignal
+                    isLive={isLive}
+                    isError={isError}
+                    isUnread={isUnread}
+                    queuedCount={queuedCount}
+                    status={session.status}
+                    age={age}
+                  />
+                )}
+              </span>
+            </span>
+          </button>
+
+          {canShowActions && (
+            // Absolute so the menu overlays the age slot instead of reserving
+            // its own column. Without this, recents rows sit ~28px further from
+            // the right edge than scheduled rows (gap-2 + w-5) and read as
+            // misaligned even when the menu is invisible.
+            <div className="absolute right-2.5 top-1/2 -translate-y-1/2 h-5 w-5 flex items-center justify-end">
+              <DropdownMenu
+                open={menuOpen}
+                onOpenChange={(open) => {
+                  setOpenConversationMenuId?.(open ? session.id : null);
+                }}
+              >
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    onPointerDown={(e) => e.stopPropagation()}
+                    onClick={(e) => e.stopPropagation()}
+                    className={cn(
+                      "p-0.5 rounded hover:bg-muted transition-opacity duration-150 inline-flex items-center justify-center",
+                      menuOpen
+                        ? "opacity-100 visible"
+                        : "opacity-0 invisible group-hover:opacity-100 group-hover:visible"
+                    )}
+                    aria-label="conversation actions"
+                  >
+                    <MoreVertical className="h-3.5 w-3.5 text-muted-foreground" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent
+                  align="end"
+                  alignOffset={2}
+                  side="bottom"
+                  sideOffset={4}
+                  collisionPadding={8}
+                  className="w-[156px] p-1 rounded-none border border-border bg-background shadow-none"
+                  onClick={(e) => e.stopPropagation()}
+                  onPointerDown={(e) => e.stopPropagation()}
+                  onKeyDown={handleRowMenuShortcut}
+                >
+                  <RowMenuItems variant="dropdown" session={session} {...rowMenuActions} />
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          )}
         </div>
-      )}
-    </div>
       </ContextMenuTrigger>
       {canShowActions && (
         <ContextMenuContent
@@ -3181,8 +3186,8 @@ function RowRightSignal({
     if (isLive) {
       const live =
         status === "thinking" ? "thinking" :
-        status === "tool" ? "using tool" :
-        "streaming";
+          status === "tool" ? "using tool" :
+            "streaming";
       return { content: <LiveSignal ariaLabel={live} />, label: live };
     }
     if (queuedCount > 0) {

--- a/apps/screenpipe-app-tauri/components/settings/privacy-section.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/privacy-section.tsx
@@ -23,6 +23,10 @@ export const searchIndex: SettingsField[] = [
   },
   { label: "PII masking", keywords: ["mask", "redact", "columns", "url", "fields"] },
   {
+    label: "Import local Claude Code / Codex chats",
+    keywords: ["claude", "codex", "agent", "import", "sync", "transcript"],
+  },
+  {
     label: "Remote support logs",
     keywords: ["support", "diagnostic", "troubleshooting", "remote", "logs"],
   },
@@ -177,18 +181,18 @@ const REDACTION_PREVIEW_PARTS: (
   | { text: string }
   | { cat: string; value: string; ph: string }
 )[] = [
-  { text: "hi, i'm " },
-  { cat: "person", value: "Jordan Lee", ph: "[PERSON]" },
-  { text: " — email " },
-  { cat: "email", value: "jordan@example.com", ph: "[EMAIL]" },
-  { text: ", cell " },
-  { cat: "phone", value: "(555) 010-2983", ph: "[PHONE]" },
-  { text: ", ssn " },
-  { cat: "id", value: "412-09-1764", ph: "[ID]" },
-  { text: ", key " },
-  { cat: "secret", value: "AKIA…X7Q", ph: "[SECRET]" },
-  { text: "." },
-];
+    { text: "hi, i'm " },
+    { cat: "person", value: "Jordan Lee", ph: "[PERSON]" },
+    { text: " — email " },
+    { cat: "email", value: "jordan@example.com", ph: "[EMAIL]" },
+    { text: ", cell " },
+    { cat: "phone", value: "(555) 010-2983", ph: "[PHONE]" },
+    { text: ", ssn " },
+    { cat: "id", value: "412-09-1764", ph: "[ID]" },
+    { text: ", key " },
+    { cat: "secret", value: "AKIA…X7Q", ph: "[SECRET]" },
+    { text: "." },
+  ];
 
 function RedactionExamplePreview({ labels }: { labels: string[] }) {
   const isOn = (cat: string) => cat === "secret" || labels.includes(cat);
@@ -250,7 +254,7 @@ function RedactionWherePreview({
       className={cn(
         "relative inline-block rounded-sm align-baseline",
         hovered === r &&
-          "outline outline-2 outline-foreground outline-offset-2",
+        "outline outline-2 outline-foreground outline-offset-2",
       )}
     >
       <span className={cn(mono && "font-mono", on(r) && "invisible")}>
@@ -596,16 +600,16 @@ export function PrivacySection() {
     desc: string;
     always?: boolean;
   }[] = [
-    { value: "secret", label: "Passwords & keys", desc: "passwords, API keys, tokens", always: true },
-    { value: "id", label: "ID numbers", desc: "SSNs, credit cards, account & license numbers" },
-    { value: "person", label: "Names", desc: "people's names" },
-    { value: "email", label: "Email addresses", desc: "email addresses" },
-    { value: "phone", label: "Phone numbers", desc: "phone numbers" },
-    { value: "address", label: "Mailing addresses", desc: "postal addresses" },
-    { value: "url", label: "Links with tokens", desc: "links carrying tokens or session IDs" },
-    { value: "date", label: "Dates", desc: "dates of birth, timestamps" },
-    { value: "sensitive", label: "Health & financial details", desc: "health, financial, identity context" },
-  ];
+      { value: "secret", label: "Passwords & keys", desc: "passwords, API keys, tokens", always: true },
+      { value: "id", label: "ID numbers", desc: "SSNs, credit cards, account & license numbers" },
+      { value: "person", label: "Names", desc: "people's names" },
+      { value: "email", label: "Email addresses", desc: "email addresses" },
+      { value: "phone", label: "Phone numbers", desc: "phone numbers" },
+      { value: "address", label: "Mailing addresses", desc: "postal addresses" },
+      { value: "url", label: "Links with tokens", desc: "links carrying tokens or session IDs" },
+      { value: "date", label: "Dates", desc: "dates of birth, timestamps" },
+      { value: "sensitive", label: "Health & financial details", desc: "health, financial, identity context" },
+    ];
 
   const piiRedactionLabels = useMemo<string[]>(() => {
     const raw = (settings.piiRedactionLabels as string[] | undefined) ?? ["secret"];
@@ -652,6 +656,16 @@ export function PrivacySection() {
     );
   };
 
+  const importExternalChatsEnabled = Boolean(
+    settings.importExternalChatsEnabled ?? true,
+  );
+  const handleImportExternalChatsToggle = (checked: boolean) => {
+    handleSettingsChange(
+      { importExternalChatsEnabled: checked } as Partial<Settings>,
+      false,
+    );
+  };
+
   // WHICH captured columns get scrubbed (orthogonal to the categories
   // above). Typed text / clipboard / transcripts / window titles /
   // on-screen text are always redacted; these extra surfaces are opt-in.
@@ -683,33 +697,33 @@ export function PrivacySection() {
     desc: string;
     recommended?: boolean;
   }[] = [
-    {
-      value: "element_properties",
-      label: "Form field values",
-      desc: "what you type into forms — catches passwords and field contents that on-screen text misses",
-      recommended: true,
-    },
-    {
-      value: "browser_url",
-      label: "Web addresses",
-      desc: "the address bar — usually not private, and hiding them breaks links",
-    },
-    {
-      value: "ui_element_name",
-      label: "Button & menu labels",
-      desc: "names like “Submit” or “Search” — rarely private",
-    },
-    {
-      value: "ui_element_description",
-      label: "Help text on controls",
-      desc: "the longer description some buttons and menus expose",
-    },
-    {
-      value: "a11y_url_field",
-      label: "Links inside app data",
-      desc: "URLs embedded in an app’s underlying structure",
-    },
-  ];
+      {
+        value: "element_properties",
+        label: "Form field values",
+        desc: "what you type into forms — catches passwords and field contents that on-screen text misses",
+        recommended: true,
+      },
+      {
+        value: "browser_url",
+        label: "Web addresses",
+        desc: "the address bar — usually not private, and hiding them breaks links",
+      },
+      {
+        value: "ui_element_name",
+        label: "Button & menu labels",
+        desc: "names like “Submit” or “Search” — rarely private",
+      },
+      {
+        value: "ui_element_description",
+        label: "Help text on controls",
+        desc: "the longer description some buttons and menus expose",
+      },
+      {
+        value: "a11y_url_field",
+        label: "Links inside app data",
+        desc: "URLs embedded in an app’s underlying structure",
+      },
+    ];
 
   const piiRedactionColumns = useMemo<string[]>(() => {
     return (
@@ -744,9 +758,9 @@ export function PrivacySection() {
       checked
         ? { ignoreIncognitoWindows: true }
         : {
-            ignoreIncognitoWindows: false,
-            enhancedIncognitoDetection: false,
-          },
+          ignoreIncognitoWindows: false,
+          enhancedIncognitoDetection: false,
+        },
       true,
     );
   };
@@ -901,22 +915,22 @@ export function PrivacySection() {
       </p>
 
       <div className="flex items-center justify-end">
-          {hasUnsavedChanges && (
-            <Button
-              onClick={handleUpdate}
-              disabled={isUpdating || Object.keys(validationErrors).length > 0}
-              size="sm"
-              data-testid="privacy-apply-restart"
-              className="flex items-center gap-1.5 h-7 text-xs bg-foreground text-background hover:bg-background hover:text-foreground transition-colors duration-150"
-            >
-              {isUpdating ? (
-                <Loader2 className="h-3 w-3 animate-spin" />
-              ) : (
-                <RefreshCw className="h-3 w-3" />
-              )}
-              Apply & Restart
-            </Button>
-          )}
+        {hasUnsavedChanges && (
+          <Button
+            onClick={handleUpdate}
+            disabled={isUpdating || Object.keys(validationErrors).length > 0}
+            size="sm"
+            data-testid="privacy-apply-restart"
+            className="flex items-center gap-1.5 h-7 text-xs bg-foreground text-background hover:bg-background hover:text-foreground transition-colors duration-150"
+          >
+            {isUpdating ? (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+              <RefreshCw className="h-3 w-3" />
+            )}
+            Apply & Restart
+          </Button>
+        )}
       </div>
 
       {/* Security */}
@@ -925,147 +939,147 @@ export function PrivacySection() {
           Security
         </h2>
         <LockedSetting settingKey="api_auth">
-        <Card className="border-border bg-card">
-          <CardContent className="px-3 py-2.5">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center space-x-2.5">
-                <Shield className="h-4 w-4 text-muted-foreground shrink-0" />
-                <div>
-                  <h3 className="text-sm font-medium text-foreground">
-                    Require API Authentication
-                  </h3>
-                  <p className="text-xs text-muted-foreground mt-0.5">
-                    All API requests require a valid token when enabled — including local ones. Most apps pair automatically; use this key only for manual API clients and troubleshooting.
-                  </p>
+          <Card className="border-border bg-card">
+            <CardContent className="px-3 py-2.5">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center space-x-2.5">
+                  <Shield className="h-4 w-4 text-muted-foreground shrink-0" />
+                  <div>
+                    <h3 className="text-sm font-medium text-foreground">
+                      Require API Authentication
+                    </h3>
+                    <p className="text-xs text-muted-foreground mt-0.5">
+                      All API requests require a valid token when enabled — including local ones. Most apps pair automatically; use this key only for manual API clients and troubleshooting.
+                    </p>
+                  </div>
                 </div>
-              </div>
-              <Switch
-                checked={settings.apiAuth ?? true}
-                onCheckedChange={(checked) => {
-                  handleSettingsChange({ apiAuth: checked });
-                }}
-                data-testid="privacy-api-auth-switch"
-              />
-            </div>
-            {hasUnsavedChanges && (
-              <p className="text-xs text-amber-600 dark:text-amber-400 mt-2 flex items-center gap-1">
-                <RefreshCw className="h-3 w-3 shrink-0" />
-                click &quot;Apply &amp; Restart&quot; above for auth changes to take effect; existing browser connections keep using the old key until then
-              </p>
-            )}
-            <LockedSetting settingKey="api_key">
-            {(settings.apiAuth ?? true) && (
-              <div className="mt-2.5 flex items-center space-x-2.5 pl-6.5">
-                <Input
-                  type="text"
-                  readOnly={!revealApiKey}
-                  placeholder="e.g. sp-abc12345"
-                  data-testid="privacy-api-key-input"
-                  value={
-                    liveApiKey
-                      ? revealApiKey
-                        ? liveApiKey
-                        : "•".repeat(Math.min(liveApiKey.length, 32))
-                      : ""
-                  }
-                  onChange={(e) => {
-                    if (!revealApiKey) return;
-                    const val = e.target.value;
-                    setLiveApiKey(val);
-                    setPendingApiKey(val);
-                    if (!val.trim()) {
-                      setValidationErrors((prev) => ({ ...prev, apiKey: "API key cannot be empty" }));
-                    } else {
-                      setValidationErrors(({ apiKey: _, ...rest }) => rest);
-                    }
-                    setHasUnsavedChanges(true);
+                <Switch
+                  checked={settings.apiAuth ?? true}
+                  onCheckedChange={(checked) => {
+                    handleSettingsChange({ apiAuth: checked });
                   }}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" && pendingApiKey && pendingApiKey.trim()) {
-                      handleUpdate();
-                    }
-                  }}
-                  onClick={(e) => (e.target as HTMLInputElement).select()}
-                  className="h-8 text-xs font-mono cursor-text select-all"
+                  data-testid="privacy-api-auth-switch"
                 />
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="h-8 px-2 shrink-0"
-                  title={revealApiKey ? "Hide key" : "Reveal key"}
-                  onClick={() => setRevealApiKey((v) => !v)}
-                  disabled={!liveApiKey}
-                  data-testid="privacy-api-key-reveal"
-                >
-                  {revealApiKey ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="h-8 px-2 shrink-0"
-                  title="Copy key"
-                  disabled={!liveApiKey}
-                  data-testid="privacy-api-key-copy"
-                  onClick={async () => {
-                    if (!liveApiKey) return;
-                    try {
-                      await commands.copyTextToClipboard(liveApiKey);
-                      toast({ title: "API key copied to clipboard" });
-                    } catch (error) {
-                      toast({
-                        title: "couldn't copy API key",
-                        description: error instanceof Error ? error.message : String(error),
-                        variant: "destructive",
-                      });
-                    }
-                  }}
-                >
-                  <Copy className="h-3.5 w-3.5" />
-                </Button>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="h-8 px-2 shrink-0"
-                  title="Regenerate key"
-                  disabled={regeneratingKey}
-                  data-testid="privacy-api-key-regenerate"
-                  onClick={async () => {
-                    const { confirm } = await import("@tauri-apps/plugin-dialog");
-                    const confirmed = await confirm(
-                      "Regenerate API key? Existing browser extensions stay connected until you Apply & Restart, then they must reconnect with the new key.",
-                      { title: "screenpipe", kind: "info" },
-                    );
-                    if (!confirmed) return;
-                    setRegeneratingKey(true);
-                    try {
-                      const res = await commands.regenerateApiAuthKey();
-                      if (res.status === "error") throw new Error(res.error);
-                      const newKey = res.data;
-                      setLiveApiKey(newKey);
-                      setRevealApiKey(true);
-                      setHasUnsavedChanges(true);
-                      toast({
-                        title: "API key regenerated",
-                        description: "Click Apply & Restart. Browser extensions will need to reconnect after restart.",
-                      });
-                    } catch (e: any) {
-                      toast({
-                        title: "Failed to regenerate API key",
-                        description: String(e?.message ?? e),
-                        variant: "destructive",
-                      });
-                    } finally {
-                      setRegeneratingKey(false);
-                    }
-                  }}
-                >
-                  <RefreshCw className={cn("h-3.5 w-3.5", regeneratingKey && "animate-spin")} />
-                </Button>
               </div>
-            )}
-            </LockedSetting>
-          </CardContent>
-        </Card>
+              {hasUnsavedChanges && (
+                <p className="text-xs text-amber-600 dark:text-amber-400 mt-2 flex items-center gap-1">
+                  <RefreshCw className="h-3 w-3 shrink-0" />
+                  click &quot;Apply &amp; Restart&quot; above for auth changes to take effect; existing browser connections keep using the old key until then
+                </p>
+              )}
+              <LockedSetting settingKey="api_key">
+                {(settings.apiAuth ?? true) && (
+                  <div className="mt-2.5 flex items-center space-x-2.5 pl-6.5">
+                    <Input
+                      type="text"
+                      readOnly={!revealApiKey}
+                      placeholder="e.g. sp-abc12345"
+                      data-testid="privacy-api-key-input"
+                      value={
+                        liveApiKey
+                          ? revealApiKey
+                            ? liveApiKey
+                            : "•".repeat(Math.min(liveApiKey.length, 32))
+                          : ""
+                      }
+                      onChange={(e) => {
+                        if (!revealApiKey) return;
+                        const val = e.target.value;
+                        setLiveApiKey(val);
+                        setPendingApiKey(val);
+                        if (!val.trim()) {
+                          setValidationErrors((prev) => ({ ...prev, apiKey: "API key cannot be empty" }));
+                        } else {
+                          setValidationErrors(({ apiKey: _, ...rest }) => rest);
+                        }
+                        setHasUnsavedChanges(true);
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" && pendingApiKey && pendingApiKey.trim()) {
+                          handleUpdate();
+                        }
+                      }}
+                      onClick={(e) => (e.target as HTMLInputElement).select()}
+                      className="h-8 text-xs font-mono cursor-text select-all"
+                    />
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-8 px-2 shrink-0"
+                      title={revealApiKey ? "Hide key" : "Reveal key"}
+                      onClick={() => setRevealApiKey((v) => !v)}
+                      disabled={!liveApiKey}
+                      data-testid="privacy-api-key-reveal"
+                    >
+                      {revealApiKey ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-8 px-2 shrink-0"
+                      title="Copy key"
+                      disabled={!liveApiKey}
+                      data-testid="privacy-api-key-copy"
+                      onClick={async () => {
+                        if (!liveApiKey) return;
+                        try {
+                          await commands.copyTextToClipboard(liveApiKey);
+                          toast({ title: "API key copied to clipboard" });
+                        } catch (error) {
+                          toast({
+                            title: "couldn't copy API key",
+                            description: error instanceof Error ? error.message : String(error),
+                            variant: "destructive",
+                          });
+                        }
+                      }}
+                    >
+                      <Copy className="h-3.5 w-3.5" />
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-8 px-2 shrink-0"
+                      title="Regenerate key"
+                      disabled={regeneratingKey}
+                      data-testid="privacy-api-key-regenerate"
+                      onClick={async () => {
+                        const { confirm } = await import("@tauri-apps/plugin-dialog");
+                        const confirmed = await confirm(
+                          "Regenerate API key? Existing browser extensions stay connected until you Apply & Restart, then they must reconnect with the new key.",
+                          { title: "screenpipe", kind: "info" },
+                        );
+                        if (!confirmed) return;
+                        setRegeneratingKey(true);
+                        try {
+                          const res = await commands.regenerateApiAuthKey();
+                          if (res.status === "error") throw new Error(res.error);
+                          const newKey = res.data;
+                          setLiveApiKey(newKey);
+                          setRevealApiKey(true);
+                          setHasUnsavedChanges(true);
+                          toast({
+                            title: "API key regenerated",
+                            description: "Click Apply & Restart. Browser extensions will need to reconnect after restart.",
+                          });
+                        } catch (e: any) {
+                          toast({
+                            title: "Failed to regenerate API key",
+                            description: String(e?.message ?? e),
+                            variant: "destructive",
+                          });
+                        } finally {
+                          setRegeneratingKey(false);
+                        }
+                      }}
+                    >
+                      <RefreshCw className={cn("h-3.5 w-3.5", regeneratingKey && "animate-spin")} />
+                    </Button>
+                  </div>
+                )}
+              </LockedSetting>
+            </CardContent>
+          </Card>
         </LockedSetting>
 
         {isManagedDeployment && <AdminTeamTokenCard />}
@@ -1074,38 +1088,38 @@ export function PrivacySection() {
             (the backend mirrors this guard in RecordingConfig::from_settings
             so the API is never exposed to the network unauthenticated). */}
         <LockedSetting settingKey="listen_on_lan">
-        <Card className="border-border bg-card">
-          <CardContent className="px-3 py-2.5">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center space-x-2.5">
-                <Shield className="h-4 w-4 text-muted-foreground shrink-0" />
-                <div>
-                  <h3 className="text-sm font-medium text-foreground">
-                    Allow LAN access
-                  </h3>
-                  <p className="text-xs text-muted-foreground mt-0.5">
-                    Bind the API to <code className="text-[10px]">0.0.0.0</code> so other devices on your local
-                    network can query it. API authentication is force-enabled
-                    whenever this is on. Restart the app to apply.
-                  </p>
+          <Card className="border-border bg-card">
+            <CardContent className="px-3 py-2.5">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center space-x-2.5">
+                  <Shield className="h-4 w-4 text-muted-foreground shrink-0" />
+                  <div>
+                    <h3 className="text-sm font-medium text-foreground">
+                      Allow LAN access
+                    </h3>
+                    <p className="text-xs text-muted-foreground mt-0.5">
+                      Bind the API to <code className="text-[10px]">0.0.0.0</code> so other devices on your local
+                      network can query it. API authentication is force-enabled
+                      whenever this is on. Restart the app to apply.
+                    </p>
+                  </div>
                 </div>
+                <Switch
+                  checked={settings.listenOnLan ?? false}
+                  onCheckedChange={(checked) => {
+                    // Keep the UI consistent with the backend guard: flipping
+                    // LAN on also flips api_auth on, so the user can't
+                    // accidentally leave themselves open.
+                    if (checked) {
+                      handleSettingsChange({ listenOnLan: true, apiAuth: true });
+                    } else {
+                      handleSettingsChange({ listenOnLan: false });
+                    }
+                  }}
+                />
               </div>
-              <Switch
-                checked={settings.listenOnLan ?? false}
-                onCheckedChange={(checked) => {
-                  // Keep the UI consistent with the backend guard: flipping
-                  // LAN on also flips api_auth on, so the user can't
-                  // accidentally leave themselves open.
-                  if (checked) {
-                    handleSettingsChange({ listenOnLan: true, apiAuth: true });
-                  } else {
-                    handleSettingsChange({ listenOnLan: false });
-                  }
-                }}
-              />
-            </div>
-          </CardContent>
-        </Card>
+            </CardContent>
+          </Card>
         </LockedSetting>
 
         <EncryptDataCard
@@ -1122,491 +1136,491 @@ export function PrivacySection() {
           Capture rules
         </h2>
 
-      {/* Incognito Detection */}
-      <Card className="border-border bg-card">
-        <CardContent className="px-3 py-2.5">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center space-x-2.5">
-              <EyeOff className="h-4 w-4 text-muted-foreground shrink-0" />
-              <div>
-                <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
-                  Ignore Incognito Windows
-                  <HelpTooltip text="automatically detects and skips private/incognito browser windows in 20+ languages without extra access. on macOS, enhance enables browser-native detection for supported Chromium browsers." />
-                </h3>
-                <p className="text-xs text-muted-foreground">
-                  Skip private browsing sessions
-                </p>
-              </div>
-            </div>
-            <div className="flex items-center gap-1.5">
-              {isMacOS && Boolean(settings.ignoreIncognitoWindows ?? true) && (
-                <Button
-                  type="button"
-                  variant={enhancedIncognitoDetection ? "outline" : "ghost"}
-                  size="sm"
-                  className="h-7 px-2 text-[10px] uppercase tracking-wide"
-                  onClick={handleEnhancedIncognitoDetection}
-                  disabled={isEnhancingIncognito}
-                  aria-pressed={enhancedIncognitoDetection}
-                  title="use browser-native detection; requires macOS Automation access"
-                >
-                  {isEnhancingIncognito ? (
-                    <Loader2 className="mr-1 h-3 w-3 animate-spin" />
-                  ) : (
-                    <Shield className="mr-1 h-3 w-3" />
-                  )}
-                  {enhancedIncognitoDetection ? "enhanced" : "enhance"}
-                </Button>
-              )}
-              <Switch
-                id="ignoreIncognitoWindows"
-                checked={Boolean(settings.ignoreIncognitoWindows ?? true)}
-                onCheckedChange={handleIncognitoToggle}
-              />
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Window Filtering */}
-      {/* Pause for content-protected apps (DRM streaming + remote desktop) */}
-      <Card>
-        <CardContent className="px-3 py-2.5">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center space-x-2.5">
-              <Tv className="h-4 w-4 text-muted-foreground shrink-0" />
-              <div>
-                <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
-                  Pause for DRM & Remote Desktop
-                  <HelpTooltip text="pauses all screen capture when a DRM-protected streaming app (netflix, disney+, hulu, prime video, apple tv, etc.) or a remote-desktop client (Omnissa/VMware Horizon) is focused. these apps blank their windows when any app is recording the screen — pausing capture while they're focused keeps them usable. capture resumes automatically when you switch away." />
-                </h3>
-                <p className="text-xs text-muted-foreground">
-                  Avoid DRM black screens (Netflix, Disney+) and gray Horizon windows.
-                </p>
-              </div>
-            </div>
-            <Switch
-              id="pauseOnDrmContent"
-              checked={Boolean(settings.pauseOnDrmContent ?? false)}
-              onCheckedChange={handleDrmPauseToggle}
-            />
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Clipboard capture toggle */}
-      <Card>
-        <CardContent className="px-3 py-2.5">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center space-x-2.5">
-              <ClipboardX className="h-4 w-4 text-muted-foreground shrink-0" />
-              <div>
-                <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
-                  Capture clipboard
-                  <HelpTooltip text="when on, screenpipe records clipboard copy/paste events and contents. turn off if you ship ~/.screenpipe to a remote LLM or share it — passwords, API keys, and private keys frequently pass through the clipboard." />
-                </h3>
-                <p className="text-xs text-muted-foreground">
-                  Skip if your data leaves the machine (passwords, keys often
-                  pass through copy/paste).
-                </p>
-              </div>
-            </div>
-            <Switch
-              id="captureClipboard"
-              checked={!(settings.disableClipboardCapture ?? true)}
-              onCheckedChange={handleClipboardCaptureToggle}
-            />
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Keyboard capture toggle */}
-      <Card>
-        <CardContent className="px-3 py-2.5">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center space-x-2.5">
-              <Keyboard className="h-4 w-4 text-muted-foreground shrink-0" />
-              <div>
-                <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
-                  Capture keyboard
-                  <HelpTooltip text="when on, screenpipe records what you type (your keystrokes). off by default. the accessibility tree and OCR still capture on-screen text either way, so Rewind and Ask keep working — this only controls the raw keystroke stream, where passwords, API keys, and secrets you type would otherwise be logged." />
-                </h3>
-                <p className="text-xs text-muted-foreground">
-                  {managedKeyboardCapture !== undefined
-                    ? "Managed by your organization."
-                    : "Off by default. Records the raw keystroke stream (secrets often get typed). On-screen text is still captured."}
-                </p>
-              </div>
-            </div>
-            <Switch
-              id="captureKeyboard"
-              checked={
-                managedKeyboardCapture !== undefined
-                  ? managedKeyboardCapture === "false"
-                  : !(settings.disableKeyboardCapture ?? true)
-              }
-              disabled={managedKeyboardCapture !== undefined}
-              onCheckedChange={handleKeyboardCaptureToggle}
-            />
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Click capture toggle */}
-      <Card>
-        <CardContent className="px-3 py-2.5">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center space-x-2.5">
-              <MousePointerClick className="h-4 w-4 text-muted-foreground shrink-0" />
-              <div>
-                <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
-                  Capture clicks
-                  <HelpTooltip text="when on, screenpipe records mouse click events (where and what you clicked). on by default — clicks carry no text payload and power workflow analysis and task mining. turning this off only skips the click rows; clicks still trigger screen captures." />
-                </h3>
-                <p className="text-xs text-muted-foreground">
-                  {managedClickCapture !== undefined
-                    ? "Managed by your organization."
-                    : "On by default. Click events power workflow analysis; no text is recorded."}
-                </p>
-              </div>
-            </div>
-            <Switch
-              id="captureClicks"
-              checked={
-                managedClickCapture !== undefined
-                  ? managedClickCapture === "false"
-                  : !(settings.disableClickCapture ?? false)
-              }
-              disabled={managedClickCapture !== undefined}
-              onCheckedChange={handleClickCaptureToggle}
-            />
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Input Monitoring permission (macOS) — the OS-level TCC grant that
-          lets the keyboard/click capture toggles above actually record.
-          Lives here, next to those toggles, instead of under Connections. */}
-      {isMacOS && (
-        <Card>
-          <CardContent className="px-3 py-2.5">
-            <div className="flex items-center space-x-2.5">
-              <Keyboard className="h-4 w-4 text-muted-foreground shrink-0" />
-              <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
-                Input Monitoring permission
-                <HelpTooltip text="macOS permission that lets screenpipe capture keystrokes and mouse clicks. without it, capture runs in reduced mode — clipboard and app/window switches still work, but keyboard and click recording is dropped." />
-              </h3>
-            </div>
-            <div className="mt-2 ml-[26px]">
-              <InputMonitoringPanel />
-            </div>
-          </CardContent>
-        </Card>
-      )}
-
-      {/* Record While Locked */}
-      <Card>
-        <CardContent className="px-3 py-2.5">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center space-x-2.5">
-              <Lock className="h-4 w-4 text-muted-foreground shrink-0" />
-              <div>
-                <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
-                  Record Audio While Locked
-                  <HelpTooltip text="when enabled, audio recording continues even when your screen is locked. by default, audio recording pauses when the screen is locked to save resources and protect privacy." />
-                </h3>
-                <p className="text-xs text-muted-foreground">
-                  Continue audio capture when screen is locked
-                </p>
-              </div>
-            </div>
-            <Switch
-              id="recordWhileLocked"
-              checked={Boolean(settings.recordWhileLocked ?? false)}
-              onCheckedChange={handleRecordWhileLockedToggle}
-            />
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Recording Schedule */}
-      <ScheduleSettings
-        enabled={settings.scheduleEnabled ?? false}
-        rules={(settings.scheduleRules as any[]) ?? []}
-        onChange={(enabled, rules) => {
-          handleSettingsChange({ scheduleEnabled: enabled, scheduleRules: rules } as any);
-        }}
-      />
-      </div>
-
-      {/* Data Protection */}
-      <LockedSetting settingKey="pii_removal">
-      <div className="space-y-2">
-        <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider px-1">
-          Data protection
-        </h2>
-        {/* One PII Removal section with two modes — Basic (regex on the
-            hot path) and Smart (regex + AI background worker, also
-            covers images). Smart progressively discloses backend +
-            field selection. See piiMode comment above for the
-            three-flag mapping. */}
+        {/* Incognito Detection */}
         <Card className="border-border bg-card">
           <CardContent className="px-3 py-2.5">
             <div className="flex items-center justify-between">
               <div className="flex items-center space-x-2.5">
-                <Shield className="h-4 w-4 text-muted-foreground shrink-0" />
+                <EyeOff className="h-4 w-4 text-muted-foreground shrink-0" />
                 <div>
                   <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
-                    PII Removal
-                    <HelpTooltip text="Redacts emails, phones, secrets, and more from captures. Smart mode adds names, addresses, and image redaction." />
+                    Ignore Incognito Windows
+                    <HelpTooltip text="automatically detects and skips private/incognito browser windows in 20+ languages without extra access. on macOS, enhance enables browser-native detection for supported Chromium browsers." />
                   </h3>
                   <p className="text-xs text-muted-foreground">
-                    {piiMode === "off"
-                      ? "Off — captures store raw text and pixels."
-                      : piiMode === "basic"
-                      ? "Basic — regex on capture. Emails, phones, SSNs, cards, API keys."
-                      : "Smart — AI background worker. Adds names, addresses, image redaction."}
+                    Skip private browsing sessions
                   </p>
                 </div>
               </div>
-              <ManagedSwitch
-                settingKey="usePiiRemoval"
-                id="usePiiRemoval"
-                checked={piiMode !== "off"}
-                onCheckedChange={(checked) =>
-                  handlePiiModeChange(checked ? "basic" : "off")
-                }
-              />
+              <div className="flex items-center gap-1.5">
+                {isMacOS && Boolean(settings.ignoreIncognitoWindows ?? true) && (
+                  <Button
+                    type="button"
+                    variant={enhancedIncognitoDetection ? "outline" : "ghost"}
+                    size="sm"
+                    className="h-7 px-2 text-[10px] uppercase tracking-wide"
+                    onClick={handleEnhancedIncognitoDetection}
+                    disabled={isEnhancingIncognito}
+                    aria-pressed={enhancedIncognitoDetection}
+                    title="use browser-native detection; requires macOS Automation access"
+                  >
+                    {isEnhancingIncognito ? (
+                      <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                    ) : (
+                      <Shield className="mr-1 h-3 w-3" />
+                    )}
+                    {enhancedIncognitoDetection ? "enhanced" : "enhance"}
+                  </Button>
+                )}
+                <Switch
+                  id="ignoreIncognitoWindows"
+                  checked={Boolean(settings.ignoreIncognitoWindows ?? true)}
+                  onCheckedChange={handleIncognitoToggle}
+                />
+              </div>
             </div>
-            {piiMode !== "off" && (
-              <div className="mt-3 ml-6 space-y-3 border-l-2 border-border pl-3">
-                <div className="space-y-2">
-                  <p className="text-xs font-medium text-foreground">Mode</p>
-                  <label className="flex cursor-pointer items-start gap-2 text-xs">
-                    <input
-                      type="radio"
-                      name="piiMode"
-                      className="mt-0.5"
-                      checked={piiMode === "basic"}
-                      onChange={() => handlePiiModeChange("basic")}
-                    />
-                    <span>
-                      <span className="font-medium text-foreground">Basic</span>
-                      <span className="text-muted-foreground">
-                        {" "}— regex on capture. Free, instant, deterministic.
-                        Catches emails, phones, SSNs, cards, JWTs, API keys,
-                        private keys, connection strings.
-                      </span>
-                    </span>
-                  </label>
-                  <label className="flex cursor-pointer items-start gap-2 text-xs">
-                    <input
-                      type="radio"
-                      name="piiMode"
-                      className="mt-0.5"
-                      checked={piiMode === "smart"}
-                      onChange={() => handlePiiModeChange("smart")}
-                    />
-                    <span>
-                      <span className="font-medium text-foreground">Smart</span>
-                      <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground bg-muted px-1.5 py-0.5 rounded ml-1">
-                        Experimental
-                      </span>
-                      <span className="text-muted-foreground">
-                        {" "}— includes Basic, plus an AI background worker
-                        for semantic PII (names, addresses, sensitive context)
-                        and image redaction on screen frames. Downloads a
-                        ~100 MB model on first run.
-                      </span>
-                    </span>
-                  </label>
+          </CardContent>
+        </Card>
 
-                  {piiMode === "smart" && (
-                    <div className="ml-6 space-y-1.5 pt-1">
-                      <p className="text-xs font-medium text-foreground">
-                        Apply to
-                      </p>
-                      <label className="flex items-start gap-2 text-xs cursor-pointer">
-                        <input
-                          type="checkbox"
-                          className="mt-0.5"
-                          checked={textRedactionOn}
-                          onChange={(e) =>
-                            handleModalityToggle("text", e.target.checked)
-                          }
-                        />
-                        <span>
-                          <span className="font-medium text-foreground">
-                            Text
-                          </span>
-                          <span className="text-muted-foreground">
-                            {" "}— scrub captured text (OCR, accessibility,
-                            transcripts, typed &amp; clipboard input)
-                          </span>
-                        </span>
-                      </label>
-                      <label className="flex items-start gap-2 text-xs cursor-pointer">
-                        <input
-                          type="checkbox"
-                          className="mt-0.5"
-                          checked={imageRedactionOn}
-                          onChange={(e) =>
-                            handleModalityToggle("image", e.target.checked)
-                          }
-                        />
-                        <span>
-                          <span className="font-medium text-foreground">
-                            Images
-                          </span>
-                          <span className="text-muted-foreground">
-                            {" "}— black out PII in screenshot frames (on-device
-                            vision model)
-                          </span>
-                        </span>
-                      </label>
-                    </div>
-                  )}
+        {/* Window Filtering */}
+        {/* Pause for content-protected apps (DRM streaming + remote desktop) */}
+        <Card>
+          <CardContent className="px-3 py-2.5">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center space-x-2.5">
+                <Tv className="h-4 w-4 text-muted-foreground shrink-0" />
+                <div>
+                  <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
+                    Pause for DRM & Remote Desktop
+                    <HelpTooltip text="pauses all screen capture when a DRM-protected streaming app (netflix, disney+, hulu, prime video, apple tv, etc.) or a remote-desktop client (Omnissa/VMware Horizon) is focused. these apps blank their windows when any app is recording the screen — pausing capture while they're focused keeps them usable. capture resumes automatically when you switch away." />
+                  </h3>
+                  <p className="text-xs text-muted-foreground">
+                    Avoid DRM black screens (Netflix, Disney+) and gray Horizon windows.
+                  </p>
                 </div>
               </div>
-            )}
-            {aiPiiRemovalEnabled && (
-              <div className="mt-3 ml-6 space-y-2 border-l-2 border-border pl-3">
-                <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs">
-                  <span className="font-medium text-foreground">Where it runs</span>
-                  <label className={`flex items-center gap-1.5 ${managedPiiBackend ? "cursor-not-allowed opacity-60" : "cursor-pointer"}`}>
-                    <input
-                      type="radio"
-                      name="piiBackend"
-                      checked={piiBackend === "local"}
-                      disabled={!!managedPiiBackend}
-                      onChange={() => handlePiiBackendChange("local")}
-                    />
-                    <span className="text-foreground">Local</span>
-                  </label>
-                  <label className={`flex items-center gap-1.5 ${managedPiiBackend ? "cursor-not-allowed opacity-60" : "cursor-pointer"}`}>
-                    <input
-                      type="radio"
-                      name="piiBackend"
-                      checked={piiBackend === "tinfoil"}
-                      disabled={!!managedPiiBackend}
-                      onChange={() => handlePiiBackendChange("tinfoil")}
-                    />
-                    <span className="text-foreground">Cloud (enclave)</span>
-                  </label>
-                </div>
-                <p className="text-[11px] text-muted-foreground">
-                  Local stays on-device — strongest privacy, slower on weak
-                  hardware. Cloud uses screenpipe&apos;s attested
-                  confidential-compute enclave — fast everywhere; your device
-                  verifies the open-source build before sending anything.
-                </p>
+              <Switch
+                id="pauseOnDrmContent"
+                checked={Boolean(settings.pauseOnDrmContent ?? false)}
+                onCheckedChange={handleDrmPauseToggle}
+              />
+            </div>
+          </CardContent>
+        </Card>
 
-                {/* Axis 1 — WHAT to hide (PII categories). The primary knob:
-                    content-type, applies wherever it's found. */}
-                <p className="text-xs font-medium text-foreground pt-2">
-                  What to hide
-                </p>
-                {PII_FIELD_OPTIONS.map((opt) => {
-                  const checked =
-                    opt.always || piiRedactionLabels.includes(opt.value);
-                  return (
-                    <label
-                      key={opt.value}
-                      className={cn(
-                        "flex items-start gap-2 text-xs",
-                        opt.always ? "cursor-default" : "cursor-pointer",
-                      )}
-                    >
+        {/* Clipboard capture toggle */}
+        <Card>
+          <CardContent className="px-3 py-2.5">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center space-x-2.5">
+                <ClipboardX className="h-4 w-4 text-muted-foreground shrink-0" />
+                <div>
+                  <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
+                    Capture clipboard
+                    <HelpTooltip text="when on, screenpipe records clipboard copy/paste events and contents. turn off if you ship ~/.screenpipe to a remote LLM or share it — passwords, API keys, and private keys frequently pass through the clipboard." />
+                  </h3>
+                  <p className="text-xs text-muted-foreground">
+                    Skip if your data leaves the machine (passwords, keys often
+                    pass through copy/paste).
+                  </p>
+                </div>
+              </div>
+              <Switch
+                id="captureClipboard"
+                checked={!(settings.disableClipboardCapture ?? true)}
+                onCheckedChange={handleClipboardCaptureToggle}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Keyboard capture toggle */}
+        <Card>
+          <CardContent className="px-3 py-2.5">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center space-x-2.5">
+                <Keyboard className="h-4 w-4 text-muted-foreground shrink-0" />
+                <div>
+                  <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
+                    Capture keyboard
+                    <HelpTooltip text="when on, screenpipe records what you type (your keystrokes). off by default. the accessibility tree and OCR still capture on-screen text either way, so Rewind and Ask keep working — this only controls the raw keystroke stream, where passwords, API keys, and secrets you type would otherwise be logged." />
+                  </h3>
+                  <p className="text-xs text-muted-foreground">
+                    {managedKeyboardCapture !== undefined
+                      ? "Managed by your organization."
+                      : "Off by default. Records the raw keystroke stream (secrets often get typed). On-screen text is still captured."}
+                  </p>
+                </div>
+              </div>
+              <Switch
+                id="captureKeyboard"
+                checked={
+                  managedKeyboardCapture !== undefined
+                    ? managedKeyboardCapture === "false"
+                    : !(settings.disableKeyboardCapture ?? true)
+                }
+                disabled={managedKeyboardCapture !== undefined}
+                onCheckedChange={handleKeyboardCaptureToggle}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Click capture toggle */}
+        <Card>
+          <CardContent className="px-3 py-2.5">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center space-x-2.5">
+                <MousePointerClick className="h-4 w-4 text-muted-foreground shrink-0" />
+                <div>
+                  <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
+                    Capture clicks
+                    <HelpTooltip text="when on, screenpipe records mouse click events (where and what you clicked). on by default — clicks carry no text payload and power workflow analysis and task mining. turning this off only skips the click rows; clicks still trigger screen captures." />
+                  </h3>
+                  <p className="text-xs text-muted-foreground">
+                    {managedClickCapture !== undefined
+                      ? "Managed by your organization."
+                      : "On by default. Click events power workflow analysis; no text is recorded."}
+                  </p>
+                </div>
+              </div>
+              <Switch
+                id="captureClicks"
+                checked={
+                  managedClickCapture !== undefined
+                    ? managedClickCapture === "false"
+                    : !(settings.disableClickCapture ?? false)
+                }
+                disabled={managedClickCapture !== undefined}
+                onCheckedChange={handleClickCaptureToggle}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Input Monitoring permission (macOS) — the OS-level TCC grant that
+          lets the keyboard/click capture toggles above actually record.
+          Lives here, next to those toggles, instead of under Connections. */}
+        {isMacOS && (
+          <Card>
+            <CardContent className="px-3 py-2.5">
+              <div className="flex items-center space-x-2.5">
+                <Keyboard className="h-4 w-4 text-muted-foreground shrink-0" />
+                <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
+                  Input Monitoring permission
+                  <HelpTooltip text="macOS permission that lets screenpipe capture keystrokes and mouse clicks. without it, capture runs in reduced mode — clipboard and app/window switches still work, but keyboard and click recording is dropped." />
+                </h3>
+              </div>
+              <div className="mt-2 ml-[26px]">
+                <InputMonitoringPanel />
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Record While Locked */}
+        <Card>
+          <CardContent className="px-3 py-2.5">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center space-x-2.5">
+                <Lock className="h-4 w-4 text-muted-foreground shrink-0" />
+                <div>
+                  <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
+                    Record Audio While Locked
+                    <HelpTooltip text="when enabled, audio recording continues even when your screen is locked. by default, audio recording pauses when the screen is locked to save resources and protect privacy." />
+                  </h3>
+                  <p className="text-xs text-muted-foreground">
+                    Continue audio capture when screen is locked
+                  </p>
+                </div>
+              </div>
+              <Switch
+                id="recordWhileLocked"
+                checked={Boolean(settings.recordWhileLocked ?? false)}
+                onCheckedChange={handleRecordWhileLockedToggle}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Recording Schedule */}
+        <ScheduleSettings
+          enabled={settings.scheduleEnabled ?? false}
+          rules={(settings.scheduleRules as any[]) ?? []}
+          onChange={(enabled, rules) => {
+            handleSettingsChange({ scheduleEnabled: enabled, scheduleRules: rules } as any);
+          }}
+        />
+      </div>
+
+      {/* Data Protection */}
+      <LockedSetting settingKey="pii_removal">
+        <div className="space-y-2">
+          <h2 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider px-1">
+            Data protection
+          </h2>
+          {/* One PII Removal section with two modes — Basic (regex on the
+            hot path) and Smart (regex + AI background worker, also
+            covers images). Smart progressively discloses backend +
+            field selection. See piiMode comment above for the
+            three-flag mapping. */}
+          <Card className="border-border bg-card">
+            <CardContent className="px-3 py-2.5">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center space-x-2.5">
+                  <Shield className="h-4 w-4 text-muted-foreground shrink-0" />
+                  <div>
+                    <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
+                      PII Removal
+                      <HelpTooltip text="Redacts emails, phones, secrets, and more from captures. Smart mode adds names, addresses, and image redaction." />
+                    </h3>
+                    <p className="text-xs text-muted-foreground">
+                      {piiMode === "off"
+                        ? "Off — captures store raw text and pixels."
+                        : piiMode === "basic"
+                          ? "Basic — regex on capture. Emails, phones, SSNs, cards, API keys."
+                          : "Smart — AI background worker. Adds names, addresses, image redaction."}
+                    </p>
+                  </div>
+                </div>
+                <ManagedSwitch
+                  settingKey="usePiiRemoval"
+                  id="usePiiRemoval"
+                  checked={piiMode !== "off"}
+                  onCheckedChange={(checked) =>
+                    handlePiiModeChange(checked ? "basic" : "off")
+                  }
+                />
+              </div>
+              {piiMode !== "off" && (
+                <div className="mt-3 ml-6 space-y-3 border-l-2 border-border pl-3">
+                  <div className="space-y-2">
+                    <p className="text-xs font-medium text-foreground">Mode</p>
+                    <label className="flex cursor-pointer items-start gap-2 text-xs">
                       <input
-                        type="checkbox"
+                        type="radio"
+                        name="piiMode"
                         className="mt-0.5"
-                        checked={checked}
-                        disabled={opt.always}
-                        onChange={(e) =>
-                          handlePiiLabelToggle(opt.value, e.target.checked)
-                        }
+                        checked={piiMode === "basic"}
+                        onChange={() => handlePiiModeChange("basic")}
                       />
                       <span>
-                        <span className="font-medium text-foreground">
-                          {opt.label}
-                        </span>
-                        {opt.always && (
-                          <span className="text-muted-foreground">
-                            {" "}(always on)
-                          </span>
-                        )}
+                        <span className="font-medium text-foreground">Basic</span>
                         <span className="text-muted-foreground">
-                          {" "}— {opt.desc}
+                          {" "}— regex on capture. Free, instant, deterministic.
+                          Catches emails, phones, SSNs, cards, JWTs, API keys,
+                          private keys, connection strings.
                         </span>
                       </span>
                     </label>
-                  );
-                })}
-                {textRedactionOn && (
-                  <RedactionExamplePreview labels={piiRedactionLabels} />
-                )}
-                <p className="text-[11px] text-muted-foreground pt-0.5">
-                  Unselected types stay visible so your timeline remains
-                  searchable. Secrets are always removed in both modes.
-                </p>
+                    <label className="flex cursor-pointer items-start gap-2 text-xs">
+                      <input
+                        type="radio"
+                        name="piiMode"
+                        className="mt-0.5"
+                        checked={piiMode === "smart"}
+                        onChange={() => handlePiiModeChange("smart")}
+                      />
+                      <span>
+                        <span className="font-medium text-foreground">Smart</span>
+                        <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground bg-muted px-1.5 py-0.5 rounded ml-1">
+                          Experimental
+                        </span>
+                        <span className="text-muted-foreground">
+                          {" "}— includes Basic, plus an AI background worker
+                          for semantic PII (names, addresses, sensitive context)
+                          and image redaction on screen frames. Downloads a
+                          ~100 MB model on first run.
+                        </span>
+                      </span>
+                    </label>
 
-                {/* Axis 2 — WHERE to look (captured surfaces). Advanced and
+                    {piiMode === "smart" && (
+                      <div className="ml-6 space-y-1.5 pt-1">
+                        <p className="text-xs font-medium text-foreground">
+                          Apply to
+                        </p>
+                        <label className="flex items-start gap-2 text-xs cursor-pointer">
+                          <input
+                            type="checkbox"
+                            className="mt-0.5"
+                            checked={textRedactionOn}
+                            onChange={(e) =>
+                              handleModalityToggle("text", e.target.checked)
+                            }
+                          />
+                          <span>
+                            <span className="font-medium text-foreground">
+                              Text
+                            </span>
+                            <span className="text-muted-foreground">
+                              {" "}— scrub captured text (OCR, accessibility,
+                              transcripts, typed &amp; clipboard input)
+                            </span>
+                          </span>
+                        </label>
+                        <label className="flex items-start gap-2 text-xs cursor-pointer">
+                          <input
+                            type="checkbox"
+                            className="mt-0.5"
+                            checked={imageRedactionOn}
+                            onChange={(e) =>
+                              handleModalityToggle("image", e.target.checked)
+                            }
+                          />
+                          <span>
+                            <span className="font-medium text-foreground">
+                              Images
+                            </span>
+                            <span className="text-muted-foreground">
+                              {" "}— black out PII in screenshot frames (on-device
+                              vision model)
+                            </span>
+                          </span>
+                        </label>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+              {aiPiiRemovalEnabled && (
+                <div className="mt-3 ml-6 space-y-2 border-l-2 border-border pl-3">
+                  <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs">
+                    <span className="font-medium text-foreground">Where it runs</span>
+                    <label className={`flex items-center gap-1.5 ${managedPiiBackend ? "cursor-not-allowed opacity-60" : "cursor-pointer"}`}>
+                      <input
+                        type="radio"
+                        name="piiBackend"
+                        checked={piiBackend === "local"}
+                        disabled={!!managedPiiBackend}
+                        onChange={() => handlePiiBackendChange("local")}
+                      />
+                      <span className="text-foreground">Local</span>
+                    </label>
+                    <label className={`flex items-center gap-1.5 ${managedPiiBackend ? "cursor-not-allowed opacity-60" : "cursor-pointer"}`}>
+                      <input
+                        type="radio"
+                        name="piiBackend"
+                        checked={piiBackend === "tinfoil"}
+                        disabled={!!managedPiiBackend}
+                        onChange={() => handlePiiBackendChange("tinfoil")}
+                      />
+                      <span className="text-foreground">Cloud (enclave)</span>
+                    </label>
+                  </div>
+                  <p className="text-[11px] text-muted-foreground">
+                    Local stays on-device — strongest privacy, slower on weak
+                    hardware. Cloud uses screenpipe&apos;s attested
+                    confidential-compute enclave — fast everywhere; your device
+                    verifies the open-source build before sending anything.
+                  </p>
+
+                  {/* Axis 1 — WHAT to hide (PII categories). The primary knob:
+                    content-type, applies wherever it's found. */}
+                  <p className="text-xs font-medium text-foreground pt-2">
+                    What to hide
+                  </p>
+                  {PII_FIELD_OPTIONS.map((opt) => {
+                    const checked =
+                      opt.always || piiRedactionLabels.includes(opt.value);
+                    return (
+                      <label
+                        key={opt.value}
+                        className={cn(
+                          "flex items-start gap-2 text-xs",
+                          opt.always ? "cursor-default" : "cursor-pointer",
+                        )}
+                      >
+                        <input
+                          type="checkbox"
+                          className="mt-0.5"
+                          checked={checked}
+                          disabled={opt.always}
+                          onChange={(e) =>
+                            handlePiiLabelToggle(opt.value, e.target.checked)
+                          }
+                        />
+                        <span>
+                          <span className="font-medium text-foreground">
+                            {opt.label}
+                          </span>
+                          {opt.always && (
+                            <span className="text-muted-foreground">
+                              {" "}(always on)
+                            </span>
+                          )}
+                          <span className="text-muted-foreground">
+                            {" "}— {opt.desc}
+                          </span>
+                        </span>
+                      </label>
+                    );
+                  })}
+                  {textRedactionOn && (
+                    <RedactionExamplePreview labels={piiRedactionLabels} />
+                  )}
+                  <p className="text-[11px] text-muted-foreground pt-0.5">
+                    Unselected types stay visible so your timeline remains
+                    searchable. Secrets are always removed in both modes.
+                  </p>
+
+                  {/* Axis 2 — WHERE to look (captured surfaces). Advanced and
                     orthogonal to the categories above; collapsed by default so
                     most users only deal with "What to hide". Text-only, so
                     hide it entirely when text redaction is off (Images-only
                     Smart mode). */}
-                {textRedactionOn && (
-                  <details className="group pt-3 mt-1.5 border-t border-border">
-                    <summary className="flex cursor-pointer select-none items-center gap-1.5 text-xs font-medium text-foreground list-none [&::-webkit-details-marker]:hidden">
-                      <ChevronRight className="h-3 w-3 shrink-0 transition-transform group-open:rotate-90" />
-                      Where we look
-                      <span className="font-normal text-muted-foreground">
-                        — advanced
-                      </span>
-                    </summary>
-                    <div className="mt-2 space-y-1.5">
-                      <p className="text-[11px] text-muted-foreground">
-                        We always scan what you type, your clipboard,
-                        transcripts, window titles, and on-screen text. Turn on
-                        any of these extra places the same info can hide —
-                        hover a row to see what it covers.
-                      </p>
-                      <RedactionWherePreview
-                        options={PII_COLUMN_OPTIONS}
-                        selected={piiRedactionColumns}
-                        onToggle={handlePiiColumnToggle}
-                      />
-                    </div>
-                  </details>
-                )}
+                  {textRedactionOn && (
+                    <details className="group pt-3 mt-1.5 border-t border-border">
+                      <summary className="flex cursor-pointer select-none items-center gap-1.5 text-xs font-medium text-foreground list-none [&::-webkit-details-marker]:hidden">
+                        <ChevronRight className="h-3 w-3 shrink-0 transition-transform group-open:rotate-90" />
+                        Where we look
+                        <span className="font-normal text-muted-foreground">
+                          — advanced
+                        </span>
+                      </summary>
+                      <div className="mt-2 space-y-1.5">
+                        <p className="text-[11px] text-muted-foreground">
+                          We always scan what you type, your clipboard,
+                          transcripts, window titles, and on-screen text. Turn on
+                          any of these extra places the same info can hide —
+                          hover a row to see what it covers.
+                        </p>
+                        <RedactionWherePreview
+                          options={PII_COLUMN_OPTIONS}
+                          selected={piiRedactionColumns}
+                          onToggle={handlePiiColumnToggle}
+                        />
+                      </div>
+                    </details>
+                  )}
 
-                <label className="flex items-start gap-2 text-xs cursor-pointer pt-2 mt-1.5 border-t border-border">
-                  <input
-                    type="checkbox"
-                    className="mt-0.5"
-                    checked={piiRedactionPseudonyms}
-                    onChange={(e) => handlePseudonymsToggle(e.target.checked)}
-                  />
-                  <span>
-                    <span className="font-medium text-foreground">
-                      Consistent pseudonyms
+                  <label className="flex items-start gap-2 text-xs cursor-pointer pt-2 mt-1.5 border-t border-border">
+                    <input
+                      type="checkbox"
+                      className="mt-0.5"
+                      checked={piiRedactionPseudonyms}
+                      onChange={(e) => handlePseudonymsToggle(e.target.checked)}
+                    />
+                    <span>
+                      <span className="font-medium text-foreground">
+                        Consistent pseudonyms
+                      </span>
+                      <span className="text-muted-foreground">
+                        {" "}— replace each value with a stable token like{" "}
+                        <code>[PERSON_1a2b3c4d5e6f]</code> instead of a generic{" "}
+                        <code>[PERSON]</code>, so the same person or value stays
+                        linkable across your timeline without being exposed.
+                        One-way and on-device — the original can&apos;t be
+                        recovered. Applies to newly-recorded activity going
+                        forward.
+                      </span>
                     </span>
-                    <span className="text-muted-foreground">
-                      {" "}— replace each value with a stable token like{" "}
-                      <code>[PERSON_1a2b3c4d5e6f]</code> instead of a generic{" "}
-                      <code>[PERSON]</code>, so the same person or value stays
-                      linkable across your timeline without being exposed.
-                      One-way and on-device — the original can&apos;t be
-                      recovered. Applies to newly-recorded activity going
-                      forward.
-                    </span>
-                  </span>
-                </label>
-              </div>
-            )}
-          </CardContent>
-        </Card>
-      </div>
+                  </label>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
       </LockedSetting>
 
       <div className="space-y-2">
@@ -1637,6 +1651,43 @@ export function PrivacySection() {
                 </span>
               </span>
             </label>
+          </CardContent>
+        </Card>
+
+        <Card className="border-border bg-card">
+          <CardContent className="px-3 py-2.5">
+            <div className="flex items-start justify-between gap-3">
+              <label
+                htmlFor="importExternalChatsEnabled"
+                className="flex flex-1 items-start gap-2 text-xs cursor-pointer"
+              >
+                <input
+                  id="importExternalChatsEnabled"
+                  type="checkbox"
+                  className="mt-0.5"
+                  checked={importExternalChatsEnabled}
+                  onChange={(e) =>
+                    handleImportExternalChatsToggle(e.target.checked)
+                  }
+                  data-testid="privacy-import-external-chats-checkbox"
+                />
+                <span>
+                  <h3 className="font-medium text-foreground">
+                    Import local Claude Code / Codex chats
+                  </h3>
+                  <span className="text-muted-foreground">
+                    {" "}— the chat sidebar watches Claude Code
+                    (<code className="text-[10px]">~/.claude/projects</code>)
+                    and Codex
+                    (<code className="text-[10px]">~/.codex/sessions</code>)
+                    transcripts and copies them into your local chat index so
+                    they appear in Recents. Flip off to stop the watcher and
+                    prevent any further copies. Already-imported chats stay
+                    visible — delete them individually if you want them gone.
+                  </span>
+                </span>
+              </label>
+            </div>
           </CardContent>
         </Card>
       </div>
@@ -1685,30 +1736,30 @@ export function PrivacySection() {
           Telemetry
         </h2>
         <LockedSetting settingKey="telemetry">
-        <Card className="border-border bg-card">
-          <CardContent className="px-3 py-2.5">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center space-x-2.5">
-                <Monitor className="h-4 w-4 text-muted-foreground shrink-0" />
-                <div>
-                  <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
-                    Analytics
-                    <HelpTooltip text="Product usage events only — features used, errors, performance. Never your screen recordings, audio, transcripts, or OCR text. Signed out, events carry only a random device ID. Signed in, they are linked to your account, including your email." />
-                  </h3>
-                  <p className="text-xs text-muted-foreground">
-                    Usage data, linked to your account when signed in
-                  </p>
+          <Card className="border-border bg-card">
+            <CardContent className="px-3 py-2.5">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center space-x-2.5">
+                  <Monitor className="h-4 w-4 text-muted-foreground shrink-0" />
+                  <div>
+                    <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
+                      Analytics
+                      <HelpTooltip text="Product usage events only — features used, errors, performance. Never your screen recordings, audio, transcripts, or OCR text. Signed out, events carry only a random device ID. Signed in, they are linked to your account, including your email." />
+                    </h3>
+                    <p className="text-xs text-muted-foreground">
+                      Usage data, linked to your account when signed in
+                    </p>
+                  </div>
                 </div>
+                <ManagedSwitch
+                  settingKey="analyticsEnabled"
+                  id="analyticsEnabled"
+                  checked={settings.analyticsEnabled}
+                  onCheckedChange={handleAnalyticsToggle}
+                />
               </div>
-              <ManagedSwitch
-                settingKey="analyticsEnabled"
-                id="analyticsEnabled"
-                checked={settings.analyticsEnabled}
-                onCheckedChange={handleAnalyticsToggle}
-              />
-            </div>
-          </CardContent>
-        </Card>
+            </CardContent>
+          </Card>
         </LockedSetting>
       </div>
 
@@ -1834,10 +1885,10 @@ function AdminTeamTokenCard() {
     pendingToken !== null
       ? pendingToken
       : liveToken
-      ? revealToken
-        ? liveToken
-        : "•".repeat(Math.min(liveToken.length, 32))
-      : "";
+        ? revealToken
+          ? liveToken
+          : "•".repeat(Math.min(liveToken.length, 32))
+        : "";
   const hasPending = pendingToken !== null && pendingToken !== (liveToken ?? "");
 
   return (

--- a/apps/screenpipe-app-tauri/lib/chat/external-chat-sync.test.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/external-chat-sync.test.ts
@@ -188,4 +188,23 @@ describe("external chat live sync", () => {
     expect(mocks.watch).toHaveBeenCalledTimes(2);
     controller.stop();
   });
+
+  it("does not watch or import anything when disabled (#6696)", async () => {
+    const controller = await startExternalChatSync({
+      home: "/fixture",
+      enabled: false,
+    });
+
+    expect(mocks.watch).not.toHaveBeenCalled();
+    expect(mocks.scanExternalChatHistory).not.toHaveBeenCalled();
+    expect(mocks.importExternalChatHistory).not.toHaveBeenCalled();
+    expect(mocks.exists).not.toHaveBeenCalled();
+
+    await controller.syncNow();
+    await controller.syncNow(true);
+    expect(mocks.scanExternalChatHistory).not.toHaveBeenCalled();
+    expect(mocks.importExternalChatHistory).not.toHaveBeenCalled();
+
+    controller.stop();
+  });
 });

--- a/apps/screenpipe-app-tauri/lib/chat/external-chat-sync.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/external-chat-sync.ts
@@ -97,13 +97,20 @@ function candidatesFromScan(scan: Awaited<ReturnType<typeof scanExternalChatHist
 }
 
 export async function startExternalChatSync(
-  options: { home?: string } = {},
+  options: { home?: string; enabled?: boolean } = {},
 ): Promise<ExternalChatSyncController> {
+  if (options.enabled === false) {
+    return {
+      syncNow: async () => { },
+      stop: () => { },
+    };
+  }
+
   const home = await resolveExternalChatHome(options.home);
   if (!home) {
     return {
-      syncNow: async () => {},
-      stop: () => {},
+      syncNow: async () => { },
+      stop: () => { },
     };
   }
 
@@ -117,7 +124,7 @@ export async function startExternalChatSync(
     const next = operationQueue.then(async () => {
       if (!stopped) await operation();
     });
-    operationQueue = next.catch(() => {});
+    operationQueue = next.catch(() => { });
     return next;
   };
 

--- a/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -563,6 +563,11 @@ export type Settings = SettingsStore & {
 	 * window) has been completed or skipped. Stored here so it persists in the
 	 * normal settings store with no bindings regen. Default off. */
 	firstRunGuideDone?: boolean;
+	/** Auto-import local Claude Code (~/.claude/projects/**.jsonl) and Codex
+	 * (~/.codex/sessions/**.jsonl) transcripts into the chat index. Default on
+	 * so the Recents list shows those chats next to screenpipe chats; flip
+	 * off to stop the file watcher and any further copies (#6696). */
+	importExternalChatsEnabled?: boolean;
 }
 
 export function getEffectiveFilters(settings: Settings) {
@@ -819,6 +824,7 @@ let DEFAULT_SETTINGS: Settings = {
 			hideAppInScreenShare: true,
 			disableTimeline: false,
 			firstRunGuideDone: false,
+			importExternalChatsEnabled: true,
 			videoQuality: "balanced",
 			transcriptionMode: "batch",
 			cloudArchiveEnabled: false,


### PR DESCRIPTION
## description

Adds an opt-out toggle for the automatic synchronization of local Claude Code and Codex chats into the Recents view. 
By default, `startExternalChatSync` sweeps disk directories to ingest agent logs. This adds `importExternalChatsEnabled` to the app's settings and a UI toggle under Settings -> Privacy -> Agent Logs. Toggling it off immediately terminates the frontend watcher and prevents any future transcripts from being imported. 

related issue: #6696

## AI assistance and human ownership

- AI tool(s) used: Google Antigravity
- autonomy level: agent
- what I personally verified: I manually verified the feature end-to-end by running the app, toggling the setting, creating new mock transcript files in the Claude Code directory, and confirming they were ignored by the sync loop.

- [x] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [x] The problem statement, rationale, and replies to maintainers are my own.

## evidence type

- [x] UI or behavior change - before/after recording
- [ ] Backend change - regression tests and relevant logs/results
- [ ] Performance change - reproducible before/after benchmarks
- [ ] Docs, CI, or pure refactor - relevant checks and an explanation; no video required

## before

*(Drag and drop your "before" screenshot/recording here of the automatic import, or write "not applicable")*

## after

*(Drag and drop your "after" screenshot/recording here showing the new toggle in Settings -> Privacy and the ignored chats)*

## how to test

1. Launch the app and check the Recents list.
2. Go to Settings -> Privacy, scroll to "Agent logs", and disable "Import local Claude Code / Codex chats".
3. In a terminal, run:
   ```bash
   mkdir -p ~/.claude/projects/ignored-project
   echo '{"type": "user", "message": {"text": "this should be totally ignored"}}' > ~/.claude/projects/ignored-project/transcript.jsonl
   ```
4. Verify that the new mock transcript does **not** appear in the Recents list.
5. Run tests: `cd apps/screenpipe-app-tauri && bun run test` to verify the new `external-chat-sync.test.ts` logic.

## desktop app checklist (if applicable)

- [ ] `bun run bindings:generate` (if bindings changed)
- [ ] `bun run bindings:check`
- [ ] `bun run typecheck`