### PR TITLE
fix(ai-gateway): classify oversized tool arrays

### DIFF
--- a/packages/ai-gateway/src/handlers/chat.ts
+++ b/packages/ai-gateway/src/handlers/chat.ts
@@ -144,6 +144,10 @@ const CLIENT_PAYLOAD_PATTERNS: Array<{ re: RegExp; message: string }> = [
     re: /at least one message is required/i,
     message: 'The request must include at least one user or assistant message.',
   },
+  {
+    re: /invalid '(?:tools|messages\[\d+\]\.tool_calls)': array too long/i,
+    message: 'The request contains too many tools or tool calls. Reduce them and try again.',
+  },
 ];
 
 export function clientPayloadMessage(status: number, msg: string): string | null {

--- a/packages/ai-gateway/src/test/chat-fallback.unit.test.ts
+++ b/packages/ai-gateway/src/test/chat-fallback.unit.test.ts
@@ -273,8 +273,22 @@ describe('chat handler — client payload classification (SCREENPIPE-AI-PROXY-1A
 		expect(msg).toContain('at least one user or assistant message');
 	});
 
+	it('maps provider tool-array length 400s to actionable guidance', () => {
+		const messages = [
+			"400 Invalid 'tools': array too long. Expected an array with maximum length 128, but got an array with length 157 instead.",
+			"400 Invalid 'messages[14].tool_calls': array too long. Expected an array with maximum length 128, but got an array with length 261 instead.",
+		];
+
+		for (const message of messages) {
+			expect(clientPayloadMessage(400, message)).toBe(
+				'The request contains too many tools or tool calls. Reduce them and try again.',
+			);
+		}
+	});
+
 	it('leaves unrelated 400s unclassified', () => {
 		expect(clientPayloadMessage(400, 'invalid tool schema')).toBeNull();
+		expect(clientPayloadMessage(400, "Invalid 'messages[0].content': array too long.")).toBeNull();
 		expect(clientPayloadMessage(500, 'failed to decode image data')).toBeNull();
 	});
 });


### PR DESCRIPTION
## Source

- Sentry: https://mediar.sentry.io/issues/7602937125/
- Cluster members: `7602937125`, `7652011352`
- Observed volume: 883 clustered events in 24 hours
- User-impact signal: the `user` tag was present on 799 sampled cluster events (not asserted as 799 unique users)

## Intent

Return actionable client-payload guidance when an OpenAI-compatible provider rejects an oversized top-level `tools` array or indexed `messages[n].tool_calls` array, instead of treating the expected malformed-input response as a fatal fallback error.

## Root cause

The gateway intentionally forwards tool arrays unchanged so it does not alter tool-call semantics or orphan results. Providers reject arrays over their 128-entry limit, but the existing `CLIENT_PAYLOAD_PATTERNS` / `clientPayloadMessage()` seam did not recognize either observed `array too long` path. `tryModel()` therefore classified these expected 400 responses as fatal and captured them in Sentry.

## Fix

- Reuse the existing client-payload classifier with one path-specific pattern for only `tools` and `messages[n].tool_calls` array-length failures.
- Return guidance to reduce tools/tool calls and retry.
- Cover both exact observed variants plus an unrelated-path negative case.
- Preserve provider forwarding, message sanitization, retries, headers, and every tool array unchanged.

This covers the full observed surface because both provider error paths converge on the same classifier seam. The expression accepts any numeric message index while remaining fail-closed to unrelated array paths and non-client statuses.

## Before / after

```text
Before: oversized tools/tool_calls -> provider 400 -> classifier miss -> fallback_fatal + Sentry
After:  oversized tools/tool_calls -> provider 400 -> client guidance -> no fatal fallback capture
```

No product UI changed; the flow diagram and regression evidence are the applicable visual evidence.

## RED / GREEN evidence

Recorded verbatim from the implementation handoff:

```text
RED: /home/ezra/.bun/bin/bun test src/test/chat-fallback.unit.test.ts --timeout=10000 => 29 pass, 1 fail; expected guidance, received `null` at the new provider tool-array test.
GREEN before commit: same command => 30 pass, 0 fail, 78 expectations.
Fresh post-commit GREEN: same command => 30 pass, 0 fail, 78 expectations.
Full package: PATH=/home/ezra/.bun/bin:$PATH /home/ezra/.bun/bin/bun run test => 1013 pass, 0 fail, 3911 expectations across 66 files.
```

Independent review additionally exercised a 3-positive / 7-negative classifier matrix covering both exact paths, HTTP 422 support, unrelated paths, and non-400/422 statuses.

## Scope and risk

- Platform scope: AI gateway / Cloudflare API behavior for all clients; no desktop, native, OS-specific, database, capture, or audio changes.
- Diff: 2 files, +18/-0.
- No dependency, configuration, credential, retry, truncation, provider, sanitizer, or header changes.
- Typecheck remains blocked only by the pre-existing `AccountPlan` / `super_admin` mismatch reproduced on the exact base and candidate.
- Independent review approved exact commit `a59585ae567903e8c840ba19d439bf38fa6f3451`.
