### PR TITLE
fix(enterprise): preserve recording during account handoff

### DIFF
--- a/apps/screenpipe-app-tauri/lib/hooks/__tests__/use-enterprise-policy.test.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/__tests__/use-enterprise-policy.test.tsx
@@ -815,6 +815,59 @@ describe("enterprise policy runtime manual activation", () => {
     );
   });
 
+  it("preserves recording while handing an account-required key off to a saved account", async () => {
+    mocks.commands.getEnterpriseLicenseKey.mockResolvedValue(KEY);
+    Object.assign(mocks.settings, { user: { token: "account-token" } });
+
+    let releaseAccountPolicy!: () => void;
+    const accountPolicyPending = new Promise<void>((resolve) => {
+      releaseAccountPolicy = resolve;
+    });
+    mocks.tauriFetch.mockImplementation(async (
+      url: string,
+      init?: { headers?: Record<string, string> },
+    ) => {
+      if (url.includes("/api/enterprise/policy")) {
+        if (init?.headers?.Authorization === "Bearer account-token") {
+          await accountPolicyPending;
+        }
+        return policyResponse({ requireAccountLogin: true });
+      }
+      if (url.includes("/api/enterprise/heartbeat")) return heartbeatResponse();
+      throw new Error(`unexpected fetch ${url}`);
+    });
+
+    const { result } = await renderEnterprisePolicy();
+
+    await waitFor(() =>
+      expect(mocks.tauriFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/api/enterprise/policy"),
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: "Bearer account-token" }),
+        }),
+      ),
+    );
+    expect(result.current.authenticationState).toBe("checking");
+    expect(mocks.commands.setEnterpriseRecordingAuthorized).not.toHaveBeenCalledWith(
+      false,
+      null,
+      null,
+    );
+
+    releaseAccountPolicy();
+    await waitFor(() => expect(result.current.isEnterpriseAuthenticated).toBe(true));
+    expect(mocks.commands.setEnterpriseRecordingAuthorized).toHaveBeenCalledWith(
+      true,
+      "account",
+      "account-token",
+    );
+    expect(mocks.commands.setEnterpriseRecordingAuthorized).not.toHaveBeenCalledWith(
+      false,
+      null,
+      null,
+    );
+  });
+
   it("recovers a rotated saved key through the signed-in account", async () => {
     mocks.commands.getEnterpriseLicenseKey.mockResolvedValue(KEY);
     Object.assign(mocks.settings, { user: { token: "account-token" } });

--- a/apps/screenpipe-app-tauri/lib/hooks/use-enterprise-policy.ts
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-enterprise-policy.ts
@@ -1161,8 +1161,19 @@ export function useEnterprisePolicyRuntime() {
       // employee to sign in with their screenpipe account. Device policy was
       // already applied by fetchPolicy; only authentication is refused.
       if (credential.type === "license_key" && result.policy.requireAccountLogin) {
-        await setNativeRecordingAuthorized(false);
         setPolicy(result.policy);
+        // A saved account is the next credential in this same startup check.
+        // Keep the existing process-local grant while that viable credential is
+        // still being verified; revoking here stops capture between two successful
+        // checks and races the account grant against the in-flight teardown. The
+        // account attempt below still revokes on an explicit denial, and a key-only
+        // device still fails closed immediately.
+        if (accountTokenRef.current) {
+          setAuthenticationState("checking");
+          setAuthenticationError(null);
+          return { authenticated: false, retryable: false };
+        }
+        await setNativeRecordingAuthorized(false);
         setAuthenticationState("account");
         setAuthenticationError(ACCOUNT_LOGIN_REQUIRED_ERROR);
         return { authenticated: false, retryable: false };


### PR DESCRIPTION
## description

When an enterprise license-key policy requires account login and a saved account token is already available, keep the current native recording grant while the account credential is checked. A key-only device still revokes immediately, and explicit account denial still fails closed.

This removes the stop/restart race without changing credential priority, denial behavior, or the native recording lifecycle.

related issue: n/a

### historical intent

Reviewed the relevant history before changing behavior:

- #6404 introduced the native grant and intentionally preserves verified in-process authorization across transient failures while revoking explicit denials.
- #6311 made recording lifecycle acquisition nonblocking to avoid a long startup wait.
- #6838, already on latest main, reuses startup authentication for recording access.

This change complements #6838 at the later frontend credential-handoff boundary and does not modify its Rust startup-auth path.

## AI assistance and human ownership

- AI tool(s) used: Codex
- autonomy level: agent
- what I personally verified: pending human owner review; Codex ran the automated checks listed below and the ownership checkboxes are intentionally left unchecked.

- [ ] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [ ] The problem statement, rationale, and replies to maintainers are my own.

## evidence type

- [x] UI or behavior change — deterministic hook-level before/after regression below; no packaged-app recording was performed
- [ ] Backend change — regression tests and relevant logs/results
- [ ] Performance change — reproducible before/after benchmarks
- [ ] Docs, CI, or pure refactor — relevant checks and an explanation; no video required

## before

    verified key -> account required -> revoke native grant -> capture stops
                                                |
                                   account check succeeds
                                                |
                                   restart races teardown

The added regression fails before the implementation change with authentication state `account` instead of `checking`, and observes the native revoke.

## after

    verified key -> account required + saved token -> keep grant/checking
                                                        |
                                           account check succeeds
                                                        |
                                           grant updates; no stop

The test holds the account request pending to prove that recording authorization is not revoked in the handoff window.

No Windows VM or packaged-app recording was performed; this PR is intentionally scoped to the deterministic credential state machine requested for this incident.

## how to test

1. From `apps/screenpipe-app-tauri/`:

   ```sh
   auth_test_storage=$(mktemp)
   NODE_OPTIONS="--localstorage-file=$auth_test_storage" bun run test:vitest -- lib/hooks/__tests__/use-enterprise-policy.test.tsx
   ```

   Result: 44 passed.

2. `bun run typecheck` — passed.
3. `git diff --check upstream/main...HEAD` — passed.
4. Red/green verification: with the implementation branch removed, the new regression failed with `expected checking, received account`; after restoring it, the focused suite passed.

## desktop app checklist (if applicable)

No Tauri command handlers or exported Rust types changed.

- [ ] `bun run bindings:generate` (if bindings changed)
- [ ] `bun run bindings:check`
- [x] `bun run typecheck`
