### PR TITLE
Rename legal entity to Negentropy Labs, Inc.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # Screenpipe Commercial License
 
-Copyright (c) 2024-2026 Mediar, Inc. (dba Screenpipe). All rights reserved.
+Copyright (c) 2024-2026 Negentropy Labs, Inc. (dba Screenpipe). All rights reserved.
 
 ## 1. Definitions
 
@@ -8,7 +8,7 @@ Copyright (c) 2024-2026 Mediar, Inc. (dba Screenpipe). All rights reserved.
 including its source code and documentation, and any binaries built from
 that source code.
 
-"Licensor" means Mediar, Inc. (dba Screenpipe).
+"Licensor" means Negentropy Labs, Inc. (dba Screenpipe).
 
 "You" means the individual or entity exercising rights under this license.
 

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ Each pipe supports YAML frontmatter fields (allow-apps, deny-apps, deny-windows,
 
 ## Company
 
-Built by screenpipe (Mediar, Inc.). Founded 2024. Based in San Francisco, CA.
+Built by screenpipe (Negentropy Labs, Inc.). Founded 2024. Based in San Francisco, CA.
 
 - Founder: Louis Beaumont (@louis030195)
 - Twitter: @screenpipe

--- a/apps/screenpipe-app-tauri/src-tauri/tauri.beta.conf.json
+++ b/apps/screenpipe-app-tauri/src-tauri/tauri.beta.conf.json
@@ -11,11 +11,11 @@
   "bundle": {
     "createUpdaterArtifacts": true,
     "active": true,
-    "publisher": "Mediar, Inc.",
+    "publisher": "Negentropy Labs, Inc.",
     "category": "DeveloperTool",
     "shortDescription": "24/7 memory for your desktop",
     "longDescription": "24/7 memory for your desktop. 100% local. You own your data.",
-    "copyright": "",
+    "copyright": "Copyright © 2024-2026 Negentropy Labs, Inc. All rights reserved.",
     "targets": [
       "app",
       "dmg",

--- a/apps/screenpipe-app-tauri/src-tauri/tauri.conf.json
+++ b/apps/screenpipe-app-tauri/src-tauri/tauri.conf.json
@@ -10,11 +10,11 @@
   },
   "bundle": {
     "active": true,
-    "publisher": "Mediar, Inc.",
+    "publisher": "Negentropy Labs, Inc.",
     "category": "DeveloperTool",
     "shortDescription": "24/7 memory for your desktop",
     "longDescription": "24/7 memory for your desktop. 100% local. You own your data.",
-    "copyright": "",
+    "copyright": "Copyright © 2024-2026 Negentropy Labs, Inc. All rights reserved.",
     "targets": [
       "app",
       "dmg",

--- a/apps/screenpipe-app-tauri/src-tauri/tauri.enterprise.conf.json
+++ b/apps/screenpipe-app-tauri/src-tauri/tauri.enterprise.conf.json
@@ -11,11 +11,11 @@
   "bundle": {
     "createUpdaterArtifacts": true,
     "active": true,
-    "publisher": "Screenpipe Inc.",
+    "publisher": "Negentropy Labs, Inc.",
     "category": "DeveloperTool",
     "shortDescription": "24/7 memory for your desktop",
     "longDescription": "24/7 memory for your desktop. 100% local. You own your data.",
-    "copyright": "",
+    "copyright": "Copyright © 2024-2026 Negentropy Labs, Inc. All rights reserved.",
     "targets": [
       "app",
       "dmg",

--- a/apps/screenpipe-app-tauri/src-tauri/tauri.linux.conf.json
+++ b/apps/screenpipe-app-tauri/src-tauri/tauri.linux.conf.json
@@ -1,6 +1,6 @@
 {
     "bundle": {
-        "publisher": "Mediar, Inc.",
+        "publisher": "Negentropy Labs, Inc.",
         "resources": [
             "assets/*"
         ],

--- a/apps/screenpipe-app-tauri/src-tauri/tauri.macos.conf.json
+++ b/apps/screenpipe-app-tauri/src-tauri/tauri.macos.conf.json
@@ -1,6 +1,6 @@
 {
     "bundle": {
-        "publisher": "Mediar, Inc.",
+        "publisher": "Negentropy Labs, Inc.",
         "macOS": {
             "entitlements": "entitlements.plist",
             "hardenedRuntime": true,

--- a/apps/screenpipe-app-tauri/src-tauri/tauri.prod.conf.json
+++ b/apps/screenpipe-app-tauri/src-tauri/tauri.prod.conf.json
@@ -11,11 +11,11 @@
   "bundle": {
     "createUpdaterArtifacts": true,
     "active": true,
-    "publisher": "Mediar, Inc.",
+    "publisher": "Negentropy Labs, Inc.",
     "category": "DeveloperTool",
     "shortDescription": "24/7 memory for your desktop",
     "longDescription": "24/7 memory for your desktop. 100% local. You own your data.",
-    "copyright": "",
+    "copyright": "Copyright © 2024-2026 Negentropy Labs, Inc. All rights reserved.",
     "targets": [
       "app",
       "dmg",

--- a/apps/screenpipe-app-tauri/src-tauri/tauri.windows.conf.json
+++ b/apps/screenpipe-app-tauri/src-tauri/tauri.windows.conf.json
@@ -1,6 +1,6 @@
 {
     "bundle": {
-        "publisher": "Mediar, Inc.",
+        "publisher": "Negentropy Labs, Inc.",
         "windows": {
             "nsis": {
                 "headerImage": "assets/nsis-header.bmp",


### PR DESCRIPTION
## Summary\n- update the Screenpipe Commercial License licensor and copyright holder\n- update the company name in the README\n- use Negentropy Labs, Inc. as the desktop publisher on macOS, Windows, and Linux\n- add the legal copyright notice to app bundle metadata\n\n## Verification\n- all changed Tauri configuration files parse as valid JSON\n- git diff --check passed