### PR TITLE
chore: instrument meeting capture transitions

### DIFF
--- a/crates/screenpipe-audio/src/audio_manager/meeting_piggyback.rs
+++ b/crates/screenpipe-audio/src/audio_manager/meeting_piggyback.rs
@@ -912,6 +912,38 @@ pub(crate) fn captured_no_audio(t: &MeetingTelemetry) -> bool {
     t.meeting_seen && t.tap_streaming_ticks == 0 && !t.mic_session_started
 }
 
+pub(crate) fn piggyback_stop_reason(
+    flag_on: bool,
+    meeting_seen: bool,
+    meeting_pid_count: usize,
+    tap_available: bool,
+) -> &'static str {
+    if !flag_on {
+        "flag_disabled"
+    } else if !meeting_seen {
+        "meeting_unpublished"
+    } else if meeting_pid_count == 0 {
+        "meeting_pid_missing"
+    } else if !tap_available {
+        "tap_unavailable"
+    } else {
+        "unknown"
+    }
+}
+
+#[derive(Debug, serde::Serialize)]
+struct PiggybackCaptureTransition {
+    transition: &'static str,
+    reason: &'static str,
+    meeting_seen: bool,
+    pid_known: bool,
+    tap_available: bool,
+    tap_was_streaming: bool,
+    tap_started_count: u32,
+    tap_strikes: u32,
+    platform: &'static str,
+}
+
 pub(crate) fn classify_outcome(t: &MeetingTelemetry) -> &'static str {
     if t.unavailable {
         return "unavailable";
@@ -1479,6 +1511,32 @@ pub(crate) async fn run_meeting_piggyback_sweep(
     //    so the next meeting starts fresh. `warned_unavailable` is per-boot and
     //    deliberately NOT reset here.
     if state.was_piggybacking && !piggybacking_now {
+        let reason = piggyback_stop_reason(engaged, meeting_seen, meeting_pids.len(), tap_avail);
+        info!(
+            "[MEETING_PIGGYBACK] capture disengaged (reason={}, meeting_seen={}, pid_count={}, \
+             tap_available={}, tap_was_streaming={}, tap_started_count={}, tap_strikes={})",
+            reason,
+            meeting_seen,
+            meeting_pids.len(),
+            tap_avail,
+            tap_streaming,
+            state.telemetry.tap_started_count,
+            state.tap_strikes,
+        );
+        let _ = screenpipe_events::send_event(
+            "piggyback_capture_transition",
+            PiggybackCaptureTransition {
+                transition: "engaged_to_disengaged",
+                reason,
+                meeting_seen,
+                pid_known: !meeting_pids.is_empty(),
+                tap_available: tap_avail,
+                tap_was_streaming: tap_streaming,
+                tap_started_count: state.telemetry.tap_started_count,
+                tap_strikes: state.tap_strikes,
+                platform: std::env::consts::OS,
+            },
+        );
         // Fold the volatile counters into the telemetry accumulator BEFORE the
         // resets below zero them — this edge can fire mid-meeting on a pid
         // flap, well before the meeting actually ends (see module docs on
@@ -2439,6 +2497,23 @@ mod tests {
         t.unavailable = true;
         t.tap_streaming_ticks = 900;
         assert_eq!(classify_outcome(&t), "unavailable");
+    }
+
+    #[test]
+    fn piggyback_stop_reason_identifies_the_disengagement_gate() {
+        assert_eq!(
+            piggyback_stop_reason(true, true, 0, true),
+            "meeting_pid_missing"
+        );
+        assert_eq!(
+            piggyback_stop_reason(true, false, 0, true),
+            "meeting_unpublished"
+        );
+        assert_eq!(piggyback_stop_reason(false, true, 1, true), "flag_disabled");
+        assert_eq!(
+            piggyback_stop_reason(true, true, 1, false),
+            "tap_unavailable"
+        );
     }
 
     #[test]

--- a/crates/screenpipe-engine/src/meeting_watcher/audio_process/mod.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/audio_process/mod.rs
@@ -14,7 +14,8 @@ use crate::meeting_watcher::shared::ignore::{
 };
 use crate::meeting_watcher::shared::profiles::{load_detection_profiles, MeetingDetectionProfile};
 use crate::meeting_watcher::shared::telemetry::{
-    capture_detection_decision, capture_detection_outcome,
+    capture_detection_decision, capture_detection_outcome, capture_detection_transition,
+    MeetingDetectionTransitionTelemetry,
 };
 use crate::routes::meetings::{emit_meeting_status_changed, resolve_meeting_status_from};
 use chrono::Utc;
@@ -279,6 +280,28 @@ pub async fn run_audio_process_meeting_detection_loop(
         if is_active_ending_flap(was_active, was_ending, &new_state) {
             flap_count = flap_count.saturating_add(1);
         }
+        let transition = active_ending_transition(was_active, was_ending, &new_state).map(|edge| {
+            let published_meeting_before = detector.as_ref().and_then(|d| d.active_meeting());
+            let published_pid_before = published_meeting_before
+                .as_ref()
+                .and_then(|meeting| meeting.pid);
+            let live_pid =
+                resolved_platform_identity(&live_candidates, &edge.platform).map(|(pid, _)| pid);
+            let published_pid_in_input_snapshot = published_pid_before
+                .is_some_and(|pid| processes.iter().any(|process| process.pid == Some(pid)));
+            let live_pid_in_input_snapshot = live_pid
+                .is_some_and(|pid| processes.iter().any(|process| process.pid == Some(pid)));
+            (
+                edge,
+                published_meeting_before.is_some(),
+                published_pid_before,
+                live_pid,
+                published_pid_in_input_snapshot,
+                live_pid_in_input_snapshot,
+                !candidates.is_empty(),
+                !live_candidates.is_empty(),
+            )
+        });
         state = new_state;
 
         // A browser holding the mic that we can't attribute to a platform is
@@ -371,6 +394,59 @@ pub async fn run_audio_process_meeting_detection_loop(
             &in_meeting_flag,
             &detector,
         );
+        if let Some((
+            edge,
+            published_meeting_before,
+            published_pid_before,
+            live_pid,
+            published_pid_in_input_snapshot,
+            live_pid_in_input_snapshot,
+            has_candidates,
+            has_live_candidates,
+        )) = transition
+        {
+            let published_meeting_after = detector.as_ref().and_then(|d| d.active_meeting());
+            let published_pid_after = published_meeting_after
+                .as_ref()
+                .and_then(|meeting| meeting.pid);
+            info!(
+                "audio-process meeting detector: transition {} (meeting_id={}, app={}, \
+                 published_meeting_before={}, published_meeting_after={}, \
+                 published_pid_before={:?}, published_pid_after={:?}, live_pid={:?}, \
+                 published_pid_in_input_snapshot={}, live_pid_in_input_snapshot={}, \
+                 candidates={}, live_candidates={}, flap_count={})",
+                edge.transition,
+                edge.meeting_id,
+                edge.platform,
+                published_meeting_before,
+                published_meeting_after.is_some(),
+                published_pid_before,
+                published_pid_after,
+                live_pid,
+                published_pid_in_input_snapshot,
+                live_pid_in_input_snapshot,
+                candidates.len(),
+                live_candidates.len(),
+                flap_count,
+            );
+            capture_detection_transition(
+                &edge.platform,
+                MeetingDetectionTransitionTelemetry {
+                    meeting_id: edge.meeting_id,
+                    transition: edge.transition,
+                    flap_count,
+                    published_meeting_before,
+                    published_meeting_after: published_meeting_after.is_some(),
+                    published_pid_before: published_pid_before.is_some(),
+                    published_pid_after: published_pid_after.is_some(),
+                    live_pid: live_pid.is_some(),
+                    published_pid_in_input_snapshot,
+                    live_pid_in_input_snapshot,
+                    has_candidates,
+                    has_live_candidates,
+                },
+            );
+        }
         interval = if processes.is_empty() {
             IDLE_POLL_INTERVAL
         } else {

--- a/crates/screenpipe-engine/src/meeting_watcher/audio_process/state.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/audio_process/state.rs
@@ -59,6 +59,45 @@ pub(crate) enum AudioProcessStateAction {
     },
 }
 
+/// A low-volume diagnostic emitted only when an active meeting crosses the
+/// ending grace boundary in either direction. Keeping this classification in
+/// the pure state-machine module makes the instrumentation testable without
+/// running the detector loop.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AudioProcessTransitionDiagnostic {
+    pub transition: &'static str,
+    pub meeting_id: i64,
+    pub platform: String,
+}
+
+pub(crate) fn active_ending_transition(
+    was_active: bool,
+    was_ending: bool,
+    next: &AudioProcessMeetingState,
+) -> Option<AudioProcessTransitionDiagnostic> {
+    match next {
+        AudioProcessMeetingState::Ending {
+            meeting_id,
+            platform,
+            ..
+        } if was_active => Some(AudioProcessTransitionDiagnostic {
+            transition: "active_to_ending",
+            meeting_id: *meeting_id,
+            platform: platform.clone(),
+        }),
+        AudioProcessMeetingState::Active {
+            meeting_id,
+            platform,
+            ..
+        } if was_ending => Some(AudioProcessTransitionDiagnostic {
+            transition: "ending_to_active",
+            meeting_id: *meeting_id,
+            platform: platform.clone(),
+        }),
+        _ => None,
+    }
+}
+
 pub(crate) fn advance_audio_process_state(
     state: AudioProcessMeetingState,
     live_candidates: &[ResolvedMeetingCandidate],
@@ -556,5 +595,51 @@ mod tests {
             }
             other => panic!("expected StartMeeting, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn classifies_only_active_ending_edges() {
+        let now = Instant::now();
+        let key = ProcessKey::from_process(&zoom_process()).unwrap();
+        let ending = AudioProcessMeetingState::Ending {
+            meeting_id: 7,
+            platform: "zoom".into(),
+            session_key: key.clone(),
+            meeting_url: None,
+            first_seen_at: now,
+            since: now,
+            is_browser: false,
+        };
+        assert_eq!(
+            active_ending_transition(true, false, &ending),
+            Some(AudioProcessTransitionDiagnostic {
+                transition: "active_to_ending",
+                meeting_id: 7,
+                platform: "zoom".into(),
+            })
+        );
+
+        let active = AudioProcessMeetingState::Active {
+            meeting_id: 7,
+            platform: "zoom".into(),
+            session_key: key,
+            meeting_url: None,
+            first_seen_at: now,
+            last_seen_at: now,
+            is_browser: false,
+        };
+        assert_eq!(
+            active_ending_transition(false, true, &active),
+            Some(AudioProcessTransitionDiagnostic {
+                transition: "ending_to_active",
+                meeting_id: 7,
+                platform: "zoom".into(),
+            })
+        );
+        assert_eq!(active_ending_transition(true, false, &active), None);
+        assert_eq!(
+            active_ending_transition(false, false, &AudioProcessMeetingState::Idle),
+            None
+        );
     }
 }

--- a/crates/screenpipe-engine/src/meeting_watcher/shared/telemetry.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/shared/telemetry.rs
@@ -110,6 +110,56 @@ pub(crate) fn capture_detection_outcome(
     );
 }
 
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct MeetingDetectionTransitionTelemetry {
+    pub meeting_id: i64,
+    pub transition: &'static str,
+    pub flap_count: u32,
+    pub published_meeting_before: bool,
+    pub published_meeting_after: bool,
+    pub published_pid_before: bool,
+    pub published_pid_after: bool,
+    pub live_pid: bool,
+    pub published_pid_in_input_snapshot: bool,
+    pub live_pid_in_input_snapshot: bool,
+    pub has_candidates: bool,
+    pub has_live_candidates: bool,
+}
+
+fn detection_transition_props(
+    platform: &str,
+    transition: MeetingDetectionTransitionTelemetry,
+) -> serde_json::Value {
+    json!({
+        "meeting_event_key": meeting_event_key(transition.meeting_id),
+        "transition": transition.transition,
+        "app_bucket": app_bucket(platform),
+        "flap_bucket": flap_bucket(transition.flap_count),
+        "published_meeting_before": transition.published_meeting_before,
+        "published_meeting_after": transition.published_meeting_after,
+        "published_pid_before": transition.published_pid_before,
+        "published_pid_after": transition.published_pid_after,
+        "live_pid": transition.live_pid,
+        "published_pid_in_input_snapshot": transition.published_pid_in_input_snapshot,
+        "live_pid_in_input_snapshot": transition.live_pid_in_input_snapshot,
+        "has_candidates": transition.has_candidates,
+        "has_live_candidates": transition.has_live_candidates,
+    })
+}
+
+/// Emitted only on `Active -> Ending` and `Ending -> Active`. Properties use
+/// booleans and stable buckets so process IDs and raw application names never
+/// leave the device.
+pub(crate) fn capture_detection_transition(
+    platform: &str,
+    transition: MeetingDetectionTransitionTelemetry,
+) {
+    analytics::capture_event_nonblocking(
+        "meeting_detection_transition",
+        detection_transition_props(platform, transition),
+    );
+}
+
 /// Bucket the Active<->Ending oscillation count so we never emit a raw,
 /// fingerprintable number.
 fn flap_bucket(flaps: u32) -> &'static str {
@@ -331,6 +381,36 @@ mod tests {
         assert!(props.contains("\"flap_bucket\":\"high\""));
         assert!(props.contains("\"end_reason\":\"auto_timeout\""));
         assert!(props.contains("\"app_bucket\":\"zoom\""));
+    }
+
+    #[test]
+    fn transition_props_bucket_identity_without_raw_values() {
+        let props = detection_transition_props(
+            "Unexpected Private App Name",
+            MeetingDetectionTransitionTelemetry {
+                meeting_id: 99,
+                transition: "ending_to_active",
+                flap_count: 4,
+                published_meeting_before: false,
+                published_meeting_after: false,
+                published_pid_before: false,
+                published_pid_after: false,
+                live_pid: true,
+                published_pid_in_input_snapshot: false,
+                live_pid_in_input_snapshot: true,
+                has_candidates: true,
+                has_live_candidates: true,
+            },
+        )
+        .to_string();
+
+        assert!(!props.contains("Unexpected Private App Name"));
+        assert!(!props.contains("\"meeting_id\""));
+        assert!(props.contains("\"app_bucket\":\"other_meeting_app\""));
+        assert!(props.contains("\"flap_bucket\":\"elevated\""));
+        assert!(props.contains("\"published_meeting_after\":false"));
+        assert!(props.contains("\"published_pid_after\":false"));
+        assert!(props.contains("\"live_pid\":true"));
     }
 
     #[test]

--- a/crates/screenpipe-engine/src/piggyback_telemetry.rs
+++ b/crates/screenpipe-engine/src/piggyback_telemetry.rs
@@ -19,6 +19,7 @@ use crate::analytics;
 fn posthog_event_name(bus_name: &str) -> Option<&'static str> {
     match bus_name {
         "piggyback_meeting_summary" => Some("piggyback_meeting_summary"),
+        "piggyback_capture_transition" => Some("piggyback_capture_transition"),
         "audio_capture_health_mic_capture_failed" => {
             Some("audio_capture_health_mic_capture_failed")
         }
@@ -45,10 +46,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn allowlist_maps_exactly_the_two_names() {
+    fn allowlist_maps_exactly_the_piggyback_telemetry_names() {
         assert_eq!(
             posthog_event_name("piggyback_meeting_summary"),
             Some("piggyback_meeting_summary")
+        );
+        assert_eq!(
+            posthog_event_name("piggyback_capture_transition"),
+            Some("piggyback_capture_transition")
         );
         assert_eq!(
             posthog_event_name("audio_capture_health_mic_capture_failed"),


### PR DESCRIPTION
## Summary

- log audio-process Active/Ending transition identity and candidate evidence
- emit privacy-safe meeting detection transition telemetry
- report explicit smart-recording piggyback disengagement reasons

This is instrumentation-only; meeting detection and capture behavior are unchanged.

## Tests

- `cargo test -p screenpipe-audio audio_manager::meeting_piggyback::tests --lib` — 50 passed
- `cargo test -p screenpipe-engine meeting_watcher::audio_process --lib` — 84 passed
- `cargo test -p screenpipe-engine meeting_watcher::shared::telemetry::tests --lib` — 7 passed
- `cargo test -p screenpipe-engine piggyback_telemetry::tests --lib` — 1 passed
- `git diff --check`