### PR TITLE
fix(updater): defer restarts until meetings end

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -23,14 +23,14 @@ results and `cargo llvm-cov` data on top when judging release confidence.
 ### Tauri E2E
 
 - Mapped specs: 140
-- Declared test blocks: 401
-- Weighted coverage points: 322.1
+- Declared test blocks: 402
+- Weighted coverage points: 322.8
 
 | Platform | Specs | Declared tests | Weighted points | Layers | Features | Critical score |
 | --- | --- | --- | --- | --- | --- | --- |
-| windows | 107 | 340 | 283.1 | 15 | 122 | 85% |
-| macos | 136 | 363 | 291.9 | 17 | 132 | 88% |
-| linux | 95 | 298 | 252.5 | 14 | 119 | 80% |
+| windows | 107 | 341 | 283.8 | 15 | 123 | 85% |
+| macos | 136 | 364 | 292.6 | 17 | 133 | 88% |
+| linux | 95 | 299 | 253.2 | 14 | 120 | 80% |
 
 ### Core Engine
 

--- a/apps/screenpipe-app-tauri/components/update-banner.tsx
+++ b/apps/screenpipe-app-tauri/components/update-banner.tsx
@@ -36,6 +36,7 @@ interface UpdateBannerState {
   isInstalling: boolean;
   pendingUpdate: Update | null;
   authRequired: AuthRequiredInfo | null;
+  waitingForMeeting: boolean;
   // Version the user dismissed in this session. Periodic re-checks and
   // providers-remount hydration would otherwise re-show the same banner
   // immediately after the user clicked X.
@@ -45,6 +46,7 @@ interface UpdateBannerState {
   setIsInstalling: (installing: boolean) => void;
   setPendingUpdate: (update: Update | null) => void;
   setAuthRequired: (info: AuthRequiredInfo | null) => void;
+  setWaitingForMeeting: (waiting: boolean) => void;
   dismiss: (version: string) => void;
   resetDismissed: () => void;
 }
@@ -55,12 +57,14 @@ export const useUpdateBanner = create<UpdateBannerState>((set) => ({
   isInstalling: false,
   pendingUpdate: null,
   authRequired: null,
+  waitingForMeeting: false,
   dismissedVersion: null,
   setIsVisible: (visible) => set({ isVisible: visible }),
   setUpdateInfo: (info) => set({ updateInfo: info }),
   setIsInstalling: (installing) => set({ isInstalling: installing }),
   setPendingUpdate: (update) => set({ pendingUpdate: update }),
   setAuthRequired: (info) => set({ authRequired: info }),
+  setWaitingForMeeting: (waiting) => set({ waitingForMeeting: waiting }),
   dismiss: (version) => set({ isVisible: false, authRequired: null, dismissedVersion: version }),
   resetDismissed: () => set({ dismissedVersion: null }),
 }));
@@ -103,7 +107,7 @@ async function getWindowsUpdateOptions(settings: Settings | null | undefined) {
 }
 
 export function UpdateBanner({ className, compact = false, variant = "default" }: UpdateBannerProps) {
-  const { isVisible, updateInfo, isInstalling, setIsInstalling, pendingUpdate, authRequired, dismiss } = useUpdateBanner();
+  const { isVisible, updateInfo, isInstalling, setIsInstalling, pendingUpdate, authRequired, waitingForMeeting, dismiss } = useUpdateBanner();
   const { toast } = useToast();
   const { settings } = useSettings();
 
@@ -197,14 +201,21 @@ export function UpdateBanner({ className, compact = false, variant = "default" }
         const outcome = res.status === "ok" ? res.data : "errored";
         if (outcome !== "proceed") {
           setIsInstalling(false);
-          toast({
-            title: "screenpipe is still starting up",
-            description:
-              outcome === "errored"
-                ? "startup error — open settings to see details before restarting"
-                : "finish startup first, then click update again",
-            variant: "destructive",
-          });
+          if (outcome === "meeting") {
+            toast({
+              title: "update paused during your meeting",
+              description: "screenpipe will keep recording — try the update again after your meeting ends",
+            });
+          } else {
+            toast({
+              title: "screenpipe is still starting up",
+              description:
+                outcome === "errored"
+                  ? "startup error — open settings to see details before restarting"
+                  : "finish startup first, then click update again",
+              variant: "destructive",
+            });
+          }
           return;
         }
         // restart scheduled off-thread; runtime will tear down shortly.
@@ -280,7 +291,7 @@ export function UpdateBanner({ className, compact = false, variant = "default" }
         type="button"
         data-testid="update-banner"
         onClick={handleUpdate}
-        disabled={isInstalling}
+        disabled={isInstalling || waitingForMeeting}
         className={cn(
           "w-full flex items-center gap-2.5 px-2.5 py-2 rounded-lg border border-border bg-card/50 hover:bg-card transition-colors text-left disabled:opacity-60",
           className,
@@ -289,9 +300,11 @@ export function UpdateBanner({ className, compact = false, variant = "default" }
         <Sparkles className="h-4 w-4 text-primary shrink-0" />
         <div className="flex-1 min-w-0">
           <div className="text-xs font-medium text-foreground truncate">
-            {isInstalling ? "Restarting…" : "Restart to update"}
+            {isInstalling ? "Restarting…" : waitingForMeeting ? "Update ready" : "Restart to update"}
           </div>
-          <div className="text-[10px] text-muted-foreground truncate">v{updateInfo.version}</div>
+          <div className="text-[10px] text-muted-foreground truncate">
+            v{updateInfo.version}{waitingForMeeting ? " · restarts after your meeting" : ""}
+          </div>
         </div>
       </button>
     );
@@ -304,15 +317,15 @@ export function UpdateBanner({ className, compact = false, variant = "default" }
         className
       )}>
         <Sparkles className="h-3 w-3 text-primary" />
-        <span>v{updateInfo.version} ready</span>
+        <span>v{updateInfo.version} ready{waitingForMeeting ? " — restarts after your meeting" : ""}</span>
         <Button
           variant="ghost"
           size="sm"
           className="h-5 px-2 text-xs"
           onClick={handleUpdate}
-          disabled={isInstalling}
+          disabled={isInstalling || waitingForMeeting}
         >
-          {isInstalling ? "restarting..." : "restart to update"}
+          {isInstalling ? "restarting..." : waitingForMeeting ? "waiting for meeting" : "restart to update"}
         </Button>
       </div>
     );
@@ -327,6 +340,7 @@ export function UpdateBanner({ className, compact = false, variant = "default" }
         <Sparkles className="h-4 w-4 text-primary" />
         <span>
           screenpipe <span className="font-medium">v{updateInfo.version}</span> is ready
+          {waitingForMeeting ? " — restarts after your meeting" : ""}
         </span>
       </div>
       <div className="flex items-center gap-2">
@@ -335,9 +349,9 @@ export function UpdateBanner({ className, compact = false, variant = "default" }
           size="sm"
           className="h-7 px-3 text-xs"
           onClick={handleUpdate}
-          disabled={isInstalling}
+          disabled={isInstalling || waitingForMeeting}
         >
-          {isInstalling ? "restarting..." : "restart to update"}
+          {isInstalling ? "restarting..." : waitingForMeeting ? "waiting for meeting" : "restart to update"}
         </Button>
         <Button
           variant="ghost"
@@ -366,11 +380,13 @@ interface PendingUpdateSnapshot {
 // state from Rust so it can recover if the event fired before this hook
 // registered (boot-time webview race).
 export function useUpdateListener() {
-  const { setIsVisible, setUpdateInfo, setAuthRequired } = useUpdateBanner();
+  const { setIsVisible, setUpdateInfo, setAuthRequired, setWaitingForMeeting } = useUpdateBanner();
 
   useEffect(() => {
     let unlistenAvailable: (() => void) | undefined;
     let unlistenAuth: (() => void) | undefined;
+    let unlistenWaiting: (() => void) | undefined;
+    let unlistenMeetingFinished: (() => void) | undefined;
 
     // Rust re-emits update-available on every periodic check, and providers
     // hydration runs on every remount — both would otherwise resurrect a
@@ -378,6 +394,7 @@ export function useUpdateListener() {
     // callback so a newer version still shows even if an older one is dismissed.
     const showIfNotDismissed = (info: UpdateInfo) => {
       setUpdateInfo(info);
+      setWaitingForMeeting(false);
       if (useUpdateBanner.getState().dismissedVersion !== info.version) {
         setIsVisible(true);
       }
@@ -400,6 +417,23 @@ export function useUpdateListener() {
         showAuthIfNotDismissed(event.payload);
       });
 
+      unlistenWaiting = await listen<{ version: string }>("update-waiting-for-meeting", (event) => {
+        const state = useUpdateBanner.getState();
+        if (
+          state.updateInfo?.version === event.payload.version &&
+          state.dismissedVersion !== event.payload.version
+        ) {
+          setWaitingForMeeting(true);
+          setIsVisible(true);
+        }
+      });
+
+      unlistenMeetingFinished = await listen<{ version: string }>("update-meeting-finished", (event) => {
+        if (useUpdateBanner.getState().updateInfo?.version === event.payload.version) {
+          setWaitingForMeeting(false);
+        }
+      });
+
       // Hydrate from Rust in case the event fired before we mounted.
       try {
         const resPending = await commands.getPendingUpdate();
@@ -409,6 +443,7 @@ export function useUpdateListener() {
             showAuthIfNotDismissed({ version: pending.version, message: "sign in to get the latest update" });
           } else if (pending.downloaded) {
             showIfNotDismissed({ version: pending.version, body: pending.body });
+            setWaitingForMeeting(pending.waiting_for_meeting);
           }
         }
       } catch (e) {
@@ -422,6 +457,8 @@ export function useUpdateListener() {
     return () => {
       unlistenAvailable?.();
       unlistenAuth?.();
+      unlistenWaiting?.();
+      unlistenMeetingFinished?.();
     };
-  }, [setIsVisible, setUpdateInfo, setAuthRequired]);
+  }, [setIsVisible, setUpdateInfo, setAuthRequired, setWaitingForMeeting]);
 }

--- a/apps/screenpipe-app-tauri/e2e/COVERAGE.md
+++ b/apps/screenpipe-app-tauri/e2e/COVERAGE.md
@@ -11,8 +11,8 @@ and layer declared in the manifest, weighted by confidence and criticality.
 - Manifest: `e2e/coverage-map.json`
 - Specs directory: `e2e/specs`
 - Mapped specs: 140
-- Declared test blocks: 401
-- Weighted coverage points: 322.1
+- Declared test blocks: 402
+- Weighted coverage points: 322.8
 
 Confidence weights: strong=1.0, partial=0.7, conditional=0.4, smoke=0.3.
 Criticality weights: high=1.0, medium=0.7, low=0.4.
@@ -23,9 +23,9 @@ can execute more runtime cases than this number shows.
 
 | Platform | Specs | Declared tests | Weighted points | Layers | Features | Critical score |
 | --- | --- | --- | --- | --- | --- | --- |
-| windows | 107 | 340 | 283.1 | 15 | 122 | 85% |
-| macos | 136 | 363 | 291.9 | 17 | 132 | 88% |
-| linux | 95 | 298 | 252.5 | 14 | 119 | 80% |
+| windows | 107 | 341 | 283.8 | 15 | 123 | 85% |
+| macos | 136 | 364 | 292.6 | 17 | 133 | 88% |
+| linux | 95 | 299 | 253.2 | 14 | 120 | 80% |
 
 ## Runtime Results
 
@@ -49,8 +49,8 @@ pass/fail/skip counts.
 | os-integration | 7 specs / 32 tests / 26.9 pts | 15 specs / 30 tests / 18.4 pts | 2 specs / 15 tests / 10.8 pts |
 | performance | 3 specs / 45 tests / 45.0 pts | 5 specs / 36 tests / 31.8 pts | 2 specs / 30 tests / 30.0 pts |
 | pipes | 6 specs / 20 tests / 20.0 pts | 8 specs / 26 tests / 26.0 pts | 6 specs / 20 tests / 20.0 pts |
-| real-ui-e2e | 80 specs / 238 tests / 201.9 pts | 97 specs / 255 tests / 215.9 pts | 74 specs / 214 tests / 187.9 pts |
-| settings | 15 specs / 42 tests / 39.0 pts | 17 specs / 36 tests / 31.7 pts | 14 specs / 33 tests / 30.0 pts |
+| real-ui-e2e | 80 specs / 239 tests / 202.6 pts | 97 specs / 256 tests / 216.6 pts | 74 specs / 215 tests / 188.6 pts |
+| settings | 15 specs / 43 tests / 39.7 pts | 17 specs / 37 tests / 32.4 pts | 14 specs / 34 tests / 30.7 pts |
 | storage-privacy | 10 specs / 44 tests / 35.3 pts | 10 specs / 29 tests / 28.1 pts | 7 specs / 22 tests / 21.1 pts |
 | tauri-command | 23 specs / 62 tests / 48.9 pts | 35 specs / 84 tests / 66.3 pts | 22 specs / 63 tests / 49.8 pts |
 | window-lifecycle | 22 specs / 71 tests / 59.5 pts | 23 specs / 54 tests / 39.9 pts | 16 specs / 44 tests / 34.4 pts |
@@ -231,7 +231,7 @@ pass/fail/skip counts.
 | tray-recording-status.spec.ts | windows | os-integration, tauri-command | tray-recording-status | high | strong | command | 1 | Drives Starting to Recording and reads back the status item from the successfully installed native tray menu. |
 | tray-recording-toggle.spec.ts | macos | os-integration, tauri-command, capture-ocr | tray-recording-toggle | high | strong | command | 1 | Runs the tray's shared native action and proves a real CaptureSession pauses and resumes without the frontend shortcut-event path. |
 | tray-search.spec.ts | windows, macos, linux | window-lifecycle, tauri-command, real-ui-e2e | tray-search, home-search, window-lifecycle | high | partial | command | 2 | Invokes open_search_window and verifies focused floating Search. |
-| updater-banner.spec.ts | windows, macos, linux | real-ui-e2e, settings | update-surfacing, settings-persistence | high | partial | mixed | 2 | Synthetic update-available event surfaces the restart-to-update banner. A real Auto-update toggle plus delayed store save verifies restart waits for preference persistence and survives settings-store re-hydration; an E2E-only handoff suppresses the destructive relaunch. Real check/download/install + rollback stay manual via e2e/mock-updates because the debug E2E build disables updater checks. |
+| updater-banner.spec.ts | windows, macos, linux | real-ui-e2e, settings | update-surfacing, updater-meeting-safety, settings-persistence | high | partial | mixed | 3 | Synthetic updater events surface the restart-to-update banner, then show and disable its meeting-deferral state until meeting-finished resumes it. A real Auto-update toggle plus delayed store save verifies restart waits for preference persistence and survives settings-store re-hydration; an E2E-only handoff suppresses the destructive relaunch. Native unit tests cover the durable meeting probe, fail-closed unknown state, and quiet-window reset when a meeting starts during the countdown. Real check/download/install + rollback stay manual via e2e/mock-updates because the debug E2E build disables updater checks. |
 | viewer-deeplink.spec.ts | windows, macos, linux | window-lifecycle, tauri-command | viewer-deeplink, window-lifecycle | medium | partial | command | 3 | Viewer window creation and per-path dedupe. |
 | window-activation.spec.ts | macos | window-lifecycle, tauri-command, real-ui-e2e | window-lifecycle, chat | medium | conditional | real-user-flow | 2 | macOS-only show_window_activated focus coverage. |
 | window-lifecycle.spec.ts | windows, macos, linux | window-lifecycle, tauri-command, real-ui-e2e | window-lifecycle, onboarding, tray-search | high | strong | mixed | 3 | Home, Search, and onboarding window routing. |

--- a/apps/screenpipe-app-tauri/e2e/coverage-map.json
+++ b/apps/screenpipe-app-tauri/e2e/coverage-map.json
@@ -2898,12 +2898,13 @@
       ],
       "features": [
         "update-surfacing",
+        "updater-meeting-safety",
         "settings-persistence"
       ],
       "criticality": "high",
       "confidence": "partial",
       "ux": "mixed",
-      "notes": "Synthetic update-available event surfaces the restart-to-update banner. A real Auto-update toggle plus delayed store save verifies restart waits for preference persistence and survives settings-store re-hydration; an E2E-only handoff suppresses the destructive relaunch. Real check/download/install + rollback stay manual via e2e/mock-updates because the debug E2E build disables updater checks."
+      "notes": "Synthetic updater events surface the restart-to-update banner, then show and disable its meeting-deferral state until meeting-finished resumes it. A real Auto-update toggle plus delayed store save verifies restart waits for preference persistence and survives settings-store re-hydration; an E2E-only handoff suppresses the destructive relaunch. Native unit tests cover the durable meeting probe, fail-closed unknown state, and quiet-window reset when a meeting starts during the countdown. Real check/download/install + rollback stay manual via e2e/mock-updates because the debug E2E build disables updater checks."
     },
     {
       "spec": "viewer-deeplink.spec.ts",

--- a/apps/screenpipe-app-tauri/e2e/specs/updater-banner.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/updater-banner.spec.ts
@@ -4,9 +4,9 @@
 
 /**
  * E2E coverage for the update-available BANNER surfacing — the user-visible
- * "restart to update" prompt and the settings-save handoff immediately before
- * restart. These are the updater slices that are deterministic inside the
- * shared WebDriver session.
+ * "restart to update" prompt, meeting deferral state, and settings-save
+ * handoff immediately before restart. These are the updater slices that are
+ * deterministic inside the shared WebDriver session.
  *
  * Why only the banner (and not a real check / download / install):
  *   - The WDIO suite drives a `--profile debug-dev --features e2e` build, and
@@ -24,11 +24,12 @@
  * when Rust emits `update-available {version, body}` (src-tauri/src/updates.rs),
  * `useUpdateListener` (mounted globally in app/providers.tsx) flips the banner
  * visible and the home sidebar renders the "Restart to update / v<version>"
- * affordance (components/update-banner.tsx). It also makes the settings save
- * deliberately slow, enables Auto-update, and clicks restart immediately. An
- * E2E-only handoff stops before the destructive relaunch so WebDriver survives
- * while the test proves that restart becomes ready only after the preference
- * reaches disk.
+ * affordance (components/update-banner.tsx). A meeting-deferral event then
+ * disables that action and explains when restart will resume. The spec also
+ * makes the settings save deliberately slow, enables Auto-update, and clicks
+ * restart immediately. An E2E-only handoff stops before the destructive
+ * relaunch so WebDriver survives while the test proves that restart becomes
+ * ready only after the preference reaches disk.
  *
  * Run against an existing --features e2e debug build:
  *   cd apps/screenpipe-app-tauri
@@ -123,6 +124,59 @@ describe("Update banner surfacing", function () {
 
     const filepath = await saveScreenshot("updater-banner-visible");
     expect(existsSync(filepath)).toBe(true);
+  });
+
+  it("shows that auto-update is waiting for the meeting and prevents an early restart", async () => {
+    const emitErr = (await browser.executeAsync(
+      (payload: { version: string }, done: (v?: unknown) => void) => {
+        const g = globalThis as unknown as {
+          __TAURI__?: { event?: { emit: (n: string, p: unknown) => Promise<unknown> } };
+        };
+        const emit = g.__TAURI__?.event?.emit;
+        if (!emit) {
+          done("global __TAURI__.event.emit unavailable");
+          return;
+        }
+        void emit("update-waiting-for-meeting", payload)
+          .then(() => done(null))
+          .catch((e) => done(String(e)));
+      },
+      { version: SYNTHETIC_VERSION },
+    )) as string | null;
+    expect(emitErr).toBeNull();
+
+    const banner = await waitForTestId("update-banner", 15_000);
+    await browser.waitUntil(
+      async () => (await banner.getText()).toLowerCase().includes("restarts after your meeting"),
+      { timeout: t(10_000), timeoutMsg: "meeting-aware updater state did not appear" },
+    );
+    expect(await banner.isEnabled()).toBe(false);
+
+    const filepath = await saveScreenshot("updater-waits-for-meeting");
+    expect(existsSync(filepath)).toBe(true);
+
+    const resumeErr = (await browser.executeAsync(
+      (payload: { version: string }, done: (v?: unknown) => void) => {
+        const g = globalThis as unknown as {
+          __TAURI__?: { event?: { emit: (n: string, p: unknown) => Promise<unknown> } };
+        };
+        const emit = g.__TAURI__?.event?.emit;
+        if (!emit) {
+          done("global __TAURI__.event.emit unavailable");
+          return;
+        }
+        void emit("update-meeting-finished", payload)
+          .then(() => done(null))
+          .catch((e) => done(String(e)));
+      },
+      { version: SYNTHETIC_VERSION },
+    )) as string | null;
+    expect(resumeErr).toBeNull();
+    await browser.waitUntil(async () => banner.isEnabled(), {
+      timeout: t(10_000),
+      timeoutMsg: "update banner did not resume after meeting finished",
+    });
+    expect((await banner.getText()).toLowerCase()).toContain("restart to update");
   });
 
   it("persists an Auto-update opt-in before a back-to-back update restart", async () => {

--- a/apps/screenpipe-app-tauri/lib/utils/tauri.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/tauri.ts
@@ -3360,7 +3360,11 @@ downloaded: boolean;
 /**
  * True when download failed with 401/403 — user must sign in.
  */
-auth_required: boolean }
+auth_required: boolean;
+/**
+ * True while auto-update is waiting for the active meeting to end.
+ */
+waiting_for_meeting: boolean }
 export type PersistedActivityHistory = { entries: ActivityHistoryEntry[]; coverage: ActivityHistoryCoverage[] }
 export type PiBackend = "acp"
 export type PiCheckResult = { available: boolean; path: string | null }

--- a/apps/screenpipe-app-tauri/src-tauri/src/updates.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/updates.rs
@@ -11,11 +11,12 @@ use dark_light::Mode;
 use log::{debug, error, info, warn};
 use semver::Version;
 use serde_json;
+use std::future::Future;
 #[cfg(any(target_os = "macos", test))]
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tauri::menu::{MenuItem, MenuItemBuilder};
 use tauri::{Emitter, Manager, Wry};
 use tauri_plugin_dialog::DialogExt;
@@ -202,6 +203,8 @@ pub struct PendingUpdateSnapshot {
     pub downloaded: bool,
     /// True when download failed with 401/403 — user must sign in.
     pub auth_required: bool,
+    /// True while auto-update is waiting for the active meeting to end.
+    pub waiting_for_meeting: bool,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -268,6 +271,89 @@ const AUTO_UPDATE_GATE_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 /// is actively waiting after a click — better to surface "still starting,
 /// try again" than to block the click indefinitely.
 const BANNER_GATE_TIMEOUT_SECS: u64 = 60;
+
+/// Existing auto-update grace period, now also used as a quiet window: a
+/// meeting must remain inactive for the full interval before Screenpipe exits.
+/// If a call starts during the countdown, the countdown resets.
+const AUTO_UPDATE_RESTART_QUIET_PERIOD: Duration = Duration::from_secs(30);
+
+/// Meeting DB polling backs up lifecycle events and closes the race where an
+/// event fires just before the updater subscribes. One second keeps the
+/// post-meeting restart responsive without putting meaningful load on SQLite.
+const AUTO_UPDATE_MEETING_POLL_INTERVAL: Duration = Duration::from_secs(1);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum MeetingActivity {
+    Inactive,
+    Active,
+    /// A failed status read is treated conservatively: never restart while we
+    /// cannot prove that no meeting is active.
+    Unknown(String),
+}
+
+/// Read the same durable meeting-row state as `GET /meetings/status` without
+/// routing an internal request through the local HTTP server.
+async fn meeting_activity_for_update(app: &tauri::AppHandle) -> MeetingActivity {
+    let db = {
+        let state = app.state::<RecordingState>();
+        let server = state.server.lock().await;
+        let Some(server) = server.as_ref() else {
+            // Signed-out / idle installs have no engine and therefore no
+            // Screenpipe-managed active meeting to interrupt.
+            return MeetingActivity::Inactive;
+        };
+        server.db.clone()
+    };
+
+    match db.has_active_meeting().await {
+        Ok(true) => MeetingActivity::Active,
+        Ok(false) => MeetingActivity::Inactive,
+        Err(error) => MeetingActivity::Unknown(error.to_string()),
+    }
+}
+
+/// Wait until meeting state is continuously inactive for `quiet_period`.
+///
+/// Polling is deliberate. Meeting start/end events are lossy broadcast signals;
+/// the meetings table is the durable source of truth and also covers manual,
+/// calendar, and auto-detected calls through one path. `on_deferred` fires once
+/// when an active/unknown state first interrupts the countdown.
+async fn wait_for_meeting_safe_window<Probe, ProbeFuture, OnDeferred, DeferredFuture>(
+    quiet_period: Duration,
+    poll_interval: Duration,
+    mut probe: Probe,
+    mut on_deferred: OnDeferred,
+) -> bool
+where
+    Probe: FnMut() -> ProbeFuture,
+    ProbeFuture: Future<Output = MeetingActivity>,
+    OnDeferred: FnMut(MeetingActivity) -> DeferredFuture,
+    DeferredFuture: Future<Output = ()>,
+{
+    let mut inactive_since: Option<Instant> = None;
+    let mut was_deferred = false;
+
+    loop {
+        match probe().await {
+            MeetingActivity::Inactive => {
+                let since = inactive_since.get_or_insert_with(Instant::now);
+                let elapsed = since.elapsed();
+                if elapsed >= quiet_period {
+                    return was_deferred;
+                }
+                tokio::time::sleep(poll_interval.min(quiet_period - elapsed)).await;
+            }
+            blocking_state => {
+                inactive_since = None;
+                if !was_deferred {
+                    was_deferred = true;
+                    on_deferred(blocking_state).await;
+                }
+                tokio::time::sleep(poll_interval).await;
+            }
+        }
+    }
+}
 
 /// Cooldown after an update *download/install* fails for a non-auth reason.
 /// The periodic check runs every 5 min; without this, a machine that can
@@ -357,6 +443,24 @@ pub async fn restart_for_update(
     let gate = await_restart_gate(cap, "banner-triggered restart").await;
     if !gate.should_restart() {
         return Ok(gate.as_str().to_string());
+    }
+
+    // A manual banner/tray click must obey the same meeting boundary as the
+    // automatic path. Auto-update already has a waiter that resumes after the
+    // meeting; manual-update users can click again when their call is over.
+    match meeting_activity_for_update(&app).await {
+        MeetingActivity::Inactive => {}
+        MeetingActivity::Active => {
+            info!("banner restart: active meeting detected, deferring update");
+            return Ok("meeting".to_string());
+        }
+        MeetingActivity::Unknown(error) => {
+            warn!(
+                "banner restart: meeting status unavailable, deferring update: {}",
+                error
+            );
+            return Ok("meeting".to_string());
+        }
     }
 
     // The native tray calls this function directly, without passing through
@@ -581,11 +685,19 @@ pub async fn trigger_update_now(app: tauri::AppHandle) {
             Ok(outcome) => {
                 warn!("tray update flow: restart deferred (outcome={})", outcome);
                 manager.set_menu_restart_ready();
-                notify_update_state(
-                    &app,
-                    "screenpipe is still starting up",
-                    "the update will install once startup finishes — try again in a moment.",
-                );
+                if outcome == "meeting" {
+                    notify_update_state(
+                        &app,
+                        "update paused during your meeting",
+                        "screenpipe will keep recording. try the update again after the meeting ends.",
+                    );
+                } else {
+                    notify_update_state(
+                        &app,
+                        "screenpipe is still starting up",
+                        "the update will install once startup finishes — try again in a moment.",
+                    );
+                }
             }
             Err(e) => {
                 error!("tray update flow: restart for update failed: {}", e);
@@ -879,6 +991,85 @@ impl UpdatesManager {
         })
     }
 
+    /// Hold an automatic restart until no meeting has been active for the
+    /// normal 30-second restart grace period. This protects both already-active
+    /// calls and calls that begin while the update countdown is running.
+    async fn wait_for_auto_update_restart_window(&self, version: &str) -> bool {
+        let probe_app = self.app.clone();
+        let waiting_app = self.app.clone();
+        let waiting_pending = self.pending_update.clone();
+        let waiting_menu = self.update_menu_item.clone();
+        let waiting_version = version.to_string();
+
+        let was_deferred = wait_for_meeting_safe_window(
+            AUTO_UPDATE_RESTART_QUIET_PERIOD,
+            AUTO_UPDATE_MEETING_POLL_INTERVAL,
+            move || {
+                let app = probe_app.clone();
+                async move { meeting_activity_for_update(&app).await }
+            },
+            move |activity| {
+                let app = waiting_app.clone();
+                let pending = waiting_pending.clone();
+                let menu = waiting_menu.clone();
+                let version = waiting_version.clone();
+                async move {
+                    match activity {
+                        MeetingActivity::Active => info!(
+                            "auto-update v{} paused until the active meeting ends",
+                            version
+                        ),
+                        MeetingActivity::Unknown(error) => warn!(
+                            "auto-update v{} paused because meeting status is unavailable: {}",
+                            version, error
+                        ),
+                        MeetingActivity::Inactive => unreachable!(
+                            "the deferral callback only runs for blocking meeting states"
+                        ),
+                    }
+
+                    if let Some(snapshot) = pending.lock().await.as_mut() {
+                        snapshot.waiting_for_meeting = true;
+                    }
+                    if let Some(item) = menu.as_ref() {
+                        let _ = item.set_enabled(false);
+                        let _ = item.set_text("Update ready — waiting for meeting to end");
+                    }
+                    let _ = app.emit(
+                        "update-waiting-for-meeting",
+                        serde_json::json!({ "version": version }),
+                    );
+                    notify_update_state(
+                        &app,
+                        "update ready — meeting in progress",
+                        "screenpipe will keep recording and restart after your meeting ends.",
+                    );
+                }
+            },
+        )
+        .await;
+
+        if was_deferred {
+            if let Some(snapshot) = self.pending_update.lock().await.as_mut() {
+                snapshot.waiting_for_meeting = false;
+            }
+            if let Some(item) = self.update_menu_item.as_ref() {
+                let _ = item.set_text("Installing update after meeting…");
+                let _ = item.set_enabled(false);
+            }
+            let _ = self.app.emit(
+                "update-meeting-finished",
+                serde_json::json!({ "version": version }),
+            );
+            info!(
+                "auto-update v{} resuming after meeting-safe quiet window",
+                version
+            );
+        }
+
+        was_deferred
+    }
+
     /// `force` = user-initiated check (tray/dock/Settings). Bypasses the
     /// post-failure cooldown so "click to retry" always re-attempts the
     /// download; periodic and boot checks pass `false`.
@@ -1087,6 +1278,7 @@ impl UpdatesManager {
                 body: update.body.clone().unwrap_or_default(),
                 downloaded: false,
                 auth_required: false,
+                waiting_for_meeting: false,
             });
 
             let auto_update = load_auto_update_enabled(&self.app);
@@ -1187,6 +1379,23 @@ impl UpdatesManager {
             if let Some(ref item) = self.update_menu_item {
                 item.set_enabled(false)?;
                 item.set_text("Downloading latest version of screenpipe")?;
+            }
+
+            // On Windows `download_and_install` launches the installer and can
+            // terminate this process before control returns. Therefore its
+            // meeting and boot gates must run before download/install, unlike
+            // macOS/Linux where download/staging is non-destructive.
+            #[cfg(target_os = "windows")]
+            if auto_update {
+                let label = format!("auto-update v{}", update.version);
+                if !await_restart_gate(AUTO_UPDATE_GATE_TIMEOUT, &label)
+                    .await
+                    .should_restart()
+                {
+                    return Result::Ok(true);
+                }
+                self.wait_for_auto_update_restart_window(&update.version)
+                    .await;
             }
 
             #[cfg(target_os = "windows")]
@@ -1418,7 +1627,10 @@ impl UpdatesManager {
                 let result = if auto_update {
                     notification
                         .title("screenpipe updating")
-                        .body(format!("v{} downloaded — restarting now", version_str))
+                        .body(format!(
+                            "v{} downloaded — restarting when no meeting is active",
+                            version_str
+                        ))
                         .show()
                 } else {
                     notification
@@ -1448,6 +1660,14 @@ impl UpdatesManager {
                     return Result::Ok(true);
                 }
 
+                // Windows already passed this gate before invoking the
+                // exit-capable installer. macOS/Linux stage safely first, then
+                // wait here. The quiet window replaces the old blind 30-second
+                // sleep and resets whenever a meeting starts.
+                #[cfg(not(target_os = "windows"))]
+                self.wait_for_auto_update_restart_window(&update.version)
+                    .await;
+
                 // Only the first trigger applies; defer to an in-flight restart.
                 if UPDATE_RESTART_STARTED.swap(true, Ordering::SeqCst) {
                     info!("auto-update: update-restart already in progress, deferring");
@@ -1460,10 +1680,9 @@ impl UpdatesManager {
                     "update-restarting",
                     serde_json::json!({
                         "version": update.version,
-                        "delay_secs": 30,
+                        "delay_secs": 0,
                     }),
                 );
-                tokio::time::sleep(Duration::from_secs(30)).await;
                 // Time-bounded: never let a wedged capture/audio teardown stall
                 // the relaunch (see PRE_EXIT_TEARDOWN_TIMEOUT / 2026-06-26 report).
                 match bounded_teardown(
@@ -1785,6 +2004,107 @@ mod tests {
 
     const HOUR: Duration = Duration::from_secs(3600);
 
+    #[tokio::test]
+    async fn update_restart_waits_until_meeting_ends() {
+        let probes = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let deferred = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let probe_counter = probes.clone();
+        let deferred_counter = deferred.clone();
+
+        let was_deferred = wait_for_meeting_safe_window(
+            Duration::from_millis(6),
+            Duration::from_millis(1),
+            move || {
+                let call = probe_counter.fetch_add(1, Ordering::SeqCst);
+                async move {
+                    if call < 3 {
+                        MeetingActivity::Active
+                    } else {
+                        MeetingActivity::Inactive
+                    }
+                }
+            },
+            move |_| {
+                deferred_counter.fetch_add(1, Ordering::SeqCst);
+                async {}
+            },
+        )
+        .await;
+
+        assert!(was_deferred);
+        assert_eq!(deferred.load(Ordering::SeqCst), 1);
+        assert!(probes.load(Ordering::SeqCst) >= 5);
+    }
+
+    #[tokio::test]
+    async fn meeting_start_during_countdown_resets_restart_window() {
+        let probes = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let deferred = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let probe_counter = probes.clone();
+        let deferred_counter = deferred.clone();
+
+        let was_deferred = wait_for_meeting_safe_window(
+            Duration::from_millis(8),
+            Duration::from_millis(2),
+            move || {
+                let call = probe_counter.fetch_add(1, Ordering::SeqCst);
+                async move {
+                    if call == 2 {
+                        MeetingActivity::Active
+                    } else {
+                        MeetingActivity::Inactive
+                    }
+                }
+            },
+            move |_| {
+                deferred_counter.fetch_add(1, Ordering::SeqCst);
+                async {}
+            },
+        )
+        .await;
+
+        assert!(was_deferred, "a meeting interrupted the initial countdown");
+        assert_eq!(deferred.load(Ordering::SeqCst), 1);
+        assert!(
+            probes.load(Ordering::SeqCst) >= 7,
+            "the full quiet window must elapse again after the meeting"
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_meeting_state_fails_closed_then_recovers() {
+        let probes = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let observed_reason = Arc::new(std::sync::Mutex::new(None::<MeetingActivity>));
+        let probe_counter = probes.clone();
+        let reason_slot = observed_reason.clone();
+
+        let was_deferred = wait_for_meeting_safe_window(
+            Duration::from_millis(4),
+            Duration::from_millis(1),
+            move || {
+                let call = probe_counter.fetch_add(1, Ordering::SeqCst);
+                async move {
+                    if call == 0 {
+                        MeetingActivity::Unknown("database busy".to_string())
+                    } else {
+                        MeetingActivity::Inactive
+                    }
+                }
+            },
+            move |reason| {
+                *reason_slot.lock().unwrap() = Some(reason);
+                async {}
+            },
+        )
+        .await;
+
+        assert!(was_deferred);
+        assert_eq!(
+            *observed_reason.lock().unwrap(),
+            Some(MeetingActivity::Unknown("database busy".to_string()))
+        );
+    }
+
     #[test]
     fn sweep_removes_installer_leftovers_only() {
         let dir = tempfile::tempdir().unwrap();
@@ -1989,8 +2309,9 @@ mod tests {
     #[test]
     fn old_settings_use_stable_update_channel() {
         assert_eq!(consumer_update_channel(None), "stable");
-        assert!(consumer_update_endpoint(consumer_update_channel(None))
-            .contains("/app-update/stable/"));
+        assert!(
+            consumer_update_endpoint(consumer_update_channel(None)).contains("/app-update/stable/")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## description

Prevents Screenpipe updates from interrupting an active meeting.

- automatic updates poll the durable active-meeting state and require a continuous 30-second meeting-free window before restart
- a meeting that starts during the countdown resets the window
- an unavailable meeting-state read fails closed instead of risking an interruption
- Windows gates before its exit-capable installer; macOS/Linux gate after safe staging and before restart
- manual banner and tray restarts refuse to proceed while a meeting is active
- the update banner explains that the update will restart after the meeting and disables the early-restart action

related issue: none

## AI assistance and human ownership

- AI tool(s) used (`none` if not used): OpenAI Codex
- autonomy level (`none`, `autocomplete`, `chat`, or `agent`): agent
- what I personally verified: no personal human verification is represented by this submission; exact automated checks and results are listed below

- [ ] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [ ] The problem statement, rationale, and replies to maintainers are my own.

## evidence type

- [x] UI or behavior change — before/after recording
- [x] Backend change — regression tests and relevant logs/results
- [ ] Performance change — reproducible before/after benchmarks
- [ ] Docs, CI, or pure refactor — relevant checks and an explanation; no video required

## before

Auto-update used a blind 30-second delay and could restart Screenpipe during an active meeting. The debug E2E build intentionally disables real updater installation, so a destructive before recording was not produced.

## after

Packaged desktop E2E screenshot: the update is ready, explicitly waits for the meeting, and the restart action is disabled.

![Packaged Screenpipe desktop app showing Update ready and restarts after your meeting](https://github.com/screenpipe/screenpipe/releases/download/media/pr-6850-updater-waits-for-meeting.png)

Native behavior is covered by focused tests for an already-active meeting, a meeting starting during the countdown, and an unknown meeting state that later recovers.

## verification

- `bun scripts/native-build-queue.ts test updates::tests -- --test-threads=1` — 49 passed, 0 failed
- `bun run test:e2e -- --spec e2e/specs/updater-banner.spec.ts` — 3 passed, 0 failed in the packaged desktop app
- `bun run build:tauri:e2e` — passed
- `bun run bindings:check` — passed (1 test)
- `bun run typecheck` — passed
- `bun run coverage:all:check` — passed
- `rustfmt --edition 2021 --check src-tauri/src/updates.rs` — passed
- `git diff --check` — passed

Real update download/install and rollback remain manual because the debug E2E build disables updater checks; the meeting boundary, fail-closed policy, resettable quiet window, generated binding, and visible waiting/resume state are automated.
