### PR TITLE
fix(ai-gateway): grant enterprise top gateway allowance

### DIFF
--- a/packages/ai-gateway/src/services/cloudflare-ai-gateway.ts
+++ b/packages/ai-gateway/src/services/cloudflare-ai-gateway.ts
@@ -81,6 +81,7 @@ export function isHostedChatGatewayEnabled(env: Pick<Env, 'HOSTED_CHAT_GATEWAY_M
 
 function collapsePlan(auth: AuthResult): HostedChatPlan {
 	if (auth.service === true) return 'internal';
+	if (auth.accountPlan === 'enterprise') return 'business_ultra';
 	if (auth.accountPlan === 'business_max' || auth.accountPlan === 'business_ultra') {
 		return auth.accountPlan;
 	}

--- a/packages/ai-gateway/src/test/cloudflare-ai-gateway.unit.test.ts
+++ b/packages/ai-gateway/src/test/cloudflare-ai-gateway.unit.test.ts
@@ -50,7 +50,7 @@ describe('Cloudflare hosted-chat metadata', () => {
 	});
 
 	it('preserves Max and Ultra allowance tiers while collapsing catalog-equivalent plans', async () => {
-		for (const accountPlan of ['business', 'team', 'enterprise'] as const) {
+		for (const accountPlan of ['business', 'team'] as const) {
 			const context = await buildHostedChatGatewayContext(auth({ accountPlan }), 'gpt-5.6-sol', 'background');
 			expect(context).toMatchObject({ plan: 'business', lane: 'frontier', workload: 'background' });
 		}
@@ -58,6 +58,8 @@ describe('Cloudflare hosted-chat metadata', () => {
 			const context = await buildHostedChatGatewayContext(auth({ accountPlan }), 'auto', 'background');
 			expect(context).toMatchObject({ plan: accountPlan, lane: 'auto', workload: 'background' });
 		}
+		const enterprise = await buildHostedChatGatewayContext(auth({ accountPlan: 'enterprise' }), 'auto', 'background');
+		expect(enterprise).toMatchObject({ plan: 'business_ultra', lane: 'auto', workload: 'background' });
 		const trial = await buildHostedChatGatewayContext(auth({ accountPlan: 'basic', hostedAiTrial: true }), 'auto', 'interactive');
 		expect(trial).toMatchObject({ plan: 'basic', trial: true });
 		const internal = await buildHostedChatGatewayContext(auth({ service: true, userId: undefined }), 'auto', 'background');

--- a/packages/ai-gateway/src/utils/auth.test.ts
+++ b/packages/ai-gateway/src/utils/auth.test.ts
@@ -495,6 +495,32 @@ describe('validateAuth — verified identities only', () => {
 		});
 	});
 
+	it('uses the server-verified enterprise identity instead of the consumer billing tier', async () => {
+		verifyTokenMock.mockImplementation(async () => ({ sub: 'user_enterprise' }) as any);
+		globalThis.fetch = mock(async () => new Response(JSON.stringify({
+			success: true,
+			user: {
+				clerk_id: 'user_enterprise',
+				cloud_subscribed: true,
+				app_entitled: true,
+				subscription_plan: 'pro',
+				billing_plan: 'pro',
+				is_enterprise_user: true,
+				entitlement: { active: true, plan: 'pro', features: { app: true } },
+			},
+		}), { status: 200 })) as typeof fetch;
+
+		expect(await validateAuth(requestFor('eyJ.enterprise.clerk'), env)).toEqual({
+			isValid: true,
+			tier: 'subscribed',
+			accountPlan: 'enterprise',
+			deviceId: 'user_enterprise',
+			userId: 'user_enterprise',
+			clerkUserId: 'user_enterprise',
+			clerkUserIdVerified: true,
+		});
+	});
+
   it('uses canonical Max and Ultra billing plans with desktop-compatible access labels', async () => {
     for (const [plan, accountPlan, usageTier] of [
       ['pro_max', 'business_max', 'business_max'],

--- a/packages/ai-gateway/src/utils/auth.ts
+++ b/packages/ai-gateway/src/utils/auth.ts
@@ -181,6 +181,7 @@ interface ScreenpipeUserData {
   app_entitled?: boolean;
   subscription_plan?: string | null;
   billing_plan?: string | null;
+  is_enterprise_user?: boolean;
   hosted_ai_trial?: boolean;
   entitlement?: {
     active?: boolean;
@@ -324,11 +325,15 @@ function resolveAccountPlan(user: ScreenpipeUserData): AccountPlan {
     accountPlan = billingPlan;
   }
 
-  return user.app_entitled === true &&
-    user.entitlement?.active === true &&
-    user.entitlement?.features?.app === true
-    ? accountPlan
-    : 'unknown';
+  if (
+    user.app_entitled !== true ||
+    user.entitlement?.active !== true ||
+    user.entitlement?.features?.app !== true
+  ) {
+    return 'unknown';
+  }
+
+  return user.is_enterprise_user === true ? 'enterprise' : accountPlan;
 }
 
 async function validateScreenpipeToken(token: string): Promise<ScreenpipeTokenResult> {


### PR DESCRIPTION
## Summary

- recognize the website API server-verified enterprise membership signal during AI-proxy authentication
- keep enterprise as a managed internal plan while emitting business_ultra, the highest existing allowance label, to Cloudflare AI Gateway
- preserve Louis super_admin override and all existing entitlement validation and fail-closed behavior

## Verification

- bun test src/utils/auth.test.ts src/test/cloudflare-ai-gateway.unit.test.ts --timeout=10000 — 47 passed, 0 failed
- bun test --timeout=10000 — 1,011 passed, 0 failed
- git diff --check — passed
- standalone TypeScript check is blocked by the pre-existing super_admin/AccountPlan mismatch on main at packages/ai-gateway/src/handlers/chat.ts:800; this patch does not alter that path

## Historical intent

Inspected PR #5806 / commit 77334e8e341b, PR #5833 / commit ac80d137f5ed, and PR #6805 / commit e30d1d196f. The Gateway metadata contract intentionally collapses catalog plans while preserving distinct Max/Ultra allowance labels, and the later super-admin change overrides only the emitted pseudonymous Cloudflare plan. This change preserves both boundaries: enterprise status must come from the authenticated website API and pass the existing entitlement tuple checks, then only the Cloudflare metadata label is promoted to the already-established highest tier. No customer identifiers, allowance values, or prompt data are added.