### PR TITLE
fix(app): recover recording after trial expiry

### DIFF
--- a/apps/screenpipe-app-tauri/lib/app-entitlement.test.ts
+++ b/apps/screenpipe-app-tauri/lib/app-entitlement.test.ts
@@ -800,6 +800,61 @@ describe("isAuthenticatedFreeUser", () => {
     expect(isAuthenticatedFreeUser(normalized)).toBe(true);
     expect(hasVerifiedPaidPlan(normalized)).toBe(false);
   });
+
+  it.each(["manual", "subscription"])(
+    "falls back to recording-capable free policy when an expired %s entitlement refresh omits app_entitled",
+    (source) => {
+      const normalized = normalizeAppUser(
+        {
+          id: "user_expired_consumer",
+          subscription_plan: "standard",
+          cloud_subscribed: false,
+          entitlement: {
+            active: false,
+            plan: "standard",
+            source,
+            status: "expired",
+            expires_at: "2026-06-04T12:00:00.000Z",
+            grace_until: null,
+            features: { app: false, cloud: false },
+          },
+        },
+        "token",
+      );
+
+      expect(getLocalPlanPolicy(normalized)).toBe("verified-free");
+      expect(normalized.subscription_plan).toBe("none");
+      expect(normalized.entitlement).toMatchObject({
+        active: false,
+        plan: "none",
+        source: "none",
+        features: { app: false, cloud: false },
+      });
+    },
+  );
+
+  it.each(["enterprise", "lifetime", "dev"])(
+    "keeps an inactive %s entitlement fail-closed when app_entitled is omitted",
+    (source) => {
+      const normalized = normalizeAppUser(
+        {
+          id: "user_restricted",
+          subscription_plan: "standard",
+          cloud_subscribed: false,
+          entitlement: {
+            active: false,
+            plan: "standard",
+            source,
+            grace_until: null,
+            features: { app: false, cloud: false },
+          },
+        },
+        "token",
+      );
+
+      expect(getLocalPlanPolicy(normalized)).toBe("unknown");
+    },
+  );
 });
 
 describe("isSignedInCloudSubscriber", () => {

--- a/apps/screenpipe-app-tauri/lib/app-entitlement.ts
+++ b/apps/screenpipe-app-tauri/lib/app-entitlement.ts
@@ -625,10 +625,20 @@ export function normalizeAppUser(rawUser: any, token: string): AppUser {
     rawUser?.app_entitled === undefined &&
     rawUser?.subscription_plan === undefined &&
     rawUser?.entitlement === undefined;
+  const entitlementSource = rawEntitlement?.source?.trim().toLowerCase();
+  const expiredConsumerDenial =
+    rawUser?.cloud_subscribed === false &&
+    rawUser?.app_entitled === undefined &&
+    rawEntitlement?.active === false &&
+    rawEntitlement.features?.app === false &&
+    rawEntitlement.features?.cloud === false &&
+    !hasFutureGrace(rawEntitlement) &&
+    (entitlementSource === "manual" || entitlementSource === "subscription");
   // Explicit server denial is stronger than a stale users.plan label left by a
   // canceled or refunded account.
   const explicitlyFree =
     legacyVerifiedFree ||
+    expiredConsumerDenial ||
     (rawUser?.app_entitled === false && !cloudSubscribed);
   // The server computes `subscription_plan` per request and can omit it while
   // still returning a full entitlement. The cloud_subscribed/app_entitled


### PR DESCRIPTION
## Source feedback

- Discord feedback message `1544701827323273277` in channel `1339037549926289500`
- Internal source task: `t_2cdb5642`
- Reported on Windows 10 with app 2.7.12: after the 7-day trial ended, recording stopped at startup and the app showed no capture devices.

## Root cause

A definitive expired consumer entitlement response can omit top-level `app_entitled` while still returning all of the evidence that the consumer subscription is inactive: `active=false`, `cloud_subscribed=false`, app and cloud feature denials, no future grace period, and source `manual` or `subscription`.

Normalization previously kept the stale paid plan and classified this response as `unknown`. The existing fail-closed entitlement gate then stopped capture, which surfaced as an empty capture-device UI.

## Fix

Normalize only that complete, explicit inactive-consumer response to `verified-free`. This restores local recording after trial expiry without granting paid or cloud capabilities.

The fix covers the normalization boundary shared by the entitlement gate rather than special-casing the device UI. Enterprise, lifetime, and dev sources remain fail-closed, as do incomplete or conflicting responses. The independent security review also confirmed that the enterprise restriction gate remains enforced.

## Evidence

### RED

With the regression tests present and the production fix removed:

- `bun x vitest run --config vitest.config.ts lib/app-entitlement.test.ts`
- Result: 2 expected failures for manual/subscription responses (`unknown` received, `verified-free` expected); 55 tests passed.

### GREEN and broad verification

- Focused entitlement + gate Vitest: 103/103 passed
- Full `bun run test`: Vitest 4,975/4,975 and Bun 242/242 passed
- `bun run typecheck`: passed
- Focused ESLint for both changed files: passed
- `git diff --check`: passed
- Independent review: unconditionally approved exact commit `61768b28d4020198e17b03a4369f9a7711fc34e5`

## Platform scope

The report is from Windows. The change is platform-independent TypeScript entitlement normalization and uses the existing recorder-gate lifecycle. Verification was deterministic policy/gate coverage on Linux; a packaged Windows UI run was not performed.

## Visual evidence

This is a non-visual policy transition; the user-visible capture-device symptom is downstream of the existing gate. The before/after flow is:

```text
BEFORE
expired consumer response
  -> entitlement = unknown
  -> fail-closed gate stops capture
  -> no capture devices shown

AFTER
complete explicit inactive consumer response
  -> entitlement = verified-free
  -> local-only capture may start
  -> capture devices remain available

UNCHANGED SAFETY BOUNDARIES
enterprise/lifetime/dev or incomplete/conflicting evidence
  -> entitlement = unknown
  -> fail-closed gate remains active
```

## Files changed

- `apps/screenpipe-app-tauri/lib/app-entitlement.ts`
- `apps/screenpipe-app-tauri/lib/app-entitlement.test.ts`
