### PR TITLE
fix(updater): defer automatic restart during meetings

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/updates.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/updates.rs
@@ -8,6 +8,7 @@ use crate::store::{get_store, SettingsStore};
 use crate::RecordingState;
 use anyhow::Error;
 use dark_light::Mode;
+use futures::StreamExt;
 use log::{debug, error, info, warn};
 use semver::Version;
 use serde_json;
@@ -309,6 +310,41 @@ pub async fn await_safe_restart(timeout_secs: Option<u64>) -> String {
 /// True once a surface has committed to applying a staged update; keeps a
 /// second trigger from starting a parallel teardown+relaunch.
 static UPDATE_RESTART_STARTED: AtomicBool = AtomicBool::new(false);
+
+async fn meeting_active(app: &tauri::AppHandle) -> bool {
+    let state = app.state::<RecordingState>();
+    let server = state.server.lock().await;
+    let Some(server) = server.as_ref() else {
+        return false;
+    };
+    screenpipe_engine::routes::meetings::resolve_meeting_status_from(
+        server.db.as_ref(),
+        server.manual_meeting.as_ref(),
+    )
+    .await
+    .map(|status| status.active)
+    .unwrap_or_else(|error| {
+        warn!("auto-update: could not verify meeting status: {}", error);
+        true
+    })
+}
+
+/// Require 30 meeting-free seconds before an automatic restart.
+async fn wait_for_meeting_restart_window(app: &tauri::AppHandle) {
+    let mut started = screenpipe_events::subscribe_to_event::<serde_json::Value>("meeting_started");
+    let mut ended = screenpipe_events::subscribe_to_event::<serde_json::Value>("meeting_ended");
+
+    if meeting_active(app).await {
+        ended.next().await;
+    }
+
+    loop {
+        tokio::select! {
+            _ = tokio::time::sleep(Duration::from_secs(30)) => return,
+            _ = started.next() => { ended.next().await; }
+        }
+    }
+}
 
 /// Banner-click restart. Mirror the auto-update path: gate, stop server, then
 /// spawn the replacement app and `_exit` the old process so C/C++ atexit
@@ -1104,6 +1140,9 @@ impl UpdatesManager {
 
             #[cfg(target_os = "windows")]
             {
+                if auto_update {
+                    wait_for_meeting_restart_window(&self.app).await;
+                }
                 // Windows: stop screenpipe before replacing the binary
                 if let Err(err) =
                     stop_screenpipe(self.app.state::<RecordingState>(), self.app.clone()).await
@@ -1376,7 +1415,7 @@ impl UpdatesManager {
                         "delay_secs": 30,
                     }),
                 );
-                tokio::time::sleep(Duration::from_secs(30)).await;
+                wait_for_meeting_restart_window(&self.app).await;
                 // Time-bounded: never let a wedged capture/audio teardown stall
                 // the relaunch (see PRE_EXIT_TEARDOWN_TIMEOUT / 2026-06-26 report).
                 match bounded_teardown(


### PR DESCRIPTION
## Problem

Automatic updates could restart Screenpipe during an active meeting.

## Fix

Use the existing `meeting_started` and `meeting_ended` event subscriptions for the automatic restart path:

- subscribe before reading current meeting state;
- if already in a meeting, await `meeting_ended`;
- wait 30 seconds;
- if `meeting_started` fires during that window, await the matching `meeting_ended` and begin a fresh 30-second window;
- return and drop both local subscriptions when the window completes.

The event API exposes streams, so one loop handles any number of back-to-back meetings. There is no polling, nested loop, resubscription, or explicit registration state.

On Windows, the same window completes before Screenpipe is stopped and the installer runs. Manual **Restart to update** behavior is unchanged.

## Before / after

```text
before: update ready -> 30 seconds -> restart, even in a meeting
after:  update ready -> meeting ended -> 30 meeting-free seconds -> restart
                            ^ a new meeting cancels and resets this window
```

## Historical intent

Inspected `19522fd252`, `391d1e3789`, and PR #6147. The existing restart gate and 30-second delay are preserved; meeting lifecycle events now reset that delay for automatic restarts.

## Scope

One file, 40 additions and 1 deletion.

## Validation

- `cargo test --manifest-path apps/screenpipe-app-tauri/src-tauri/Cargo.toml updates::tests`
  - 39 passed, 0 failed
- `rustfmt --edition 2021 --check apps/screenpipe-app-tauri/src-tauri/src/updates.rs`
- `git diff --check`