### PR TITLE
fix(chat): explain engine context overflow

### DIFF
--- a/apps/screenpipe-app-tauri/lib/chat/__tests__/provider-errors.test.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/__tests__/provider-errors.test.ts
@@ -355,6 +355,17 @@ describe("provider error copy", () => {
     expect(msg).not.toContain("invalid_request_error");
   });
 
+  it("maps the engine protocol context-size-exceeded signature", () => {
+    const raw =
+      'Error: Engine protocol predict stream returned an error: {"code":500,"message":"Context size has been exceeded.","type":"server_error"}';
+
+    expect(
+      buildProviderErrorMessage(raw, { provider: "screenpipe-cloud", model: "auto" })
+    ).toBe(
+      "This chat is too long for the selected model. Match Settings → AI → Advanced → model context tokens to the provider's context window. Start a new chat or remove large attachments/screenshots, then retry."
+    );
+  });
+
   it("explains llama.cpp context mismatches with reported token counts", () => {
     const raw = 'Engine protocol predict request returned 400: {"error":{"code":400,"message":"request (13069 tokens) exceeds the available context size (8192 tokens), try increasing it","type":"exceed_context_size_error","n_prompt_tokens":13069,"n_ctx":8192}}';
     expect(

--- a/apps/screenpipe-app-tauri/lib/chat/provider-errors.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/provider-errors.ts
@@ -135,6 +135,7 @@ function isContextOverflowError(errorStr: string): boolean {
   return (
     normalized.includes("context_length_exceeded") ||
     normalized.includes("exceed_context_size_error") ||
+    normalized.includes("context size has been exceeded") ||
     normalized.includes("exceeds the available context size") ||
     normalized.includes("context window") ||
     normalized.includes("maximum context length") ||


### PR DESCRIPTION
## Summary

A user-reported Windows chat failure surfaced the raw Engine protocol 500 message `Context size has been exceeded.` instead of actionable guidance.

The provider-error classifier now recognizes that narrow, case-insensitive normalized signature and reuses the existing sanitized context-overflow guidance. Because chat provider failures already pass through this shared classifier, the fix covers the full chat error-formatting surface without provider-specific handling or interpolation of untrusted error text.

## Changed files

- `apps/screenpipe-app-tauri/lib/chat/provider-errors.ts`
- `apps/screenpipe-app-tauri/lib/chat/__tests__/provider-errors.test.ts`

## Before / after

```text
Before: Engine 500 -> unclassified -> raw protocol error shown in chat
After:  Engine 500 -> context overflow -> safe guidance to start a new chat or increase context
```

## Verification

- RED on the exact parent with only the regression test: failed as expected because classification returned `null` (1 failed, 46 skipped)
- Focused provider-errors suite: 47/47 passed
- Full app suite: 4,983 Vitest tests and 242 Bun tests passed
- TypeScript `--noEmit`: passed
- Scoped ESLint for both changed files: passed
- `git diff --check`: passed
- Manual behavior matrix: observed phrase is matched case-insensitively; nearby non-signatures remain unclassified; guidance remains static and sanitized
- Independent review: exact two-file, 12-line additive commit approved with no scope or security concerns

## Platform scope

The report was observed on Windows. The classifier is shared TypeScript chat logic, so behavior is platform-independent; no native or platform-specific code changes.