### PR TITLE
fix(app): retire stale webview IPC before recovery

### DIFF
--- a/apps/screenpipe-app-tauri/e2e/COVERAGE.md
+++ b/apps/screenpipe-app-tauri/e2e/COVERAGE.md
@@ -11,8 +11,8 @@ and layer declared in the manifest, weighted by confidence and criticality.
 - Manifest: `e2e/coverage-map.json`
 - Specs directory: `e2e/specs`
 - Mapped specs: 140
-- Declared test blocks: 401
-- Weighted coverage points: 322.1
+- Declared test blocks: 402
+- Weighted coverage points: 323.1
 
 Confidence weights: strong=1.0, partial=0.7, conditional=0.4, smoke=0.3.
 Criticality weights: high=1.0, medium=0.7, low=0.4.
@@ -24,7 +24,7 @@ can execute more runtime cases than this number shows.
 | Platform | Specs | Declared tests | Weighted points | Layers | Features | Critical score |
 | --- | --- | --- | --- | --- | --- | --- |
 | windows | 107 | 340 | 283.1 | 15 | 122 | 85% |
-| macos | 136 | 363 | 291.9 | 17 | 132 | 88% |
+| macos | 136 | 364 | 292.9 | 17 | 132 | 88% |
 | linux | 95 | 298 | 252.5 | 14 | 119 | 80% |
 
 ## Runtime Results
@@ -43,17 +43,17 @@ pass/fail/skip counts.
 | capture-ocr | 2 specs / 16 tests / 6.4 pts | 9 specs / 13 tests / 5.8 pts | 1 specs / 3 tests / 1.2 pts |
 | chat-ai | 37 specs / 87 tests / 71.3 pts | 51 specs / 116 tests / 90.8 pts | 35 specs / 86 tests / 70.8 pts |
 | entitlement | - | 1 specs / 1 tests / 1.0 pts | - |
-| local-api | 29 specs / 119 tests / 100.0 pts | 39 specs / 115 tests / 98.5 pts | 24 specs / 87 tests / 78.2 pts |
+| local-api | 29 specs / 119 tests / 100.0 pts | 39 specs / 116 tests / 99.5 pts | 24 specs / 87 tests / 78.2 pts |
 | notifications | 4 specs / 26 tests / 17.3 pts | 3 specs / 5 tests / 3.4 pts | 2 specs / 4 tests / 3.1 pts |
 | onboarding | 9 specs / 38 tests / 33.8 pts | 11 specs / 42 tests / 37.2 pts | 9 specs / 38 tests / 33.8 pts |
 | os-integration | 7 specs / 32 tests / 26.9 pts | 15 specs / 30 tests / 18.4 pts | 2 specs / 15 tests / 10.8 pts |
 | performance | 3 specs / 45 tests / 45.0 pts | 5 specs / 36 tests / 31.8 pts | 2 specs / 30 tests / 30.0 pts |
 | pipes | 6 specs / 20 tests / 20.0 pts | 8 specs / 26 tests / 26.0 pts | 6 specs / 20 tests / 20.0 pts |
-| real-ui-e2e | 80 specs / 238 tests / 201.9 pts | 97 specs / 255 tests / 215.9 pts | 74 specs / 214 tests / 187.9 pts |
+| real-ui-e2e | 80 specs / 238 tests / 201.9 pts | 97 specs / 256 tests / 216.9 pts | 74 specs / 214 tests / 187.9 pts |
 | settings | 15 specs / 42 tests / 39.0 pts | 17 specs / 36 tests / 31.7 pts | 14 specs / 33 tests / 30.0 pts |
 | storage-privacy | 10 specs / 44 tests / 35.3 pts | 10 specs / 29 tests / 28.1 pts | 7 specs / 22 tests / 21.1 pts |
-| tauri-command | 23 specs / 62 tests / 48.9 pts | 35 specs / 84 tests / 66.3 pts | 22 specs / 63 tests / 49.8 pts |
-| window-lifecycle | 22 specs / 71 tests / 59.5 pts | 23 specs / 54 tests / 39.9 pts | 16 specs / 44 tests / 34.4 pts |
+| tauri-command | 23 specs / 62 tests / 48.9 pts | 35 specs / 85 tests / 67.3 pts | 22 specs / 63 tests / 49.8 pts |
+| window-lifecycle | 22 specs / 71 tests / 59.5 pts | 23 specs / 55 tests / 40.9 pts | 16 specs / 44 tests / 34.4 pts |
 
 ## Critical Feature Matrix
 
