### PR TITLE
fix: retire first-result card after viewing

### DIFF
--- a/apps/screenpipe-app-tauri/components/deeplink-handler.tsx
+++ b/apps/screenpipe-app-tauri/components/deeplink-handler.tsx
@@ -32,7 +32,7 @@ import {
 } from "@/lib/first-run/agent-handoff";
 import {
   LEARNING_SUMMARY_OPENED_EVENT,
-  markLearningSummaryOpened,
+  markLearningDone,
   readLearningWindow,
 } from "@/lib/first-run/learning-window";
 import { trackFirstRunSummaryNotificationOpened } from "@/lib/first-run/telemetry";
@@ -122,7 +122,7 @@ export function DeeplinkHandler() {
           conversationId: chatId,
           targetWindow: "home",
         });
-        markLearningSummaryOpened();
+        markLearningDone();
         await emit(LEARNING_SUMMARY_OPENED_EVENT);
         posthog.capture("first_run_summary_opened", {
           source: "notification",

--- a/apps/screenpipe-app-tauri/components/first-run/learning-banner.test.tsx
+++ b/apps/screenpipe-app-tauri/components/first-run/learning-banner.test.tsx
@@ -11,7 +11,6 @@ import {
   TrialActivationSummaryExperience,
   TrialActivationUnlockPrompt,
 } from "./learning-banner";
-import { FIRST_RUN_SEARCH_SHORTCUT_STORAGE_KEY } from "./search-shortcut-practice";
 import type { LearningWindowView } from "@/lib/first-run/use-learning-window";
 
 const mocks = vi.hoisted(() => ({
@@ -80,6 +79,7 @@ function view(over: Partial<LearningWindowView> = {}): LearningWindowView {
     markSummaryOpened: vi.fn(),
     markSummaryRendered: vi.fn().mockResolvedValue(undefined),
     markNotificationSent: vi.fn(),
+    markReadyShown: vi.fn(),
     dismiss: vi.fn(),
     ...over,
   } as LearningWindowView;
@@ -213,6 +213,15 @@ describe("first-run learning banner", () => {
     expect(
       screen.getByText("screenpipe learned enough to help"),
     ).toBeInTheDocument();
+    expect(mocks.view.markReadyShown).toHaveBeenCalledTimes(1);
+
+    mocks.view = view({ phase: "done" });
+    rerender(
+      <FirstRunLearningBanner
+        fallback={<div data-testid="normal-home">How can I help today?</div>}
+      />,
+    );
+    expect(screen.getByTestId("normal-home")).toBeInTheDocument();
   });
 
   it("shows the countdown while learning", () => {
@@ -251,14 +260,12 @@ describe("first-run learning banner", () => {
     expect(screen.queryByText("Reading from")).not.toBeInTheDocument();
   });
 
-  it("opens the seeded chat without dismissing the learning result", async () => {
+  it("opens the seeded chat and retires the learning result", async () => {
     const dismiss = vi.fn();
-    const markSummaryOpened = vi.fn();
     mocks.view = view({
       phase: "ready",
       chatId: "first-run-1",
       dismiss,
-      markSummaryOpened,
     });
     render(<FirstRunLearningBanner />);
 
@@ -269,42 +276,7 @@ describe("first-run learning banner", () => {
         conversationId: "first-run-1",
       }),
     );
-    expect(markSummaryOpened).toHaveBeenCalledTimes(1);
-    expect(dismiss).not.toHaveBeenCalled();
-  });
-
-  it("keeps compact first-summary tips over the opened summary", async () => {
-    const dismiss = vi.fn();
-    mocks.view = view({
-      phase: "ready",
-      chatId: "first-run-1",
-      summaryOpenedAt: "2026-08-19T17:00:00.000Z",
-      dismiss,
-    });
-    render(<FirstRunLearningBanner />);
-
-    await waitFor(() =>
-      expect(
-        screen.getByTestId("first-run-search-shortcut-start"),
-      ).toBeEnabled(),
-    );
-
-    expect(screen.getByTestId("first-run-setup-dock")).toBeInTheDocument();
-    expect(
-      screen.queryByText("screenpipe learned enough to help"),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByTestId("first-run-next-steps"),
-    ).not.toBeInTheDocument();
-
-    fireEvent.click(screen.getByTestId("first-run-hide-setup"));
     expect(dismiss).toHaveBeenCalledTimes(1);
-    expect(
-      JSON.parse(
-        window.localStorage.getItem(FIRST_RUN_SEARCH_SHORTCUT_STORAGE_KEY) ||
-          "{}",
-      ),
-    ).toMatchObject({ status: "dismissed" });
   });
 
   it("does not repeat onboarding setup after learning resolves", () => {

--- a/apps/screenpipe-app-tauri/components/first-run/learning-banner.tsx
+++ b/apps/screenpipe-app-tauri/components/first-run/learning-banner.tsx
@@ -7,7 +7,7 @@
 import React from "react";
 import { emit } from "@tauri-apps/api/event";
 import posthog from "posthog-js";
-import { Clock, ListChecks, Loader2 } from "lucide-react";
+import { Clock, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { commands } from "@/lib/utils/tauri";
 import {
@@ -17,10 +17,6 @@ import {
 import { appIconUrl } from "@/lib/first-run/recent-activity";
 import { AgentHandoffPicker } from "@/components/first-run/agent-handoff-picker";
 import { useFirstRunLearningWindow } from "@/components/first-run/learning-window-provider";
-import {
-  dismissFirstRunSearchShortcutFromParent,
-  FirstRunSearchShortcutPractice,
-} from "@/components/first-run/search-shortcut-practice";
 import type { AgentHandoffTarget } from "@/lib/first-run/agent-handoff";
 
 function CapturedAppIcon({ app }: { app: FirstRunCapturedApp }) {
@@ -158,37 +154,6 @@ export function FirstRunSetupReadyPanel({
   );
 }
 
-export function FirstRunSetupDock({ onDismiss }: { onDismiss: () => void }) {
-  return (
-    <div data-testid="first-run-setup-dock">
-      <div className="flex flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center">
-        <span className="flex h-8 w-8 shrink-0 items-center justify-center border border-signal text-signal">
-          <ListChecks className="h-4 w-4" aria-hidden="true" />
-        </span>
-        <div className="min-w-0 flex-1">
-          <p className="font-mono text-[9px] uppercase tracking-[0.2em] text-signal">
-            getting started
-          </p>
-          <p className="mt-0.5 text-[11px] leading-relaxed text-muted-foreground">
-            your summary is open. try the search shortcut above, or keep
-            chatting.
-          </p>
-        </div>
-        <Button
-          type="button"
-          size="sm"
-          variant="ghost"
-          className="h-7 shrink-0 px-2 text-[9px]"
-          data-testid="first-run-hide-setup"
-          onClick={onDismiss}
-        >
-          hide tips
-        </Button>
-      </div>
-    </div>
-  );
-}
-
 /**
  * First-run learning window.
  *
@@ -205,12 +170,15 @@ export function FirstRunLearningBanner(
     capturedApps,
     remainingMs,
     chatId,
-    summaryOpenedAt,
     showProgress,
-    markSummaryOpened,
+    markReadyShown,
     dismiss,
   } = learning;
   const { targets: handoffTargets, hint: handoffHint, askAgent } = handoff;
+
+  React.useEffect(() => {
+    if (phase === "ready") markReadyShown();
+  }, [markReadyShown, phase]);
 
   // Only show progress when setup just caused it. A foreground empty result is
   // still a terminal onboarding state: hiding it also hid the daily-summary
@@ -228,41 +196,14 @@ export function FirstRunLearningBanner(
 
   const openSummary = async () => {
     if (!chatId) return;
-    // Distinct from dismiss(). Opening the result keeps optional setup alive,
-    // while hiding the dock explicitly retires it.
     posthog.capture("first_run_summary_opened");
     try {
       await emit("chat-load-conversation", { conversationId: chatId });
-      markSummaryOpened();
+      dismiss();
     } catch {
-      // Keep the full result card so the user can retry instead of collapsing
-      // setup around a summary that did not open.
+      // Keep the result card so the user can retry if the summary did not open.
     }
   };
-
-  // Once the result opens, keep setup as a compact workspace-level control
-  // instead of destroying it or leaving the large onboarding card above every
-  // chat. A blank chat can still render its normal starter beneath the dock.
-  if (phase === "ready" && summaryOpenedAt) {
-    return (
-      <>
-        <section
-          data-testid="first-run-learning-banner"
-          data-phase="ready"
-          className="mx-auto mb-4 w-full max-w-3xl overflow-hidden border border-border bg-background"
-        >
-          <FirstRunSearchShortcutPractice />
-          <FirstRunSetupDock
-            onDismiss={() => {
-              dismissFirstRunSearchShortcutFromParent();
-              dismiss();
-            }}
-          />
-        </section>
-        {fallback ? <>{fallback}</> : null}
-      </>
-    );
-  }
 
   return (
     <section

--- a/apps/screenpipe-app-tauri/e2e/specs/first-run-agent-handoff.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/first-run-agent-handoff.spec.ts
@@ -25,8 +25,7 @@
 //   2. The probe cannot break the banner. It touches the filesystem several
 //      times on mount, and a throw there must degrade to "no handoff", never
 //      to a dead ready state or an unclickable summary.
-//   3. Clicking the summary still opens it and collapses the large result into
-//      the compact setup dock with the handoff wired in.
+//   3. Clicking the summary still opens it and retires the one-shot banner.
 //
 // Does NOT assert which agent is offered. `detectAiTools()` runs in the
 // webview and resolves the REAL home directory: `SCREENPIPE_E2E_AI_TOOLS_HOME`
@@ -239,9 +238,6 @@ describeOrSkip("first-run agent handoff", () => {
     const summary = await browser.$(SUMMARY);
     await summary.click();
 
-    // Opening the result deliberately keeps optional setup in a compact dock.
-    // The old oracle expected the whole banner to disappear, contradicting
-    // the current product contract and reporting a working click as a failure.
     await browser.waitUntil(
       async () =>
         Boolean(
@@ -249,8 +245,8 @@ describeOrSkip("first-run agent handoff", () => {
             (key: string) => {
               const state = JSON.parse(localStorage.getItem(key) ?? "{}");
               return (
-                state.summaryOpenedAt &&
-                document.querySelector('[data-testid="first-run-setup-dock"]') &&
+                state.phase === "done" &&
+                !document.querySelector('[data-testid="first-run-learning-banner"]') &&
                 !document.querySelector('[data-testid="first-run-open-summary"]')
               );
             },
@@ -259,7 +255,7 @@ describeOrSkip("first-run agent handoff", () => {
         ),
       {
       timeout: t(10_000),
-        timeoutMsg: "summary did not open into the compact setup dock",
+        timeoutMsg: "summary did not open and retire the ready banner",
       },
     );
   });

--- a/apps/screenpipe-app-tauri/e2e/specs/first-run-ai-summary.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/first-run-ai-summary.spec.ts
@@ -583,7 +583,7 @@ describe("First-run summary is written by the model", function () {
           await browser.execute(
             (key: string) => {
               const stored = JSON.parse(localStorage.getItem(key) ?? "{}");
-              return stored.summaryOpenedAt;
+              return stored.phase === "done";
             },
             LEARNING_STORAGE_KEY,
           ),

--- a/apps/screenpipe-app-tauri/e2e/specs/first-run-learning-window.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/first-run-learning-window.spec.ts
@@ -23,8 +23,8 @@
 //      never gated on this result.
 //   3. A late retry runs in the background and surfaces only if a summary is
 //      ready. Reopening hours later must not look like onboarding restarted.
-//   4. Foreground terminal choices survive reload until the user dismisses
-//      them; background terminal states stay silent.
+//   4. Foreground empty choices survive reload until the user dismisses them;
+//      a ready result retires after opening or after an app restart.
 //
 // The summary text and the seed-once rules are pure functions covered in
 // lib/first-run/learning-window.test.ts. This spec drives the state machine
@@ -50,7 +50,6 @@ const seedFlags = E2E_SEED_FLAGS.split(",")
 const canRun = seedFlags.includes("onboarding");
 
 const LEARNING_STORAGE_KEY = "screenpipe.first-run.learning-window.v1";
-const SEARCH_SHORTCUT_STORAGE_KEY = "screenpipe.first-run.search-shortcut.v1";
 // The app's own E2E account hook (components/app-entitlement-gate.tsx), compiled
 // in only for e2e builds. Brain sits behind the account gate, and no seed flag
 // creates a signed-in user, so without this the section never renders.
@@ -118,34 +117,6 @@ const storedLearningState = async (): Promise<Record<string, unknown> | null> =>
       return null;
     }
   }, LEARNING_STORAGE_KEY)) as Record<string, unknown> | null;
-
-const emitTauri = async (event: string, payload: unknown): Promise<void> => {
-  await browser.executeAsync(
-    (name: string, value: unknown, done: (result?: unknown) => void) => {
-      const runtime = globalThis as unknown as {
-        __TAURI__?: {
-          event?: {
-            emit: (eventName: string, body: unknown) => Promise<unknown>;
-          };
-        };
-        __TAURI_INTERNALS__?: {
-          invoke: (command: string, args: object) => Promise<unknown>;
-        };
-      };
-      const emit = runtime.__TAURI__?.event?.emit;
-      const promise = emit
-        ? emit(name, value)
-        : runtime.__TAURI_INTERNALS__?.invoke("plugin:event|emit", {
-            event: name,
-            payload: value,
-          });
-      if (!promise) return done();
-      void promise.then(() => done()).catch(() => done());
-    },
-    event,
-    payload,
-  );
-};
 
 /**
  * Seed window state and land on Home.
@@ -373,11 +344,8 @@ const learningState = (over: Record<string, unknown> = {}) => ({
     expect((await storedLearningState())?.phase).toBe("done");
   });
 
-  it("opens the summary without inventing a user turn or losing tips", async () => {
+  it("opens the summary without inventing a user turn or covering Home", async () => {
     writeSummaryConversation();
-    await browser.execute((key: string) => {
-      window.localStorage.removeItem(key);
-    }, SEARCH_SHORTCUT_STORAGE_KEY);
     await openHomeWith(
       learningState({
         phase: "ready",
@@ -403,29 +371,15 @@ const learningState = (over: Record<string, unknown> = {}) => ({
         const text = (await browser.execute(
           () => document.body.textContent ?? "",
         )) as string;
-        return Boolean(state?.summaryOpenedAt) && text.includes(SUMMARY_TEXT);
+        return state?.phase === "done" && text.includes(SUMMARY_TEXT);
       },
       {
         timeout: t(20_000),
-        timeoutMsg: "summary chat never opened with persistent setup",
+        timeoutMsg: "summary chat did not open and retire the ready card",
       },
     );
 
-    expect(await bannerCount()).toBe(1);
-    expect(await bannerPhase()).toBe("ready");
-    expect(
-      await browser.execute(
-        () => !!document.querySelector('[data-testid="first-run-setup-dock"]'),
-      ),
-    ).toBe(true);
-    expect(
-      await browser.execute(
-        () =>
-          !!document.querySelector(
-            '[data-testid="first-run-search-shortcut-practice"]',
-          ),
-      ),
-    ).toBe(true);
+    expect(await bannerCount()).toBe(0);
 
     const bodyText = (await browser.execute(
       () => document.body.textContent ?? "",
@@ -443,77 +397,8 @@ const learningState = (over: Record<string, unknown> = {}) => ({
     })) as boolean;
     expect(composerAvailable).toBe(true);
 
-    const teachScreenshot = await saveScreenshot(
-      "first-run-summary-shortcut-teach",
-    );
-    expect(existsSync(teachScreenshot)).toBe(true);
-
-    await (
-      await browser.$('[data-testid="first-run-search-shortcut-start"]')
-    ).click();
-    await browser.waitUntil(
-      async () =>
-        Boolean(
-          await browser.execute(
-            () =>
-              !!document.querySelector(
-                '[data-testid="first-run-search-shortcut-waiting"]',
-              ),
-          ),
-        ),
-      {
-        timeout: t(10_000),
-        timeoutMsg: "shortcut lesson never entered its practice state",
-      },
-    );
-    const waitingScreenshot = await saveScreenshot(
-      "first-run-summary-shortcut-waiting",
-    );
-    expect(existsSync(waitingScreenshot)).toBe(true);
-
-    await emitTauri("shortcut-show-search", { success: true });
-    await browser.waitUntil(
-      async () =>
-        Boolean(
-          await browser.execute(
-            () =>
-              !!document.querySelector(
-                '[data-testid="first-run-search-shortcut-complete"]',
-              ),
-          ),
-        ),
-      {
-        timeout: t(10_000),
-        timeoutMsg: "native shortcut event did not complete the lesson",
-      },
-    );
-    const completionScreenshot = await saveScreenshot(
-      "first-run-summary-shortcut-complete",
-    );
-    expect(existsSync(completionScreenshot)).toBe(true);
-    expect(
-      await browser.execute((key: string) => {
-        const raw = window.localStorage.getItem(key);
-        return raw ? JSON.parse(raw) : null;
-      }, SEARCH_SHORTCUT_STORAGE_KEY),
-    ).toMatchObject({ status: "completed", acknowledged: false });
-
-    const done = await browser.$(
-      '[data-testid="first-run-search-shortcut-done"]',
-    );
-    await done.click();
-    expect(
-      await browser.execute((key: string) => {
-        const raw = window.localStorage.getItem(key);
-        return raw ? JSON.parse(raw) : null;
-      }, SEARCH_SHORTCUT_STORAGE_KEY),
-    ).toMatchObject({ status: "completed", acknowledged: true });
-
-    expect(
-      await browser.execute(
-        () => !!document.querySelector('[data-testid="first-run-next-steps"]'),
-      ),
-    ).toBe(false);
+    const openedScreenshot = await saveScreenshot("first-run-summary-open");
+    expect(existsSync(openedScreenshot)).toBe(true);
   });
 
   // Regression guard for the bug this spec originally missed: the window used

--- a/apps/screenpipe-app-tauri/e2e/specs/first-run-learning-window.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/first-run-learning-window.spec.ts
@@ -391,7 +391,7 @@ const learningState = (over: Record<string, unknown> = {}) => ({
 
     const composerAvailable = (await browser.execute(() => {
       const composer = document.querySelector<HTMLTextAreaElement>(
-        'textarea[placeholder^="Ask about your screen"]',
+        '[data-firstrun-target="composer"] textarea',
       );
       return Boolean(composer && !composer.disabled);
     })) as boolean;

--- a/apps/screenpipe-app-tauri/lib/first-run/learning-window.test.ts
+++ b/apps/screenpipe-app-tauri/lib/first-run/learning-window.test.ts
@@ -21,6 +21,7 @@ import {
   markLearningDone,
   markLearningEmpty,
   markLearningReady,
+  markLearningReadyShown,
   markLearningSummaryOpened,
   markLearningWriting,
   normalizeEmptyReason,
@@ -390,6 +391,18 @@ describe("window lifecycle", () => {
     claimLearningSeed();
     expect(markLearningReady("chat-1").chatId).toBe("chat-1");
     expect(readLearningWindow().chatId).toBe("chat-1");
+  });
+
+  it("persists when the ready card was shown", () => {
+    beginLearningWindow();
+    markLearningReady("chat-1");
+
+    const shown = markLearningReadyShown("2026-08-19T16:00:00.000Z");
+
+    expect(shown.readyShownAt).toBe("2026-08-19T16:00:00.000Z");
+    expect(readLearningWindow().readyShownAt).toBe(
+      "2026-08-19T16:00:00.000Z",
+    );
   });
 
   it("keeps setup alive after the summary opens", () => {

--- a/apps/screenpipe-app-tauri/lib/first-run/learning-window.ts
+++ b/apps/screenpipe-app-tauri/lib/first-run/learning-window.ts
@@ -70,6 +70,8 @@ export type FirstRunLearningState = {
   /** Set once a summary lands, so a reload cannot re-seed a second chat. */
   seededAt: string | null;
   chatId: string | null;
+  /** Set when Home has rendered the ready card at least once. */
+  readyShownAt: string | null;
   /**
    * Set after the user opens the summary.
    *
@@ -172,6 +174,7 @@ const EMPTY_STATE: FirstRunLearningState = {
   showProgress: false,
   seededAt: null,
   chatId: null,
+  readyShownAt: null,
   summaryOpenedAt: null,
   notificationSentAt: null,
   emptyReason: null,
@@ -581,6 +584,8 @@ function normalize(value: unknown): FirstRunLearningState {
     showProgress: state.showProgress === true,
     seededAt: typeof state.seededAt === "string" ? state.seededAt : null,
     chatId: typeof state.chatId === "string" ? state.chatId : null,
+    readyShownAt:
+      typeof state.readyShownAt === "string" ? state.readyShownAt : null,
     summaryOpenedAt:
       typeof state.summaryOpenedAt === "string"
         ? state.summaryOpenedAt
@@ -673,7 +678,21 @@ export function markLearningWriting(): FirstRunLearningState {
 
 export function markLearningReady(chatId: string): FirstRunLearningState {
   const current = readLearningWindow();
-  return writeLearningWindow({ ...current, phase: "ready", chatId });
+  return writeLearningWindow({
+    ...current,
+    phase: "ready",
+    chatId,
+    readyShownAt: current.chatId === chatId ? current.readyShownAt : null,
+  });
+}
+
+/** Persist that the one-shot ready card reached the user's Home surface. */
+export function markLearningReadyShown(
+  shownAt = new Date().toISOString(),
+): FirstRunLearningState {
+  const current = readLearningWindow();
+  if (current.phase !== "ready" || current.readyShownAt) return current;
+  return writeLearningWindow({ ...current, readyShownAt: shownAt });
 }
 
 /**

--- a/apps/screenpipe-app-tauri/lib/first-run/use-learning-window.test.ts
+++ b/apps/screenpipe-app-tauri/lib/first-run/use-learning-window.test.ts
@@ -27,6 +27,12 @@ vi.mock("@/lib/first-run/recent-activity", () => ({
 }));
 
 import { useLearningWindow } from "./use-learning-window";
+import {
+  beginLearningWindow,
+  markLearningReady,
+  markLearningReadyShown,
+  readLearningWindow,
+} from "./learning-window";
 
 function nativeStatus(
   phase: string,
@@ -88,6 +94,20 @@ describe("native first-run summary projection", () => {
       "first_run_learning_resolved",
       expect.anything(),
     );
+  });
+
+  it("retires a ready card that was already shown before restart", async () => {
+    beginLearningWindow();
+    markLearningReady("first-run-native-chat");
+    markLearningReadyShown("2026-08-27T07:05:00.000Z");
+    mocks.getOnboardingStatus.mockResolvedValue(
+      nativeStatus("ready", "first-run-native-chat"),
+    );
+
+    const { result } = renderHook(() => useLearningWindow());
+
+    await waitFor(() => expect(result.current.phase).toBe("done"));
+    expect(readLearningWindow().phase).toBe("done");
   });
 
   it("persists the paywall only after the treatment summary reports a render", async () => {

--- a/apps/screenpipe-app-tauri/lib/first-run/use-learning-window.ts
+++ b/apps/screenpipe-app-tauri/lib/first-run/use-learning-window.ts
@@ -19,6 +19,7 @@ import {
   markLearningDone,
   markLearningEmpty,
   markLearningReady,
+  markLearningReadyShown,
   markLearningSummaryOpened,
   markLearningWriting,
   resetLearningWindow,
@@ -39,6 +40,7 @@ export type LearningWindowView = FirstRunLearningState & {
   markSummaryOpened: () => void;
   markSummaryRendered: () => Promise<void>;
   markNotificationSent: () => void;
+  markReadyShown: () => void;
   dismiss: () => void;
 };
 
@@ -53,9 +55,14 @@ export type LearningWindowOptions = {
 export function useLearningWindow(
   _options: LearningWindowOptions = {},
 ): LearningWindowView {
-  const [state, setState] = useState<FirstRunLearningState>(() =>
-    readLearningWindow(),
-  );
+  const [state, setState] = useState<FirstRunLearningState>(() => {
+    const stored = readLearningWindow();
+    // A ready card is a one-session announcement, not a replacement for the
+    // normal Home starter on every later app launch. The chat remains durable.
+    return stored.phase === "ready" && stored.readyShownAt
+      ? markLearningDone()
+      : stored;
+  });
   const [capturedApps, setCapturedApps] = useState<FirstRunCapturedApp[]>([]);
   const [remainingMs, setRemainingMs] = useState(() =>
     learningWindowRemainingMs(readLearningWindow().startedAt),
@@ -90,9 +97,12 @@ export function useLearningWindow(
       }
       if (phase === "ready" && native.firstRunSummaryChatId) {
         const stored = readLearningWindow();
+        // Local dismissal is final for this first-run result. `done` clears the
+        // chat id, so comparing ids first would revive the card every second.
+        if (stored.phase === "done") return;
         if (
           stored.chatId !== native.firstRunSummaryChatId ||
-          (stored.phase !== "done" && stored.phase !== "ready")
+          stored.phase !== "ready"
         ) {
           setState(markLearningReady(native.firstRunSummaryChatId));
         }
@@ -156,6 +166,9 @@ export function useLearningWindow(
   }, [activationState]);
   // Notification persistence is native; retained for the existing view contract.
   const markNotificationSent = useCallback(() => {}, []);
+  const markReadyShown = useCallback(() => {
+    markLearningReadyShown();
+  }, []);
   const dismiss = useCallback(() => {
     posthog.capture("first_run_learning_dismissed", {
       phase: state.phase,
@@ -172,6 +185,7 @@ export function useLearningWindow(
     markSummaryOpened,
     markSummaryRendered,
     markNotificationSent,
+    markReadyShown,
     dismiss,
   };
 }


### PR DESCRIPTION
## description

The first-result ready card no longer permanently replaces the normal Home starter.

- record when the ready card actually reaches Home;
- retire it after the user opens the summary, including notification deep links;
- retire an already-seen card on the next app/webview start;
- prevent the one-second native projection from reviving a locally completed result;
- preserve the generated summary in chat history.

related issue: none

## Historical intent

Inspected commit `aac2ef873e` / PR #6446, which intentionally kept optional setup beside the opened first summary. This PR supersedes that persistent setup-dock lifetime based on the current product decision while preserving the original invariant that the generated summary remains a durable assistant-only chat and no fabricated user prompt is inserted.

## AI assistance and human ownership

- AI tool(s) used (`none` if not used): OpenAI Codex
- autonomy level (`none`, `autocomplete`, `chat`, or `agent`): agent
- what I personally verified: automated local checks and exact app-code Orchard validation were run by Codex; see the Orchard comment for results and harness deviations.

- [ ] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [ ] The problem statement, rationale, and replies to maintainers are my own.

## evidence type

- [x] UI or behavior change — before/after ASCII below; Orchard native UI screenshots are retained in the private test evidence prefix
- [ ] Backend change — regression tests and relevant logs/results
- [ ] Performance change — reproducible before/after benchmarks
- [ ] Docs, CI, or pure refactor — relevant checks and an explanation; no video required

## before

```text
Home
┌────────────────────────────────────────────┐
│ FIRST RESULT · READY                       │
│ screenpipe learned enough to help          │
└────────────────────────────────────────────┘
(normal Home starter hidden)

open summary or restart → ready card can return
```

## after

```text
first display → one-shot ready card
open summary → generated chat opens; ready card retires
restart after display → ready card retires
next blank Home → normal Home starter
```

The generated summary remains available in chat history.

## how to test

1. `cd apps/screenpipe-app-tauri && bun x vitest run --config vitest.config.ts components/first-run/learning-banner.test.tsx lib/first-run/use-learning-window.test.ts lib/first-run/learning-window.test.ts` — 83/83 passed locally and in Orchard.
2. `cd apps/screenpipe-app-tauri && bun run typecheck` — passed.
3. `cd apps/screenpipe-app-tauri && bun x eslint components/deeplink-handler.tsx components/first-run/learning-banner.tsx components/first-run/learning-banner.test.tsx lib/first-run/learning-window.ts lib/first-run/learning-window.test.ts lib/first-run/use-learning-window.ts lib/first-run/use-learning-window.test.ts e2e/specs/first-run-learning-window.spec.ts e2e/specs/first-run-agent-handoff.spec.ts e2e/specs/first-run-ai-summary.spec.ts` — passed.
4. `cd apps/screenpipe-app-tauri && bun run e2e:coverage:check` — passed; coverage report is current.
5. Orchard fresh macOS 26.6.2 arm64 VM: scoped native UI scenario — 1/1 passed. The ready card disappeared after opening, the saved assistant-only summary remained, and the enabled normal Home composer returned. The restart-state regression is included in the 83/83 focused suite.

## desktop app checklist (if applicable)

No Tauri commands or exported Rust types changed.

- [ ] `bun run bindings:generate` (not applicable)
- [ ] `bun run bindings:check` (not applicable)
- [x] `bun run typecheck`
