### PR TITLE
fix(auth): wire startup authentication into server access

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -1880,7 +1880,7 @@ async fn main() {
                 }
                 let store_clone = store.clone();
                 let data_dir_clone = data_dir.clone();
-                if !crate::recording::server_access_allowed(&store_clone) {
+                if !crate::recording::server_access_allowed(&app_handle, &store_clone) {
                     info!("Skipping server auto-start: screenpipe account access required");
                     crate::health::set_recording_status(crate::health::RecordingStatus::Paused);
                     let _ = app_handle.emit("app-entitlement-required", ());

--- a/apps/screenpipe-app-tauri/src-tauri/src/recording.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/recording.rs
@@ -170,7 +170,22 @@ fn server_access_policy(
     has_verified_local_plan
 }
 
-pub(crate) fn server_access_allowed(store: &SettingsStore) -> bool {
+pub(crate) fn server_access_allowed(app: &tauri::AppHandle, store: &SettingsStore) -> bool {
+    let startup_authentication = app
+        .try_state::<crate::startup_auth::AuthenticationStatus>()
+        .map(|status| *status)
+        .unwrap_or(crate::startup_auth::AuthenticationStatus::LoggedOut);
+    let authenticated_after_startup = if cfg!(feature = "enterprise-build") {
+        crate::enterprise_policy::recording_authorized()
+    } else {
+        store.has_cloud_authentication()
+    };
+    if startup_authentication == crate::startup_auth::AuthenticationStatus::LoggedOut
+        && !authenticated_after_startup
+    {
+        return false;
+    }
+
     server_access_policy(
         cfg!(feature = "enterprise-build"),
         cfg!(debug_assertions),
@@ -230,8 +245,8 @@ fn require_recording_access(app: &tauri::AppHandle, store: &SettingsStore) -> Re
     Err("account_required: sign in to start screenpipe recording".to_string())
 }
 
-fn require_server_access(store: &SettingsStore) -> Result<(), String> {
-    if server_access_allowed(store) {
+fn require_server_access(app: &tauri::AppHandle, store: &SettingsStore) -> Result<(), String> {
+    if server_access_allowed(app, store) {
         return Ok(());
     }
 
@@ -938,7 +953,7 @@ pub async fn spawn_screenpipe(
     // A summary-paywall install still needs the long-lived local read server
     // for Timeline, but it must not publish capture intent or restart capture.
     let store = SettingsStore::get(&app).ok().flatten().unwrap_or_default();
-    require_server_access(&store)?;
+    require_server_access(&app, &store)?;
     let capture_allowed = recording_access_allowed(&app, &store);
 
     // Normal starts publish capture intent before touching lifecycle state.
@@ -1023,7 +1038,7 @@ async fn spawn_screenpipe_inner(
     }
 
     let store = SettingsStore::get(&app).ok().flatten().unwrap_or_default();
-    if let Err(err) = require_server_access(&store) {
+    if let Err(err) = require_server_access(&app, &store) {
         state.is_starting.store(false, Ordering::SeqCst);
         state.is_starting_capture.store(false, Ordering::SeqCst);
         return Err(err);


### PR DESCRIPTION
## Summary

- pass the app handle into the existing server-access gate so it can read the authentication result persisted by startup
- fail closed when startup resolved `LoggedOut`, while retaining the existing post-start sign-in path
- leave plan verification, summary-trial behavior, Enterprise authorization, capture intent, and engine-start decisions unchanged

## Before / after

```text
Before: server access evaluated plan and deployment policy without the persisted startup auth result
After:  persisted startup auth can deny server access; every existing downstream policy still decides as before
```

## Historical intent

Inspected PRs #5191, #6809, and #6810. This preserves the fail-closed unknown-plan behavior from #5191, the summary-trial server/capture split from #6809, and the startup authentication authority introduced by #6810. The patch only supplies that authentication result to the existing server gate.

## Validation

- `git diff --check` — passed
