### PR TITLE
fix(meetings): gate browser call attribution (SCR-521)

### DIFF
--- a/crates/screenpipe-db/src/db/meetings.rs
+++ b/crates/screenpipe-db/src/db/meetings.rs
@@ -50,6 +50,28 @@ impl DatabaseManager {
         attendees: Option<&str>,
         calendar_event_id: Option<&str>,
     ) -> Result<i64, SqlxError> {
+        self.insert_meeting_with_calendar_at(
+            meeting_app,
+            detection_source,
+            title,
+            attendees,
+            calendar_event_id,
+            chrono::Utc::now(),
+        )
+        .await
+    }
+
+    /// Insert a meeting with an explicit start timestamp in the same immediate
+    /// transaction that creates the row.
+    pub async fn insert_meeting_with_calendar_at(
+        &self,
+        meeting_app: &str,
+        detection_source: &str,
+        title: Option<&str>,
+        attendees: Option<&str>,
+        calendar_event_id: Option<&str>,
+        meeting_start: chrono::DateTime<chrono::Utc>,
+    ) -> Result<i64, SqlxError> {
         match self
             .try_insert_meeting(
                 meeting_app,
@@ -57,14 +79,22 @@ impl DatabaseManager {
                 title,
                 attendees,
                 calendar_event_id,
+                meeting_start,
             )
             .await
         {
             Err(e) if calendar_event_id.is_some() && is_calendar_event_conflict(&e) => {
                 // Lost the race to another meeting between the pre-check and
                 // this insert. The event belongs to whoever claimed it first.
-                self.try_insert_meeting(meeting_app, detection_source, None, None, None)
-                    .await
+                self.try_insert_meeting(
+                    meeting_app,
+                    detection_source,
+                    None,
+                    None,
+                    None,
+                    meeting_start,
+                )
+                .await
             }
             other => other,
         }
@@ -77,15 +107,14 @@ impl DatabaseManager {
         title: Option<&str>,
         attendees: Option<&str>,
         calendar_event_id: Option<&str>,
+        meeting_start: chrono::DateTime<chrono::Utc>,
     ) -> Result<i64, SqlxError> {
         let mut tx = self.begin_immediate_with_retry().await?;
-        let now = chrono::Utc::now()
-            .format("%Y-%m-%dT%H:%M:%S%.3fZ")
-            .to_string();
+        let meeting_start = meeting_start.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string();
         let id = sqlx::query(
             "INSERT INTO meetings (meeting_start, meeting_app, detection_source, title, attendees, calendar_event_id) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
         )
-        .bind(&now)
+        .bind(&meeting_start)
         .bind(meeting_app)
         .bind(detection_source)
         .bind(title)

--- a/crates/screenpipe-engine/src/meeting_watcher/audio_process/lifecycle.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/audio_process/lifecycle.rs
@@ -13,12 +13,31 @@ pub(crate) enum AutoStartOutcome {
     Failed,
 }
 
+pub(crate) fn episode_start_utc(
+    first_seen_at: Instant,
+    action_now: Instant,
+    action_now_utc: DateTime<Utc>,
+) -> DateTime<Utc> {
+    let elapsed = action_now.saturating_duration_since(first_seen_at);
+    match chrono::Duration::from_std(elapsed) {
+        Ok(elapsed) => action_now_utc - elapsed,
+        Err(error) => {
+            warn!(
+                "audio-process meeting detector: failed to convert episode duration: {}",
+                error
+            );
+            action_now_utc
+        }
+    }
+}
+
 pub(crate) async fn start_or_adopt_auto_meeting(
     db: &DatabaseManager,
     manual_meeting: &tokio::sync::RwLock<Option<i64>>,
     platform: &str,
     calendar: Option<&CalendarBinding>,
     last_explicit_stop_id: Option<i64>,
+    meeting_start: DateTime<Utc>,
 ) -> AutoStartOutcome {
     let title = calendar.map(|c| c.title.as_str());
     let attendees = calendar.and_then(|c| c.attendees.as_deref());
@@ -94,16 +113,16 @@ pub(crate) async fn start_or_adopt_auto_meeting(
                     "audio-process meeting detector: failed to reopen meeting {}: {}",
                     recent.id, e
                 );
-                insert_new_audio_process_meeting(db, platform, calendar).await
+                insert_new_audio_process_meeting(db, platform, calendar, meeting_start).await
             }
         },
-        Ok(None) => insert_new_audio_process_meeting(db, platform, calendar).await,
+        Ok(None) => insert_new_audio_process_meeting(db, platform, calendar, meeting_start).await,
         Err(e) => {
             warn!(
                 "audio-process meeting detector: failed to find recent meeting: {}",
                 e
             );
-            insert_new_audio_process_meeting(db, platform, calendar).await
+            insert_new_audio_process_meeting(db, platform, calendar, meeting_start).await
         }
     }
 }
