### PR TITLE
fix(app): stop reporting self-healed DB quarantines as unresolved

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/db_self_heal.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/db_self_heal.rs
@@ -39,8 +39,15 @@ use tracing::{info, warn};
 use crate::notifications::client;
 use crate::notifications::store::NotificationPriority;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LaunchSelfHealOutcome {
+    RecordingResumed,
+    QuarantineUnresolved,
+    QuarantineResolvedStartupFailed,
+}
+
 pub async fn finish_launch_quarantine<Failure, Report, ReportFuture>(
-    self_healed: bool,
+    outcome: LaunchSelfHealOutcome,
     on_failure: Failure,
     report: Report,
 ) where
@@ -48,7 +55,7 @@ pub async fn finish_launch_quarantine<Failure, Report, ReportFuture>(
     Report: FnOnce() -> ReportFuture,
     ReportFuture: std::future::Future<Output = ()>,
 {
-    if self_healed {
+    if outcome != LaunchSelfHealOutcome::QuarantineUnresolved {
         return;
     }
     on_failure();
@@ -230,23 +237,30 @@ where
 /// Full launch path: resolve the quarantine when it is safe to, then bring
 /// recording back through the same entry point the health watchdog uses.
 ///
-/// Returns true when recording was resumed, so the caller can skip the
-/// recovery notification it would otherwise publish.
+/// Launch observed a durable marker, then `try_resolve_quarantine` skipped.
+/// A marker that vanished in between is a resolved quarantine, not an
+/// unresolved one, so startup continues; every other skip stays fail-closed.
+fn launch_outcome_after_skip(reason: SelfHealSkip) -> Option<LaunchSelfHealOutcome> {
+    if reason == SelfHealSkip::NotQuarantined {
+        return None;
+    }
+    info!(
+        reason = reason.as_str(),
+        "db self-heal: keeping the fail-closed launch path"
+    );
+    Some(LaunchSelfHealOutcome::QuarantineUnresolved)
+}
+
+/// Distinguishes an unresolved quarantine from a post-resolution startup
+/// failure, so the caller reports only durable quarantine failures.
 pub async fn try_self_heal_at_launch(
     app: AppHandle,
     database_path: PathBuf,
     notify_user: bool,
-) -> bool {
-    match try_resolve_quarantine(&database_path).await {
-        Ok(()) => {}
-        Err(reason) => {
-            if reason != SelfHealSkip::NotQuarantined {
-                info!(
-                    reason = reason.as_str(),
-                    "db self-heal: keeping the fail-closed launch path"
-                );
-            }
-            return false;
+) -> LaunchSelfHealOutcome {
+    if let Err(reason) = try_resolve_quarantine(&database_path).await {
+        if let Some(outcome) = launch_outcome_after_skip(reason) {
+            return outcome;
         }
     }
 
@@ -262,7 +276,7 @@ pub async fn try_self_heal_at_launch(
             error = %error,
             "db self-heal: quarantine cleared but the first start failed — leaving it to the watchdog"
         );
-        return false;
+        return LaunchSelfHealOutcome::QuarantineResolvedStartupFailed;
     }
 
     if notify_user {
@@ -274,7 +288,7 @@ pub async fn try_self_heal_at_launch(
             NotificationPriority::Normal,
         );
     }
-    true
+    LaunchSelfHealOutcome::RecordingResumed
 }
 
 #[cfg(test)]
@@ -322,14 +336,35 @@ mod tests {
         }
     }
 
+    #[test]
+    fn marker_removed_before_self_heal_does_not_report_quarantine() {
+        assert_eq!(
+            launch_outcome_after_skip(SelfHealSkip::NotQuarantined),
+            None
+        );
+        for reason in [
+            SelfHealSkip::AlreadyLatchedThisProcess,
+            SelfHealSkip::UnreadableMarker,
+        ] {
+            assert_eq!(
+                launch_outcome_after_skip(reason),
+                Some(LaunchSelfHealOutcome::QuarantineUnresolved)
+            );
+        }
+    }
+
     #[tokio::test]
-    async fn launch_quarantine_reports_only_after_self_heal_fails() {
-        for (self_healed, expected_failures) in [(true, 0), (false, 1)] {
+    async fn launch_quarantine_reports_only_when_quarantine_remains() {
+        for (outcome, expected_failures) in [
+            (LaunchSelfHealOutcome::RecordingResumed, 0),
+            (LaunchSelfHealOutcome::QuarantineUnresolved, 1),
+            (LaunchSelfHealOutcome::QuarantineResolvedStartupFailed, 0),
+        ] {
             let mut boot_errors = 0;
             let mut recovery_reports = 0;
 
             finish_launch_quarantine(
-                self_healed,
+                outcome,
                 || boot_errors += 1,
                 || async { recovery_reports += 1 },
             )

--- a/apps/screenpipe-app-tauri/src-tauri/src/db_self_heal.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/db_self_heal.rs
@@ -39,6 +39,22 @@ use tracing::{info, warn};
 use crate::notifications::client;
 use crate::notifications::store::NotificationPriority;
 
+pub async fn finish_launch_quarantine<Failure, Report, ReportFuture>(
+    self_healed: bool,
+    on_failure: Failure,
+    report: Report,
+) where
+    Failure: FnOnce(),
+    Report: FnOnce() -> ReportFuture,
+    ReportFuture: std::future::Future<Output = ()>,
+{
+    if self_healed {
+        return;
+    }
+    on_failure();
+    report().await;
+}
+
 /// Why a launch-time quarantine was not self-healed. Recorded so the decision
 /// is auditable in logs instead of looking like the check never ran.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -303,6 +319,24 @@ mod tests {
                 seen.insert(reason.as_str()),
                 "duplicate log token for {reason:?}"
             );
+        }
+    }
+
+    #[tokio::test]
+    async fn launch_quarantine_reports_only_after_self_heal_fails() {
+        for (self_healed, expected_failures) in [(true, 0), (false, 1)] {
+            let mut boot_errors = 0;
+            let mut recovery_reports = 0;
+
+            finish_launch_quarantine(
+                self_healed,
+                || boot_errors += 1,
+                || async { recovery_reports += 1 },
+            )
+            .await;
+
+            assert_eq!(boot_errors, expected_failures);
+            assert_eq!(recovery_reports, expected_failures);
         }
     }
 

--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -1861,9 +1861,6 @@ async fn main() {
             if launch_db_quarantined {
                 // Preserve the cross-launch fail-closed boundary before any
                 // server, SQLite pool, watchdog, or capture thread is started.
-                crate::health::set_boot_error(
-                    "database remains quarantined after a SQLite hard fault; run `screenpipe db recover` while screenpipe is closed",
-                );
                 crate::health::set_recording_status(crate::health::RecordingStatus::Error);
             }
 
@@ -2332,20 +2329,28 @@ async fn main() {
                 let recovery_app = app_handle.clone();
                 let automatic_recovery = headless_startup;
                 tauri::async_runtime::spawn(async move {
-                    if crate::db_self_heal::try_self_heal_at_launch(
+                    let self_healed = crate::db_self_heal::try_self_heal_at_launch(
                         self_heal_app,
                         self_heal_db_path,
                         !automatic_recovery,
                     )
-                    .await
-                    {
-                        return;
-                    }
-                    crate::db_relaunch::surface_quarantined_recovery_at_launch(
-                        &launch_db_path,
-                        !automatic_recovery,
+                    .await;
+                    crate::db_self_heal::finish_launch_quarantine(
+                        self_healed,
+                        || {
+                            crate::health::set_boot_error(
+                                "database remains quarantined after a SQLite hard fault; run `screenpipe db recover` while screenpipe is closed",
+                            );
+                        },
+                        || crate::db_relaunch::surface_quarantined_recovery_at_launch(
+                            &launch_db_path,
+                            !automatic_recovery,
+                        ),
                     )
                     .await;
+                    if self_healed {
+                        return;
+                    }
                     if automatic_recovery {
                         let recovery = crate::db_recovery_notifications::
                             start_headless_quarantined_database_recovery(

--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -2329,14 +2329,14 @@ async fn main() {
                 let recovery_app = app_handle.clone();
                 let automatic_recovery = headless_startup;
                 tauri::async_runtime::spawn(async move {
-                    let self_healed = crate::db_self_heal::try_self_heal_at_launch(
+                    let self_heal_outcome = crate::db_self_heal::try_self_heal_at_launch(
                         self_heal_app,
                         self_heal_db_path,
                         !automatic_recovery,
                     )
                     .await;
                     crate::db_self_heal::finish_launch_quarantine(
-                        self_healed,
+                        self_heal_outcome,
                         || {
                             crate::health::set_boot_error(
                                 "database remains quarantined after a SQLite hard fault; run `screenpipe db recover` while screenpipe is closed",
@@ -2348,7 +2348,9 @@ async fn main() {
                         ),
                     )
                     .await;
-                    if self_healed {
+                    if self_heal_outcome
+                        != crate::db_self_heal::LaunchSelfHealOutcome::QuarantineUnresolved
+                    {
                         return;
                     }
                     if automatic_recovery {


### PR DESCRIPTION
﻿Makes the Azure Windows dev VM own development, native validation, desktop recording, evidence upload, and PR delivery after a one-shot dispatch.

## Autonomous Windows proof

- [Watch/download the VM-owned desktop recording](https://stscpwinrun975ec0.blob.core.windows.net/evidence/windows-autonomous/sentry6888win3-20260904/acceptance.mp4?se=2026-09-11T00%3A45Z&sp=r&spr=https&sv=2026-04-06&sr=b&skoid=0c2ba06f-c424-43ad-b5a0-773b2ebc2b67&sktid=f5b06fdb-14b4-4b65-82cf-622fce71ee27&skt=2026-09-05T00%3A45%3A12Z&ske=2026-09-11T00%3A45%3A00Z&sks=b&skv=2026-04-06&sig=nufMn2tXE1XfaqyIn4nnux7A52HYY0LWm7TTGohUD8A%3D) (read-only link expires **2026-09-11T00:45Z**)
- Task: `sentry6888win3-20260904`
- Tested commit: `4fcd2eab66d3c0782a0f2be610e6c7ee60405a89`
- Tested tree: `901e8ac5a339dedafa07aa981e9d0f529c828d68`
- The disposable VM ran Codex, native validation, recording, push, and PR creation without an inbound desktop connection or a host-held process.
