### PR TITLE
fix(login): use preferred browser on macOS

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -434,8 +434,8 @@ commits: `87abb00d`, `9464fdc9`, `0f9e43aa`, `7ea15f32`
 - [ ] **onboarding versus existing account destination** — an auth callback during incomplete setup returns to Onboarding and auto-advances after login; an auth callback from an established app returns to Home.
 - [ ] **wrong browser account retry** — when the browser is already signed into the wrong account, sign out on the login page and sign in again. The original build scheme and callback version survive the Clerk round trip.
 - [ ] **blocked automatic protocol launch** — block the browser's automatic custom-protocol launch, then use the visible "open screenpipe" fallback. The callback is delivered once to the correct build.
-- [ ] **default browser unavailable** — make the OS browser launch fail and verify `open_login_window` falls back to the isolated in-app WebView, including "use different account".
-- [ ] **macOS and Linux parity** — macOS ASWebAuthenticationSession and Linux system-browser login use the same versioned callback contract and return to the initiating build.
+- [ ] **default browser unavailable** — make the OS browser launch fail and verify `open_login_window` falls back to ASWebAuthenticationSession on macOS or the isolated in-app WebView on Windows/Linux. "Use different account" must remain isolated on every platform.
+- [ ] **macOS preferred-browser login** — repeat normal login with Safari, Chrome, and Arc selected as the default browser. Existing browser SSO is reused, the versioned callback returns to the initiating build, and a first-touch `screenpipe.com` attribution cookie is linked to the signed-in account.
 - [ ] **CLI login remains separate** — `/login?code=…&redirect=…` completes the device-code flow without attempting a desktop custom-scheme callback.
 
 ### 12. timeline & search

