### PR TITLE
fix(app): recover onboarding from predecessor server

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -133,6 +133,7 @@ mod tray;
 mod staged_update;
 mod stale_tier;
 mod startup_auth;
+mod startup_server_owner;
 mod updates;
 mod voice_training;
 mod window;
@@ -147,6 +148,32 @@ mod windows_webview_env;
 mod linux_webkit_env;
 
 pub use server::*;
+
+async fn probe_startup_server_health(port: u16, api_key: Option<&str>) -> bool {
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        let client = reqwest::Client::new();
+        let mut request = client
+            .get(format!("http://localhost:{port}/health"))
+            .timeout(std::time::Duration::from_secs(1));
+        if let Some(key) = api_key {
+            request = request.header("Authorization", format!("Bearer {key}"));
+        }
+        let response = match request.send().await {
+            Ok(response) => response,
+            Err(_) => return false,
+        };
+        let status = response.status().as_u16();
+        response
+            .json::<serde_json::Value>()
+            .await
+            .map(|payload| {
+                screenpipe_engine::health_identity::is_screenpipe_health_response(status, &payload)
+            })
+            .unwrap_or(false)
+    })
+    .await
+    .unwrap_or(false)
+}
 
 pub use recording::*;
 
@@ -1991,36 +2018,69 @@ async fn main() {
                             }
                             let config = store_clone.to_recording_config(data_dir_clone.clone());
 
-                            // Check if server already running
-                            let server_running = tokio::time::timeout(
-                                std::time::Duration::from_secs(2),
-                                async {
-                                    let client = reqwest::Client::new();
-                                    let mut request = client
-                                        .get(format!("http://localhost:{}/health", config.port))
-                                        .timeout(std::time::Duration::from_secs(1));
-                                    if let Some(ref key) = config.api_auth_key {
-                                        request = request.header(
-                                            "Authorization",
-                                            format!("Bearer {}", key),
-                                        );
-                                    }
-                                    let response = match request.send().await {
-                                        Ok(response) => response,
-                                        Err(_) => return false,
-                                    };
-                                    let status = response.status().as_u16();
-                                    match response.json::<serde_json::Value>().await {
-                                        Ok(payload) => screenpipe_engine::health_identity::is_screenpipe_health_response(status, &payload),
-                                        Err(_) => false,
-                                    }
-                                }
-                            ).await.unwrap_or(false);
+                            let mut server_running = probe_startup_server_health(
+                                config.port,
+                                config.api_auth_key.as_deref(),
+                            )
+                            .await;
 
                             if server_running {
-                                info!("Healthy screenpipe server already running, skipping startup");
-                                is_starting_clone.store(false, std::sync::atomic::Ordering::SeqCst);
-                                return;
+                                // A health response is not an ownership handle. During a
+                                // permission relaunch the predecessor can answer briefly
+                                // after this process creates a fresh RecordingState. The
+                                // old early return left `server=None`, so onboarding could
+                                // never create a managed capture session.
+                                const PREDECESSOR_RELEASE_GRACE: std::time::Duration =
+                                    std::time::Duration::from_secs(5);
+                                let release_started = std::time::Instant::now();
+                                loop {
+                                    let action =
+                                        startup_server_owner::startup_server_owner_action(
+                                            server_running,
+                                            release_started.elapsed()
+                                                >= PREDECESSOR_RELEASE_GRACE,
+                                        );
+                                    match action {
+                                        startup_server_owner::StartupServerOwnerAction::StartOwned => {
+                                            info!(
+                                                "Previous healthy server released port {}; starting an owned server",
+                                                config.port
+                                            );
+                                            break;
+                                        }
+                                        startup_server_owner::StartupServerOwnerAction::WaitForRelease => {
+                                            tokio::time::sleep(std::time::Duration::from_millis(
+                                                250,
+                                            ))
+                                            .await;
+                                            server_running = probe_startup_server_health(
+                                                config.port,
+                                                config.api_auth_key.as_deref(),
+                                            )
+                                            .await;
+                                        }
+                                        startup_server_owner::StartupServerOwnerAction::PreserveExternal => {
+                                            let message = format!(
+                                                "another healthy screenpipe is already using local port {}",
+                                                config.port
+                                            );
+                                            warn!("{message}; preserving its capture session");
+                                            crate::health::set_boot_error(&message);
+                                            crate::health::set_recording_status(
+                                                crate::health::RecordingStatus::Error,
+                                            );
+                                            crate::port_conflict::show_healthy_screenpipe(
+                                                &app_for_owned,
+                                                config.port,
+                                            );
+                                            is_starting_clone.store(
+                                                false,
+                                                std::sync::atomic::Ordering::SeqCst,
+                                            );
+                                            return;
+                                        }
+                                    }
+                                }
                             }
 
                             // Permissions check

