### PR TITLE
feat(enterprise): enforce enterprise-build-only access

### DIFF
--- a/apps/screenpipe-app-tauri/components/app-entitlement-gate.test.tsx
+++ b/apps/screenpipe-app-tauri/components/app-entitlement-gate.test.tsx
@@ -833,6 +833,32 @@ describe("AppEntitlementGate", () => {
     expect(mocks.stopScreenpipe).not.toHaveBeenCalled();
   });
 
+  it("routes restricted enterprise members away even with a consumer subscription", () => {
+    mocks.state.user = baseUser({
+      app_entitled: true,
+      cloud_subscribed: true,
+      subscription_plan: "pro",
+      enterprise_account: {
+        org_name: "Bungalow",
+        role: "member",
+        requires_enterprise_app: true,
+        restrict_consumer_build_access: true,
+      },
+      entitlement: {
+        active: true,
+        plan: "pro",
+        source: "subscription",
+        checked_at: minsAgo(1),
+        features: { app: true, cloud: true },
+      },
+    });
+
+    render(<AppEntitlementGate>{protectedApp}</AppEntitlementGate>);
+
+    expect(screen.getByText(/enterprise app required/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("protected-app")).not.toBeInTheDocument();
+  });
+
   it.each(["pro_max", "pro_ultra"] as const)(
     "does not route an enterprise workspace admin with a %s consumer plan away",
     (plan) => {

--- a/apps/screenpipe-app-tauri/components/app-entitlement-gate.tsx
+++ b/apps/screenpipe-app-tauri/components/app-entitlement-gate.tsx
@@ -247,8 +247,9 @@ export function AppEntitlementGate({
     !devBypass &&
     !isManagedDeployment &&
     Boolean(user?.token) &&
-    !hasConsumerSubscription &&
-    enterpriseAccount?.requires_enterprise_app === true;
+    enterpriseAccount?.requires_enterprise_app === true &&
+    (!hasConsumerSubscription ||
+      enterpriseAccount.restrict_consumer_build_access === true);
   const shouldGateForEntitlement = shouldGateForUnknownConsumerPolicy;
   const shouldGate = isOnboardingRoute
     ? false
@@ -307,8 +308,7 @@ export function AppEntitlementGate({
       // Must follow the same precedence as the render branches below (and as
       // `gate_path`). Checking unknown-policy before enterprise-app reported
       // "plan_verification_required" for users who were actually looking at the
-      // "enterprise app required" screen — both flags are true at once, since an
-      // unknown plan is what clears hasConsumerAppSubscription in the first place.
+      // "enterprise app required" screen — both flags can be true at once.
       reason: shouldGateForEnterpriseLogin
         ? "enterprise_login_required"
         : shouldGateForEnterpriseApp

--- a/apps/screenpipe-app-tauri/lib/app-entitlement.ts
+++ b/apps/screenpipe-app-tauri/lib/app-entitlement.ts
@@ -52,6 +52,7 @@ export type AppEnterpriseAccount = {
   org_name?: string | null;
   role?: string | null;
   requires_enterprise_app?: boolean | null;
+  restrict_consumer_build_access?: boolean | null;
   is_screenpipe_user?: boolean | null;
 };
 


### PR DESCRIPTION
## What changed

- recognizes the new `enterprise_account.restrict_consumer_build_access` policy signal
- blocks the consumer build after sign-in when an enterprise admin explicitly enabled the restriction
- sends the user to the existing enterprise download/builds screen
- preserves the existing behavior when the flag is absent: separately paid consumer subscribers remain allowed

## Behavior

```text
legacy enterprise signal + consumer subscription -> consumer app remains available
new restriction flag enabled                 -> enterprise download gate
enterprise build                             -> unchanged
```

Companion policy/API PR: https://github.com/screenpipe/website/pull/882

## Historical intent

- inspected commit `ec859296b3`, which introduced enterprise-app steering
- inspected PR #4542 / commit `9721f9f22c`, which intentionally preserved access for enterprise members with a separate consumer subscription
- keeps that invariant for old API responses and intentionally supersedes it only when the new admin flag is explicitly true

## Validation

- `bun x vitest run --config vitest.config.ts components/app-entitlement-gate.test.tsx` — 40 passed
- `bun x tsc --noEmit --pretty false` — passed
- `git diff --check` — passed