### PR TITLE
fix(ai-gateway): compact Pi context for GLM

### DIFF
--- a/packages/ai-gateway/src/providers/screenpipe-glm.ts
+++ b/packages/ai-gateway/src/providers/screenpipe-glm.ts
@@ -6,6 +6,13 @@ import { OpenAIProvider } from './openai';
 
 export const SCREENPIPE_GLM_MODEL = 'glm-5.3-flash-reap50-iq3m';
 const DIRECT_GLM_BASE_URL = 'https://pii.screenpipe.containers.tinfoil.dev/glm/v1';
+const GLM_CORE_SKILLS = new Set([
+	'render-html-report',
+	'screenpipe-api',
+	'screenpipe-chats',
+	'screenpipe-cli',
+	'screenpipe-team',
+]);
 
 type GlmTool = {
 	type?: string;
@@ -238,10 +245,57 @@ function normalizeGlmToolCallStream(stream: ReadableStream, tools: unknown[]): R
 	});
 }
 
-function normalizeGlmRequest(body: RequestBody): RequestBody {
+function compactGlmSkillCatalog(content: string): string {
+	return content.replace(
+		/<available_skills>([\s\S]*?)<\/available_skills>/g,
+		(fullCatalog, entries: string) => {
+			const skillBlocks = entries.match(/\s*<skill>[\s\S]*?<\/skill>/g);
+			if (!skillBlocks) return fullCatalog;
+			const retained = skillBlocks.filter((block) => {
+				const name = block.match(/<name>\s*([^<]+?)\s*<\/name>/)?.[1];
+				return name ? GLM_CORE_SKILLS.has(name) : false;
+			});
+			return `<available_skills>${retained.join('')}\n</available_skills>`;
+		},
+	);
+}
+
+function compactGlmSystemMessage(message: RequestBody['messages'][number]): RequestBody['messages'][number] {
+	if (message.role !== 'system' && message.role !== 'developer') return message;
+	if (typeof message.content === 'string') {
+		return { ...message, content: compactGlmSkillCatalog(message.content) };
+	}
+	return {
+		...message,
+		content: message.content.map((part) =>
+			part.type === 'text' && typeof part.text === 'string'
+				? { ...part, text: compactGlmSkillCatalog(part.text) }
+				: part,
+		),
+	};
+}
+
+function isSubagentTool(tool: unknown): boolean {
+	if (!tool || typeof tool !== 'object') return false;
+	const candidate = tool as { type?: unknown; function?: { name?: unknown } };
+	return candidate.type === 'function' && candidate.function?.name === 'subagent';
+}
+
+/**
+ * Pi's normal prompt advertises every installed skill and the full subagent
+ * orchestration schema. That baseline alone is about 31K tokens on Louis's
+ * real Screenpipe profile, leaving a 32K model one token for its answer.
+ *
+ * Keep the core Screenpipe skills and ordinary tools, but omit capabilities
+ * that this single-slot model cannot fit. The files remain local and richer
+ * models keep the complete catalog; this changes only what GLM sees.
+ */
+export function normalizeGlmRequest(body: RequestBody): RequestBody {
 	return {
 		...body,
 		model: SCREENPIPE_GLM_MODEL,
+		messages: body.messages.map(compactGlmSystemMessage),
+		tools: Array.isArray(body.tools) ? body.tools.filter((tool) => !isSubagentTool(tool)) : body.tools,
 	};
 }
 

--- a/packages/ai-gateway/src/test/openai-models.unit.test.ts
+++ b/packages/ai-gateway/src/test/openai-models.unit.test.ts
@@ -259,6 +259,41 @@ describe('OpenAI API accounting and routing', () => {
 		expect(capturedParams!['tool_choice']).toBe('required');
 	});
 
+	it('compacts the Pi catalog to fit GLM while preserving core Screenpipe capabilities', async () => {
+		const provider = new ScreenpipeGlmProvider('glm-container-secret') as any;
+		const coreSkill = `  <skill>\n    <name>screenpipe-api</name>\n    <description>Query local history</description>\n  </skill>`;
+		const unrelatedSkill = `  <skill>\n    <name>talking-head-recut</name>\n    <description>Edit a video</description>\n  </skill>`;
+		const readTool = {
+			type: 'function',
+			function: { name: 'read', description: 'Read a file', parameters: { type: 'object', properties: {} } },
+		};
+		const subagentTool = {
+			type: 'function',
+			function: { name: 'subagent', description: 'Large orchestration schema', parameters: { type: 'object', properties: {} } },
+		};
+		let capturedParams: Record<string, any> | null = null;
+		provider.client.chat.completions.create = mock(async (params: Record<string, any>) => {
+			capturedParams = params;
+			return { choices: [{ message: { role: 'assistant', content: 'done' } }] };
+		});
+
+		await provider.createCompletion({
+			model: 'glm-5.3-flash-reap50-iq3m',
+			messages: [{
+				role: 'system',
+				content: `Keep this system policy.\n<available_skills>\n${coreSkill}\n${unrelatedSkill}\n</available_skills>`,
+			}, { role: 'user', content: 'Summarize today.' }],
+			tools: [readTool, subagentTool],
+		});
+
+		expect(capturedParams).not.toBeNull();
+		const system = capturedParams!.messages[0].content as string;
+		expect(system).toContain('Keep this system policy.');
+		expect(system).toContain('<name>screenpipe-api</name>');
+		expect(system).not.toContain('talking-head-recut');
+		expect(capturedParams!.tools).toEqual([readTool]);
+	});
+
 	it('normalizes GLM native tagged content into an executable Pi tool call', async () => {
 		const provider = new ScreenpipeGlmProvider('glm-container-secret') as any;
 		provider.client.chat.completions.create = mock(async () => ({


### PR DESCRIPTION
## What changed

GLM's 32K context was being consumed almost entirely by Pi's full installed-skill catalog and the large subagent orchestration schema. The Screenpipe GLM provider now keeps the core Screenpipe skill catalog and ordinary tools while omitting unrelated skill advertisements and the `subagent` tool for this model only.

Richer models keep the complete catalog. Skill files stay local and unchanged.

## Real failure

Fresh Day Recap on the production desktop/runtime:

```text
before
31K / 32.8K context
stopReason: length
assistant output: 1 token ("The")
```

The saved Pi session reported 22,676 input + 8,192 cached input tokens, 1 output token, and no reasoning tokens.

## Candidate smoke

Zero-traffic Worker version override with a 108,662-byte Pi-shaped request containing 110 advertised skills and the large subagent schema:

```text
before gateway compaction       after GLM compaction
108,662 request bytes     ->    5,961 upstream prompt tokens
                               READY, finish=stop
                               first event 8.4s / total 8.5s
```

## Tests

- `bun test src/test/openai-models.unit.test.ts src/test/openai-streaming-tool-calls.unit.test.ts` — 55 pass, 0 fail
- `bun test` — 1,028 pass, 0 fail
- `git diff --check` — pass
- `bunx tsc --noEmit` — one pre-existing unrelated error remains at `src/handlers/chat.ts:800` (`super_admin` vs `AccountPlan`)
