### PR TITLE
fix(e2e): seed auth for onboarding setup

### DIFF
--- a/apps/screenpipe-app-tauri/package.json
+++ b/apps/screenpipe-app-tauri/package.json
@@ -48,7 +48,7 @@
     "test:e2e:first-run-learning-window": "SCREENPIPE_E2E_SEED=onboarding,no-recording SCREENPIPE_PORT=3048 bun run wdio run e2e/wdio.conf.ts --spec e2e/specs/first-run-learning-window.spec.ts",
     "test:e2e:onboarding-first-run": "SCREENPIPE_E2E_SEED=no-recording SCREENPIPE_PORT=3047 bun run wdio run e2e/wdio.conf.ts --spec e2e/specs/onboarding-first-run.spec.ts",
     "test:e2e:onboarding-h1-follow-up": "SCREENPIPE_E2E_SEED=onboarding,no-recording SCREENPIPE_PORT=3046 bun run wdio run e2e/wdio.conf.ts --spec e2e/specs/onboarding-h1-follow-up.spec.ts",
-    "test:e2e:onboarding-background-ai-tools": "SCREENPIPE_E2E_SEED=no-recording,background-ai-tools SCREENPIPE_PORT=3045 bun run wdio run e2e/wdio.conf.ts --spec e2e/specs/onboarding-background-ai-tools.spec.ts",
+    "test:e2e:onboarding-background-ai-tools": "SCREENPIPE_E2E_SEED=no-recording,background-ai-tools,cloud-authenticated SCREENPIPE_PORT=3045 bun run wdio run e2e/wdio.conf.ts --spec e2e/specs/onboarding-background-ai-tools.spec.ts",
     "test:e2e:screen-recording-restart:macos": "SCREENPIPE_E2E_SEED=onboarding,no-recording bun run wdio run e2e/wdio.conf.ts --spec e2e/specs/screen-recording-restart.spec.ts",
     "test:e2e:hd:macos": "SCREENPIPE_E2E_SEED=onboarding bun run wdio run e2e/wdio.conf.ts --spec e2e/specs/hd-recording-pipeline.spec.ts",
     "test:e2e:hd-duration-recovery:macos": "SCREENPIPE_E2E_SEED=onboarding,no-audio,hd-writer-stall-once bun run wdio run e2e/wdio.conf.ts --spec e2e/specs/hd-recording-pipeline.spec.ts",

--- a/apps/screenpipe-app-tauri/src-tauri/src/e2e/seeds.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/e2e/seeds.rs
@@ -59,6 +59,12 @@ pub(crate) fn apply_settings(app: &AppHandle, store: &mut SettingsStore) {
     // "no-audio" keeps vision enabled while disabling only audio, which
     // lets Windows hosted runners exercise OCR without booting Whisper.
     let e2e_flags = flags();
+    if e2e_flags.iter().any(|f| f == "cloud-authenticated") {
+        let token = "e2e-fake-token-onboarding-background-ai-tools".to_string();
+        store.user.token = Some(token.clone());
+        crate::auth_token::seed_cloud_token(Some(token));
+        info!("E2E seed: synthetic cloud authentication enabled");
+    }
     if e2e_flags.iter().any(|f| f == "no-recording") {
         store.recording.disable_audio = true;
         store.recording.disable_vision = true;


### PR DESCRIPTION
## Summary

- seed a synthetic cloud credential only when the feature-gated E2E app requests `cloud-authenticated`
- enable that seed for the onboarding background AI-tool lane
- keep onboarding incomplete so the spec still exercises the real first-run engine transition
- leave production authentication and the ordinary logged-out onboarding tests unchanged

## Root cause

PR #6810 correctly made engine startup require resolved authentication. This E2E lane intentionally starts with onboarding incomplete but had no cloud session, so startup resolved `logged_out` and the engine returned `account_required: sign in to start screenpipe`. Both downstream test assertions then timed out.

Failing run: https://github.com/screenpipe/screenpipe/actions/runs/33670032267/job/100381148730

## Before / after

```text
before: incomplete onboarding + no auth -> LoggedOut -> account_required -> setup stuck
 after: incomplete onboarding + E2E auth -> Authenticated -> engine ready -> setup completes
```

## Verification

- `bun run build:tauri:e2e` — passed
- `bun run test:e2e:onboarding-background-ai-tools` — passed, 2/2 tests
- observed startup log: `startup authentication resolved status=Authenticated`
- observed engine log: `boot phase → ready`
- `rustfmt --edition 2021 --check src-tauri/src/e2e/seeds.rs` — passed
- `bun x prettier --check package.json` — passed
- `git diff --check` — passed
