### PR TITLE
fix(chat): open home agent deep links cross-platform

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat/home-card-agent-actions.test.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/home-card-agent-actions.test.tsx
@@ -5,6 +5,7 @@
 import React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import tauriConfig from "../../src-tauri/tauri.conf.json";
 
 import {
   buildHomeCardAgentPrompt,
@@ -26,8 +27,8 @@ vi.mock("@/lib/utils/tauri", () => ({
   commands: { copyTextToClipboard: mocks.copyTextToClipboard },
 }));
 
-vi.mock("@tauri-apps/plugin-opener", () => ({
-  openUrl: mocks.openUrl,
+vi.mock("@/lib/open-external-url", () => ({
+  openExternalUrl: mocks.openUrl,
 }));
 
 const DAY_RECAP = {
@@ -185,6 +186,17 @@ describe("HomeCardAgentActions", () => {
       "home_card_agent_handoff_completed",
       expect.objectContaining({ agent: "codex", card: "custom" }),
     );
+    const prompt = buildHomeCardAgentPrompt(
+      {
+        name: "custom-tpl-1",
+        title: "Client recap",
+        previewPrompt: "Summarize my client work",
+      },
+      "codex",
+    );
+    expect(mocks.openUrl).toHaveBeenCalledWith(
+      `codex://threads/new?prompt=${encodeURIComponent(prompt)}`,
+    );
   });
 
   it("shows the copied fallback when the app cannot open", async () => {
@@ -226,6 +238,10 @@ describe("HomeCardAgentActions", () => {
     await waitFor(() =>
       expect(screen.getByRole("status")).toHaveTextContent("unavailable"),
     );
+    const prompt = buildHomeCardAgentPrompt(DAY_RECAP, "cursor");
+    expect(mocks.openUrl).toHaveBeenCalledWith(
+      `cursor://anysphere.cursor-deeplink/prompt?text=${encodeURIComponent(prompt)}`,
+    );
     expect(mocks.capture).toHaveBeenCalledWith(
       "home_card_agent_handoff_completed",
       expect.objectContaining({
@@ -235,5 +251,15 @@ describe("HomeCardAgentActions", () => {
         clipboard_copied: false,
       }),
     );
+  });
+
+  it("allows every agent deeplink through the cross-platform shell validator", () => {
+    const validator = new RegExp(`^${tauriConfig.plugins.shell.open}$`);
+
+    expect(validator.test("claude://claude.ai/new?q=test")).toBe(true);
+    expect(
+      validator.test("cursor://anysphere.cursor-deeplink/prompt?text=test"),
+    ).toBe(true);
+    expect(validator.test("codex://threads/new?prompt=test")).toBe(true);
   });
 });

--- a/apps/screenpipe-app-tauri/components/chat/home-card-agent-actions.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/home-card-agent-actions.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/lib/first-run/agent-handoff";
 import { entryCardForHomeTemplate } from "@/lib/chat/response-feedback";
 import { type ChatEntryCard } from "@/lib/chat/types";
+import { openExternalUrl } from "@/lib/open-external-url";
 import { commands } from "@/lib/utils/tauri";
 
 type HomeCardAgentId = "claude" | "cursor" | "codex";
@@ -156,8 +157,7 @@ export function HomeCardAgentActions({
           if (copied.status === "error") throw new Error(copied.error);
         },
         openUrl: async (url) => {
-          const { openUrl } = await import("@tauri-apps/plugin-opener");
-          await openUrl(url);
+          await openExternalUrl(url);
         },
       },
       prompt,

--- a/apps/screenpipe-app-tauri/src-tauri/tauri.conf.json
+++ b/apps/screenpipe-app-tauri/src-tauri/tauri.conf.json
@@ -45,6 +45,9 @@
     }
   },
   "plugins": {
+    "shell": {
+      "open": "(?:https?://.*|mailto:.*|tel:.*|x-apple-reminderkit://.*|claude://claude\\.ai/new\\?q=.*|cursor://anysphere\\.cursor-deeplink/prompt\\?text=.*|codex://threads/new\\?prompt=.*)"
+    },
     "updater": {
       "endpoints": [],
       "pubkey": ""


### PR DESCRIPTION
## Summary

- route home-card Claude, Cursor, and Codex URLs through the existing cross-platform shell opener
- allow only the exact `claude://`, `cursor://`, and `codex://` prompt routes in the shell validator
- preserve copy-first fallback behavior and prompt-free handoff telemetry

## Before / after

Before:

    home card click -> custom URL opener fails -> prompt copied only

After:

    home card click -> shell.open(deeplink) -> registered chat app opens
                    `-> clipboard remains available as fallback

## Verification

- manual macOS acceptance: deep links opened the external chat apps
- `bun x vitest run --config vitest.config.ts components/chat/home-card-agent-actions.test.tsx lib/first-run/agent-handoff.test.ts` — 32 passed
- `bun run build:tauri:dev` — passed
- `git diff --check` — passed

Windows and Linux use the same `plugin-shell.open(deeplink)` code path and their registered protocol handlers; they were not runtime-tested in this change.

## Historical intent

- PR #6822 introduced the compact home-card actions with verified agent deep links and a clipboard fallback.
- PR #6830 replaced that interaction with ACP-backed in-app agents.
- PR #6859 reverted #6830 to restore the compact external-app handoff.

This preserves the restored compact UI, deep-link routes, and clipboard recovery from #6822/#6859. The old test only mocked URL opening and therefore could not exercise the shell validator; the updated regression asserts that all three emitted deep-link shapes match the real Tauri shell configuration.