### PR TITLE
fix(meetings): keep completed summary visible

### DIFF
--- a/apps/screenpipe-app-tauri/components/meeting-notes/meeting-workspace.test.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/meeting-workspace.test.tsx
@@ -7,6 +7,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import {
   extractMeetingSummary,
+  meetingSummarySaveIsVisible,
   MEETING_QUIET_CONTROL_CLASS,
   MEETING_READING_COLUMN_CLASS,
   MEETING_SHELL_CLASS,
@@ -208,6 +209,33 @@ describe("meeting workspace tabs", () => {
 });
 
 describe("meeting summary surface", () => {
+  it("waits for the completed run's summary to be visible in the saved note", () => {
+    expect(meetingSummarySaveIsVisible("notes only", "notes only", true)).toBe(
+      false,
+    );
+    expect(
+      meetingSummarySaveIsVisible(
+        "## Summary\nEarlier summary.",
+        "## Summary\nEarlier summary.",
+        true,
+      ),
+    ).toBe(false);
+    expect(
+      meetingSummarySaveIsVisible(
+        "## Summary\nEarlier summary.",
+        "## Summary\nUpdated summary.",
+        true,
+      ),
+    ).toBe(true);
+    expect(
+      meetingSummarySaveIsVisible(
+        "## Summary\nAlready saved.",
+        "## Summary\nAlready saved.",
+        false,
+      ),
+    ).toBe(true);
+  });
+
   it("uses the latest appended summary without including the user's notes", () => {
     const onGenerate = vi.fn();
     const note = [
@@ -359,7 +387,7 @@ describe("meeting summary surface", () => {
   });
 
   it("replaces the placeholder with the real summary as it streams", () => {
-    render(
+    const { rerender } = render(
       <MeetingSummarySurface
         note={"## Summary\nEarlier summary."}
         state="working"
@@ -380,6 +408,30 @@ describe("meeting summary surface", () => {
     expect(screen.queryByText("Earlier summary.")).not.toBeInTheDocument();
     expect(screen.getByRole("status")).toHaveTextContent("writing summary");
     expect(screen.getByTestId("meeting-summary-stream-cursor")).toBeVisible();
+
+    rerender(
+      <MeetingSummarySurface
+        note={"## Summary\nEarlier summary."}
+        state="ready"
+        detail="saved to this meeting note"
+        streamedSummary="The team **approved** the launch."
+        onGenerate={vi.fn()}
+        canGenerate
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        (_, element) =>
+          element?.textContent === "The team approved the launch.",
+        { selector: "p" },
+      ),
+    ).toBeVisible();
+    expect(screen.queryByText("Earlier summary.")).not.toBeInTheDocument();
+    expect(screen.queryByText("no summary yet")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("meeting-summary-stream-cursor"),
+    ).not.toBeInTheDocument();
   });
 
   it("turns a terminal usage limit into explicit upgrade and model recovery", async () => {

--- a/apps/screenpipe-app-tauri/components/meeting-notes/meeting-workspace.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/meeting-workspace.tsx
@@ -204,6 +204,15 @@ export interface MeetingSummaryRecovery {
   };
 }
 
+export function meetingSummarySaveIsVisible(
+  currentNote: string,
+  refreshedNote: string,
+  awaitedNewSummary: boolean,
+): boolean {
+  if (!extractMeetingSummary(refreshedNote)) return false;
+  return !awaitedNewSummary || refreshedNote !== currentNote;
+}
+
 export function MeetingSummarySurface({
   note,
   state,
@@ -228,8 +237,15 @@ export function MeetingSummarySurface({
   activity?: React.ReactNode;
 }) {
   const savedSummary = extractMeetingSummary(note);
-  const isStreaming = state === "working" && Boolean(streamedSummary?.trim());
-  const summary = isStreaming ? streamedSummary! : savedSummary;
+  const liveSummary = streamedSummary?.trim() || null;
+  // A Pipe run completes immediately after its final message, while the
+  // meeting-note PUT from that message can still be reaching the API. Keep
+  // the draft that was already on screen through that handoff instead of
+  // briefly replacing it with an older summary (or "no summary yet").
+  const showingLiveSummary =
+    Boolean(liveSummary) && (state === "working" || state === "ready");
+  const isStreaming = state === "working" && showingLiveSummary;
+  const summary = showingLiveSummary ? liveSummary : savedSummary;
   const attention = state === "attention" ? recovery : undefined;
 
   return (

--- a/apps/screenpipe-app-tauri/components/meeting-notes/note-view.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/note-view.tsx
@@ -174,6 +174,7 @@ import {
 } from "./meeting-summary-stream";
 import {
   extractMeetingSummary,
+  meetingSummarySaveIsVisible,
   MEETING_QUIET_CONTROL_CLASS,
   MEETING_READING_COLUMN_CLASS,
   MEETING_RULE_ACTION_CLASS,
@@ -571,7 +572,8 @@ export function NoteView({
       visibleSummaryLifecycle.kind === "running");
   const summaryExecutionId =
     visibleSummaryLifecycle.kind === "queued" ||
-    visibleSummaryLifecycle.kind === "running"
+    visibleSummaryLifecycle.kind === "running" ||
+    visibleSummaryLifecycle.kind === "completed"
       ? visibleSummaryLifecycle.execution.id
       : null;
   const summaryExecutionIdRef = useRef<number | null>(summaryExecutionId);
@@ -717,35 +719,45 @@ export function NoteView({
             });
           }
         }
-        setSummaryLifecycle(next);
-
+        let summarySavePending = false;
         if (
           next.kind === "completed" &&
           refreshedSummaryExecutionRef.current !== next.execution.id
         ) {
-          refreshedSummaryExecutionRef.current = next.execution.id;
           const meetingResponse = await localFetch(`/meetings/${meeting.id}`);
           if (meetingResponse.ok && !cancelled) {
             const updatedMeeting =
               (await meetingResponse.json()) as MeetingRecord;
-            if (
-              summaryRevealPendingRef.current &&
-              updatedMeeting.note !== meeting.note
-            ) {
+            const saveIsVisible = meetingSummarySaveIsVisible(
+              meeting.note ?? "",
+              updatedMeeting.note ?? "",
+              summaryRevealPendingRef.current,
+            );
+            if (saveIsVisible) {
+              refreshedSummaryExecutionRef.current = next.execution.id;
               summaryRevealPendingRef.current = false;
-              setSummaryRevealKey((key) => key + 1);
+              if (updatedMeeting.note !== meeting.note) {
+                setSummaryRevealKey((key) => key + 1);
+              }
+              onSavedRef.current(updatedMeeting);
             } else {
-              summaryRevealPendingRef.current = false;
+              // Execution completion and the meeting-note write are separate
+              // observable operations. Retry the authoritative meeting read
+              // until the summary is actually there; marking this execution
+              // refreshed on the first stale read made the empty state stick.
+              summarySavePending = true;
             }
-            onSavedRef.current(updatedMeeting);
+          } else {
+            summarySavePending = true;
           }
         }
+        setSummaryLifecycle(next);
 
         // Never stop: settling to idle used to end the poll, which is how a
         // deleted Pipe or a late run stayed invisible until the note remounted.
         pollHandle = setTimeout(
           () => void poll(),
-          summaryLifecycleIsWorking(next)
+          summarySavePending || summaryLifecycleIsWorking(next)
             ? SUMMARY_ACTIVE_POLL_MS
             : SUMMARY_IDLE_POLL_MS,
         );


### PR DESCRIPTION
## Summary

- keep the streamed meeting summary visible when its execution reaches `completed`
- retry the meeting record read until the appended summary is actually observable instead of permanently deduplicating the first stale response
- keep completed polling at the active cadence while the note write is still catching up

## Why

The Pipe's final streamed message and its meeting-note `PUT` are separate observable operations. The UI dropped the stream as soon as execution status became `completed`, then marked that execution refreshed before verifying that `GET /meetings/:id` contained the appended summary. If that read won the race, the screen changed from a valid summary to the contradictory state “summary ready / saved to this meeting note” plus “no summary yet.”

## Before / after

```text
before: streamed summary -> execution completed -> stale meeting read -> no summary yet
 after: streamed summary -> execution completed -> retain summary -> retry read -> saved summary
```

## Test plan

- `bun x vitest run --config vitest.config.ts components/meeting-notes` (31 files, 328 tests passed)
- `bun run typecheck`
- `bun x eslint components/meeting-notes/meeting-workspace.tsx components/meeting-notes/meeting-workspace.test.tsx components/meeting-notes/note-view.tsx` (0 errors; 3 pre-existing hook warnings)
- `git diff --check upstream/main...HEAD`

The regression test transitions a visible streamed summary to `ready` while the saved note is still stale and verifies that the new summary remains visible with no “no summary yet” fallback.

## Historical intent

- Inspected `cfe97ffa240` / #5695, which introduced completed-run polling so an open meeting note refreshes from the authoritative saved meeting record.
- Inspected `bfaeef6183c` / #5836, which added the stop-to-summary reveal while preserving local note edits.
- Inspected `92648ba1ff` / #6398, which refined the progress surfaces and explicitly kept the real draft visible while a replacement summary is written.

This restores those invariants at the completion boundary: the visible draft must not regress while persistence catches up, and the saved meeting record remains authoritative once the new summary is observable. No test expectation or publication behavior is superseded.
