### PR TITLE
fix(meetings): keep hidden meetings out of the list

### DIFF
--- a/apps/screenpipe-app-tauri/components/meeting-notes/past-meetings.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/past-meetings.tsx
@@ -4,7 +4,7 @@
 "use client";
 
 import React from "react";
-import { Check, Copy, FileText, Loader2, Phone, Trash2 } from "lucide-react";
+import { Check, Copy, EyeOff, FileText, Loader2, Phone } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { localFetch } from "@/lib/api";
 import { useToast } from "@/components/ui/use-toast";
@@ -321,16 +321,19 @@ function PastMeetingRow({
     }
   };
 
-  const handleDelete = async () => {
+  const handleHide = async () => {
     try {
       const res = await localFetch(`/meetings/${meeting.id}`, {
-        method: "DELETE",
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ hidden: true }),
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       onDelete(meeting.id);
+      toast({ title: "meeting hidden" });
     } catch (err) {
       toast({
-        title: "couldn't delete meeting",
+        title: "couldn't hide meeting",
         description: String(err),
         variant: "destructive",
       });
@@ -424,25 +427,24 @@ function PastMeetingRow({
               <AlertDialogTrigger asChild>
                 <button
                   className="opacity-0 group-hover:opacity-100 transition-opacity h-7 w-7 flex items-center justify-center bg-transparent text-muted-foreground hover:text-destructive"
-                  title="delete meeting"
+                  title="hide meeting"
                 >
-                  <Trash2 className="h-3 w-3" />
+                  <EyeOff className="h-3 w-3" />
                 </button>
               </AlertDialogTrigger>
               <AlertDialogContent>
                 <AlertDialogHeader>
-                  <AlertDialogTitle>delete meeting</AlertDialogTitle>
+                  <AlertDialogTitle>hide meeting</AlertDialogTitle>
                   <AlertDialogDescription>
-                    your notes and transcript will be permanently deleted.
+                    this meeting will disappear from the list. your notes and transcript will be kept.
                   </AlertDialogDescription>
                 </AlertDialogHeader>
                 <AlertDialogFooter>
                   <AlertDialogCancel>cancel</AlertDialogCancel>
                   <AlertDialogAction
-                    variant="destructive"
-                    onClick={() => void handleDelete()}
+                    onClick={() => void handleHide()}
                   >
-                    delete
+                    hide
                   </AlertDialogAction>
                 </AlertDialogFooter>
               </AlertDialogContent>

--- a/apps/screenpipe-app-tauri/lib/utils/meeting-format.ts
+++ b/apps/screenpipe-app-tauri/lib/utils/meeting-format.ts
@@ -10,6 +10,7 @@ export interface MeetingRecord {
   title: string | null;
   attendees: string | null;
   note: string | null;
+  hidden: boolean;
   detection_source: string;
   created_at: string;
 }

--- a/crates/screenpipe-db/src/db/meetings.rs
+++ b/crates/screenpipe-db/src/db/meetings.rs
@@ -530,8 +530,8 @@ impl DatabaseManager {
         for attempt in 1..=max_retries {
             let mut conn = self.pool.acquire().await?;
             match sqlx::query_as::<_, MeetingRecord>(
-                "SELECT id, meeting_start, meeting_end, meeting_app, title, attendees, note, \
-                 detection_source, created_at FROM meetings WHERE id = ?1 AND meeting_end IS NULL",
+                "SELECT id, meeting_start, meeting_end, meeting_app, title, attendees, note, hidden, \
+                 detection_source, created_at FROM meetings WHERE id = ?1 AND hidden = 0 AND meeting_end IS NULL",
             )
             .bind(id)
             .fetch_optional(&mut *conn)
@@ -594,8 +594,8 @@ impl DatabaseManager {
         for attempt in 1..=max_retries {
             let mut conn = self.pool.acquire().await?;
             match sqlx::query_as::<_, MeetingRecord>(
-                "SELECT id, meeting_start, meeting_end, meeting_app, title, attendees, note, \
-                 detection_source, created_at FROM meetings WHERE meeting_end IS NULL \
+                "SELECT id, meeting_start, meeting_end, meeting_app, title, attendees, note, hidden, \
+                 detection_source, created_at FROM meetings WHERE hidden = 0 AND meeting_end IS NULL \
                  ORDER BY id DESC LIMIT 1",
             )
             .fetch_optional(&mut *conn)
@@ -630,8 +630,8 @@ impl DatabaseManager {
         offset: u32,
     ) -> Result<Vec<MeetingRecord>, SqlxError> {
         let mut sql = String::from(
-            "SELECT id, meeting_start, meeting_end, meeting_app, title, attendees, note, \
-             detection_source, created_at FROM meetings WHERE 1=1",
+            "SELECT id, meeting_start, meeting_end, meeting_app, title, attendees, note, hidden, \
+             detection_source, created_at FROM meetings WHERE hidden = 0",
         );
         if start_time.is_some() {
             sql.push_str(" AND meeting_start >= ?");
@@ -697,7 +697,7 @@ impl DatabaseManager {
         for attempt in 1..=max_retries {
             let mut conn = self.pool.acquire().await?;
             match sqlx::query_as::<_, MeetingRecord>(
-                "SELECT id, meeting_start, meeting_end, meeting_app, title, attendees, note, \
+                "SELECT id, meeting_start, meeting_end, meeting_app, title, attendees, note, hidden, \
                  detection_source, created_at FROM meetings WHERE id = ?1",
             )
             .bind(id)
@@ -1401,6 +1401,7 @@ impl DatabaseManager {
         attendees: Option<&str>,
         note: Option<&str>,
         meeting_app: Option<&str>,
+        hidden: Option<bool>,
     ) -> Result<(), SqlxError> {
         let mut sets: Vec<&str> = Vec::new();
         if meeting_start.is_some() {
@@ -1420,6 +1421,9 @@ impl DatabaseManager {
         }
         if meeting_app.is_some() {
             sets.push("meeting_app = ?");
+        }
+        if hidden.is_some() {
+            sets.push("hidden = ?");
         }
         if sets.is_empty() {
             return Ok(());
@@ -1453,6 +1457,9 @@ impl DatabaseManager {
             query = query.bind(v);
         }
         if let Some(v) = meeting_app {
+            query = query.bind(v);
+        }
+        if let Some(v) = hidden {
             query = query.bind(v);
         }
         query.bind(id).execute(&mut **tx.conn()).await?;

--- a/crates/screenpipe-db/src/migrations/20260903000000_add_hidden_to_meetings.sql
+++ b/crates/screenpipe-db/src/migrations/20260903000000_add_hidden_to_meetings.sql
@@ -1,0 +1,3 @@
+ALTER TABLE meetings ADD COLUMN hidden INTEGER NOT NULL DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS idx_meetings_hidden_start ON meetings(hidden, meeting_start);

--- a/crates/screenpipe-db/src/types.rs
+++ b/crates/screenpipe-db/src/types.rs
@@ -456,6 +456,7 @@ pub struct MeetingRecord {
     pub title: Option<String>,
     pub attendees: Option<String>,
     pub note: Option<String>,
+    pub hidden: bool,
     pub detection_source: String,
     pub created_at: String,
 }

--- a/crates/screenpipe-engine/src/meeting_summary/finalizer.rs
+++ b/crates/screenpipe-engine/src/meeting_summary/finalizer.rs
@@ -425,6 +425,7 @@ mod db_tests {
             &store,
             &format!("{}@2026-08-25T20:17:43.382Z", meeting_id),
             &agent_end_stdout("## Summary\nGeneration-keyed run body long enough to persist."),
+            None,
         )
         .await;
 
@@ -508,6 +509,7 @@ mod db_tests {
             None,
             Some("prep\n\n## Summary\nthe agent-saved one"),
             None,
+            None,
         )
         .await
         .unwrap();
@@ -558,6 +560,7 @@ mod db_tests {
             None,
             None,
             Some("## Summary\nalready here"),
+            None,
             None,
         )
         .await

--- a/crates/screenpipe-engine/src/meeting_watcher/audio_process/lifecycle.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/audio_process/lifecycle.rs
@@ -205,7 +205,7 @@ pub(crate) async fn start_or_adopt_auto_meeting_guarded(
                             if recent.title.as_ref().is_none_or(|t| t.is_empty()) {
                                 if let Err(e) = db
                                     .update_meeting(
-                                        recent.id, None, None, title, attendees, None, None,
+                                        recent.id, None, None, title, attendees, None, None, None,
                                     )
                                     .await
                                 {

--- a/crates/screenpipe-engine/src/meeting_watcher/audio_process/tests.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/audio_process/tests.rs
@@ -2988,6 +2988,7 @@ async fn manually_started_meeting_claims_its_calendar_event() {
         binding.attendees.as_deref(),
         None,
         None,
+        None,
     )
     .await
     .unwrap();

--- a/crates/screenpipe-engine/src/meeting_watcher/ui_scan/lifecycle.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/ui_scan/lifecycle.rs
@@ -350,6 +350,7 @@ pub(crate) async fn apply_state_action(
                                             calendar.attendees.as_deref(),
                                             None,
                                             None,
+                                            None,
                                         )
                                         .await
                                     {

--- a/crates/screenpipe-engine/src/routes/meetings.rs
+++ b/crates/screenpipe-engine/src/routes/meetings.rs
@@ -36,6 +36,7 @@ pub struct UpdateMeetingRequest {
     pub attendees: Option<String>,
     pub note: Option<String>,
     pub meeting_app: Option<String>,
+    pub hidden: Option<bool>,
     /// Set when `title`/`attendees` come from a calendar event. The event is
     /// claimed for this meeting first; if another meeting already owns it, the
     /// calendar-derived fields are dropped and the rest of the update applies.
@@ -677,6 +678,8 @@ pub(crate) async fn update_meeting_handler(
             attendees,
             body.note.as_deref(),
             body.meeting_app.as_deref(),
+            body.hidden,
+            None,
         )
         .await
         .map_err(|e| {
@@ -958,6 +961,7 @@ pub(crate) async fn start_meeting_handler(
                         attendees_update,
                         None,
                         None,
+                        None,
                     )
                     .await
                 {
@@ -986,6 +990,7 @@ pub(crate) async fn start_meeting_handler(
                         None,
                         title_update,
                         attendees_update,
+                        None,
                         None,
                         None,
                     )


### PR DESCRIPTION
## Problem
Hiding a meeting from the Meetings list currently uses the destructive delete action, so users lose the notes and transcript instead of merely dismissing the row.

## Change
- Add a persisted `hidden` flag to meeting records.
- Exclude hidden meetings from list and active-meeting queries.
- Add `hidden` to the update API.
- Change the row action to **hide meeting**, preserving its notes and transcript.

## Verification
- `cargo fmt --all`
- `git diff --check`
- `cargo check -p screenpipe-engine -p screenpipe-db` (started successfully; command exceeded the 5-minute execution limit after compiling dependencies)
- Frontend Vitest could not start in the isolated worktree because dependencies are not installed there (`vitest/config` and `@vitejs/plugin-react` unresolved).

## Remaining risk
The frontend interaction test still needs to be run in a dependency-complete checkout. Hidden meetings are intentionally not exposed by the existing list endpoint, so a future restore UI/API would need a separate explicit scope.