@@ -219,7 +219,7 @@ pass/fail/skip counts.
 | privacy-installed-apps.spec.ts | windows, macos, linux | settings, storage-privacy, real-ui-e2e | settings-privacy-filters, installed-apps | medium | strong | real-user-flow | 1 | Privacy content filters surface installed-but-not-captured apps as typeable options with the not-captured hint (fetch-intercepted /installed-apps for determinism). |
 | recording-health-focus-cold.spec.ts | macos | capture-ocr, local-api, os-integration, real-ui-e2e | app-launch, capture-ocr, health, recording-health-alerts | high | conditional | mixed | 1 | Opt-in macOS focus-aware Cold-state reproduction proves capture attempts can remain intentionally flat while the independent loop heartbeat advances, /health stays ok, and the recording-health overlay remains normal in the original process. |
 | recording-health-return-race.spec.ts | windows, macos, linux | tauri-command, os-integration, real-ui-e2e | app-launch, recording-health-alerts | high | strong | command | 1 | Accelerated app-level replay of the idle-to-attended stale race verifies that return input does not raise the recording-health failure overlay before capture recovery can be observed. |
-| renderer-recovery.spec.ts | macos | window-lifecycle, tauri-command, real-ui-e2e, local-api | app-launch, window-lifecycle, webview-renderer-recovery, local-api-auth | high | strong | mixed | 3 | Suspends the isolated app's real com.apple.WebKit.GPU process, verifies WebContent's main thread and render queue are blocked in remote WebKit GPU IPC, holds the fault until the production watchdog destroys stale Home, then proves a new page generation repaints in the same app PID with uninterrupted local API health. Also forces three consecutive missed-heartbeat recoveries and reopens discarded Search and Chat webviews. |
+| renderer-recovery.spec.ts | macos | window-lifecycle, tauri-command, real-ui-e2e, local-api | app-launch, window-lifecycle, webview-renderer-recovery, local-api-auth | high | strong | mixed | 4 | Suspends the isolated app's real com.apple.WebKit.GPU process, verifies WebContent's main thread and render queue are blocked in remote WebKit GPU IPC, holds the fault until the production watchdog destroys stale Home, then proves a new page generation repaints in the same app PID with uninterrupted local API health. Also forces three consecutive missed-heartbeat recoveries and reopens discarded Search and Chat webviews. |
 | sck-startup-recovery.spec.ts | macos | capture-ocr, local-api, os-integration | app-launch, capture-ocr, health, local-api-search | high | conditional | api | 1 | Opt-in macOS fault injection verifies bounded SCK enumeration recovery, same-process capture, and OCR persistence. |
 | screen-recording-restart.spec.ts | macos | onboarding, os-integration, real-ui-e2e, tauri-command | onboarding, permission-recovery | high | conditional | real-user-flow | 1 | A deterministic post-Later TCC mismatch drives the packaged onboarding UI through the explicit restart button and into the native restart command without destroying the WebDriver session. |
 | search-request-priority.spec.ts | windows, macos, linux | real-ui-e2e, local-api | home-search, local-api-search | medium | partial | synthetic | 1 | Verifies keyword search request fires before secondary search, facet, and speaker requests. |

--- a/apps/screenpipe-app-tauri/e2e/specs/renderer-recovery.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/renderer-recovery.spec.ts
@@ -445,6 +445,27 @@ describeMacOS("macOS renderer-stall recovery", function () {
     expect(existsSync(filepath)).toBe(true);
   });
 
