### PR TITLE
fix(pipes): remove WSL dependency and require verified completion

### DIFF
--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -3567,7 +3567,41 @@ pub fn kill_process_group(pid: u32) -> Result<()> {
 /// (where bash is always available). Checks:
 /// 1. Our bundled PortableGit in %LOCALAPPDATA%\screenpipe\git-portable\
 /// 2. Standard Git for Windows install
-/// 3. bash.exe on PATH (Git Bash, MSYS2, WSL, etc.)
+/// 3. A native Windows bash.exe on PATH (Git Bash, MSYS2, etc.)
+///
+/// Windows' `System32\\bash.exe` and the WindowsApps alias are WSL launchers,
+/// not standalone shells. Treating either as usable makes Pi depend on an
+/// installed WSL distribution and prevents the PortableGit fallback.
+#[cfg(any(windows, test))]
+fn is_windows_bash_launcher(path: &str) -> bool {
+    let normalized = path
+        .trim()
+        .trim_matches('"')
+        .replace('/', "\\")
+        .to_ascii_lowercase();
+
+    normalized.ends_with("\\windows\\system32\\bash.exe")
+        || normalized.ends_with("\\windows\\sysnative\\bash.exe")
+        || normalized.ends_with("\\windows\\syswow64\\bash.exe")
+        || normalized.contains("\\microsoft\\windowsapps\\bash.exe")
+}
+
+#[cfg(any(windows, test))]
+fn first_usable_windows_bash_candidate<F>(stdout: &str, mut exists: F) -> Option<String>
+where
+    F: FnMut(&Path) -> bool,
+{
+    stdout.lines().find_map(|line| {
+        let candidate = line.trim().trim_matches('"');
+        if candidate.is_empty() || is_windows_bash_launcher(candidate) {
+            return None;
+        }
+
+        let path = Path::new(candidate);
+        exists(path).then(|| candidate.to_string())
+    })
+}
+
 #[cfg(windows)]
 pub fn find_bash_executable() -> Option<String> {
     // 1. Bundled PortableGit in screenpipe's data directory
@@ -3606,12 +3640,14 @@ pub fn find_bash_executable() -> Option<String> {
         {
             if output.status.success() {
                 let stdout = String::from_utf8_lossy(&output.stdout);
-                if let Some(line) = stdout.lines().next() {
-                    let path = line.trim().to_string();
-                    if !path.is_empty() && Path::new(&path).exists() {
-                        info!("Found bash on PATH: {}", path);
-                        return Some(path);
-                    }
+                if let Some(path) =
+                    first_usable_windows_bash_candidate(&stdout, |path| path.exists())
+                {
+                    info!("Found native bash on PATH: {}", path);
+                    return Some(path);
+                }
+                if stdout.lines().any(is_windows_bash_launcher) {
+                    info!("Ignoring Windows WSL bash launcher; PortableGit is required instead");
                 }
             }
         }
@@ -4067,6 +4103,32 @@ pub fn ensure_bash_available() -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn windows_bash_launcher_detection_rejects_wsl_shims() {
+        assert!(is_windows_bash_launcher(r#"C:\Windows\System32\bash.exe"#));
+        assert!(is_windows_bash_launcher(r#"C:\Windows\Sysnative\bash.exe"#));
+        assert!(is_windows_bash_launcher(
+            r#"C:\Users\steve\AppData\Local\Microsoft\WindowsApps\bash.exe"#
+        ));
+        assert!(!is_windows_bash_launcher(
+            r#"C:\Program Files\Git\bin\bash.exe"#
+        ));
+    }
+
+    #[test]
+    fn windows_bash_candidate_skips_wsl_and_uses_native_shell() {
+        let candidates = [
+            r#"C:\Windows\System32\bash.exe"#,
+            r#"C:\Program Files\Git\bin\bash.exe"#,
+        ]
+        .join("\n");
+
+        assert_eq!(
+            first_usable_windows_bash_candidate(&candidates, |_| true).as_deref(),
+            Some(r#"C:\Program Files\Git\bin\bash.exe"#)
+        );
+    }
 
     #[test]
     fn managed_pi_install_disables_dependency_lifecycle_scripts() {

--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -3743,6 +3743,25 @@ fn download_portable_git() -> std::result::Result<String, String> {
 }
 
 #[cfg(windows)]
+fn rename_directory_with_retry(source: &Path, destination: &Path) -> std::io::Result<()> {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        match std::fs::rename(source, destination) {
+            Ok(()) => return Ok(()),
+            Err(error)
+                if error.kind() == std::io::ErrorKind::PermissionDenied
+                    && std::time::Instant::now() < deadline =>
+            {
+                // Git Bash under Windows-on-ARM emulation and endpoint security
+                // may briefly retain image handles after the startup probe exits.
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+#[cfg(windows)]
 fn download_portable_git_into(screenpipe_dir: &Path) -> std::result::Result<String, String> {
     let git_dir = screenpipe_dir.join("git-portable");
     let bash_path = git_dir.join("bin").join("bash.exe");
@@ -3907,7 +3926,7 @@ fn download_portable_git_into(screenpipe_dir: &Path) -> std::result::Result<Stri
 
     // Atomic rename: move extracted dir to final location
     let _ = std::fs::remove_dir_all(&git_dir);
-    std::fs::rename(&extract_temp, &git_dir).map_err(|e| {
+    rename_directory_with_retry(&extract_temp, &git_dir).map_err(|e| {
         let _ = std::fs::remove_dir_all(&extract_temp);
         format!(
             "Failed to move extracted PortableGit to final location: {}",

--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -3743,13 +3743,16 @@ fn download_portable_git() -> std::result::Result<String, String> {
 }
 
 #[cfg(windows)]
-fn rename_directory_with_retry(source: &Path, destination: &Path) -> std::io::Result<()> {
+fn retry_transient_windows_file_lock(
+    mut operation: impl FnMut() -> std::io::Result<()>,
+) -> std::io::Result<()> {
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
     loop {
-        match std::fs::rename(source, destination) {
+        match operation() {
             Ok(()) => return Ok(()),
             Err(error)
-                if error.kind() == std::io::ErrorKind::PermissionDenied
+                if (error.kind() == std::io::ErrorKind::PermissionDenied
+                    || matches!(error.raw_os_error(), Some(32 | 33)))
                     && std::time::Instant::now() < deadline =>
             {
                 // Git Bash under Windows-on-ARM emulation and endpoint security
@@ -3762,7 +3765,33 @@ fn rename_directory_with_retry(source: &Path, destination: &Path) -> std::io::Re
 }
 
 #[cfg(windows)]
+fn rename_directory_with_retry(source: &Path, destination: &Path) -> std::io::Result<()> {
+    retry_transient_windows_file_lock(|| std::fs::rename(source, destination))
+}
+
+#[cfg(windows)]
+fn remove_directory_with_retry(path: &Path) -> std::io::Result<()> {
+    retry_transient_windows_file_lock(|| match std::fs::remove_dir_all(path) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        result => result,
+    })
+}
+
+#[cfg(windows)]
+fn remove_file_with_retry(path: &Path) -> std::io::Result<()> {
+    retry_transient_windows_file_lock(|| match std::fs::remove_file(path) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        result => result,
+    })
+}
+
+#[cfg(windows)]
 fn download_portable_git_into(screenpipe_dir: &Path) -> std::result::Result<String, String> {
+    static INSTALL_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    let _install_guard = INSTALL_LOCK
+        .lock()
+        .map_err(|_| "PortableGit install lock was poisoned".to_string())?;
+
     let git_dir = screenpipe_dir.join("git-portable");
     let bash_path = git_dir.join("bin").join("bash.exe");
 
@@ -3771,12 +3800,12 @@ fn download_portable_git_into(screenpipe_dir: &Path) -> std::result::Result<Stri
         info!("PortableGit already present at {}", git_dir.display());
         return Ok(bash_path.to_string_lossy().to_string());
     }
-    if bash_path.exists() {
+    if git_dir.exists() {
         warn!(
-            "PortableGit at {} failed its startup probe; reinstalling it",
+            "PortableGit at {} is incomplete or failed its startup probe; reinstalling it",
             git_dir.display()
         );
-        std::fs::remove_dir_all(&git_dir)
+        remove_directory_with_retry(&git_dir)
             .map_err(|e| format!("Failed to remove broken PortableGit install: {}", e))?;
     }
 
@@ -3796,9 +3825,17 @@ fn download_portable_git_into(screenpipe_dir: &Path) -> std::result::Result<Stri
         .map_err(|e| format!("Failed to create screenpipe data dir: {}", e))?;
 
     // Download to temp file
+    let unique_suffix = format!(
+        "{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|e| format!("System clock is before Unix epoch: {}", e))?
+            .as_nanos()
+    );
     let temp_file = std::env::temp_dir().join(format!(
-        "PortableGit-{}-64-bit.7z.exe",
-        PORTABLE_GIT_VERSION
+        "PortableGit-{}-{}.7z.exe",
+        PORTABLE_GIT_VERSION, unique_suffix
     ));
 
     // Use bun or curl to download (bun is always available since we bundle it)
@@ -3834,7 +3871,7 @@ fn download_portable_git_into(screenpipe_dir: &Path) -> std::result::Result<Stri
         }
         Ok(output) => {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            let _ = std::fs::remove_file(&temp_file);
+            let _ = remove_file_with_retry(&temp_file);
             return Err(format!("PortableGit download failed: {}", stderr));
         }
         Err(e) => {
@@ -3851,8 +3888,7 @@ fn download_portable_git_into(screenpipe_dir: &Path) -> std::result::Result<Stri
     info!("Extracting PortableGit to {}...", git_dir.display());
 
     // Extract to a temp directory first (atomic: rename on success)
-    let extract_temp = screenpipe_dir.join("git-portable-extracting");
-    let _ = std::fs::remove_dir_all(&extract_temp);
+    let extract_temp = screenpipe_dir.join(format!("git-portable-extracting-{}", unique_suffix));
 
     {
         let mut cmd = std::process::Command::new(&temp_file);
@@ -3872,13 +3908,13 @@ fn download_portable_git_into(screenpipe_dir: &Path) -> std::result::Result<Stri
             }
             Ok(output) => {
                 let stderr = String::from_utf8_lossy(&output.stderr);
-                let _ = std::fs::remove_dir_all(&extract_temp);
-                let _ = std::fs::remove_file(&temp_file);
+                let _ = remove_directory_with_retry(&extract_temp);
+                let _ = remove_file_with_retry(&temp_file);
                 return Err(format!("PortableGit extraction failed: {}", stderr));
             }
             Err(e) => {
-                let _ = std::fs::remove_dir_all(&extract_temp);
-                let _ = std::fs::remove_file(&temp_file);
+                let _ = remove_directory_with_retry(&extract_temp);
+                let _ = remove_file_with_retry(&temp_file);
                 return Err(format!("Failed to run PortableGit extractor: {}", e));
             }
         }
@@ -3887,8 +3923,8 @@ fn download_portable_git_into(screenpipe_dir: &Path) -> std::result::Result<Stri
     // Verify extraction produced bash.exe
     let extracted_bash = extract_temp.join("bin").join("bash.exe");
     if !extracted_bash.exists() {
-        let _ = std::fs::remove_dir_all(&extract_temp);
-        let _ = std::fs::remove_file(&temp_file);
+        let _ = remove_directory_with_retry(&extract_temp);
+        let _ = remove_file_with_retry(&temp_file);
         return Err("Extraction completed but bash.exe not found in expected location".to_string());
     }
 
@@ -3919,15 +3955,20 @@ fn download_portable_git_into(screenpipe_dir: &Path) -> std::result::Result<Stri
     }
 
     if !bash_executable_is_usable(&extracted_bash) {
-        let _ = std::fs::remove_dir_all(&extract_temp);
-        let _ = std::fs::remove_file(&temp_file);
+        let _ = remove_directory_with_retry(&extract_temp);
+        let _ = remove_file_with_retry(&temp_file);
         return Err("Extracted PortableGit bash.exe failed its startup probe".to_string());
     }
 
     // Atomic rename: move extracted dir to final location
-    let _ = std::fs::remove_dir_all(&git_dir);
+    if git_dir.exists() {
+        remove_directory_with_retry(&git_dir).map_err(|e| {
+            let _ = remove_directory_with_retry(&extract_temp);
+            format!("Failed to clear PortableGit destination: {}", e)
+        })?;
+    }
     rename_directory_with_retry(&extract_temp, &git_dir).map_err(|e| {
-        let _ = std::fs::remove_dir_all(&extract_temp);
+        let _ = remove_directory_with_retry(&extract_temp);
         format!(
             "Failed to move extracted PortableGit to final location: {}",
             e
@@ -3935,7 +3976,7 @@ fn download_portable_git_into(screenpipe_dir: &Path) -> std::result::Result<Stri
     })?;
 
     // Clean up temp download
-    let _ = std::fs::remove_file(&temp_file);
+    let _ = remove_file_with_retry(&temp_file);
 
     let final_bash = git_dir.join("bin").join("bash.exe");
     info!(
@@ -4293,7 +4334,7 @@ mod tests {
             .expect("fresh PortableGit install should succeed");
         assert!(bash_executable_is_usable(Path::new(&first)));
 
-        std::fs::write(&first, b"broken portable git")
+        retry_transient_windows_file_lock(|| std::fs::write(&first, b"broken portable git"))
             .expect("test should corrupt the managed bash executable");
         assert!(!bash_executable_is_usable(Path::new(&first)));
 
@@ -4302,7 +4343,14 @@ mod tests {
         assert_eq!(repaired, first);
         assert!(bash_executable_is_usable(Path::new(&repaired)));
 
-        std::fs::remove_dir_all(&root).expect("test should clean up its PortableGit install");
+        remove_file_with_retry(Path::new(&repaired))
+            .expect("test should remove bash from the managed install");
+        let repaired_incomplete = download_portable_git_into(&screenpipe_dir)
+            .expect("incomplete managed PortableGit install should be replaced");
+        assert_eq!(repaired_incomplete, first);
+        assert!(bash_executable_is_usable(Path::new(&repaired_incomplete)));
+
+        remove_directory_with_retry(&root).expect("test should clean up its PortableGit install");
     }
 
     #[test]

--- a/crates/screenpipe-core/src/agents/pi.rs
+++ b/crates/screenpipe-core/src/agents/pi.rs
@@ -3426,7 +3426,7 @@ fn build_async_command(path: &str) -> tokio::process::Command {
                 let mut new_path = format!("{};{}", bun_dir.display(), current_path);
 
                 // On Windows, ensure bash is available for Pi's bash tool.
-                // ensure_bash_available: fast file-existence check first, then
+                // ensure_bash_available: bounded startup probe first, then
                 // OnceLock-guarded PortableGit download if needed (one-time ~50MB).
                 // Concurrent callers block on the single download, never duplicate.
                 if let Some(bash_dir) = ensure_bash_available() {
@@ -3587,7 +3587,7 @@ fn is_windows_bash_launcher(path: &str) -> bool {
 }
 
 #[cfg(any(windows, test))]
-fn first_usable_windows_bash_candidate<F>(stdout: &str, mut exists: F) -> Option<String>
+fn first_usable_windows_bash_candidate<F>(stdout: &str, mut is_usable: F) -> Option<String>
 where
     F: FnMut(&Path) -> bool,
 {
@@ -3598,8 +3598,82 @@ where
         }
 
         let path = Path::new(candidate);
-        exists(path).then(|| candidate.to_string())
+        is_usable(path).then(|| candidate.to_string())
     })
+}
+
+#[cfg(windows)]
+fn bash_executable_is_usable(path: &Path) -> bool {
+    use std::os::windows::process::CommandExt;
+
+    const CREATE_NO_WINDOW: u32 = 0x08000000;
+    const PROBE_OUTPUT: &[u8] = b"screenpipe-bash-ok";
+
+    let mut child = match std::process::Command::new(path)
+        .args(["--noprofile", "--norc", "-c", "printf screenpipe-bash-ok"])
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .creation_flags(CREATE_NO_WINDOW)
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(error) => {
+            warn!(
+                "bash candidate {} could not start: {}",
+                path.display(),
+                error
+            );
+            return false;
+        }
+    };
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let mut stdout = Vec::new();
+                let Some(mut pipe) = child.stdout.take() else {
+                    warn!("bash candidate {} had no stdout pipe", path.display());
+                    return false;
+                };
+                if let Err(error) = pipe.read_to_end(&mut stdout) {
+                    warn!(
+                        "bash candidate {} probe output failed: {}",
+                        path.display(),
+                        error
+                    );
+                    return false;
+                }
+                let usable = status.success() && stdout == PROBE_OUTPUT;
+                if !usable {
+                    warn!(
+                        "bash candidate {} failed its startup probe (status: {})",
+                        path.display(),
+                        status
+                    );
+                }
+                return usable;
+            }
+            Ok(None) if std::time::Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                warn!("bash candidate {} startup probe timed out", path.display());
+                return false;
+            }
+            Ok(None) => std::thread::sleep(std::time::Duration::from_millis(20)),
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                warn!(
+                    "bash candidate {} startup probe failed: {}",
+                    path.display(),
+                    error
+                );
+                return false;
+            }
+        }
+    }
 }
 
 #[cfg(windows)]
@@ -3611,7 +3685,7 @@ pub fn find_bash_executable() -> Option<String> {
             .join("git-portable")
             .join("bin")
             .join("bash.exe");
-        if bundled.exists() {
+        if bundled.exists() && bash_executable_is_usable(&bundled) {
             info!("Found bundled bash at: {}", bundled.display());
             return Some(bundled.to_string_lossy().to_string());
         }
@@ -3623,7 +3697,7 @@ pub fn find_bash_executable() -> Option<String> {
         r"C:\Program Files (x86)\Git\bin\bash.exe",
     ];
     for p in &standard_paths {
-        if Path::new(p).exists() {
+        if Path::new(p).exists() && bash_executable_is_usable(Path::new(p)) {
             info!("Found system bash at: {}", p);
             return Some(p.to_string());
         }
@@ -3641,7 +3715,7 @@ pub fn find_bash_executable() -> Option<String> {
             if output.status.success() {
                 let stdout = String::from_utf8_lossy(&output.stdout);
                 if let Some(path) =
-                    first_usable_windows_bash_candidate(&stdout, |path| path.exists())
+                    first_usable_windows_bash_candidate(&stdout, bash_executable_is_usable)
                 {
                     info!("Found native bash on PATH: {}", path);
                     return Some(path);
@@ -3665,13 +3739,26 @@ fn download_portable_git() -> std::result::Result<String, String> {
     let local_app_data =
         std::env::var("LOCALAPPDATA").map_err(|_| "LOCALAPPDATA env var not set".to_string())?;
     let screenpipe_dir = PathBuf::from(&local_app_data).join("screenpipe");
+    download_portable_git_into(&screenpipe_dir)
+}
+
+#[cfg(windows)]
+fn download_portable_git_into(screenpipe_dir: &Path) -> std::result::Result<String, String> {
     let git_dir = screenpipe_dir.join("git-portable");
     let bash_path = git_dir.join("bin").join("bash.exe");
 
     // Already downloaded
-    if bash_path.exists() {
+    if bash_path.exists() && bash_executable_is_usable(&bash_path) {
         info!("PortableGit already present at {}", git_dir.display());
         return Ok(bash_path.to_string_lossy().to_string());
+    }
+    if bash_path.exists() {
+        warn!(
+            "PortableGit at {} failed its startup probe; reinstalling it",
+            git_dir.display()
+        );
+        std::fs::remove_dir_all(&git_dir)
+            .map_err(|e| format!("Failed to remove broken PortableGit install: {}", e))?;
     }
 
     // Pinned version for reproducibility
@@ -3810,6 +3897,12 @@ fn download_portable_git() -> std::result::Result<String, String> {
                 warn!("Failed to run post-install.bat (non-fatal): {}", e);
             }
         }
+    }
+
+    if !bash_executable_is_usable(&extracted_bash) {
+        let _ = std::fs::remove_dir_all(&extract_temp);
+        let _ = std::fs::remove_file(&temp_file);
+        return Err("Extracted PortableGit bash.exe failed its startup probe".to_string());
     }
 
     // Atomic rename: move extracted dir to final location
@@ -4068,7 +4161,7 @@ static BASH_DIR_ONCE: std::sync::OnceLock<Option<String>> = std::sync::OnceLock:
 /// Returns the bash bin directory (for PATH injection) or None.
 #[cfg(windows)]
 pub fn ensure_bash_available() -> Option<String> {
-    // Fast path: if bash is already on disk, return immediately without touching OnceLock.
+    // Fast path: if bash is healthy, return immediately without touching OnceLock.
     // This avoids caching a stale "not found" from a previous failed attempt.
     if let Some(bash_path) = find_bash_executable() {
         return Path::new(&bash_path)
@@ -4108,8 +4201,12 @@ mod tests {
     fn windows_bash_launcher_detection_rejects_wsl_shims() {
         assert!(is_windows_bash_launcher(r#"C:\Windows\System32\bash.exe"#));
         assert!(is_windows_bash_launcher(r#"C:\Windows\Sysnative\bash.exe"#));
+        assert!(is_windows_bash_launcher(r#"C:\Windows\SysWOW64\bash.exe"#));
         assert!(is_windows_bash_launcher(
             r#"C:\Users\steve\AppData\Local\Microsoft\WindowsApps\bash.exe"#
+        ));
+        assert!(is_windows_bash_launcher(
+            r#""C:/WINDOWS/System32/BASH.EXE""#
         ));
         assert!(!is_windows_bash_launcher(
             r#"C:\Program Files\Git\bin\bash.exe"#
@@ -4128,6 +4225,65 @@ mod tests {
             first_usable_windows_bash_candidate(&candidates, |_| true).as_deref(),
             Some(r#"C:\Program Files\Git\bin\bash.exe"#)
         );
+    }
+
+    #[test]
+    fn windows_bash_candidate_skips_unusable_native_candidates() {
+        let candidates = [
+            r#"C:\tools\broken\bash.exe"#,
+            r#"C:\Windows\SysWOW64\bash.exe"#,
+            r#"C:\custom tools\git\bin\bash.exe"#,
+        ]
+        .join("\r\n");
+
+        assert_eq!(
+            first_usable_windows_bash_candidate(&candidates, |path| {
+                path == Path::new(r#"C:\custom tools\git\bin\bash.exe"#)
+            })
+            .as_deref(),
+            Some(r#"C:\custom tools\git\bin\bash.exe"#)
+        );
+    }
+
+    #[test]
+    fn windows_bash_candidate_rejects_wsl_only_output() {
+        let candidates = [
+            r#"C:\Windows\System32\bash.exe"#,
+            r#"C:\Users\steve\AppData\Local\Microsoft\WindowsApps\bash.exe"#,
+        ]
+        .join("\n");
+
+        assert_eq!(
+            first_usable_windows_bash_candidate(&candidates, |_| true),
+            None
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    #[ignore = "network-backed acceptance test for disposable Windows VMs"]
+    fn portable_git_fresh_install_and_broken_install_repair() {
+        let root = std::env::temp_dir().join(format!(
+            "screenpipe-portable-git-test-{}",
+            std::process::id()
+        ));
+        let screenpipe_dir = root.join("screenpipe");
+        let _ = std::fs::remove_dir_all(&root);
+
+        let first = download_portable_git_into(&screenpipe_dir)
+            .expect("fresh PortableGit install should succeed");
+        assert!(bash_executable_is_usable(Path::new(&first)));
+
+        std::fs::write(&first, b"broken portable git")
+            .expect("test should corrupt the managed bash executable");
+        assert!(!bash_executable_is_usable(Path::new(&first)));
+
+        let repaired = download_portable_git_into(&screenpipe_dir)
+            .expect("broken managed PortableGit install should be replaced");
+        assert_eq!(repaired, first);
+        assert!(bash_executable_is_usable(Path::new(&repaired)));
+
+        std::fs::remove_dir_all(&root).expect("test should clean up its PortableGit install");
     }
 
     #[test]

--- a/crates/screenpipe-core/src/pipes/mod.rs
+++ b/crates/screenpipe-core/src/pipes/mod.rs
@@ -2181,6 +2181,23 @@ fn classify_pipe_process_result(
     }
 
     if process_success {
+        if !stdout_has_verified_pipe_result(filtered_stdout) {
+            let missing_output = "pipe process exited successfully without a verified result";
+            let classified_stderr = if stderr.trim().is_empty() {
+                missing_output.to_string()
+            } else {
+                format!("{}\n{}", stderr.trim_end(), missing_output)
+            };
+            return ClassifiedPipeProcessResult {
+                status: "failed",
+                success: false,
+                stderr: classified_stderr,
+                error_type: Some("missing_output".to_string()),
+                error_message: Some(
+                    "automation finished without producing a verifiable result".to_string(),
+                ),
+            };
+        }
         return ClassifiedPipeProcessResult {
             status: "completed",
             success: true,
@@ -2226,6 +2243,46 @@ fn is_post_completion_continue_error(stderr: &str, stdout: &str) -> bool {
     }
 
     stdout_has_successful_agent_end_before_retry(stdout)
+}
+
+fn stdout_has_verified_pipe_result(stdout: &str) -> bool {
+    let mut saw_agent_protocol_event = false;
+
+    for line in stdout.lines() {
+        let trimmed = line.trim();
+        if !trimmed.starts_with('{') || !trimmed.ends_with('}') {
+            continue;
+        }
+
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(trimmed) else {
+            continue;
+        };
+        let event_type = value.get("type").and_then(|v| v.as_str());
+        if matches!(
+            event_type,
+            Some(
+                "agent_start"
+                    | "agent_end"
+                    | "message_start"
+                    | "message_end"
+                    | "tool_execution_start"
+                    | "tool_execution_end"
+                    | "compaction_start"
+                    | "compaction_end"
+            )
+        ) {
+            saw_agent_protocol_event = true;
+        }
+
+        if event_type == Some("agent_end") && agent_end_has_successful_assistant_text(&value) {
+            return true;
+        }
+    }
+
+    // Legacy command pipes may emit ordinary text instead of agent NDJSON.
+    // Preserve that contract while requiring an explicit successful agent end
+    // whenever the output is from Pi/ACP.
+    !saw_agent_protocol_event && !stdout.trim().is_empty()
 }
 
 fn stdout_has_successful_agent_end_before_retry(stdout: &str) -> bool {
@@ -10594,6 +10651,46 @@ Run the scheduled task.
         assert!(!classified.success);
         assert_eq!(classified.error_type.as_deref(), Some("provider_protocol"));
         assert!(classified.stderr.contains("provider_protocol_error"));
+    }
+
+    #[test]
+    fn successful_exit_without_output_is_not_completed() {
+        let classified = classify_pipe_process_result(true, false, "", "");
+
+        assert_eq!(classified.status, "failed");
+        assert!(!classified.success);
+        assert_eq!(classified.error_type.as_deref(), Some("missing_output"));
+        assert!(classified.stderr.contains("without a verified result"));
+    }
+
+    #[test]
+    fn agent_protocol_requires_a_successful_final_result() {
+        let stdout = [
+            r#"{"type":"agent_start"}"#,
+            r#"{"type":"agent_end","messages":[{"role":"assistant","content":[],"stopReason":"stop"}]}"#,
+        ]
+        .join("\n");
+        let classified = classify_pipe_process_result(true, false, "", &stdout);
+
+        assert_eq!(classified.status, "failed");
+        assert_eq!(classified.error_type.as_deref(), Some("missing_output"));
+    }
+
+    #[test]
+    fn successful_agent_result_can_be_completed() {
+        let stdout = r#"{"type":"agent_end","messages":[{"role":"assistant","content":[{"type":"text","text":"activity updated"}],"stopReason":"stop"}]}"#;
+        let classified = classify_pipe_process_result(true, false, "", stdout);
+
+        assert_eq!(classified.status, "completed");
+        assert!(classified.success);
+    }
+
+    #[test]
+    fn legacy_text_output_can_still_be_completed() {
+        let classified = classify_pipe_process_result(true, false, "", "output saved");
+
+        assert_eq!(classified.status, "completed");
+        assert!(classified.success);
     }
 
     fn successful_agent_then_compaction_retry_stdout() -> String {


### PR DESCRIPTION
## Summary

- ignore Windows `System32`, `Sysnative`, `SysWOW64`, and WindowsApps Bash launchers that require WSL, then select a verified native Git/MSYS Bash
- health-check and self-repair the managed PortableGit fallback, including incomplete installs and transient Windows-on-ARM executable locks
- require a successful final agent result before a Pi/ACP automation is recorded as completed; zero-output or incomplete exits become `missing_output`

Related dashboard/data lifecycle PR: https://github.com/screenpipe/website/pull/901

## Why

The customer log showed `where bash` resolving the Windows WSL launcher first on a corporate machine without a WSL distribution. The same run could exit without a usable agent result but still be displayed as successful.

## Verification

Exact tested head: `5fe6426ca95261d9959d2a924bbb0ddb417f4c51`

- local `cargo test -p screenpipe-core --lib`: 600 passed, 0 failed, 1 ignored
- Azure Windows Server 2022 x64, WSL disabled: native Bash launch, 4 resolver cases, real PortableGit fresh/corrupt/incomplete repair, 5 completion cases, and legacy compatibility all passed
- Azure Windows 11 Pro ARM64, WSL disabled: the same relevant matrix passed under native ARM64 Screenpipe
- x64 broad Windows library run: 595 passed, 2 existing base-reproduced worktree-test failures, 2 ignored
- independent Windows 11 x64 real-machine acceptance from Ezra: standard Git Bash and PortableGit fallback both passed
- disposable Azure checkout/target paths removed on both VMs with zero remnants

## Follow-ups outside this PR

- re-run the affected customer automation on the new Windows build and verify its actual activity update
- confirm the one-user Enterprise pilot scope, token allowance, dashboard access, pricing, and short-form agreement