--- a/apps/screenpipe-app-tauri/src-tauri/src/startup_server_owner.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/startup_server_owner.rs
@@ -1,0 +1,51 @@
+// screenpipe — AI that knows everything you've seen, said, or heard
+// https://screenpipe.com
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum StartupServerOwnerAction {
+    StartOwned,
+    WaitForRelease,
+    PreserveExternal,
+}
+
+pub(crate) fn startup_server_owner_action(
+    healthy_endpoint: bool,
+    release_grace_expired: bool,
+) -> StartupServerOwnerAction {
+    if !healthy_endpoint {
+        StartupServerOwnerAction::StartOwned
+    } else if release_grace_expired {
+        StartupServerOwnerAction::PreserveExternal
+    } else {
+        StartupServerOwnerAction::WaitForRelease
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{startup_server_owner_action, StartupServerOwnerAction};
+
+    #[test]
+    fn transient_healthy_predecessor_waits_for_release() {
+        assert_eq!(
+            startup_server_owner_action(true, false),
+            StartupServerOwnerAction::WaitForRelease
+        );
+    }
+
+    #[test]
+    fn persistent_healthy_external_owner_is_preserved() {
+        assert_eq!(
+            startup_server_owner_action(true, true),
+            StartupServerOwnerAction::PreserveExternal
+        );
+    }
+
+    #[test]
+    fn startup_proceeds_when_no_healthy_endpoint_exists() {
+        assert_eq!(
+            startup_server_owner_action(false, false),
+            StartupServerOwnerAction::StartOwned
+        );
+    }
+}


### PR DESCRIPTION
## Source feedback

Addresses an automated Screenpipe app feedback report from macOS 27.0.0 on app 2.7.12: onboarding remained stuck after startup/relaunch. No private reporter identifier is included.

## Root cause

Startup treated a healthy response from the local Screenpipe endpoint as proof that the new app process owned a `ServerCore`. During relaunch, that response could come from the predecessor process, leaving `RecordingState.server` empty. Onboarding's later `start_capture` request could then only request another restart, creating a loop.

## Fix and surface coverage

- Hold the existing lifecycle slot while waiting a bounded grace period for a transient predecessor to release the endpoint.
- If it releases, start and retain an owned `ServerCore` in `RecordingState`.
- If a healthy external Screenpipe remains, preserve it and surface the existing native conflict dialog and terminal startup error instead of reclaiming its port.
- Keep the existing account and permission gates in place before capture startup.

The decision logic is platform-neutral Rust. The reported failure was on macOS; the persistent-external-owner behavior remains safe across supported desktop platforms.

## Visual evidence

```text
Before
relaunch -> predecessor answers health check -> assumed ownership
         -> RecordingState.server = None -> start_capture -> restart loop

After
relaunch -> predecessor answers health check -> bounded wait
         +-> endpoint releases -> start and retain owned ServerCore
         `-> remains healthy  -> preserve owner + conflict dialog/error
```

## Verification

- RED: standalone Rust regression test failed on the old ownership decision as expected (`2 passed, 1 failed`: `PreserveExternal` instead of expected `WaitForRelease`).
- GREEN: standalone Rust tests passed `3/3` twice during implementation and `3/3` again in independent review.
- `bun run typecheck` — passed.
- `rustfmt --check apps/screenpipe-app-tauri/src-tauri/src/startup_server_owner.rs` — passed in independent review.
- `git diff --check` — passed.
- Independent review covered lifecycle locking, account/permission gates, port-owner safety, error state, platform scope, and the complete two-file diff.

## Bounded host limitation

`bun run test:tauri startup_server_owner --no-fail-fast` was attempted, but this Linux host could not complete native Tauri compilation because `libpipewire-0.3` pkg-config metadata is unavailable. No packages were installed, and this limitation is not counted as affirmative test evidence.
