### PR TITLE
fix(app): keep hidden meetings out of top bar

### DIFF
--- a/apps/screenpipe-app-tauri/app/(main)/home/page.tsx
+++ b/apps/screenpipe-app-tauri/app/(main)/home/page.tsx
@@ -1143,8 +1143,7 @@ function HomeContent() {
   // is exactly when the compact chrome-strip icon takes over — so the two can
   // never both render, and neither survives policy hiding the section.
   const meetingsInSidebar = visibleSidebarIds.includes("meetings");
-  const meetingsInToolbar =
-    !meetingsInSidebar && availableSidebarIds.includes("meetings");
+  const meetingsInToolbar = false;
 
   const persistSidebarLayout = (next: ReturnType<typeof normalizeSidebarNavLayout>) => {
     void updateSettings({ sidebarNavLayout: next });


### PR DESCRIPTION
## Problem\nHiding Meetings from the sidebar still rendered a Meetings button in the top bar, so the section was never truly hidden.\n\n## Fix\nRemove the UI fallback button. Sidebar customization remains the only restore path, with no database or API changes.\n\n## Verification\n- git diff --check\n- Existing sidebar layout and component tests cover hiding/showing Meetings.\n- Frontend tests not run: isolated worktree has no node_modules.