### PR TITLE
fix(api): resolve auth key for managed LAN access

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/recording.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/recording.rs
@@ -1250,12 +1250,17 @@ async fn spawn_screenpipe_inner(
         );
     }
 
-    // Resolve the API auth key exactly once per process via the shared
-    // helper and seed the cache before `to_recording_config` reads it. The
-    // helper handles env var / settings / secret-store / auth.json lookup
+    // Build the effective config before deciding whether auth needs a key.
+    // `from_settings` force-enables auth when LAN access is enabled, even if
+    // the persisted `apiAuth` field is false. Checking the persisted field
+    // here used to start an auth-enforcing server without any accepted key.
+    let mut recording_config = store.to_recording_config(data_dir.clone());
+
+    // Resolve the API auth key exactly once per process via the shared helper.
+    // The helper handles env var / settings / secret-store / auth.json lookup
     // and persists auto-generated keys to the secret store itself, so every
     // reader (server, MCP, auth CLI) sees the same value.
-    if store.recording.api_auth {
+    if recording_config.api_auth {
         let settings_key_opt = if store.recording.api_key.is_empty() {
             None
         } else {
@@ -1267,13 +1272,15 @@ async fn spawn_screenpipe_inner(
         )
         .await
         {
-            Ok(key) => crate::store::seed_api_auth_key(key),
+            Ok(key) => {
+                crate::store::seed_api_auth_key(key.clone());
+                recording_config.api_auth_key = Some(key);
+            }
             Err(e) => tracing::error!("failed to resolve api auth key: {}", e),
         }
     }
 
     notify_audio_engine_fallback(&store);
-    let recording_config = store.to_recording_config(data_dir);
 
     let server_arc = state.server.clone();
     let capture_arc = state.capture.clone();
@@ -1575,6 +1582,28 @@ mod capture_intent_tests {
         wants_recording.store(false, Ordering::SeqCst);
 
         assert!(!capture_intended_now(&wants_recording));
+    }
+}
+
+#[cfg(test)]
+mod local_api_auth_tests {
+    use super::SettingsStore;
+    use serde_json::json;
+
+    #[test]
+    fn managed_lan_access_requires_a_key_when_persisted_api_auth_is_false() {
+        // This is the exact flattened store shape produced when enterprise
+        // policy enables LAN access on a device that previously disabled API
+        // auth. Startup must follow the effective config, not `apiAuth` alone.
+        let store: SettingsStore = serde_json::from_value(json!({
+            "apiAuth": false,
+            "listenOnLan": true
+        }))
+        .expect("managed settings shape should deserialize");
+
+        let config = store.to_recording_config(std::path::PathBuf::from("test-data"));
+
+        assert!(config.api_auth);
     }
 }
 


### PR DESCRIPTION
## Summary

- build the effective recording config before deciding whether local API auth needs a key
- resolve and attach the key when LAN policy force-enables auth, even if persisted `apiAuth` is false
- cover the exact flattened enterprise-managed settings shape from the customer incident

## Customer impact

An enterprise device could persist `apiAuth: false` while managed policy enforced `listenOnLan: true`. The engine correctly forced authentication on for LAN safety, but startup skipped key resolution and created an API that rejected every Timeline, meeting, search, and WebSocket request with HTTP 403. The fixed build self-recovers on its next startup by resolving the required key.

## Before / after

```text
Before: apiAuth=false + listenOnLan=true -> effective auth=true + key=None -> localhost 403
After:  apiAuth=false + listenOnLan=true -> effective auth=true + resolved key -> authenticated UI/API
```

## Historical intent

- `c68325aa73b` centralized local API key resolution behind the persisted `apiAuth` field.
- `c8d9c83f0c` later added LAN access and intentionally forced effective auth on whenever LAN binding is enabled, preventing unauthenticated network exposure.
- PR #5168 (`6311622484d`) later made `listen_on_lan` independently enforceable by enterprise policy. That path could therefore create the previously unreachable mixed persisted state.
- This change preserves the LAN security invariant and makes key resolution follow the already-authoritative effective `RecordingConfig`; it does not weaken authentication or alter policy values.

## Validation

- `bun run test:tauri managed_lan_access_requires_a_key_when_persisted_api_auth_is_false -- --nocapture` — passed (1 passed, 0 failed; 956 filtered out)
- `git diff --check` — passed
- `SEM_NO_TELEMETRY=1 sem diff --format plain --no-cosmetics` — one modified startup function and one added regression test