+  it("keeps Tauri IPC on the IPC protocol while replacing a stale webview", async () => {
+    const baseline = await recoveryState();
+    const logOffset = readFileSync(E2E_APP_LOG_FILE).byteLength;
+
+    await browser.switchToWindow("home");
+    await invokeOrThrow("plugin:e2e|arm_renderer_stalls", {
+      label: "home",
+      count: 1,
+    });
+    await triggerHomeShowWithoutWaitingOnDestroyedContext();
+    await waitForRecoveredHome(baseline.recoveryCount + 1);
+    await delay(2_500);
+
+    const appendedLog = readFileSync(E2E_APP_LOG_FILE)
+      .subarray(logOffset)
+      .toString("utf8");
+    expect(appendedLog).not.toMatch(
+      /tauri::protocol::asset:\s+asset protocol not configured to allow the path:\s+(?:webview_renderer_heartbeat|write_browser_logs|is_enterprise_build_cmd)/,
+    );
+  });
+
   it("recreates the discarded Search and Chat surfaces on demand after recovery", async () => {
     await browser.switchToWindow("home");
     await showWindow({ Search: { query: null } });

--- a/apps/screenpipe-app-tauri/src-tauri/src/window/renderer_watchdog.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/window/renderer_watchdog.rs
@@ -19,6 +19,16 @@ const RECREATE_DELAY: Duration = Duration::from_millis(250);
 const MAX_CONSECUTIVE_RECOVERIES: u8 = 2;
 const RECOVERABLE_LABELS: [&str; 5] = ["home", "chat", "search", "main", "main-window"];
 const RECOVERY_KEEPALIVE_LABEL: &str = "renderer-recovery-keepalive";
+const RETIRE_IPC_SCRIPT: &str = r#"
+(() => {
+  const activeFetch = window.fetch.bind(window);
+  window.fetch = (input, init) => {
+    const url = input instanceof Request ? input.url : String(input);
+    if (url.startsWith("ipc://")) return new Promise(() => {});
+    return activeFetch(input, init);
+  };
+})();
+"#;
 
 #[derive(Debug, Clone)]
 struct ProbeTicket {
@@ -382,6 +392,18 @@ fn recover_on_main_thread(app: &AppHandle, target: ShowRewindWindow, failed_labe
     windows.sort_by_key(|(label, _)| label == "home");
 
     for (_, window) in &windows {
+        // WKWebView can keep the retired document alive briefly after its
+        // native window is destroyed. Stop that document at the transport
+        // boundary so its timers cannot send commands through protocol state
+        // that now belongs to the replacement webview.
+        if let Err(error) = window.eval(RETIRE_IPC_SCRIPT) {
+            warn!(
+                target: "screenpipe::renderer_watchdog",
+                label = window.label(),
+                %error,
+                "failed to retire stale webview IPC transport"
+            );
+        }
         let _ = window.hide();
     }
 


### PR DESCRIPTION
## Problem

On macOS, the renderer watchdog destroys and recreates a stale webview. WebKit can keep the retired document alive briefly after the native window is gone, so its heartbeat, browser-log, and entitlement timers continue invoking Tauri commands against torn-down protocol state. Those `ipc://` calls are then handled by the asset protocol and emit errors such as `asset protocol not configured to allow the path: webview_renderer_heartbeat`.

Adding command names to the asset scope would grant file access to non-path values and would not fix the lifecycle bug.

## Historical intent

PR #6785 deliberately recycles only the wedged UI processes while keeping capture and the local API alive. This patch preserves that bounded recovery flow, its native keepalive, and the replacement delay.

## Fix

Before hiding and destroying recoverable webviews, retire only the stale document IPC transport. The shim intercepts `ipc://` fetches in that retiring document while leaving ordinary HTTP and resource fetches alone. The replacement webview receives a fresh, normal Tauri IPC bridge.

## Regression coverage

The macOS renderer-recovery E2E now records the native-log byte offset, forces one stale Home replacement, waits for the replacement heartbeat, and asserts that heartbeat, browser-log, and enterprise-build commands were not routed through `tauri::protocol::asset`.

```text
Before: retired document timer -> ipc://command -> asset handler -> ERROR
After:  retired document timer -> retired locally
        replacement document   -> ipc://command -> IPC handler -> OK
```

The new assertion failed before the transport retirement with repeated `webview_renderer_heartbeat` and `write_browser_logs` asset-protocol errors, then passed after the fix.

## Verification

- `bun run build:tauri:e2e`
- focused `renderer-recovery.spec.ts` regression: 1 passing
- `bun run typecheck`
- `bun run bindings:check`: 1 passed
- `bun run e2e:coverage:check`
- `rustfmt --edition 2021 --check src-tauri/src/window/renderer_watchdog.rs`
- `git diff --check`