### PR TITLE
fix(macos): move open chat to active space

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/shortcuts.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/shortcuts.rs
@@ -350,7 +350,12 @@ async fn apply_shortcuts(app: &AppHandle, config: &ShortcutConfig) -> Result<(),
                     {
                         use tauri_nspanel::ManagerExt;
                         if let Ok(panel) = app.get_webview_panel("chat") {
-                            if panel.is_visible() {
+                            // A panel on another Space is also "visible". Only toggle
+                            // it closed when it is on the Space the user is viewing;
+                            // otherwise the shared show path moves it to this Space.
+                            if panel.is_visible()
+                                && crate::window::panel_is_on_active_space(&*panel)
+                            {
                                 panel.order_out(None);
                                 return;
                             }

--- a/apps/screenpipe-app-tauri/src-tauri/src/window/mod.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/window/mod.rs
@@ -164,6 +164,17 @@ pub(crate) fn make_panel_key_if_allowed(panel: &tauri_nspanel::raw_nspanel::RawN
     }
 }
 
+/// Whether a visible panel belongs to the user's currently active macOS Space.
+///
+/// `isVisible` remains true for windows pinned to a different Space, so callers
+/// must use this when deciding whether an invocation should hide the panel or
+/// move it to the Space the user is currently viewing.
+#[cfg(target_os = "macos")]
+pub(crate) fn panel_is_on_active_space(panel: &tauri_nspanel::raw_nspanel::RawNSPanel) -> bool {
+    use objc::{msg_send, sel, sel_impl};
+    unsafe { msg_send![panel, isOnActiveSpace] }
+}
+
 /// `[NSApp activateIgnoringOtherApps:YES]`, unless an e2e run is non-activating.
 ///
 /// This is the single call that yanks a developer out of their fullscreen Space,

--- a/apps/screenpipe-app-tauri/src-tauri/src/window/show.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/window/show.rs
@@ -742,6 +742,14 @@ impl ShowRewindWindow {
 
                         if let Ok(panel) = app_clone.get_webview_panel(RewindWindowId::Chat.label())
                         {
+                            // A panel pinned to another Space still reports itself as
+                            // visible. Order it out first so MoveToActiveSpace is applied
+                            // when it is ordered front again on the current Space.
+                            if panel.is_visible()
+                                && !crate::window::panel_is_on_active_space(&*panel)
+                            {
+                                panel.order_out(None);
+                            }
                             apply_chat_panel_on_top(&*panel, chat_on_top);
                             let _: () =
                                 unsafe { msg_send![&*panel, setMovableByWindowBackground: true] };


### PR DESCRIPTION
## Summary

- distinguish a Chat panel on the active macOS Space from one that is merely visible on another Space
- re-order an existing cross-Space Chat panel out before applying `MoveToActiveSpace` and showing it again
- preserve same-Space shortcut toggling while making overlay, shortcut, and tray invocations move the existing Chat window to the current Space

## Before / after

```text
Before
Desktop 1: [Chat]
Desktop 2: [Overlay] -- open Chat --> Desktop 1: [Chat]
                                      Desktop 2: [no interactive Chat]

After
Desktop 1: [Chat]
Desktop 2: [Overlay] -- open Chat --> Desktop 1: [no Chat]
                                      Desktop 2: [same Chat, focused + interactive]
```

## Historical intent

- Inspected `1ba375ca4e`: replaced `CanJoinAllSpaces` with `MoveToActiveSpace` so panels live on one Space instead of following workspace swipes.
- Inspected `b6aa5c287f`: established the show-time invariant—temporarily add `MoveToActiveSpace`, then remove it so Chat stays pinned to the selected Space.
- Inspected `c39cf2f6c`: preserved order-front-before-activation for fullscreen Spaces and avoided showing/focusing Chat during precreation.
- This change preserves those invariants and the existing same-Space shortcut toggle. It supersedes only the assumption that AppKit `isVisible` means the Chat panel is on the active Space; AppKit also returns visible for a panel pinned elsewhere.
- No test expectation was changed.

## Verification

- `bun run build:tauri:dev` — PASS on PR head `e8734299605f9f6aa57cb5d21852c7cabb42afa9`
- Disposable Orchard/Tart macOS 26.6.2 acceptance — PASS on the identical three-file logical patch before rebasing onto current `main`
  - overlay Chat moved the existing panel to Desktop 2; composer round-trip and attachments/filter interaction passed
  - global `Ctrl+Cmd+L` moved the existing panel to Desktop 2; composer round-trip passed
  - physical tray Chat click moved the existing panel to Desktop 2; composer round-trip passed
  - same-Space shortcut hid Chat
  - window handles stayed exactly `[chat, home]`; Mission Control remained on Desktop 2
- Orchard VM and all run-owned helpers, forwards, guest state, and temporary artifacts were removed after evidence collection.

The Orchard run used the repository E2E feature with an `onboarding,no-recording` seed and a manually assembled development-signed app bundle. Recording, audio, and ingest were not tested. One long-lived process appeared on both Spaces after opening the attachment menu, without creating another Chat handle; fresh isolated processes were used for the conclusive shortcut and tray cases.

Video evidence checksums:

- overlay: `334e36da98f405ce11fa0e1b3596307bfaa539de43de9b5a892568a94e01aff1`
- shortcut: `bdd23cf08a04763dffb7a865e70053866104f3981e1ca64da4525c242e72342e`
- tray: `17cfc502da13f4204344ca68d4632f5e4bb09553d385e735d94e189121c40c72`
