### PR TITLE
fix(ai-gateway): clamp reasoning effort for GPT-5.4 tools

### DIFF
--- a/packages/ai-gateway/src/providers/openai.ts
+++ b/packages/ai-gateway/src/providers/openai.ts
@@ -368,12 +368,13 @@ export class OpenAIProvider implements AIProvider {
 	}
 
 	private applyToolCompatibilityOptions(params: ChatCompletionCreateParams, body: RequestBody): void {
-		// GPT-5.5 and GPT-5.6 accept function tools through Chat Completions only when
-		// reasoning_effort is "none". Pi speaks the Chat Completions protocol,
-		// so preserve tool support there rather than silently cascading a Luna
-		// request to another provider. Agentic callers that need reasoning plus
-		// tools can use the Responses API directly.
-		if (/^gpt-5\.(?:5|6)(?:$|[.-])/i.test(body.model) && Array.isArray(body.tools) && body.tools.length > 0) {
+		// The whole GPT-5 family accepts function tools through Chat Completions
+		// only when reasoning_effort is "none" — including the 5.4 tier, which
+		// background pipes reach with an injected effort (applyBackgroundReasoningDefault).
+		// Pi speaks the Chat Completions protocol, so preserve tool support here
+		// rather than silently cascading the request to another provider. Agentic
+		// callers that need reasoning plus tools can use the Responses API directly.
+		if (/^gpt-5(?:$|[.-])/i.test(body.model) && Array.isArray(body.tools) && body.tools.length > 0) {
 			Object.assign(params, { reasoning_effort: 'none' });
 		}
 	}

--- a/packages/ai-gateway/src/test/provider-usage.unit.test.ts
+++ b/packages/ai-gateway/src/test/provider-usage.unit.test.ts
@@ -140,6 +140,28 @@ describe('OpenAIProvider usage reporting', () => {
 		expect(calls[0].reasoning_effort).toBe('none');
 	});
 
+	// Regression for the top ai-proxy 400 (47k events, all model:gpt-5.4-nano):
+	// background pipes get reasoning_effort injected by
+	// applyBackgroundReasoningDefault, and the 5.4 tier rejects function tools
+	// unless that effort is "none" — same Chat Completions rule as 5.5/5.6.
+	it('sets reasoning_effort to none for GPT-5.4 function tools with an injected background effort', async () => {
+		const { provider, calls } = makeOpenAIProvider(async () => ({
+			choices: [{ message: { content: 'answer', role: 'assistant' } }],
+		}));
+		const tools: any = [{
+			type: 'function',
+			function: {
+				name: 'search_screenpipe',
+				parameters: { type: 'object', properties: {} },
+			},
+		}];
+
+		await provider.createCompletion({ ...body, model: 'gpt-5.4-nano', reasoning_effort: 'low', tools });
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0].reasoning_effort).toBe('none');
+	});
+
 	it('does not disable reasoning for GPT-5.6 requests without tools', async () => {
 		async function* stream() {
 			yield { choices: [{ delta: { content: 'ok' }, finish_reason: 'stop' }] };


### PR DESCRIPTION
## What

Sentry [SCREENPIPE-AI-PROXY issue 7669590205](https://mediar.sentry.io/issues/7669590205/) — 47,746 events in production, all tagged `model:gpt-5.4-nano`, `error_path:fallback_fatal`.

Upstream rejects the request with:

```
400 Function tools with reasoning_effort are not supported for gpt-5.4-nano
in /v1/chat/completions. To use function tools, use /v1/responses or set
reasoning_effort to 'none'.
```

## Why it happened

`applyToolCompatibilityOptions` already exists for exactly this upstream rule: Chat Completions rejects function tools unless `reasoning_effort` is `"none"`. It was written for the 5.5/5.6 tiers and its guard was `^gpt-5\.(?:5|6)`, on the assumption that the 5.4 tier never carries an effort value.

Background pipes do carry one. `applyBackgroundReasoningDefault` injects `reasoning_effort: 'low'` into any request sent with `x-screenpipe-latency: background` that omits the field. So a tool-using 5.4 pipe arrives at the provider with an effort the clamp was designed to strip, but which the guard did not match.

The retry ladder could not absorb it either: `createWithUnsupportedParamRetry` only repairs *unknown/unsupported* params (`Unsupported value:`, `Unknown parameter:`, `Unrecognized request argument`). This is a valid-but-incompatible combination, so no repair rule matched, the model chain burned every fallback entry, and the request surfaced as `fallback_fatal`.

## Fix

Widen the existing guard from `^gpt-5\.(?:5|6)` to the GPT-5 family. That reuses the clamp already wired into both `createCompletion` and `createStreamingCompletion` — no new branch, no new retry rule, no new abstraction.

## Test evidence

New regression test pins the reported case: model `gpt-5.4-nano`, function tools, and an injected background effort of `low`.

RED — new test against the unmodified provider:

```
(fail) sets reasoning_effort to none for GPT-5.4 function tools with an injected background effort
 10 pass
 1 fail
Ran 11 tests across 1 file.
```

GREEN — with the fix, across the three suites that touch this path
(`provider-usage`, `latency`, `anthropic-caching`):

```
 40 pass
 0 fail
 111 expect() calls
Ran 40 tests across 3 files.
```

The pre-existing `gpt-5.5` / `gpt-5.6` clamp tests and the "forwards an explicit reasoning effort when tools do not require compatibility clamping" test still pass, so interactive traffic and non-tool requests are unchanged.

## Scope

Two files, +29/−6. No behavior change for requests without tools, and no change to the Responses API path.

🤖 Found and fixed by the Sentry autofix worker.
