### PR TITLE
fix(ai-gateway): forward Pi tools to GLM

### DIFF
--- a/packages/ai-gateway/src/providers/screenpipe-glm.ts
+++ b/packages/ai-gateway/src/providers/screenpipe-glm.ts
@@ -1,11 +1,239 @@
 // screenpipe — AI that knows everything you've seen, said, or heard
 // https://screenpipe.com
 
-import type { RequestBody } from '../types';
+import type { RequestBody, ToolCall } from '../types';
 import { OpenAIProvider } from './openai';
 
 export const SCREENPIPE_GLM_MODEL = 'glm-5.3-flash-reap50-iq3m';
 const DIRECT_GLM_BASE_URL = 'https://pii.screenpipe.containers.tinfoil.dev/glm/v1';
+
+type GlmTool = {
+	type?: string;
+	function?: {
+		name?: string;
+		parameters?: { properties?: Record<string, { type?: string }> };
+	};
+};
+
+function parseGlmArgument(value: string, type?: string): unknown {
+	if (type === 'string') return value;
+	try {
+		return JSON.parse(value);
+	} catch {
+		return value;
+	}
+}
+
+/**
+ * The pinned llama.cpp GLM runtime currently exposes the model's native
+ * `<tool_call>` payload as assistant content instead of OpenAI `tool_calls`.
+ * Convert only a leading, schema-known call so arbitrary model/user text can
+ * never become an executable Pi action.
+ */
+export function parseGlmToolCallContent(content: unknown, tools: unknown): ToolCall[] {
+	if (typeof content !== 'string' || !Array.isArray(tools)) return [];
+	const trimmed = content.trim();
+
+	const knownTools = new Map<string, GlmTool>();
+	for (const tool of tools as GlmTool[]) {
+		const name = tool?.type === 'function' ? tool.function?.name : undefined;
+		if (name) knownTools.set(name, tool);
+	}
+	const makeToolCall = (name: string, args: Record<string, unknown>): ToolCall => ({
+		id: `call_glm_${crypto.randomUUID().replaceAll('-', '').slice(0, 24)}`,
+		type: 'function',
+		function: { name, arguments: JSON.stringify(args) },
+	});
+
+	// Some GLM generations omit the documented XML wrapper but still return an
+	// exact JSON function-call object. Accept only the complete known-tool shape.
+	if (trimmed.startsWith('{')) {
+		try {
+			const parsed = JSON.parse(trimmed);
+			const name = parsed?.function?.name ?? parsed?.name;
+			let args = parsed?.function?.arguments ?? parsed?.arguments;
+			if (typeof args === 'string') args = JSON.parse(args);
+			if (typeof name !== 'string' || !knownTools.has(name)) return [];
+			if (!args || Array.isArray(args) || typeof args !== 'object') return [];
+			return [makeToolCall(name, args)];
+		} catch {
+			return [];
+		}
+	}
+	if (!trimmed.startsWith('<tool_call>')) return [];
+
+	const calls: ToolCall[] = [];
+	const callPattern = /<tool_call>\s*([A-Za-z0-9_.:-]+)([\s\S]*?)(?=<tool_call>|$)/g;
+	for (const match of trimmed.matchAll(callPattern)) {
+		const name = match[1];
+		const tool = knownTools.get(name);
+		if (!tool) return [];
+
+		const body = match[2].replace(/<\/tool_call>\s*$/, '').trim();
+		const properties = tool.function?.parameters?.properties ?? {};
+		const args: Record<string, unknown> = {};
+		const taggedPattern = /<arg_key>([\s\S]*?)<\/arg_key>\s*<arg_value>([\s\S]*?)<\/arg_value>/g;
+		let taggedMatch: RegExpExecArray | null;
+		let taggedCount = 0;
+		while ((taggedMatch = taggedPattern.exec(body)) !== null) {
+			const key = taggedMatch[1].trim();
+			if (!key) return [];
+			args[key] = parseGlmArgument(taggedMatch[2], properties[key]?.type);
+			taggedCount++;
+		}
+
+		if (taggedCount === 0) {
+			let jsonBody = body;
+			if (jsonBody.startsWith('"')) jsonBody = `{${jsonBody}}`;
+			try {
+				const parsed = JSON.parse(jsonBody);
+				if (!parsed || Array.isArray(parsed) || typeof parsed !== 'object') return [];
+				Object.assign(args, parsed);
+			} catch {
+				return [];
+			}
+		}
+
+		calls.push(makeToolCall(name, args));
+	}
+
+	return calls;
+}
+
+function sseEvent(data: unknown): Uint8Array {
+	return new TextEncoder().encode(`data: ${JSON.stringify(data)}\n\n`);
+}
+
+function normalizeGlmToolCallStream(stream: ReadableStream, tools: unknown[]): ReadableStream {
+	const reader = stream.getReader();
+	const decoder = new TextDecoder();
+	type Mode = 'undecided' | 'passthrough' | 'tool' | 'parsed';
+	let mode: Mode = 'undecided';
+	let pending: string[] = [];
+	let content = '';
+	let inputBuffer = '';
+
+	return new ReadableStream({
+		async start(controller) {
+			const emit = (raw: string) => controller.enqueue(new TextEncoder().encode(raw));
+			const flushPending = () => {
+				for (const raw of pending) emit(raw);
+				pending = [];
+			};
+			const handleEvent = (raw: string) => {
+				const line = raw.trim();
+				if (!line.startsWith('data: ')) {
+					if (mode === 'passthrough' || mode === 'parsed') emit(raw);
+					else pending.push(raw);
+					return;
+				}
+				if (line === 'data: [DONE]') {
+					if (mode === 'tool') {
+						const calls = parseGlmToolCallContent(content, tools);
+						if (calls.length > 0) {
+							controller.enqueue(sseEvent({
+								choices: [{ delta: { tool_calls: calls.map((call, index) => ({ index, ...call })) } }],
+							}));
+							controller.enqueue(sseEvent({ choices: [{ delta: {}, finish_reason: 'tool_calls' }] }));
+							mode = 'parsed';
+							pending = [];
+						} else {
+							mode = 'passthrough';
+							flushPending();
+						}
+					}
+					emit(raw);
+					return;
+				}
+
+				let event: any;
+				try {
+					event = JSON.parse(line.slice('data: '.length));
+				} catch {
+					if (mode === 'passthrough' || mode === 'parsed') emit(raw);
+					else pending.push(raw);
+					return;
+				}
+
+				if (mode === 'passthrough' || mode === 'parsed') {
+					emit(raw);
+					return;
+				}
+
+				const choice = event.choices?.[0];
+				const deltaContent = choice?.delta?.content;
+				if (Array.isArray(choice?.delta?.tool_calls)) {
+					mode = 'passthrough';
+					flushPending();
+					emit(raw);
+					return;
+				}
+
+				pending.push(raw);
+				if (typeof deltaContent === 'string') {
+					content += deltaContent;
+					if (mode === 'tool') return;
+					const candidate = content.trimStart();
+					if (candidate === '' || '<tool_call>'.startsWith(candidate) || candidate === '{') return;
+					if (candidate.startsWith('<tool_call>') || candidate.startsWith('{')) {
+						mode = 'tool';
+						return;
+					}
+					mode = 'passthrough';
+					flushPending();
+					return;
+				}
+
+				if (choice?.finish_reason) {
+					if (mode === 'tool') {
+						const calls = parseGlmToolCallContent(content, tools);
+						if (calls.length > 0) {
+							controller.enqueue(sseEvent({
+								choices: [{ delta: { tool_calls: calls.map((call, index) => ({ index, ...call })) } }],
+							}));
+							controller.enqueue(sseEvent({ choices: [{ delta: {}, finish_reason: 'tool_calls' }] }));
+							mode = 'parsed';
+							pending = [];
+							return;
+						}
+					}
+					mode = 'passthrough';
+					flushPending();
+				}
+			};
+
+			try {
+				while (true) {
+					const { done, value } = await reader.read();
+					if (done) break;
+					inputBuffer += decoder.decode(value, { stream: true });
+					let boundary: number;
+					while ((boundary = inputBuffer.indexOf('\n\n')) >= 0) {
+						const raw = inputBuffer.slice(0, boundary + 2);
+						inputBuffer = inputBuffer.slice(boundary + 2);
+						handleEvent(raw);
+					}
+				}
+				inputBuffer += decoder.decode();
+				if (inputBuffer) handleEvent(inputBuffer);
+				if (mode !== 'passthrough' && mode !== 'parsed') flushPending();
+				controller.close();
+			} catch (error) {
+				controller.error(error);
+			}
+		},
+		cancel() {
+			return reader.cancel();
+		},
+	});
+}
+
+function normalizeGlmRequest(body: RequestBody): RequestBody {
+	return {
+		...body,
+		model: SCREENPIPE_GLM_MODEL,
+	};
+}
 
 /**
  * Text-only GLM served beside the privacy filter in Screenpipe's Tinfoil CVM.
@@ -13,7 +241,7 @@ const DIRECT_GLM_BASE_URL = 'https://pii.screenpipe.containers.tinfoil.dev/glm/v
  * `custom-tinfoil` provider; both paths use the container-owned bearer secret.
  */
 export class ScreenpipeGlmProvider extends OpenAIProvider {
-	supportsTools = false;
+	supportsTools = true;
 	supportsVision = false;
 
 	constructor(
@@ -26,11 +254,26 @@ export class ScreenpipeGlmProvider extends OpenAIProvider {
 	}
 
 	async createCompletion(body: RequestBody): Promise<Response> {
-		return super.createCompletion({ ...body, model: SCREENPIPE_GLM_MODEL });
+		const response = await super.createCompletion(normalizeGlmRequest(body));
+		if (!Array.isArray(body.tools) || body.tools.length === 0) return response;
+		const payload: any = await response.json();
+		const message = payload.choices?.[0]?.message;
+		if (Array.isArray(message?.tool_calls) && message.tool_calls.length > 0) {
+			return new Response(JSON.stringify(payload), response);
+		}
+		const toolCalls = parseGlmToolCallContent(message?.content, body.tools);
+		if (toolCalls.length > 0) {
+			message.content = null;
+			message.tool_calls = toolCalls;
+			payload.choices[0].finish_reason = 'tool_calls';
+		}
+		return new Response(JSON.stringify(payload), response);
 	}
 
 	async createStreamingCompletion(body: RequestBody): Promise<ReadableStream> {
-		return super.createStreamingCompletion({ ...body, model: SCREENPIPE_GLM_MODEL });
+		const stream = await super.createStreamingCompletion(normalizeGlmRequest(body));
+		if (!Array.isArray(body.tools) || body.tools.length === 0) return stream;
+		return normalizeGlmToolCallStream(stream, body.tools);
 	}
 }
 

--- a/packages/ai-gateway/src/test/openai-models.unit.test.ts
+++ b/packages/ai-gateway/src/test/openai-models.unit.test.ts
@@ -219,12 +219,139 @@ describe('OpenAI API accounting and routing', () => {
 		const model = 'glm-5.3-flash-reap50-iq3m';
 		const provider = createProvider(model, env({ TINFOIL_GLM_API_KEY: 'glm-container-secret' }));
 		expect(provider).toBeInstanceOf(ScreenpipeGlmProvider);
-		expect(provider.supportsTools).toBe(false);
+		expect(provider.supportsTools).toBe(true);
 		expect(provider.supportsVision).toBe(false);
 		expect(inferProvider(model)).toBe('screenpipe-tinfoil');
 		expect(isZeroCostModel(model)).toBe(true);
 		expect(isModelAllowed(model, 'logged_in')).toBe(false);
 		expect(isModelAllowed(model, 'subscribed')).toBe(true);
+	});
+
+	it('forwards Pi function tools to the Screenpipe GLM enclave', async () => {
+		const provider = new ScreenpipeGlmProvider('glm-container-secret') as any;
+		const tools = [{
+			type: 'function',
+			function: {
+				name: 'read',
+				description: 'Read a local file',
+				parameters: {
+					type: 'object',
+					properties: { file_path: { type: 'string' } },
+					required: ['file_path'],
+				},
+			},
+		}];
+		let capturedParams: Record<string, unknown> | null = null;
+		provider.client.chat.completions.create = mock(async (params: Record<string, unknown>) => {
+			capturedParams = params;
+			return { choices: [{ message: { role: 'assistant', content: null, tool_calls: [] } }] };
+		});
+
+		await provider.createCompletion({
+			model: 'glm-5.3-flash-reap50-iq3m',
+			messages: [{ role: 'user', content: 'Read the screenpipe skill.' }],
+			tools,
+			tool_choice: 'required',
+		});
+
+		expect(capturedParams).not.toBeNull();
+		expect(capturedParams!['tools']).toEqual(tools);
+		expect(capturedParams!['tool_choice']).toBe('required');
+	});
+
+	it('normalizes GLM native tagged content into an executable Pi tool call', async () => {
+		const provider = new ScreenpipeGlmProvider('glm-container-secret') as any;
+		provider.client.chat.completions.create = mock(async () => ({
+			choices: [{
+				message: {
+					role: 'assistant',
+					content: '<tool_call>read<arg_key>path</arg_key><arg_value>/tmp/pi-tool-test</arg_value></tool_call>',
+				},
+			}],
+		}));
+
+		const response = await provider.createCompletion({
+			model: 'glm-5.3-flash-reap50-iq3m',
+			messages: [{ role: 'user', content: 'Read the test file.' }],
+			tools: [{
+				type: 'function',
+				function: {
+					name: 'read',
+					description: 'Read a local file',
+					parameters: {
+						type: 'object',
+						properties: { path: { type: 'string' } },
+						required: ['path'],
+					},
+				},
+			}],
+			tool_choice: 'required',
+		});
+		const payload: any = await response.json();
+
+		expect(payload.choices[0].message.content).toBeNull();
+		expect(payload.choices[0].message.tool_calls).toHaveLength(1);
+		expect(payload.choices[0].message.tool_calls[0].function.name).toBe('read');
+		expect(JSON.parse(payload.choices[0].message.tool_calls[0].function.arguments)).toEqual({
+			path: '/tmp/pi-tool-test',
+		});
+		expect(payload.choices[0].finish_reason).toBe('tool_calls');
+	});
+
+	it('normalizes GLM bare JSON content into an executable Pi tool call', async () => {
+		const provider = new ScreenpipeGlmProvider('glm-container-secret') as any;
+		provider.client.chat.completions.create = mock(async () => ({
+			choices: [{
+				message: {
+					role: 'assistant',
+					content: '{"name":"read","arguments":{"path":"/tmp/pi-tool-test"}}',
+				},
+			}],
+		}));
+
+		const response = await provider.createCompletion({
+			model: 'glm-5.3-flash-reap50-iq3m',
+			messages: [{ role: 'user', content: 'Read the test file.' }],
+			tools: [{
+				type: 'function',
+				function: {
+					name: 'read',
+					description: 'Read a local file',
+					parameters: { type: 'object', properties: { path: { type: 'string' } } },
+				},
+			}],
+		});
+		const payload: any = await response.json();
+
+		expect(payload.choices[0].message.content).toBeNull();
+		expect(payload.choices[0].message.tool_calls[0].function.name).toBe('read');
+		expect(JSON.parse(payload.choices[0].message.tool_calls[0].function.arguments)).toEqual({
+			path: '/tmp/pi-tool-test',
+		});
+	});
+
+	it('does not promote unknown GLM tags into executable tool calls', async () => {
+		const provider = new ScreenpipeGlmProvider('glm-container-secret') as any;
+		provider.client.chat.completions.create = mock(async () => ({
+			choices: [{ message: { role: 'assistant', content: '<tool_call>delete_everything{}' } }],
+		}));
+
+		const response = await provider.createCompletion({
+			model: 'glm-5.3-flash-reap50-iq3m',
+			messages: [{ role: 'user', content: 'Say hello.' }],
+			tools: [{
+				type: 'function',
+				function: {
+					name: 'read',
+					description: 'Read a local file',
+					parameters: { type: 'object', properties: { path: { type: 'string' } } },
+				},
+			}],
+		});
+		const payload: any = await response.json();
+
+		expect(payload.choices[0].message.content).toBe('<tool_call>delete_everything{}');
+		expect(payload.choices[0].message.tool_calls).toBeUndefined();
 	});
 
 	it('keeps Argus internal and sends the non-thinking tool-compatible template option', async () => {

--- a/packages/ai-gateway/src/test/openai-streaming-tool-calls.unit.test.ts
+++ b/packages/ai-gateway/src/test/openai-streaming-tool-calls.unit.test.ts
@@ -18,12 +18,30 @@
 
 import { describe, it, expect } from 'bun:test';
 import { OpenAIProvider } from '../providers/openai';
+import { ScreenpipeGlmProvider } from '../providers/screenpipe-glm';
 import type { RequestBody } from '../types';
 
 function makeOpenAIProvider(stream: () => AsyncGenerator<any>) {
 	const provider = new OpenAIProvider('test-key');
 	(provider as any).client = {
 		baseURL: 'https://api.openai.com/v1',
+		chat: {
+			completions: {
+				create: async () => {
+					const s: any = stream();
+					s.controller = { abort: () => {} };
+					return s;
+				},
+			},
+		},
+	};
+	return provider;
+}
+
+function makeGlmProvider(stream: () => AsyncGenerator<any>) {
+	const provider = new ScreenpipeGlmProvider('test-key');
+	(provider as any).client = {
+		baseURL: 'https://pii.screenpipe.containers.tinfoil.dev/glm/v1',
 		chat: {
 			completions: {
 				create: async () => {
@@ -116,5 +134,69 @@ describe('OpenAIProvider streaming — tool calls', () => {
 
 		const finish = events.map((e) => e.choices?.[0]?.finish_reason).find(Boolean);
 		expect(finish).toBe('stop');
+	});
+
+	it('normalizes GLM native streamed content into Pi tool-call deltas', async () => {
+		async function* stream() {
+			yield { choices: [{ delta: { content: '<tool_' } }] };
+			yield { choices: [{ delta: { content: 'call>read' } }] };
+			yield { choices: [{ delta: { content: '{"path":"/tmp/pi-tool-test"}' } }] };
+			yield { choices: [{ delta: {}, finish_reason: 'stop' }] };
+			yield { choices: [], usage: { prompt_tokens: 100, completion_tokens: 20, total_tokens: 120 } };
+		}
+
+		const provider = makeGlmProvider(stream);
+		const glmBody: RequestBody = {
+			model: 'glm-5.3-flash-reap50-iq3m',
+			messages: [{ role: 'user', content: 'Read the test file.' }],
+			tools: [{
+				type: 'function',
+				function: {
+					name: 'read',
+					description: 'Read a local file',
+					parameters: { type: 'object', properties: { path: { type: 'string' } }, required: ['path'] },
+				},
+			}],
+		};
+		const text = await new Response(await provider.createStreamingCompletion(glmBody)).text();
+		const events = parseEvents(text);
+		const toolCalls = events.flatMap((event) => event.choices?.[0]?.delta?.tool_calls ?? []);
+
+		expect(events.map((event) => event.choices?.[0]?.delta?.content ?? '').join('')).toBe('');
+		expect(toolCalls).toHaveLength(1);
+		expect(toolCalls[0].function.name).toBe('read');
+		expect(JSON.parse(toolCalls[0].function.arguments)).toEqual({ path: '/tmp/pi-tool-test' });
+		expect(events.map((event) => event.choices?.[0]?.finish_reason).find(Boolean)).toBe('tool_calls');
+		expect(events.find((event) => event.usage)?.usage.total_tokens).toBe(120);
+	});
+
+	it('normalizes GLM bare JSON streamed content into Pi tool-call deltas', async () => {
+		async function* stream() {
+			yield { choices: [{ delta: { content: '{' } }] };
+			yield { choices: [{ delta: { content: '"name":"read",' } }] };
+			yield { choices: [{ delta: { content: '"arguments":{"path":"/tmp/pi-tool-test"}}' } }] };
+			yield { choices: [{ delta: {}, finish_reason: 'stop' }] };
+		}
+
+		const provider = makeGlmProvider(stream);
+		const glmBody: RequestBody = {
+			model: 'glm-5.3-flash-reap50-iq3m',
+			messages: [{ role: 'user', content: 'Read the test file.' }],
+			tools: [{
+				type: 'function',
+				function: {
+					name: 'read',
+					description: 'Read a local file',
+					parameters: { type: 'object', properties: { path: { type: 'string' } } },
+				},
+			}],
+		};
+		const text = await new Response(await provider.createStreamingCompletion(glmBody)).text();
+		const events = parseEvents(text);
+		const toolCall = events.flatMap((event) => event.choices?.[0]?.delta?.tool_calls ?? [])[0];
+
+		expect(toolCall.function.name).toBe('read');
+		expect(JSON.parse(toolCall.function.arguments)).toEqual({ path: '/tmp/pi-tool-test' });
+		expect(events.map((event) => event.choices?.[0]?.finish_reason).find(Boolean)).toBe('tool_calls');
 	});
 });


### PR DESCRIPTION
## What changed
- advertise tool support for the Tinfoil GLM provider so the gateway no longer strips Pi function schemas
- normalize schema-known GLM native tool-call output into OpenAI `tool_calls` for both streaming and non-streaming responses
- refuse unknown tool names so arbitrary model text cannot become an executable Pi action

## Runtime counterpart
- screenpipe/privacy-filter#8 fixes second-turn tool replay in the pinned GLM chat template
- screenpipe/privacy-filter#9 pins the measured wrapper runtime without changing the PII image

## Verification
- `bun test src/test/openai-models.unit.test.ts src/test/openai-streaming-tool-calls.unit.test.ts` — 52 pass, 0 fail
- live Tinfoil debug H200: replayed assistant tool call + tool result returns the expected final answer rather than the prior Jinja 500
- final production promotion remains gated on a real Pi binary tool loop against the v0.9.8 Tinfoil candidate