### PR TITLE
fix(ai-gateway): require Anthropic tool input objects

### DIFF
--- a/packages/ai-gateway/src/providers/anthropic.ts
+++ b/packages/ai-gateway/src/providers/anthropic.ts
@@ -33,12 +33,12 @@ function safeJson(value: unknown): string {
 function safeToolInput(value: unknown): Record<string, any> {
 	if (typeof value === 'string') {
 		try {
-			return JSON.parse(value);
+			value = JSON.parse(value);
 		} catch {
 			return {};
 		}
 	}
-	return (value && typeof value === 'object') ? value as Record<string, any> : {};
+	return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, any>) : {};
 }
 
 function anthropicStopReasonToOpenAI(reason: unknown): string {

--- a/packages/ai-gateway/src/test/anthropic-proxy.unit.test.ts
+++ b/packages/ai-gateway/src/test/anthropic-proxy.unit.test.ts
@@ -678,6 +678,24 @@ describe('AnthropicProvider.formatMessages', () => {
 		expect(toolResult.content).toBe('Found: result');
 	});
 
+	it('normalizes non-object tool inputs to an empty object', () => {
+		const result = provider.formatMessages([
+			{
+				role: 'assistant',
+				content: '',
+				tool_calls: [
+					{ id: 'call_scalar', type: 'function', function: { name: 'search', arguments: '"query"' } },
+					{ id: 'call_array', type: 'function', function: { name: 'search', arguments: '["query"]' } },
+					{ id: 'call_null', type: 'function', function: { name: 'search', arguments: 'null' } },
+					{ id: 'call_native_array', name: 'search', input: ['query'] },
+				],
+			} as any,
+		]);
+
+		const content = result[0].content as any[];
+		expect(content.map((block) => block.input)).toEqual([{}, {}, {}, {}]);
+	});
+
 	it('should handle image_url content parts', () => {
 		const result = provider.formatMessages([{
 			role: 'user',


### PR DESCRIPTION
## Summary

- Fixes the exact validation failure reported by [Sentry issue 7644837007](https://mediar.sentry.io/issues/7644837007/) (`screenpipe-ai-proxy`).
- The cluster recorded 3,686 events in 24 hours across 10 grouped issues; the available tag sample contains 1,102 events attributed to one affected user identifier.
- Ensures Anthropic `tool_use.input` is always an object while preserving valid object inputs unchanged.

## Intended behavior

OpenAI-compatible function arguments should be converted into an Anthropic `tool_use` block whose `input` is an object. Malformed JSON and valid JSON with a non-object root should fail closed to the existing safe empty-object fallback.

## Root cause

The existing `safeToolInput` conversion seam parsed string arguments and returned any valid JSON root directly. Scalars, arrays, and `null` therefore reached Anthropic as `tool_use.input`, which Anthropic rejects because that field must be an object.

## Fix and coverage

The fix reuses the existing `safeToolInput` normalization point: strings are still parsed there, but only non-null, non-array objects pass through. Every other root normalizes to `{}`. This covers both parsed string inputs and native values at the single provider conversion seam rather than patching one call site or suppressing the SDK error.

The regression covers parsed scalar, array, and null roots plus a native array root. The existing object-input test continues to prove valid objects are preserved.

## RED / GREEN evidence

RED (before the implementation):

```text
/home/ezra/.bun/bin/bun test src/test/anthropic-proxy.unit.test.ts --timeout=10000 --test-name-pattern 'normalizes non-object tool inputs to an empty object'
0 pass, 1 fail; received ["query", ["query"], null, ["query"]], expected [{},{},{},{}]
```

GREEN (after the implementation):

```text
/home/ezra/.bun/bin/bun test src/test/anthropic-proxy.unit.test.ts --timeout=10000 --test-name-pattern 'normalizes non-object tool inputs to an empty object'
1 pass, 0 fail
```

Additional verification:

```text
bun test src/test/anthropic-proxy.unit.test.ts --timeout=10000 --test-name-pattern 'should convert tool results from OpenAI to Anthropic format|normalizes non-object tool inputs to an empty object'
2 pass, 0 fail, 10 expectations

bun test src/test/anthropic-proxy.unit.test.ts --timeout=10000
56 pass, 0 fail, 130 expectations

bun test <four Anthropic suites> --timeout=10000
94 pass, 0 fail, 239 expectations

PATH=/home/ezra/.bun/bin:$PATH bun test --timeout=10000
1013 pass, 0 fail, 3909 expectations across 66 files

bunx tsc --noEmit -p tsconfig.json
exit 2: one pre-existing error in unchanged src/handlers/chat.ts:800 (`super_admin` is not assignable to `AccountPlan`)
```

Independent review approved exact head `bb3d2dab7285d8dbdc769f073f57b7df577dd103` after rerunning focused, Anthropic, and full-package tests and confirming a conflict-free merge tree against current `origin/main`.

## Scope

- AI gateway Anthropic message conversion only.
- No dependency, configuration, authentication, logging, catch-all, or error-suppression changes.
- This does not claim to address unrelated 400/401/413 events, authentication failures, oversized requests, or other endpoints in the heterogeneous Sentry group.
- Platform scope: server-side Cloudflare AI gateway; no desktop-platform-specific behavior.
- Visual evidence: not applicable; this is a backend request-shape fix with no UI change.

## Diff

- `packages/ai-gateway/src/providers/anthropic.ts`
- `packages/ai-gateway/src/test/anthropic-proxy.unit.test.ts`
- 20 insertions, 2 deletions
