### PR TITLE
fix(enterprise): gate restricted members during onboarding

### DIFF
--- a/apps/screenpipe-app-tauri/components/app-entitlement-gate.test.tsx
+++ b/apps/screenpipe-app-tauri/components/app-entitlement-gate.test.tsx
@@ -193,6 +193,104 @@ describe("AppEntitlementGate", () => {
     expect(screen.queryByText(/enterprise access/i)).not.toBeInTheDocument();
   });
 
+  it("keeps an ordinary signed-in consumer in onboarding", () => {
+    window.history.replaceState({}, "", "/onboarding");
+    mocks.state.user = baseUser();
+
+    render(
+      <AppEntitlementGate authenticationStatus="logged_out">
+        {protectedApp}
+      </AppEntitlementGate>,
+    );
+
+    expect(screen.getByTestId("protected-app")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/enterprise app required/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("gates a restricted enterprise member as soon as onboarding sign-in resolves", () => {
+    window.history.replaceState({}, "", "/onboarding");
+    mocks.windowLabel = "onboarding";
+
+    const { rerender } = render(
+      <AppEntitlementGate authenticationStatus="logged_out">
+        {protectedApp}
+      </AppEntitlementGate>,
+    );
+
+    expect(screen.getByTestId("protected-app")).toBeInTheDocument();
+
+    mocks.state.user = baseUser({
+      app_entitled: true,
+      cloud_subscribed: true,
+      subscription_plan: "pro",
+      enterprise_account: {
+        org_name: "Bungalow",
+        role: "member",
+        requires_enterprise_app: true,
+        restrict_consumer_build_access: true,
+      },
+      entitlement: {
+        active: true,
+        plan: "pro",
+        source: "subscription",
+        checked_at: minsAgo(1),
+        features: { app: true, cloud: true },
+      },
+    });
+    rerender(
+      <AppEntitlementGate authenticationStatus="logged_out">
+        {protectedApp}
+      </AppEntitlementGate>,
+    );
+
+    expect(screen.getByText(/enterprise app required/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("protected-app")).not.toBeInTheDocument();
+  });
+
+  it("does not misclassify a cached restricted user before build detection resolves", () => {
+    window.history.replaceState({}, "", "/onboarding");
+    mocks.state.user = baseUser({
+      enterprise_account: {
+        org_name: "Bungalow",
+        role: "member",
+        requires_enterprise_app: true,
+        restrict_consumer_build_access: true,
+      },
+    });
+    mocks.enterprise.isManagedDeploymentResolved = false;
+
+    const { rerender } = render(
+      <AppEntitlementGate authenticationStatus="logged_out">
+        {protectedApp}
+      </AppEntitlementGate>,
+    );
+
+    expect(screen.getByTestId("protected-app")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/enterprise app required/i),
+    ).not.toBeInTheDocument();
+
+    mocks.enterprise = {
+      isManagedDeployment: true,
+      isManagedDeploymentResolved: true,
+      authenticationState: "choice",
+      authenticationError: null,
+      isManagedAuthenticated: false,
+    };
+    rerender(
+      <AppEntitlementGate authenticationStatus="logged_out">
+        {protectedApp}
+      </AppEntitlementGate>,
+    );
+
+    expect(screen.getByTestId("protected-app")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/enterprise app required/i),
+    ).not.toBeInTheDocument();
+  });
+
   it("waits for build detection before stopping a gated session", async () => {
     mocks.enterprise.isManagedDeploymentResolved = false;
 

--- a/apps/screenpipe-app-tauri/components/app-entitlement-gate.tsx
+++ b/apps/screenpipe-app-tauri/components/app-entitlement-gate.tsx
@@ -266,10 +266,13 @@ export function AppEntitlementGate({
     (!hasConsumerSubscription ||
       enterpriseAccount.restrict_consumer_build_access === true);
   const shouldGateForEntitlement = shouldGateForUnknownConsumerPolicy;
+  // Onboarding owns ordinary consumer sign-in and Enterprise-build auth.
+  // Once build detection confirms this is the consumer app, however, a
+  // restricted enterprise member must not advance into consumer setup.
   const shouldGate = authenticationStatus === "not_required"
     ? false
     : isOnboardingRoute
-    ? false
+    ? isManagedDeploymentResolved && shouldGateForEnterpriseApp
     : !isManagedDeploymentResolved
       ? true
       : isManagedDeployment


### PR DESCRIPTION
## What changed

- applies the existing enterprise-app requirement during consumer onboarding as soon as sign-in resolves
- waits for authoritative build detection before showing the wall, avoiding a false consumer classification in the Enterprise build
- preserves ordinary consumer onboarding and Enterprise-build account/key onboarding

## Why

The restriction already worked on Home for completed installs, but `/onboarding` bypassed the entire entitlement gate. Fresh installs could therefore continue into permissions and setup after signing into an enterprise-restricted account.

## Before / after

```text
before
consumer onboarding -> sign in -> restricted enterprise response -> permissions/setup -> Home -> enterprise app required

after
consumer onboarding -> sign in -> restricted enterprise response -> enterprise app required
                                          |
                                          +-> ordinary consumer: onboarding continues
                                          +-> Enterprise build: account/key onboarding continues
```

## Historical intent

- PR #5253 / `db7cf020614` moved Enterprise-build account/key authentication into onboarding and introduced the broad route exemption.
- PR #6806 / `4d2f504c8a8` added the explicit consumer-build restriction after sign-in, but its regression test covered only the normal app route.
- This keeps PR #5253's Enterprise-build onboarding invariant and supersedes the exemption only after build detection confirms a consumer build whose loaded account matches the existing enterprise-app predicate.

## Verification

- `cd apps/screenpipe-app-tauri && bun x vitest run --config vitest.config.ts components/app-entitlement-gate.test.tsx` — 46 passed
- `cd apps/screenpipe-app-tauri && bun run typecheck` — passed
- `git diff --check upstream/main...HEAD` — passed
- `cd apps/screenpipe-app-tauri && bun run coverage:all:check` — blocked by the stale `docs/coverage/CORE.md` already present on current `main`; the same `Coverage dashboards current` failure is visible in [main run 33528013153](https://github.com/screenpipe/screenpipe/actions/runs/33528013153)

No native build was run: this changes the shared React gate only, and the focused test covers the exact logged-out-to-restricted-account rerender plus the build-resolution race.
