### PR TITLE
fix(ai-gateway): accept nested json_schema response formats

### DIFF
--- a/packages/ai-gateway/src/providers/openai.ts
+++ b/packages/ai-gateway/src/providers/openai.ts
@@ -270,11 +270,15 @@ export class OpenAIProvider implements AIProvider {
 		switch (format.type) {
 			case 'json_object':
 				return { type: 'json_object' };
-			case 'json_schema':
-				if (!format.schema || !format.name) {
+			case 'json_schema': {
+				const schema = format.json_schema?.schema ?? format.schema;
+				const name = format.json_schema?.name ?? format.name;
+				const description = format.json_schema?.description ?? format.description;
+				if (!schema || !name) {
 					throw new Error('Schema and name are required for json_schema response format');
 				}
-				return this.createJSONSchemaFormat(format.schema, format.name, format.description);
+				return this.createJSONSchemaFormat(schema, name, description);
+			}
 			default:
 				return undefined;
 		}

--- a/packages/ai-gateway/src/providers/openrouter.ts
+++ b/packages/ai-gateway/src/providers/openrouter.ts
@@ -50,11 +50,15 @@ export class OpenRouterProvider implements AIProvider {
 		switch (format.type) {
 			case 'json_object':
 				return { type: 'json_object' };
-			case 'json_schema':
-				if (!format.schema || !format.name) {
+			case 'json_schema': {
+				const schema = format.json_schema?.schema ?? format.schema;
+				const name = format.json_schema?.name ?? format.name;
+				const description = format.json_schema?.description ?? format.description;
+				if (!schema || !name) {
 					throw new Error('Schema and name are required for json_schema response format');
 				}
-				return this.createJSONSchemaFormat(format.schema, format.name, format.description);
+				return this.createJSONSchemaFormat(schema, name, description);
+			}
 			default:
 				return undefined;
 		}

--- a/packages/ai-gateway/src/test/openai-models.unit.test.ts
+++ b/packages/ai-gateway/src/test/openai-models.unit.test.ts
@@ -303,6 +303,32 @@ describe('OpenAI API accounting and routing', () => {
 		expect(params['max_tokens']).toBeUndefined();
 	});
 
+	it('accepts nested and flattened json_schema response formats', async () => {
+		const formats = [
+			{ type: 'json_schema', json_schema: { name: 'answer', schema: { type: 'object' } } },
+			{ type: 'json_schema', name: 'answer', schema: { type: 'object' } },
+		];
+		for (const response_format of formats) {
+			const provider = new OpenAIProvider('sk-test') as any;
+			let capturedParams: any;
+			provider.client.chat.completions.create = mock(async (params: any) => {
+				capturedParams = params;
+				return { choices: [{ message: { content: 'ok' } }] };
+			});
+			await provider.createCompletion({
+				model: 'gpt-5.6-sol',
+				messages: [{ role: 'user', content: 'hello' }],
+				response_format,
+			} as any);
+			expect(capturedParams.response_format.json_schema).toEqual({
+				name: 'answer',
+				description: undefined,
+				schema: { type: 'object' },
+				strict: true,
+			});
+		}
+	});
+
 	it('adds stable GPT-5.6 explicit prompt-cache fields at the last leading system block', async () => {
 		const params: any = {
 			model: 'gpt-5.6-luna',

--- a/packages/ai-gateway/src/types.ts
+++ b/packages/ai-gateway/src/types.ts
@@ -112,6 +112,11 @@ export interface ResponseFormat {
 	schema?: InputSchema;
 	name?: string;
 	description?: string;
+	json_schema?: {
+		schema: InputSchema;
+		name: string;
+		description?: string;
+	};
 }
 
 export interface ImageContent {


### PR DESCRIPTION
## Source

- Sentry issue: `7642460955`
- Exact reviewed head: `92d3314f68b74fdb0b6c495dd85c5627efc474ec`

## Root cause

The OpenAI and OpenRouter provider normalization paths only read the legacy flattened `name`, `description`, `schema`, and `strict` fields from `response_format`. Standard response formats place those fields under `response_format.json_schema`, so valid nested requests were rejected before provider dispatch with `Schema and name are required for json_schema response format`.

## Fix

Normalize `json_schema` at the shared response-format seam used by both providers. Standard nested fields take precedence, while the existing flattened shape remains supported for compatibility. This covers the full affected provider surface without changing authentication, transport, retry, logging, or error-classification behavior.

## Verification

- RED on reviewed `origin/main` (`d1444289846735615b9df60c8f7f67f57574946d`): the standard nested OpenAI probe failed before dispatch with the missing schema/name error.
- GREEN: `PATH=/home/ezra/.bun/bin:$PATH bun test src/test/openai-models.unit.test.ts -t "accepts nested and flattened json_schema response formats"` — 1 pass, 0 fail, 2 assertions.
- Provider probes: OpenAI and OpenRouter both accept nested and flattened formats; mixed inputs select nested fields.
- Full package suite: `PATH=/home/ezra/.bun/bin:$PATH bun test --timeout=10000` — 1013 pass, 0 fail, 3910 assertions across 66 files.
- `PATH=/home/ezra/.bun/bin:$PATH bunx tsc --noEmit` remains blocked only by the identical pre-existing `AccountPlan` / `super_admin` mismatch at `src/handlers/chat.ts:800`, reproduced on the baseline; no new type error was introduced.
- `git diff --check HEAD^ HEAD` passes, and the worktree is clean.

## Scope and risk

- Changed only response-format normalization/types and a focused provider regression test.
- Applies to OpenAI and OpenRouter JSON-schema response formats.
- Preserves legacy flattened compatibility.
- No user-interface changes; visual evidence is not applicable.