### PR TITLE
fix(enterprise): retry denied account auth

### DIFF
--- a/apps/screenpipe-app-tauri/lib/hooks/__tests__/use-enterprise-policy.test.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/__tests__/use-enterprise-policy.test.tsx
@@ -690,6 +690,65 @@ describe("enterprise policy runtime manual activation", () => {
     );
   });
 
+  it("recovers a denied saved account on a later policy poll", async () => {
+    vi.useFakeTimers();
+    Object.assign(mocks.settings, { user: { token: "account-token" } });
+    mockEnterpriseApi({ policyStatus: 401 });
+
+    const { result } = await renderEnterprisePolicy();
+    await act(async () => {});
+    expect(result.current.authenticationState).toBe("account");
+    expect(result.current.isEnterpriseAuthenticated).toBe(false);
+
+    mockEnterpriseApi({});
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+    });
+
+    expect(result.current.authenticationState).toBe("authenticated");
+    expect(result.current.isEnterpriseAuthenticated).toBe(true);
+    expect(result.current.authenticationError).toBeNull();
+    expect(mocks.commands.setEnterpriseRecordingAuthorized).toHaveBeenLastCalledWith(
+      true,
+      "account",
+      "account-token",
+    );
+  });
+
+  it("keeps polling after an authenticated account is later denied", async () => {
+    vi.useFakeTimers();
+    Object.assign(mocks.settings, { user: { token: "account-token" } });
+    mockEnterpriseApi({});
+
+    const { result } = await renderEnterprisePolicy();
+    await act(async () => {});
+    expect(result.current.authenticationState).toBe("authenticated");
+
+    mockEnterpriseApi({ policyStatus: 401 });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+    });
+    expect(result.current.authenticationState).toBe("account");
+    expect(result.current.isEnterpriseAuthenticated).toBe(false);
+    expect(mocks.commands.setEnterpriseRecordingAuthorized).toHaveBeenLastCalledWith(
+      false,
+      null,
+      null,
+    );
+
+    mockEnterpriseApi({});
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+    });
+    expect(result.current.authenticationState).toBe("authenticated");
+    expect(result.current.isEnterpriseAuthenticated).toBe(true);
+    expect(mocks.commands.setEnterpriseRecordingAuthorized).toHaveBeenLastCalledWith(
+      true,
+      "account",
+      "account-token",
+    );
+  });
+
   it("does not wait for a hanging engine restart during activation", async () => {
     vi.useFakeTimers();
     mockEnterpriseApi({ policy: { lockedSettings: { disableKeyboardCapture: "false" } } });

--- a/apps/screenpipe-app-tauri/lib/hooks/use-enterprise-policy.ts
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-enterprise-policy.ts
@@ -648,6 +648,8 @@ export function useEnterprisePolicyRuntime() {
   });
   const [authenticationState, setAuthenticationState] =
     useState<EnterpriseAuthenticationState>("checking");
+  const authenticationStateRef = useRef(authenticationState);
+  authenticationStateRef.current = authenticationState;
   const [authenticationError, setAuthenticationError] = useState<string | null>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   // Refs for the polling handler: it must read the latest account token and
@@ -1085,6 +1087,17 @@ export function useEnterprisePolicyRuntime() {
           setAuthenticationState("authenticated");
           return;
         }
+        if (
+          credential.type === "account" &&
+          authenticationStateRef.current !== "authenticated"
+        ) {
+          if (!await setNativeRecordingAuthorized(true, credential)) {
+            setAuthenticationError(NATIVE_RECORDING_AUTH_ERROR);
+            return;
+          }
+          setAuthenticationError(null);
+          setAuthenticationState("authenticated");
+        }
       } else if (result.reason === "invalid_key") {
         console.warn("[enterprise] saved key is no longer valid, falling back to account auth");
         stopPolling();
@@ -1117,12 +1130,13 @@ export function useEnterprisePolicyRuntime() {
         setAuthenticationError(ROTATED_ENTERPRISE_KEY_ERROR);
       } else if (result.reason === "not_member") {
         console.warn("[enterprise] signed-in account is no longer an organization member");
-        stopPolling();
         await setNativeRecordingAuthorized(false);
         setAuthenticationState("account");
         setAuthenticationError("this account is not associated with the enterprise organization");
       }
-      // network_error: silently keep polling, use cached policy
+      // Account denials and network errors keep polling. The gate remains
+      // closed after a denial, but a later successful check can recover the
+      // same saved account without another login or app restart.
     }, POLL_INTERVAL_MS);
   }, [fetchPolicy, setNativeRecordingAuthorized, stopPolling]);
 
@@ -1223,6 +1237,7 @@ export function useEnterprisePolicyRuntime() {
       await setNativeRecordingAuthorized(false);
       setAuthenticationState("account");
       setAuthenticationError("this account is not associated with the enterprise organization");
+      startPolling(credential);
       return { authenticated: false, retryable: false };
     }
 


### PR DESCRIPTION
## Summary

- keep the enterprise account gate fail-closed after a 401
- continue the existing five-minute policy poll instead of stopping permanently
- restore native recording authorization and authenticated state when the same saved account later succeeds
- start the same background poll when the initial account check is denied

## Recovery flow

    account policy check
            |
          401
            |
    revoke native recording
    show account gate
            |
    retry every 5 minutes
            |
          200
            |
    restore native recording
    clear account gate

## Historical intent

Inspected db7cf02061 / PR #5253, ba00fdc22b, and 8c0affa6bd. The account-denial path intentionally gates the app and recording immediately so revoked credentials fail closed. This PR preserves that invariant. It supersedes only the permanent stopPolling behavior: while recording remains revoked, the existing policy timer is allowed to recheck the saved credential and recover after a mistaken or temporary 401.

## Verification

- NODE_OPTIONS=--no-experimental-webstorage bun run test:vitest -- lib/hooks/__tests__/use-enterprise-policy.test.tsx components/app-entitlement-gate.test.tsx
- 92 tests passed
- bun run typecheck
- git diff --check