### PR TITLE
fix(chat): bound oversized provider requests

### DIFF
--- a/packages/ai-gateway/src/handlers/chat.ts
+++ b/packages/ai-gateway/src/handlers/chat.ts
@@ -123,6 +123,7 @@ const USER_INPUT_TOO_LARGE_PATTERNS = [
   /maximum context length/i,
   /context length.*exceeded/i,
   /request payload size exceeds/i,
+  /request exceeds the maximum size/i,
   // Vertex MaaS (glm-5 etc): "The input (325052 tokens) is longer than the
   // model's context length (202752 tokens)" — SCREENPIPE-AI-PROXY-C, 28 users.
   /longer than the model'?s context length/i,

--- a/packages/ai-gateway/src/test/chat-fallback.unit.test.ts
+++ b/packages/ai-gateway/src/test/chat-fallback.unit.test.ts
@@ -78,6 +78,15 @@ describe('chat handler — oversized-input classification (SCREENPIPE-AI-PROXY-C
 		expect(isUserInputTooLarge(400, 'prompt is too long: 250000 tokens > 200000 maximum')).toBe(true);
 	});
 
+	it('matches the Anthropic request-too-large 413 response', () => {
+		expect(
+			isUserInputTooLarge(
+				413,
+				'413 {"error":{"type":"request_too_large","message":"Request exceeds the maximum size"}}',
+			),
+		).toBe(true);
+	});
+
 	it('ignores unrelated 400s and non-4xx statuses', () => {
 		expect(isUserInputTooLarge(400, 'invalid tool schema')).toBe(false);
 		expect(isUserInputTooLarge(500, 'maximum context length exceeded')).toBe(false);


### PR DESCRIPTION
## Source

- Sentry: https://mediar.sentry.io/issues/7642497381/
- Project: `screenpipe-ai-proxy`
- The over-grouped issue contains 20 HTTP 413 events from one actor. Its retained events do not include request bodies or byte composition, so they do not prove whether text, tools, or images dominated those historical payloads.

## Root cause

Anthropic's Messages API rejects request bodies above 32 MiB before inference. This byte ceiling is separate from the model context-token window, so response streaming and token-based compaction do not solve it.

Screenpipe's Pi context hook bounded oversized text, but explicitly left inline base64 image blocks untouched. Pi retains those blocks in threaded history and sends the transformed context before every model call. Image-heavy conversations could therefore remain within the token budget while their serialized request exceeded the provider's byte limit.

The previous version of this PR only classified Anthropic's 413 wording after rejection. That reduced Sentry noise but did not prevent the oversized request.

## Fix

- Bound aggregate inline base64 image history to 16 MiB in Pi's existing pre-provider context hook, leaving half of Anthropic's 32 MiB request allowance for text, system prompts, tool schemas, and JSON framing.
- Recognize Pi-native, Anthropic-native, and OpenAI data-URL image blocks.
- Remove whole image blocks oldest-first and replace them with a compact marker; never truncate or corrupt base64 data.
- Preserve the newest images unless one image alone exceeds the budget.
- Leave URL-backed images and all unrelated non-text blocks unchanged.
- Retain the Anthropic 413 classifier only as a last-resort fallback for callers outside the managed Pi context path.

No multipart transport is added: Anthropic Messages accepts a JSON request, and `stream: true` streams the response rather than bypassing the input-size ceiling.

## Historical intent

- Inspected PR #3854 / commit `e128ba1a346`: context bounding belongs in Pi's `context` hook so it applies to the exact messages sent and complements built-in compaction. That invariant is preserved.
- Inspected PR #6867 / commit `d144428984`: the hook is now installed for every native Pi and Pi-over-ACP harness, and proactive token compaction remains unchanged.
- The old test that non-text blocks remain untouched covered text clamping only; it was not a request-byte safety contract. The new media pass supersedes only oversized inline-image retention while preserving other blocks.

## Verification

- `bun x vitest run --config vitest.config.ts lib/__tests__/context-pruning.test.ts` — 40 passed
- `bun run typecheck` — passed
- `bun test src/test/chat-fallback.unit.test.ts` in `packages/ai-gateway` — 30 passed
- `git diff --check` — passed

Regression coverage includes an 18 MiB accumulated-image conversation. The hook removes the older 9 MiB image, preserves the newest image, and leaves the serialized message history below Anthropic's 32 MiB ceiling.

## Scope and risk

- Four files changed: the shared Pi context extension, its direct tests, and the existing gateway fallback classifier/test.
- No API, persistence, authentication, dependency, or schema changes.
- No user content is logged.
