### PR TITLE
fix(ai-gateway): restore GLM output after Pi compaction

### DIFF
--- a/packages/ai-gateway/src/providers/screenpipe-glm.ts
+++ b/packages/ai-gateway/src/providers/screenpipe-glm.ts
@@ -13,6 +13,7 @@ const GLM_CORE_SKILLS = new Set([
 	'screenpipe-cli',
 	'screenpipe-team',
 ]);
+const GLM_COMPACTED_MIN_OUTPUT_TOKENS = 4096;
 
 type GlmTool = {
 	type?: string;
@@ -260,6 +261,18 @@ function compactGlmSkillCatalog(content: string): string {
 	);
 }
 
+function hasGlmSkillCatalog(content: string): boolean {
+	return /<available_skills>[\s\S]*?<\/available_skills>/.test(content);
+}
+
+function isGlmCatalogMessage(message: RequestBody['messages'][number]): boolean {
+	if (message.role !== 'system' && message.role !== 'developer') return false;
+	if (typeof message.content === 'string') return hasGlmSkillCatalog(message.content);
+	return message.content.some((part) =>
+		part.type === 'text' && typeof part.text === 'string' && hasGlmSkillCatalog(part.text)
+	);
+}
+
 function compactGlmSystemMessage(message: RequestBody['messages'][number]): RequestBody['messages'][number] {
 	if (message.role !== 'system' && message.role !== 'developer') return message;
 	if (typeof message.content === 'string') {
@@ -291,12 +304,33 @@ function isSubagentTool(tool: unknown): boolean {
  * models keep the complete catalog; this changes only what GLM sees.
  */
 export function normalizeGlmRequest(body: RequestBody): RequestBody {
-	return {
+	const compactsPiContext = body.messages.some(isGlmCatalogMessage)
+		|| (Array.isArray(body.tools) && body.tools.some(isSubagentTool));
+	const normalized: RequestBody = {
 		...body,
 		model: SCREENPIPE_GLM_MODEL,
 		messages: body.messages.map(compactGlmSystemMessage),
 		tools: Array.isArray(body.tools) ? body.tools.filter((tool) => !isSubagentTool(tool)) : body.tools,
 	};
+
+	// Pi clamps the output limit against its pre-gateway prompt estimate. With a
+	// large installed skill catalog that becomes one token even though the
+	// gateway removes most of that catalog before inference. Restore a useful
+	// answer budget only for requests where this GLM-specific compaction ran;
+	// ordinary API clients that intentionally request a tiny answer are unchanged.
+	if (compactsPiContext) {
+		if (normalized.max_completion_tokens !== undefined) {
+			normalized.max_completion_tokens = Math.max(
+				normalized.max_completion_tokens,
+				GLM_COMPACTED_MIN_OUTPUT_TOKENS,
+			);
+		}
+		if (normalized.max_tokens !== undefined) {
+			normalized.max_tokens = Math.max(normalized.max_tokens, GLM_COMPACTED_MIN_OUTPUT_TOKENS);
+		}
+	}
+
+	return normalized;
 }
 
 /**

--- a/packages/ai-gateway/src/test/openai-models.unit.test.ts
+++ b/packages/ai-gateway/src/test/openai-models.unit.test.ts
@@ -284,6 +284,7 @@ describe('OpenAI API accounting and routing', () => {
 				content: `Keep this system policy.\n<available_skills>\n${coreSkill}\n${unrelatedSkill}\n</available_skills>`,
 			}, { role: 'user', content: 'Summarize today.' }],
 			tools: [readTool, subagentTool],
+			max_completion_tokens: 1,
 		});
 
 		expect(capturedParams).not.toBeNull();
@@ -292,6 +293,25 @@ describe('OpenAI API accounting and routing', () => {
 		expect(system).toContain('<name>screenpipe-api</name>');
 		expect(system).not.toContain('talking-head-recut');
 		expect(capturedParams!.tools).toEqual([readTool]);
+		expect(capturedParams!.max_completion_tokens).toBe(4096);
+	});
+
+	it('preserves an intentional small GLM output limit outside Pi context compaction', async () => {
+		const provider = new ScreenpipeGlmProvider('glm-container-secret') as any;
+		let capturedParams: Record<string, any> | null = null;
+		provider.client.chat.completions.create = mock(async (params: Record<string, any>) => {
+			capturedParams = params;
+			return { choices: [{ message: { role: 'assistant', content: 'ok' } }] };
+		});
+
+		await provider.createCompletion({
+			model: 'glm-5.3-flash-reap50-iq3m',
+			messages: [{ role: 'user', content: 'Reply with one token.' }],
+			max_tokens: 1,
+		});
+
+		expect(capturedParams).not.toBeNull();
+		expect(capturedParams!.max_tokens).toBe(1);
 	});
 
 	it('normalizes GLM native tagged content into an executable Pi tool call', async () => {


### PR DESCRIPTION
## What changed

- restore a 4K output budget when GLM-specific Pi catalog/subagent compaction actually runs
- preserve intentionally tiny output limits for ordinary GLM API requests
- add regression coverage for the exact one-token failure and the non-Pi boundary

## Why

The production context compaction reduced a fresh Day Recap from 30.9K / 32.8K to 13.8K input tokens, but the installed Pi runtime had already estimated the uncompressed prompt and clamped `max_completion_tokens` to 1. The gateway removed the excess context but retained that stale one-token output cap, so the real UI still returned one character with `stopReason: length`.

## Before / after

```text
before: full Pi prompt -> client estimates overflow -> output cap 1
        gateway compacts to 13.8K -> GLM emits 1 token -> length

after:  full Pi prompt -> client estimates overflow -> output cap 1
        gateway compacts to 13.8K -> restores 4K cap -> usable tool/answer budget

ordinary request without Pi compaction: requested output cap remains unchanged
```

## Verification

- `bun test src/test/openai-models.unit.test.ts src/test/openai-streaming-tool-calls.unit.test.ts` — 56 pass, 0 fail
- `bun test` — 1,029 pass, 0 fail
- `git diff --check` — pass
- `bunx tsc --noEmit` — only the pre-existing unrelated `src/handlers/chat.ts:800` `super_admin` / `AccountPlan` error
