### PR TITLE
fix(ai-gateway): classify Sentry 7494814662 output budget errors

### DIFF
--- a/packages/ai-gateway/src/handlers/chat.ts
+++ b/packages/ai-gateway/src/handlers/chat.ts
@@ -144,6 +144,10 @@ const CLIENT_PAYLOAD_PATTERNS: Array<{ re: RegExp; message: string }> = [
     re: /at least one message is required/i,
     message: 'The request must include at least one user or assistant message.',
   },
+  {
+    re: /could not finish the message because max_tokens or model output limit was reached/i,
+    message: 'The model reached its output limit before finishing. Increase max_tokens and try again.',
+  },
 ];
 
 export function clientPayloadMessage(status: number, msg: string): string | null {

--- a/packages/ai-gateway/src/test/chat-fallback.unit.test.ts
+++ b/packages/ai-gateway/src/test/chat-fallback.unit.test.ts
@@ -273,6 +273,14 @@ describe('chat handler — client payload classification (SCREENPIPE-AI-PROXY-1A
 		expect(msg).toContain('at least one user or assistant message');
 	});
 
+	it('maps output-budget exhaustion to actionable token guidance', () => {
+		const msg = clientPayloadMessage(
+			400,
+			'400 Could not finish the message because max_tokens or model output limit was reached. Please try again with higher max_tokens.',
+		);
+		expect(msg).toContain('Increase max_tokens');
+	});
+
 	it('leaves unrelated 400s unclassified', () => {
 		expect(clientPayloadMessage(400, 'invalid tool schema')).toBeNull();
 		expect(clientPayloadMessage(500, 'failed to decode image data')).toBeNull();


### PR DESCRIPTION
## Source

- Sentry: https://mediar.sentry.io/issues/7598703530/
- Sentry project: `screenpipe-ai-proxy`
- Impact: 1,506 events in 24 hours across a six-issue cluster; the current tag sample attributes 638 events to one redacted user identity.

## Intended behavior

A model output-budget exhaustion is a deterministic client-payload problem. The gateway should stop the fallback cascade and return actionable guidance to increase `max_tokens`.

## Root cause

The stable upstream phrase `Could not finish the message because max_tokens or model output limit was reached` was absent from the existing `CLIENT_PAYLOAD_PATTERNS` guard. `tryModel()` therefore treated the 400 as fatal, captured it, and continued through fallbacks that reused the same insufficient caller budget. Those attempts could not recover.

## Fix

- Extend the existing `clientPayloadMessage()` classifier with the stable output-budget phrase.
- Reuse the existing client-payload exit path to return `The model reached its output limit before finishing. Increase max_tokens and try again.`
- Add an exact-message regression to the existing chat fallback unit suite.

This covers the whole chat-completions fallback surface because model attempts already converge on `tryModel()` and its existing client-payload classifier; it does not add provider-specific retries or a second guard at the throw site.

## RED / GREEN evidence

RED command:

`/home/ezra/.bun/bin/bun /tmp/head_output_limit_probe_t_9a11cd3b.ts HEAD^`

Verbatim output, exit 1:

```text
HEAD^ clientPayloadMessage output-budget probe
Expected: "The model reached its output limit before finishing. Increase max_tokens and try again."
Received: null
```

GREEN command:

`PATH=/home/ezra/.bun/bin:$PATH /home/ezra/.bun/bin/bun test src/test/chat-fallback.unit.test.ts --timeout=10000`

Result: 30 pass, 0 fail, 76 assertions.

Broad package command:

`PATH=/home/ezra/.bun/bin:$PATH /home/ezra/.bun/bin/bun test --timeout=10000`

Result: 1,013 pass, 0 fail, 3,909 assertions across 66 files.

## Scope and visual evidence

- Scope: Cloudflare AI gateway `/v1/chat/completions`; platform-independent server behavior.
- Diff: 2 files, 12 insertions, 0 deletions.
- No user-interface pixels change, so visual evidence is represented as the before/after request flow:

```text
Before: output-limit 400 -> fatal classification -> same-budget fallbacks -> raw/generic 400
After:  output-limit 400 -> client-payload classification -> actionable max_tokens guidance
```

## Risk

Low and narrow: matching is limited to the stable upstream output-budget phrase and follows an established classification path. Other fatal and retryable errors are unchanged.