### PR TITLE
fix(activity): deduplicate interval generation

### DIFF
--- a/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.test.tsx
@@ -2131,6 +2131,7 @@ describe("ActivityLedger", () => {
     expect(mocks.generateActivityHistory).toHaveBeenCalledWith(
       expect.any(String),
       expect.any(String),
+      "today",
     );
   });
 

--- a/apps/screenpipe-app-tauri/components/activity-ledger.tsx
+++ b/apps/screenpipe-app-tauri/components/activity-ledger.tsx
@@ -1723,6 +1723,7 @@ export function ActivityLedger({
         const result = await commands.generateActivityHistory(
           generationRange.start.toISOString(),
           generationRange.end.toISOString(),
+          preset,
         );
         if (result.status === "error") throw new Error(result.error);
         const persisted = result.data;

--- a/apps/screenpipe-app-tauri/lib/utils/tauri.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/tauri.ts
@@ -501,9 +501,9 @@ async forceRegenerateSuggestions() : Promise<Result<CachedSuggestions, string>> 
     else return { status: "error", error: e  as any };
 }
 },
-async generateActivityHistory(start: string, end: string) : Promise<Result<PersistedActivityHistory, string>> {
+async generateActivityHistory(start: string, end: string, idempotencyKey: string) : Promise<Result<PersistedActivityHistory, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("generate_activity_history", { start, end }) };
+    return { status: "ok", data: await TAURI_INVOKE("generate_activity_history", { start, end, idempotencyKey }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };

--- a/apps/screenpipe-app-tauri/src-tauri/src/activity_history.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/activity_history.rs
@@ -15,8 +15,8 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use specta::Type;
-use std::collections::BTreeMap;
-use std::sync::Arc;
+use std::collections::{BTreeMap, HashSet};
+use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant};
 use tauri::{AppHandle, Emitter, Manager};
 use tokio::sync::Mutex;
@@ -189,6 +189,37 @@ impl QualityAudit {
 #[derive(Default)]
 pub struct ActivityHistoryState {
     run_lock: Arc<Mutex<()>>,
+    active_idempotency_keys: Arc<StdMutex<HashSet<String>>>,
+}
+
+struct ActivityGenerationKeyGuard {
+    active_idempotency_keys: Arc<StdMutex<HashSet<String>>>,
+    key: String,
+}
+
+impl Drop for ActivityGenerationKeyGuard {
+    fn drop(&mut self) {
+        self.active_idempotency_keys
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(&self.key);
+    }
+}
+
+impl ActivityHistoryState {
+    fn try_begin(&self, key: String) -> Option<ActivityGenerationKeyGuard> {
+        let mut active = self
+            .active_idempotency_keys
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if !active.insert(key.clone()) {
+            return None;
+        }
+        Some(ActivityGenerationKeyGuard {
+            active_idempotency_keys: Arc::clone(&self.active_idempotency_keys),
+            key,
+        })
+    }
 }
 
 fn track_generation_event(app: &AppHandle, event: &'static str, properties: Value) {
@@ -1278,7 +1309,16 @@ async fn generate(
     start: DateTime<Utc>,
     end: DateTime<Utc>,
     source: &'static str,
+    idempotency_key: String,
 ) -> Result<PersistedActivityHistory, String> {
+    let Some(_idempotency_guard) = state.try_begin(idempotency_key.clone()) else {
+        info!(
+            activity_source = source,
+            %idempotency_key,
+            "activity generation: matching interval is already running; skipping duplicate"
+        );
+        return Ok(history_in_range(read_all(app)?, start, end));
+    };
     let run_id = uuid::Uuid::new_v4().to_string();
     let started_at = Instant::now();
     track_generation_event(
@@ -1610,13 +1650,22 @@ pub async fn generate_activity_history(
     state: tauri::State<'_, ActivityHistoryState>,
     start: String,
     end: String,
+    idempotency_key: String,
 ) -> Result<PersistedActivityHistory, String> {
     let (start, end) = requested_range(start, end)?;
     let restricted = activity_history_is_restricted(&app);
     let Some((start, end)) = activity_access_range(start, end, Utc::now(), restricted) else {
         return Ok(PersistedActivityHistory::default());
     };
-    let history = generate(&app, state.inner(), start, end, "manual").await?;
+    let history = generate(
+        &app,
+        state.inner(),
+        start,
+        end,
+        "manual",
+        format!("manual:{idempotency_key}"),
+    )
+    .await?;
     Ok(if restricted {
         restricted_history_in_range(history, start, end)
     } else {
@@ -1732,7 +1781,16 @@ pub fn start(app: AppHandle) {
                 automatic_generation_start(next_uncovered_start(&app, now), now, interval_minutes);
             if start < now {
                 info!(%start, %now, "activity history: running scheduled generation");
-                if let Err(error) = generate(&app, state.inner(), start, now, "automatic").await {
+                if let Err(error) = generate(
+                    &app,
+                    state.inner(),
+                    start,
+                    now,
+                    "automatic",
+                    "automatic".to_string(),
+                )
+                .await
+                {
                     warn!(%error, "activity history: scheduled generation failed");
                 }
             }
@@ -1747,6 +1805,24 @@ pub fn start(app: AppHandle) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn duplicate_selected_interval_is_a_noop_until_the_original_finishes() {
+        let state = ActivityHistoryState::default();
+        let today = state
+            .try_begin("manual:today".to_string())
+            .expect("first Today generation should start");
+
+        assert!(state.try_begin("manual:today".to_string()).is_none());
+
+        let last_24_hours = state
+            .try_begin("manual:24h".to_string())
+            .expect("a different selected interval should keep its own key");
+        drop(last_24_hours);
+        drop(today);
+
+        assert!(state.try_begin("manual:today".to_string()).is_some());
+    }
 
     #[test]
     fn coverage_merges_touching_ranges() {


### PR DESCRIPTION
## Summary

- pass the selected Activities interval (`today`, `24h`, `7d`, or `custom`) to the native generation command as its idempotency key
- make a second request for the same selected interval return the persisted snapshot immediately instead of waiting behind the active run
- retain the existing serialization boundary for different intervals and scheduled generation

## Root cause

In app version 2.7.9, one `Today` click produced two native manual requests for the same 39,223-second range around a webview reinitialization. The native mutex serialized both instead of deduplicating them. The first run persisted five Activities; the queued run then produced one broad Activity and replaced all five because a complete full-range generation is authoritative for overlapping entries.

```text
before
Today request A -> generate 5 -> persist 5
Today request B -> wait -------> generate 1 -> replace with 1

after
Today request A -> generate 5 -> persist 5
Today request B -> matching key -> return persisted snapshot; no AI run or write
```

## Historical intent

- Inspected commit `b4ca8c68b2a` / PR #6470, which introduced native Activity generation and the run mutex so generation survives page teardown and scheduled/manual work cannot execute concurrently.
- Preserved native lifecycle ownership, persistence-before-event ordering, and serialization across different interval keys.
- Superseded only the mutex's duplicate behavior: matching selected intervals no longer queue, because replaying the same authoritative range can replace a better result. No prior test required duplicates to rerun.

## Validation

- `bun x vitest run components/activity-ledger.test.tsx` — 53 passed
- `bun run typecheck` — passed
- `bun run test:tauri duplicate_selected_interval_is_a_noop_until_the_original_finishes -- --nocapture` — passed
- `bun run test:tauri tauri_bindings_are_current -- --nocapture` — passed
- `git diff --check` — passed
