### PR TITLE
fix(github): include organization repositories in picker

### DIFF
--- a/crates/screenpipe-connect/src/connections/github_issues.rs
+++ b/crates/screenpipe-connect/src/connections/github_issues.rs
@@ -14,7 +14,9 @@ const GITHUB_CLIENT_ID: &str = "Ov23li9IT9uV0S9ql2ne";
 static OAUTH: OAuthConfig = OAuthConfig {
     auth_url: "https://github.com/login/oauth/authorize",
     client_id: GITHUB_CLIENT_ID,
-    extra_auth_params: &[("scope", "repo")],
+    // `repo` grants repository access, while `read:org` makes private
+    // organization memberships visible so `/user/repos` can include them.
+    extra_auth_params: &[("scope", "repo read:org")],
     redirect_uri_override: None,
 };
 
@@ -92,5 +94,15 @@ impl Integration for GithubIssues {
 
         let login = resp["login"].as_str().unwrap_or("unknown");
         Ok(format!("connected as {}", login))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OAUTH;
+
+    #[test]
+    fn oauth_requests_organization_membership_visibility() {
+        assert_eq!(OAUTH.extra_auth_params, &[("scope", "repo read:org")]);
     }
 }


### PR DESCRIPTION
## What changed

Request the GitHub `read:org` OAuth scope alongside `repo` so the authenticated `/user/repos` picker can include repositories available through private organization membership.

Existing GitHub connections must disconnect and reconnect once to grant the added scope.

## Historical intent

- Inspected the GitHub integration introduced in commit `3a6bf7b9a2` and the merged app-trigger work in PR #6836 / commit `f680d7e47b`.
- The original `repo` scope preserved private repository access, while PR #6836 began using authenticated `/user/repos` for repository discovery.
- This keeps `repo` unchanged and adds only the organization-membership visibility needed by that picker.

## Verification

- `cargo test -p screenpipe-connect oauth_requests_organization_membership_visibility` — 1 passed
- `cargo fmt --all -- --check` — passed
