### PR TITLE
fix(chat): surface Codex ACP usage limits

### DIFF
--- a/apps/screenpipe-app-tauri/lib/chat/__tests__/provider-errors.test.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/__tests__/provider-errors.test.ts
@@ -256,6 +256,19 @@ describe("provider error copy", () => {
   it("maps only the full Codex usage-limit signature to sanitized recovery guidance", () => {
     const expected =
       "The AI provider usage limit has been reached. Wait for it to reset, or switch your AI preset or provider.";
+    const acpExpected =
+      "Your Codex usage limit has been reached. Wait for it to reset, upgrade your ChatGPT plan, or switch your Screenpipe AI preset.";
+
+    expect(
+      buildProviderErrorMessage(
+        `ACP request failed Internal error: {
+          "message": "You've hit your usage limit. attacker suffix",
+          "codexErrorInfo": "usageLimitExceeded"
+        }`,
+        { provider: "acp", model: "codex-acp" },
+      ),
+    ).toBe(acpExpected);
+    expect(acpExpected).not.toContain("attacker suffix");
 
     expect(
       buildProviderErrorMessage(
@@ -269,6 +282,8 @@ describe("provider error copy", () => {
       "The usage limit has been reached.",
       "Codex error: usage limit has been reached.",
       "Codex error: the usage limit was reached.",
+      '{"codexErrorInfo":"usageLimit"}',
+      '{"codexError":"usageLimitExceeded"}',
     ]) {
       expect(
         buildProviderErrorMessage(raw, {

--- a/apps/screenpipe-app-tauri/lib/chat/provider-errors.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/provider-errors.ts
@@ -313,6 +313,10 @@ function buildGenericProviderErrorMessage(
     }
   }
 
+  if (/"codexerrorinfo"\s*:\s*"usagelimitexceeded"/i.test(errorStr)) {
+    return "Your Codex usage limit has been reached. Wait for it to reset, upgrade your ChatGPT plan, or switch your Screenpipe AI preset.";
+  }
+
   if (normalized.includes("codex error: the usage limit has been reached")) {
     return "The AI provider usage limit has been reached. Wait for it to reset, or switch your AI preset or provider.";
   }


### PR DESCRIPTION
## Summary

- Recognize the structured `codexErrorInfo: usageLimitExceeded` response emitted by Codex ACP.
- Replace the misleading `Unknown error` with Codex-specific recovery guidance.
- Keep provider-controlled error text out of the UI and preserve Screenpipe-hosted quota precedence.

Reported on Windows in app v2.7.21.

## Root cause

Codex ACP emits an assistant `message_end` without an error body before delivering the concrete structured error. The first event falls back to `Unknown error`; the later ACP payload was not recognized by the shared provider-error classifier.

## Before / after

```text
BEFORE
Codex ACP usage limit -> Error: Unknown error

AFTER
Codex ACP usage limit -> Your Codex usage limit has been reached.
                         Wait for reset, upgrade ChatGPT, or switch preset.
```

## Historical intent

- Inspected commit a61c66c904 / PR #6161, which introduced sanitized guidance for the earlier Codex usage-limit signature.
- That change intentionally required a distinctive signature and returned static copy so arbitrary provider suffix text was never shown.
- This PR preserves that invariant and adds only the newer structured ACP signature. Existing near-miss behavior and hosted quota authority remain unchanged.

## Verification

- `bun x vitest run --config vitest.config.ts lib/chat/__tests__/provider-errors.test.ts` — 46/46 passed.
- `SEM_NO_TELEMETRY=1 sem diff upstream/main..HEAD --format plain --no-cosmetics` — one production function and its focused test changed.
- `git diff --check upstream/main..HEAD` — passed.