### PR TITLE
fix(ai-gateway): tag super admin allowance traffic

### DIFF
--- a/packages/ai-gateway/src/services/cloudflare-ai-gateway.ts
+++ b/packages/ai-gateway/src/services/cloudflare-ai-gateway.ts
@@ -7,12 +7,14 @@ import { isFrontierModel } from './cost-tracker';
 import { getHostedAiPlan } from './hosted-ai-policy';
 
 export type HostedChatGatewayMode = 'legacy' | 'cloudflare';
-export type HostedChatPlan = 'free' | 'basic' | 'business' | 'business_max' | 'business_ultra' | 'internal';
+export type HostedChatPlan = 'free' | 'basic' | 'business' | 'business_max' | 'business_ultra' | 'super_admin' | 'internal';
 export type HostedChatLane = 'auto' | 'explicit' | 'frontier';
 export type HostedChatRequestLane = Exclude<HostedChatLane, 'frontier'>;
 export type HostedChatWorkload = 'interactive' | 'background';
 export type CloudflareGatewayProvider = 'openai' | 'anthropic';
 export type HostedChatLimitScope = 'combined' | 'frontier' | 'unknown';
+
+const SUPER_ADMIN_ACTOR_ID = 'f0d67846f15d207818a4016c5f12edac415d35adf8084792fec508554def5906';
 
 export interface HostedChatGatewayContext {
 	user_id: string;
@@ -113,9 +115,11 @@ export async function buildHostedChatGatewayContext(
 	model: string,
 	workload: HostedChatWorkload,
 ): Promise<HostedChatGatewayContext> {
+	const userId = await hostedChatActorId(auth);
+	const plan = collapsePlan(auth);
 	return {
-		user_id: await hostedChatActorId(auth),
-		plan: collapsePlan(auth),
+		user_id: userId,
+		plan: userId === SUPER_ADMIN_ACTOR_ID ? 'super_admin' : plan,
 		lane: hostedChatLaneForModel(
 			model,
 			model.toLowerCase() === 'auto' ? 'auto' : 'explicit',


### PR DESCRIPTION
## Summary

- emit `plan: super_admin` to Cloudflare AI Gateway for one verified pseudonymous account actor
- keep every other account on its existing authenticated plan metadata
- preserve service authentication, account-plan validation, rate limits, and all non-Cloudflare safeguards

## Production deployment

- deployed `ai-proxy` before opening this PR, as requested
- Cloudflare Worker version: `1ec5782c-e295-4224-ba94-320036933b97`

## Verification

- local tests intentionally not run per explicit request
- `git diff --check` passed
- Wrangler production deployment succeeded

## Historical intent

Inspected PR #5806 / commit `77334e8e341b` and PR #6367 / commit `3448219a3ffe`. The Cloudflare metadata contract was introduced to enforce spend policy using a pseudonymous actor ID while keeping raw account identity and request payloads out of Cloudflare and exported audit events. This change preserves that privacy boundary and still resolves the authenticated account plan first; it intentionally overrides only the emitted Cloudflare plan label for the one verified actor so a dedicated spend rule can be configured without affecting other users.