--- a/apps/screenpipe-app-tauri/components/onboarding/login-gate.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/login-gate.tsx
@@ -285,11 +285,10 @@ const OnboardingLogin: React.FC<OnboardingLoginProps> = ({
   const handleLogin = useCallback(() => {
     posthog.capture("onboarding_login_clicked");
     setBrowserFailure(null);
-    // macOS: ASWebAuthenticationSession (shares Safari's session).
-    // Windows/Linux: the user's real default browser, so the session they
-    // already have with Google/etc. is reused instead of asking them to
-    // re-type credentials into a cold embedded WebView. Either way the token
-    // comes back on the screenpipe:// deep link; nothing is typed by hand.
+    // The user's real default browser reuses the session they already have
+    // with Google/etc. instead of asking them to re-type credentials in a cold
+    // embedded browser. The token comes back on the versioned app-specific
+    // deep link; nothing is typed by hand.
     const authMode = suppressAutoAdvance ? "sign-in" : "sign-up";
     void commands
       .openLoginWindow(null, authMode)

--- a/apps/screenpipe-app-tauri/e2e/specs/onboarding-redirect.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/onboarding-redirect.spec.ts
@@ -89,7 +89,7 @@ const canRun = !seedFlags.includes("onboarding");
 
     // ─── system-browser login handoff ────────────────────────────────────
     //
-    // Windows and Linux do not sign in through a cold embedded WebView.
+    // Normal desktop login does not use a cold embedded WebView.
     // `open_login_window` opens the user's real browser at the ordinary login
     // URL and the website deep-links `screenpipe://auth?api_key=…` back, so
     // the user never reads or types anything.

--- a/apps/screenpipe-app-tauri/lib/utils/tauri.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/tauri.ts
@@ -1285,12 +1285,11 @@ async openGoogleCalendarAuthWindow(authUrl: string) : Promise<Result<null, strin
 },
 /**
  * Open the screenpipe.com login page.
- * macOS: ASWebAuthenticationSession (system-managed sheet, forwards callback).
- * Windows/Linux: in-app WebView that intercepts the screenpipe:// redirect.
+ * Normal login opens the user's default browser and returns through the
+ * versioned app-specific deep-link callback.
  *
- * `fresh_session` is used by "use different account": macOS asks
- * ASWebAuthenticationSession for an ephemeral browser session instead of
- * reusing Safari cookies, and Windows/Linux use a throwaway webview profile.
+ * `fresh_session` is used by "use different account": macOS uses an ephemeral
+ * ASWebAuthenticationSession and Windows/Linux use a throwaway webview profile.
  * Returns the device code when this call started the browser device-code flow,
  * and an empty string for every path that needs no out-of-band confirmation
  * (macOS auth session, embedded WebView fallback).

--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -24,7 +24,6 @@ use crate::window::GatedPanelPlacement;
 use crate::window::GatedWindowPlacement;
 use sha2::{Digest, Sha256};
 use tauri::{Emitter, Manager};
-#[cfg(not(target_os = "macos"))]
 use tauri_plugin_opener::OpenerExt;
 use tracing::{debug, error, info, warn};
 
@@ -1921,12 +1920,11 @@ fn reset_existing_login_window<R: tauri::Runtime>(
 }
 
 /// Open the screenpipe.com login page.
-/// macOS: ASWebAuthenticationSession (system-managed sheet, forwards callback).
-/// Windows/Linux: in-app WebView that intercepts the screenpipe:// redirect.
+/// Normal login opens the user's default browser and returns through the
+/// versioned app-specific deep-link callback.
 ///
-/// `fresh_session` is used by "use different account": macOS asks
-/// ASWebAuthenticationSession for an ephemeral browser session instead of
-/// reusing Safari cookies, and Windows/Linux use a throwaway webview profile.
+/// `fresh_session` is used by "use different account": macOS uses an ephemeral
+/// ASWebAuthenticationSession and Windows/Linux use a throwaway webview profile.
 #[tauri::command]
 #[specta::specta]
 /// Returns the device code when this call started the browser device-code flow,
@@ -1946,12 +1944,40 @@ pub async fn open_login_window(
     let fresh_session = fresh_session.unwrap_or(false);
     #[cfg(target_os = "macos")]
     {
-        // ASWebAuthenticationSession intercepts the redirect itself (no OS
-        // scheme routing), but still use the same versioned build scheme as
-        // Windows/Linux so the website contract is identical everywhere.
         let callback_scheme = deep_link_scheme();
+        let login_url = login_url_with_intent(auth_mode, Some(callback_scheme))?;
+
+        // Normal sign-in belongs in the user's preferred browser. It already
+        // has their password manager, passkeys and Google/GitHub sessions, and
+        // it is also where a prior screenpipe.com acquisition cookie is most
+        // likely to live. The website returns the token through the versioned,
+        // build-specific scheme handled by the existing cold/warm deep-link
+        // paths.
+        //
+        // "Use different account" deliberately stays in an ephemeral Apple
+        // auth session so it cannot silently reuse the browser's current user.
+        if !fresh_session {
+            match app_handle
+                .opener()
+                .open_url(login_url.as_str(), None::<&str>)
+            {
+                Ok(()) => {
+                    info!("opened system browser for login");
+                    return Ok(String::new());
+                }
+                Err(e) => {
+                    // Keep the previous, reliable native auth path when macOS
+                    // cannot launch a default browser.
+                    warn!("could not open system browser, falling back to auth session: {e}");
+                }
+            }
+        }
+
+        // ASWebAuthenticationSession intercepts the redirect itself (no OS
+        // scheme routing). It remains the isolated-account path and the
+        // launch-failure fallback.
         let callback_url = match crate::auth_session::start_session(
-            login_url_with_intent(auth_mode, Some(callback_scheme))?,
+            login_url,
             callback_scheme.to_string(),
             fresh_session,
         )


### PR DESCRIPTION
## Summary

- open normal macOS sign-in and sign-up in the preferred system browser
- preserve the versioned build-specific deep-link callback into the initiating app
- keep Use different account in an ephemeral ASWebAuthenticationSession
- fall back to ASWebAuthenticationSession if macOS cannot launch the default browser

## Flow

```text
download in browser
        |
screenpipe.com attribution cookie
        |
normal app login -> preferred browser -> existing SSO / passkeys
        |                                  |
        +------ versioned screenpipe callback
                                           |
                                      desktop app
```

## Historical intent

PR #4004 replaced the isolated WKWebView on macOS with ASWebAuthenticationSession to share Safari sessions and make callback interception and window lifecycle reliable. This change preserves that native auth session as the isolated-account path and launch-failure fallback.

The normal-login portion is intentionally superseded: the existing versioned OS callback contract from PR #6439 now provides the reliable cold/warm return path while allowing login to happen in the preferred browser, where existing SSO and the original screenpipe.com attribution cookie are more likely to exist.

## Validation

- `cargo fmt --all --check`
- `bun run typecheck`
- `cargo test -p screenpipe-app login_url_intent_tests` (2 passed)
- `cargo test -p screenpipe-app deep_link::tests` (5 passed)
- `bun run bindings:generate`
- `bun run bindings:check`
- `sem diff upstream/main..HEAD --format plain --no-cosmetics`
- `git diff --check upstream/main..HEAD`

## Manual verification required

Please test on macOS with Chrome or Arc set as the default browser:

1. Begin onboarding and choose normal login.
2. Confirm the preferred browser opens and reuses an existing Google or GitHub session.
3. Confirm the versioned callback returns to the same app build and onboarding advances.
4. Choose Use different account and confirm the ephemeral Apple auth session still opens.
5. With website PR #886 deployed, confirm a pre-download first-touch attribution cookie is linked to the signed-in user.

No app or browser UI was driven while preparing this PR.