@@ -112,16 +131,18 @@ pub(crate) async fn insert_new_audio_process_meeting(
     db: &DatabaseManager,
     platform: &str,
     calendar: Option<&CalendarBinding>,
+    meeting_start: DateTime<Utc>,
 ) -> AutoStartOutcome {
     let title = calendar.map(|c| c.title.as_str());
     let attendees = calendar.and_then(|c| c.attendees.as_deref());
     match db
-        .insert_meeting_with_calendar(
+        .insert_meeting_with_calendar_at(
             platform,
             "audio_process",
             title,
             attendees,
             calendar.map(|c| c.key.as_str()),
+            meeting_start,
         )
         .await
     {
@@ -248,6 +269,7 @@ pub(crate) async fn apply_state_action(
     last_explicit_stop_id: Option<i64>,
     calendar_events: &[CalendarEventSignal],
     now: Instant,
+    action_now_utc: DateTime<Utc>,
 ) {
     match action {
         AudioProcessStateAction::StartMeeting {
@@ -259,15 +281,21 @@ pub(crate) async fn apply_state_action(
             pid,
             bundle_id,
         } => {
-            let calendar =
-                resolve_calendar_binding(db, calendar_events, Utc::now(), meeting_url.as_deref())
-                    .await;
+            let calendar = resolve_calendar_binding(
+                db,
+                calendar_events,
+                action_now_utc,
+                meeting_url.as_deref(),
+            )
+            .await;
+            let meeting_start = episode_start_utc(first_seen_at, now, action_now_utc);
             let outcome = start_or_adopt_auto_meeting(
                 db,
                 manual_meeting,
                 &platform,
                 calendar.as_ref(),
                 last_explicit_stop_id,
+                meeting_start,
             )
             .await;
             match outcome {
@@ -329,7 +357,7 @@ pub(crate) async fn apply_state_action(
             if let Some(session) = suppressed_session {
                 suppress_session(suppressed_sessions, session);
             }
-            let now_ts = Utc::now().format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string();
+            let now_ts = action_now_utc.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string();
             match db
                 .end_meeting_with_typed_text(meeting_id, &now_ts, true, None)
                 .await

--- a/crates/screenpipe-engine/src/meeting_watcher/audio_process/mod.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/audio_process/mod.rs
@@ -17,7 +17,7 @@ use crate::meeting_watcher::shared::telemetry::{
     capture_detection_decision, capture_detection_outcome,
 };
 use crate::routes::meetings::{emit_meeting_status_changed, resolve_meeting_status_from};
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use futures::{FutureExt, StreamExt};
 use screenpipe_audio::meeting_detector::MeetingDetector;
 use screenpipe_audio::meeting_processes::{self, AudioInputProcess};
@@ -253,6 +253,7 @@ pub async fn run_audio_process_meeting_detection_loop(
             }
         };
         let now = Instant::now();
+        let now_utc = Utc::now();
 
         let (candidates, live_candidates) = build_candidates(
             &db,
@@ -322,6 +323,7 @@ pub async fn run_audio_process_meeting_detection_loop(
                 last_explicit_stop_id,
                 &calendar_events,
                 now,
+                now_utc,
             )
             .await;
         }

--- a/crates/screenpipe-engine/src/meeting_watcher/audio_process/model.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/audio_process/model.rs
@@ -147,6 +147,26 @@ pub(crate) enum ResolvedMeetingCandidate {
 }
 
 impl ResolvedMeetingCandidate {
+    pub(crate) fn call_signal_identity(
+        &self,
+    ) -> Option<(&str, &ProcessKey, &AudioInputProcess, bool)> {
+        match self {
+            Self::Native {
+                platform,
+                session_key,
+                process,
+                ..
+            } => Some((platform, session_key, process, false)),
+            Self::Browser {
+                platform,
+                session_key,
+                process,
+                ..
+            } => Some((platform, session_key, process, true)),
+            _ => None,
+        }
+    }
+
     pub(crate) fn resolved_session(&self) -> Option<ResolvedSession> {
         match self {
             Self::Native {
@@ -227,12 +247,13 @@ pub(crate) struct ResolvedSession {
 
 /// Result of scanning a messaging app's AX tree for call UI evidence.
 ///
-/// When a native platform has `requires_call_signal: true`, the audio-process
-/// detector runs this scan before promoting the candidate to `Native`. If
-/// `is_in_call` is false the candidate is downgraded to `NonMeeting`,
-/// blocking phantom meetings from voice notes (#4776).
+/// When a resolved platform has `requires_call_signal: true`, the audio-process
+/// detector runs this scan before promoting either a native or browser
+/// candidate. Evidence is tied to the candidate's audio session so one process
+/// cannot authorize another process that happens to resolve to the same app.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct CallSignalEvidence {
+    pub session_key: ProcessKey,
     /// Lowercased platform name (e.g. "whatsapp", "signal", "telegram").
     pub platform: String,
     /// Whether the AX scan found call signals confirming a real call.

--- a/crates/screenpipe-engine/src/meeting_watcher/audio_process/resolve.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/audio_process/resolve.rs
@@ -761,35 +761,105 @@ pub(crate) fn acquire_input_processes(
 /// evidence in the AX tree. Returns a `CallSignalEvidence` per scanned app.
 ///
 /// Only called during pre-active states (`needs_ax_resolution`) and only for
-/// `Native` candidates whose profile requires call signal verification.
+/// resolved candidates whose profile requires call signal verification.
 /// Platform-agnostic: delegates to `MeetingUiScanner::scan_process` which
 /// uses AX on macOS, UIA on Windows, and is a no-op on other platforms.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+struct CallSignalScanTarget {
+    session_key: ProcessKey,
+    platform: String,
+    pid: i32,
+    profile_index: usize,
+}
+
+fn candidate_call_signal_profile<'a>(
+    candidate: &ResolvedMeetingCandidate,
+    profiles: &'a [MeetingDetectionProfile],
+) -> Option<(&'a MeetingDetectionProfile, usize)> {
+    let (platform, _, _, is_browser) = candidate.call_signal_identity()?;
+    profiles.iter().enumerate().find_map(|(index, profile)| {
+        (platform_name_for_profile(profile, is_browser).eq_ignore_ascii_case(platform))
+            .then_some((profile, index))
+    })
+}
+
+fn candidate_requires_call_signal(
+    candidate: &ResolvedMeetingCandidate,
+    profiles: &[MeetingDetectionProfile],
+) -> bool {
+    candidate_call_signal_profile(candidate, profiles)
+        .is_some_and(|(profile, _)| profile.requires_call_signal)
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+fn call_signal_scan_target(
+    candidate: &ResolvedMeetingCandidate,
+    profiles: &[MeetingDetectionProfile],
+) -> Option<CallSignalScanTarget> {
+    let (platform, session_key, process, _) = candidate.call_signal_identity()?;
+    let (profile, profile_index) = candidate_call_signal_profile(candidate, profiles)?;
+    if !profile.requires_call_signal {
+        return None;
+    }
+    Some(CallSignalScanTarget {
+        session_key: session_key.clone(),
+        platform: platform.to_string(),
+        pid: process.pid?,
+        profile_index,
+    })
+}
+
+pub(crate) fn retain_candidates_with_required_call_signal(
+    candidates: &mut Vec<ResolvedMeetingCandidate>,
+    profiles: &[MeetingDetectionProfile],
+    call_evidence: &[CallSignalEvidence],
+) {
+    candidates.retain(|candidate| {
+        if !candidate_requires_call_signal(candidate, profiles) {
+            return true;
+        }
+        let Some((platform, session_key, _, _)) = candidate.call_signal_identity() else {
+            return true;
+        };
+        let platform_lower = platform.to_lowercase();
+        let evidence = call_evidence.iter().find(|evidence| {
+            evidence.session_key == *session_key && evidence.platform == platform_lower
+        });
+        if evidence.is_some_and(|evidence| evidence.is_in_call) {
+            return true;
+        }
+        debug!(
+            "audio-process meeting detector: {} candidate blocked by call signal gate ({})",
+            platform,
+            if evidence.is_some() {
+                "no call UI found"
+            } else {
+                "no keyed evidence produced"
+            }
+        );
+        false
+    });
+}
+
 #[cfg(any(target_os = "macos", target_os = "windows"))]
 async fn scan_messaging_call_signals(
     candidates: &[ResolvedMeetingCandidate],
     profiles: &[MeetingDetectionProfile],
 ) -> Vec<CallSignalEvidence> {
-    let to_scan: Vec<(String, i32, usize)> = candidates
+    let mut to_scan: Vec<CallSignalScanTarget> = candidates
         .iter()
-        .filter_map(|c| {
-            if let ResolvedMeetingCandidate::Native {
-                platform, process, ..
-            } = c
-            {
-                let profile_idx = profiles
-                    .iter()
-                    .position(|p| platform_name_for_profile(p, false) == *platform)?;
-                let profile = &profiles[profile_idx];
-                if profile.requires_call_signal {
-                    Some((platform.clone(), process.pid?, profile_idx))
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        })
+        .filter_map(|candidate| call_signal_scan_target(candidate, profiles))
         .collect();
+    to_scan.sort_by(|a, b| {
+        (&a.session_key, &a.platform, a.pid, a.profile_index).cmp(&(
+            &b.session_key,
+            &b.platform,
+            b.pid,
+            b.profile_index,
+        ))
+    });
+    to_scan.dedup();
 
     if to_scan.is_empty() {
         return Vec::new();
@@ -800,16 +870,17 @@ async fn scan_messaging_call_signals(
         let scanner = crate::meeting_watcher::shared::scanner::MeetingUiScanner::new();
         to_scan
             .into_iter()
-            .map(|(platform, pid, profile_idx)| {
-                let profile = &profiles[profile_idx];
-                let result = scanner.scan_process(pid, profile);
+            .map(|target| {
+                let profile = &profiles[target.profile_index];
+                let result = scanner.scan_process(target.pid, profile);
                 debug!(
                     "audio-process meeting detector: call signal scan for {} (pid {}): \
                      is_in_call={}, signals={:?}",
-                    platform, pid, result.is_in_call, result.matched_signals
+                    target.platform, target.pid, result.is_in_call, result.matched_signals
                 );
                 CallSignalEvidence {
-                    platform: platform.to_lowercase(),
+                    session_key: target.session_key,
+                    platform: target.platform.to_lowercase(),
                     is_in_call: result.is_in_call,
                     matched_signals: result.matched_signals,
                 }
@@ -863,51 +934,15 @@ pub(crate) async fn build_candidates(
 
     candidates.retain(|candidate| !matches!(candidate, ResolvedMeetingCandidate::Ignored));
 
-    // Call signal gate for messaging-first platforms (#4776): apps like
+    // Call signal gate for messaging-first platforms (#4776): apps/sites like
     // WhatsApp/Signal/Telegram grab the mic for voice notes identically to
-    // calls. Before promoting them to Native, scan their AX tree for real
+    // calls. Before promoting resolved native or browser candidates, scan the
+    // mic-holding process's AX tree for real
     // call UI (e.g. Calling_Window). Only run during pre-active states —
     // once a meeting is Active the platform is settled.
     if needs_ax_resolution(state) {
         let call_evidence = scan_messaging_call_signals(&candidates, profiles).await;
-        candidates.retain(|candidate| {
-            if let ResolvedMeetingCandidate::Native { platform, .. } = candidate {
-                let platform_lower = platform.to_lowercase();
-                // Check if this platform requires call signal verification.
-                let requires_gate = profiles.iter().any(|p| {
-                    p.requires_call_signal
-                        && platform_name_for_profile(p, false).to_lowercase() == platform_lower
-                });
-                if requires_gate {
-                    // Fail-closed: block unless we have explicit evidence of a
-                    // real call. If the AX scan timed out or the process had no
-                    // PID, no evidence is produced and we err on the side of NOT
-                    // starting a phantom meeting.
-                    match call_evidence.iter().find(|e| e.platform == platform_lower) {
-                        Some(evidence) if evidence.is_in_call => {
-                            // Real call confirmed — allow.
-                        }
-                        Some(_) => {
-                            debug!(
-                                "audio-process meeting detector: {} blocked by call signal gate \
-                                 (voice note / idle, no call UI found)",
-                                platform
-                            );
-                            return false;
-                        }
-                        None => {
-                            debug!(
-                                "audio-process meeting detector: {} blocked by call signal gate \
-                                 (no evidence produced — scan may have timed out)",
-                                platform
-                            );
-                            return false;
-                        }
-                    }
-                }
-            }
-            true
-        });
+        retain_candidates_with_required_call_signal(&mut candidates, profiles, &call_evidence);
     }
 
     filter_suppressed_candidates(&mut candidates, suppressed_sessions);

--- a/crates/screenpipe-engine/src/meeting_watcher/audio_process/tests.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/audio_process/tests.rs
@@ -1125,7 +1125,8 @@ async fn active_meeting_blocks_audio_process_insert() {
         .unwrap();
     let manual_meeting = tokio::sync::RwLock::new(None);
     let outcome =
-        start_or_adopt_auto_meeting(&db, &manual_meeting, "Google Meet", None, None).await;
+        start_or_adopt_auto_meeting(&db, &manual_meeting, "Google Meet", None, None, Utc::now())
+            .await;
     assert_eq!(outcome, AutoStartOutcome::BlockedByActive(active_id));
 
     let open_count: (i64,) =
@@ -1134,6 +1135,78 @@ async fn active_meeting_blocks_audio_process_insert() {
             .await
             .unwrap();
     assert_eq!(open_count.0, 1);
+}
+
+#[test]
+fn episode_start_utc_subtracts_monotonic_pending_duration() {
+    let action_now = Instant::now();
+    let action_now_utc = chrono::DateTime::parse_from_rfc3339("2026-08-22T20:44:50.168Z")
+        .unwrap()
+        .with_timezone(&Utc);
+
+    let start = episode_start_utc(
+        action_now - Duration::from_secs(681),
+        action_now,
+        action_now_utc,
+    );
+
+    assert_eq!(
+        start,
+        chrono::DateTime::parse_from_rfc3339("2026-08-22T20:33:29.168Z")
+            .unwrap()
+            .with_timezone(&Utc)
+    );
+}
+
+#[tokio::test]
+async fn late_browser_classification_persists_original_episode_start() {
+    let (_dir, db) = setup_db().await;
+    let action_now = Instant::now();
+    let first_seen_at = action_now - Duration::from_secs(681);
+    let action_now_utc = chrono::DateTime::parse_from_rfc3339("2026-08-22T20:44:50.168Z")
+        .unwrap()
+        .with_timezone(&Utc);
+    let process = arc_process();
+    let action = AudioProcessStateAction::StartMeeting {
+        platform: "WhatsApp".to_string(),
+        session_key: ProcessKey::from_process(&process).unwrap(),
+        meeting_url: Some("https://web.whatsapp.com".to_string()),
+        first_seen_at,
+        is_browser: true,
+        pid: process.pid,
+        bundle_id: process.bundle_id,
+    };
+    let manual_meeting = tokio::sync::RwLock::new(None);
+    let mut state = AudioProcessMeetingState::Idle;
+    let mut suppressed = Vec::new();
+    let mut flap_count = 0;
+    let in_meeting = AtomicBool::new(false);
+
+    apply_state_action(
+        action,
+        &db,
+        &manual_meeting,
+        &mut state,
+        &mut suppressed,
+        &mut flap_count,
+        &in_meeting,
+        &None,
+        None,
+        &[],
+        action_now,
+        action_now_utc,
+    )
+    .await;
+
+    let row = db.get_most_recent_active_meeting().await.unwrap().unwrap();
+    assert_eq!(row.meeting_start, "2026-08-22T20:33:29.168Z");
+    assert!(matches!(
+        state,
+        AudioProcessMeetingState::Active {
+            first_seen_at: active_first_seen,
+            ..
+        } if active_first_seen == first_seen_at
+    ));
 }
 
 #[test]
@@ -1252,6 +1325,97 @@ fn ax_resolution_only_runs_before_a_meeting_is_active() {
 // Call signal gate tests (#4776) — WhatsApp/Signal/Telegram voice note phantom
 // meeting prevention.
 // ---------------------------------------------------------------------------
+
+fn browser_platform_candidate(
+    platform: &str,
+    process: AudioInputProcess,
+) -> ResolvedMeetingCandidate {
+    ResolvedMeetingCandidate::Browser {
+        platform: platform.to_string(),
+        meeting_url: format!("https://web.{}.com", platform.to_lowercase()),
+        browser_app: "Arc".to_string(),
+        session_key: ProcessKey::from_process(&process).unwrap(),
+        first_seen_at: Instant::now(),
+        process,
+        live_evidence: true,
+    }
+}
+
+#[test]
+fn browser_whatsapp_without_keyed_call_signal_is_blocked() {
+    let profiles = load_detection_profiles();
+    let mut candidates = vec![browser_platform_candidate("WhatsApp", arc_process())];
+
+    retain_candidates_with_required_call_signal(&mut candidates, &profiles, &[]);
+
+    assert!(candidates.is_empty());
+}
+
+#[test]
+fn browser_whatsapp_with_same_session_call_signal_passes() {
+    let profiles = load_detection_profiles();
+    let process = arc_process();
+    let session_key = ProcessKey::from_process(&process).unwrap();
+    let mut candidates = vec![browser_platform_candidate("WhatsApp", process)];
+    let evidence = [CallSignalEvidence {
+        session_key,
+        platform: "whatsapp".to_string(),
+        is_in_call: true,
+        matched_signals: vec!["Calling_Window".to_string()],
+    }];
+
+    retain_candidates_with_required_call_signal(&mut candidates, &profiles, &evidence);
+
+    assert_eq!(candidates.len(), 1);
+}
+
+#[test]
+fn call_signal_for_other_session_does_not_admit_browser_candidate() {
+    let profiles = load_detection_profiles();
+    let mut candidates = vec![browser_platform_candidate("WhatsApp", arc_process())];
+    let evidence = [CallSignalEvidence {
+        session_key: ProcessKey::from_process(&chrome_process()).unwrap(),
+        platform: "whatsapp".to_string(),
+        is_in_call: true,
+        matched_signals: vec!["Calling_Window".to_string()],
+    }];
+
+    retain_candidates_with_required_call_signal(&mut candidates, &profiles, &evidence);
+
+    assert!(candidates.is_empty());
+}
+
+#[test]
+fn browser_telegram_without_signal_is_blocked() {
+    let profiles = load_detection_profiles();
+    let mut candidates = vec![browser_platform_candidate("Telegram", arc_process())];
+
+    retain_candidates_with_required_call_signal(&mut candidates, &profiles, &[]);
+
+    assert!(candidates.is_empty());
+}
+
+#[test]
+fn required_candidate_without_pid_fails_closed() {
+    let profiles = load_detection_profiles();
+    let mut process = arc_process();
+    process.pid = None;
+    let mut candidates = vec![browser_platform_candidate("WhatsApp", process)];
+
+    retain_candidates_with_required_call_signal(&mut candidates, &profiles, &[]);
+
+    assert!(candidates.is_empty());
+}
+
+#[test]
+fn browser_google_meet_without_call_signal_is_unchanged() {
+    let profiles = load_detection_profiles();
+    let mut candidates = vec![browser_platform_candidate("Google Meet", arc_process())];
+
+    retain_candidates_with_required_call_signal(&mut candidates, &profiles, &[]);
+
+    assert_eq!(candidates.len(), 1);
+}
 
 fn whatsapp_process() -> AudioInputProcess {
     AudioInputProcess {
@@ -1488,20 +1652,13 @@ fn whatsapp_without_call_signal_blocked_by_gate() {
 
     // Simulate what build_candidates does: check call_evidence with no call signals.
     let call_evidence = [CallSignalEvidence {
+        session_key: ProcessKey::from_process(&process).unwrap(),
         platform: "whatsapp".to_string(),
         is_in_call: false,
         matched_signals: vec![],
     }];
     let mut candidates = vec![candidate];
-    candidates.retain(|c| {
-        if let ResolvedMeetingCandidate::Native { platform, .. } = c {
-            let platform_lower = platform.to_lowercase();
-            if let Some(evidence) = call_evidence.iter().find(|e| e.platform == platform_lower) {
-                return evidence.is_in_call;
-            }
-        }
-        true
-    });
+    retain_candidates_with_required_call_signal(&mut candidates, &profiles, &call_evidence);
     assert!(
         candidates.is_empty(),
         "WhatsApp without call signals should be blocked"
@@ -1528,20 +1685,13 @@ fn whatsapp_with_call_signal_passes_gate() {
     ));
 
     let call_evidence = [CallSignalEvidence {
+        session_key: ProcessKey::from_process(&process).unwrap(),
         platform: "whatsapp".to_string(),
         is_in_call: true,
         matched_signals: vec!["AutomationIdContains(Calling_Window)".to_string()],
     }];
     let mut candidates = vec![candidate];
-    candidates.retain(|c| {
-        if let ResolvedMeetingCandidate::Native { platform, .. } = c {
-            let platform_lower = platform.to_lowercase();
-            if let Some(evidence) = call_evidence.iter().find(|e| e.platform == platform_lower) {
-                return evidence.is_in_call;
-            }
-        }
-        true
-    });
+    retain_candidates_with_required_call_signal(&mut candidates, &profiles, &call_evidence);
     assert_eq!(
         candidates.len(),
         1,
@@ -1569,18 +1719,8 @@ fn zoom_not_filtered_by_call_signal_gate() {
         ResolvedMeetingCandidate::Native { ref platform, .. } if platform == "Zoom"
     ));
 
-    // No call_evidence for Zoom (scan_messaging_call_signals skips it).
-    let call_evidence: Vec<CallSignalEvidence> = vec![];
     let mut candidates = vec![candidate];
-    candidates.retain(|c| {
-        if let ResolvedMeetingCandidate::Native { platform, .. } = c {
-            let platform_lower = platform.to_lowercase();
-            if let Some(evidence) = call_evidence.iter().find(|e| e.platform == platform_lower) {
-                return evidence.is_in_call;
-            }
-        }
-        true
-    });
+    retain_candidates_with_required_call_signal(&mut candidates, &profiles, &[]);
     assert_eq!(
         candidates.len(),
         1,
@@ -2128,8 +2268,17 @@ async fn start_meeting_with_calendar_url(
     observed_meeting_url: Option<&str>,
 ) -> AutoStartOutcome {
     let manual_meeting = tokio::sync::RwLock::new(None);
-    let calendar = resolve_calendar_binding(db, events, Utc::now(), observed_meeting_url).await;
-    start_or_adopt_auto_meeting(db, &manual_meeting, platform, calendar.as_ref(), None).await
+    let now_utc = Utc::now();
+    let calendar = resolve_calendar_binding(db, events, now_utc, observed_meeting_url).await;
+    start_or_adopt_auto_meeting(
+        db,
+        &manual_meeting,
+        platform,
+        calendar.as_ref(),
+        None,
+        now_utc,
+    )
+    .await
 }
 
 async fn end_meeting_ago(db: &DatabaseManager, id: i64, ago: chrono::Duration) {
@@ -2137,6 +2286,66 @@ async fn end_meeting_ago(db: &DatabaseManager, id: i64, ago: chrono::Duration) {
         .format("%Y-%m-%dT%H:%M:%S%.3fZ")
         .to_string();
     db.end_meeting(id, &ended_at, None).await.unwrap();
+}
+
+#[tokio::test]
+async fn explicit_audio_process_start_is_persisted_atomically() {
+    let (_dir, db) = setup_db().await;
+    let start = chrono::DateTime::parse_from_rfc3339("2026-08-22T20:32:59.123Z")
+        .unwrap()
+        .with_timezone(&Utc);
+
+    let id = db
+        .insert_meeting_with_calendar_at(
+            "WhatsApp",
+            "audio_process",
+            Some("Call"),
+            None,
+            None,
+            start,
+        )
+        .await
+        .unwrap();
+
+    let row = db.get_meeting_by_id(id).await.unwrap();
+    assert_eq!(row.meeting_start, "2026-08-22T20:32:59.123Z");
+    assert_eq!(row.meeting_app, "WhatsApp");
+    assert_eq!(row.detection_source, "audio_process");
+    assert_eq!(row.title.as_deref(), Some("Call"));
+    assert!(row.meeting_end.is_none());
+}
+
+#[tokio::test]
+async fn calendar_conflict_retry_preserves_explicit_start() {
+    let (_dir, db) = setup_db().await;
+    let first = db
+        .insert_meeting_with_calendar("Google Meet", "audio_process", None, None, Some("evt"))
+        .await
+        .unwrap();
+    end_meeting_ago(&db, first, chrono::Duration::minutes(5)).await;
+    let start = chrono::DateTime::parse_from_rfc3339("2026-08-22T20:44:50.168Z")
+        .unwrap()
+        .with_timezone(&Utc);
+
+    let second = db
+        .insert_meeting_with_calendar_at(
+            "WhatsApp",
+            "audio_process",
+            Some("Wrong calendar title"),
+            None,
+            Some("evt"),
+            start,
+        )
+        .await
+        .unwrap();
+
+    let row = db.get_meeting_by_id(second).await.unwrap();
+    assert_eq!(row.meeting_start, "2026-08-22T20:44:50.168Z");
+    assert!(row.title.is_none());
+    assert_eq!(
+        db.meeting_id_for_calendar_event("evt").await.unwrap(),
+        Some(first)
+    );
 }
 
 /// Reproduces the 2026-08-13 incident. An 11:30–12:00 calendar event was still


### PR DESCRIPTION
## Summary

- Fixes SCR-521, where an unrelated WhatsApp Web tab could reattribute an already-active Arc WebRTC microphone session to WhatsApp.
- This is the current-main replacement for closed, unmerged draft #6592.
- Applies the messaging call-signal requirement fail-closed to both browser and native candidates, keyed to the process session and platform.
- Preserves the original call-episode start when meeting creation is delayed until platform evidence appears.

## Root cause and complete surface

Browser candidates could resolve from recent URL/title evidence without passing the `requires_call_signal` gate used for native messaging candidates. Meeting persistence also used classification time, so a late false promotion both mislabeled the call and lost its earlier duration.

The six-file change covers the complete shared surface: candidate modeling and resolution, browser/native signal scanning and retention, lifecycle timestamp propagation, atomic database insertion, and positive/negative regressions. Evidence is matched by process session and platform; missing PID, unsupported platform, missing evidence, and scan failure remain fail-closed. Current-main conference-URL calendar matching is preserved.

## Before / after

```text
BEFORE: Arc mic @ t0 -> unresolved -> plain WhatsApp tab -> WhatsApp meeting @ t+11m
AFTER:  Arc mic @ t0 -> unresolved -> plain WhatsApp tab --X
                                      matching call signal -> meeting, start=t0
```

## Scope

- `crates/screenpipe-db/src/db/meetings.rs`
- `crates/screenpipe-engine/src/meeting_watcher/audio_process/{lifecycle.rs,mod.rs,model.rs,resolve.rs,tests.rs}`

Observed on macOS with Arc and WhatsApp Web; the fix is in shared Rust meeting-detection logic and explicitly covers browser and native candidate paths with platform-aware evidence.

## Verification

- Historical RED/GREEN for the same semantic patch: the unresolved Arc + plain WhatsApp evidence regression failed before the fix and passed after it; focused audio-process tests passed 77/77, screenpipe-db library tests 141 passed (2 ignored), and screenpipe-engine library tests 1452 passed (3 ignored).
- Current-main independent review: `cargo test -p screenpipe-db` passed with 54 successful result groups and no failures.
- Current-main direct `rustfmt --edition 2021 --check` on all six files, `git diff --check`, required headers, exact six-file scope, ancestry, security/secrets audit, and clean-tree checks passed.
- `cargo test -p screenpipe-engine meeting_watcher::audio_process --lib` and `cargo check -p screenpipe-engine` were attempted on the current-main repair but stopped in `libspa-sys` before compiling screenpipe-engine because this host lacks `libpipewire-0.3.pc`; no package was installed.

## Review identity

Independently approved exact head: `e0e6f3c12af7ad93db493df0d35cd23711ba24e0` on current main `a8d4bdf1c3abba5e3105b5edfb1cc6fc4197fe67`.

Issue: https://github.com/screenpipe/screenpipe/issues/6583
Linear source identity: SCR-521