### PR TITLE
fix(app): filter updater endpoint-status noise

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -266,6 +266,10 @@ fn should_prevent_window_close(label: &str) -> bool {
     label != "onboarding"
 }
 
+fn is_updater_endpoint_status_noise(text: &str) -> bool {
+    text == "update endpoint did not respond with a successful status code"
+}
+
 #[cfg(target_os = "macos")]
 fn emit_menu_close_window(app: &tauri::AppHandle) {
     let focused = app
@@ -761,7 +765,10 @@ async fn main() {
                         .collect()
                     });
 
-                    let matches_noise = |text: &str| env_patterns.iter().any(|re| re.is_match(text));
+                    let matches_noise = |text: &str| {
+                        is_updater_endpoint_status_noise(text)
+                            || env_patterns.iter().any(|re| re.is_match(text))
+                    };
                     if event.message.as_deref().map(matches_noise).unwrap_or(false) {
                         return None;
                     }
@@ -2739,6 +2746,46 @@ mod window_close_policy_tests {
         for label in ["home", "main", "main-window", "search", "chat"] {
             assert!(should_prevent_window_close(label), "label: {label}");
         }
+    }
+}
+
+#[cfg(test)]
+mod sentry_noise_tests {
+    use super::is_updater_endpoint_status_noise;
+
+    #[test]
+    fn updater_endpoint_status_error_is_filtered_from_sentry() {
+        assert!(is_updater_endpoint_status_noise(
+            "update endpoint did not respond with a successful status code"
+        ));
+    }
+
+    #[test]
+    fn updater_endpoint_status_error_with_prefix_is_reported() {
+        assert!(!is_updater_endpoint_status_noise(
+            "updater failed: update endpoint did not respond with a successful status code"
+        ));
+    }
+
+    #[test]
+    fn updater_endpoint_status_error_with_suffix_is_reported() {
+        assert!(!is_updater_endpoint_status_noise(
+            "update endpoint did not respond with a successful status code: retry exhausted"
+        ));
+    }
+
+    #[test]
+    fn compound_updater_endpoint_status_error_is_reported() {
+        assert!(!is_updater_endpoint_status_noise(
+            "database failure while handling: update endpoint did not respond with a successful status code"
+        ));
+    }
+
+    #[test]
+    fn unrelated_errors_are_not_filtered_from_sentry() {
+        assert!(!is_updater_endpoint_status_noise(
+            "failed to update all pipes: internal state unavailable"
+        ));
     }
 }
 


### PR DESCRIPTION
## Source and impact

- Sentry: https://mediar.sentry.io/issues/7557426151/
- Current intake snapshot: 3,708 events in 24 hours (cluster of 1); the visible top-user distribution contains 5 affected user IDs.
- Platforms in the event distribution: macOS arm64/x86_64 and Windows x86_64.
- Exact reviewed head: `ff7d5a8b4c2e4db97ee99f965dfedc31d2c74d85`.

## Intended behavior

Transient non-success responses from the app update endpoint should remain locally diagnosable without flooding Sentry. Updater behavior must remain unchanged, and wrapped, compound, or otherwise unrelated failures must still be reported.

## Root cause and mechanism

`tauri-plugin-updater` 2.10.1 emits the exact message `update endpoint did not respond with a successful status code` when an update endpoint returns a non-success status. Screenpipe already handles the returned boot/periodic update-check error as a warning, but the dependency emits this error before that handling, and the existing cross-platform Sentry `before_send` noise filter did not recognize it. That dependency emission generated the high-volume Sentry cluster across both macOS and Windows.

## Fix

- Add an exact-equality classifier for the demonstrated dependency message.
- Reuse the existing Sentry `before_send` noise seam for both `event.message` and exception values.
- Preserve prefix, suffix, compound, and unrelated errors so this does not become blanket error silencing.
- Leave endpoint configuration, update requests, retries, and user-visible updater behavior unchanged.

## RED / GREEN proof

Independent source-extracted RED on fetched `origin/main`:

```text
running 4 tests
test tests::compound_is_preserved ... ok
test tests::exact_dependency_message_is_noise ... FAILED
test tests::suffix_is_preserved ... ok
test tests::prefix_is_preserved ... ok

test result: FAILED. 3 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
SOURCE_EXTRACTED ref=origin/main helper_present=False exit=101
```

Independent source-extracted GREEN on the reviewed head:

```text
running 4 tests
test tests::exact_dependency_message_is_noise ... ok
test tests::compound_is_preserved ... ok
test tests::prefix_is_preserved ... ok
test tests::suffix_is_preserved ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
SOURCE_EXTRACTED ref=HEAD helper_present=True exit=0
```

## Broader verification

- Full app Vitest suite: 479 files, 4,982 tests passed.
- Full Bun suite: 21 files, 242 tests passed.
- Focused update-channel tests: 3 passed, 0 failed.
- `git diff --check HEAD^ HEAD`: passed.
- Added-line security/debug scan: no matches.
- Canonical `bun run test:tauri updater_endpoint_status_error_is_filtered_from_sentry -- --exact --nocapture` was attempted through the required queue path but was blocked before app-test execution because `libspa-sys` could not find `libpipewire-0.3` pkg-config metadata; no native pass is claimed.

## Scope and visual evidence

- One commit, one file: `apps/screenpipe-app-tauri/src-tauri/src/main.rs` (`+48/-1`).
- Cross-platform telemetry-only change in the shared Sentry filter; no per-frame/callback/database hot path is affected.
- No user-interface change; visual evidence is not applicable.
