### PR TITLE
fix(ai-gateway): keep GLM Pi tool loops inside context

### DIFF
--- a/packages/ai-gateway/src/providers/screenpipe-glm.ts
+++ b/packages/ai-gateway/src/providers/screenpipe-glm.ts
@@ -14,6 +14,8 @@ const GLM_CORE_SKILLS = new Set([
 	'screenpipe-team',
 ]);
 const GLM_COMPACTED_MIN_OUTPUT_TOKENS = 4096;
+const GLM_MAX_TOOL_RESULT_CHARS = 8000;
+const GLM_TOOL_RESULT_COMPACTION_MARKER = '\n...[tool result compacted for GLM 32K context; reread a narrower range if needed]...\n';
 
 type GlmTool = {
 	type?: string;
@@ -273,6 +275,19 @@ function isGlmCatalogMessage(message: RequestBody['messages'][number]): boolean 
 	);
 }
 
+function compactGlmToolResultText(content: string): string {
+	if (content.length <= GLM_MAX_TOOL_RESULT_CHARS) return content;
+	const available = GLM_MAX_TOOL_RESULT_CHARS - GLM_TOOL_RESULT_COMPACTION_MARKER.length;
+	const headChars = Math.ceil(available * 0.82);
+	const tailChars = available - headChars;
+	return `${content.slice(0, headChars)}${GLM_TOOL_RESULT_COMPACTION_MARKER}${content.slice(-tailChars)}`;
+}
+
+function compactGlmToolResultMessage(message: RequestBody['messages'][number]): RequestBody['messages'][number] {
+	if (message.role !== 'tool' || typeof message.content !== 'string') return message;
+	return { ...message, content: compactGlmToolResultText(message.content) };
+}
+
 function compactGlmSystemMessage(message: RequestBody['messages'][number]): RequestBody['messages'][number] {
 	if (message.role !== 'system' && message.role !== 'developer') return message;
 	if (typeof message.content === 'string') {
@@ -309,7 +324,9 @@ export function normalizeGlmRequest(body: RequestBody): RequestBody {
 	const normalized: RequestBody = {
 		...body,
 		model: SCREENPIPE_GLM_MODEL,
-		messages: body.messages.map(compactGlmSystemMessage),
+		messages: body.messages
+			.map(compactGlmSystemMessage)
+			.map((message) => compactsPiContext ? compactGlmToolResultMessage(message) : message),
 		tools: Array.isArray(body.tools) ? body.tools.filter((tool) => !isSubagentTool(tool)) : body.tools,
 	};
 

--- a/packages/ai-gateway/src/test/openai-models.unit.test.ts
+++ b/packages/ai-gateway/src/test/openai-models.unit.test.ts
@@ -314,6 +314,46 @@ describe('OpenAI API accounting and routing', () => {
 		expect(capturedParams!.max_tokens).toBe(1);
 	});
 
+	it('compacts oversized Pi tool results while retaining their beginning and end', async () => {
+		const provider = new ScreenpipeGlmProvider('glm-container-secret') as any;
+		let capturedParams: Record<string, any> | null = null;
+		provider.client.chat.completions.create = mock(async (params: Record<string, any>) => {
+			capturedParams = params;
+			return { choices: [{ message: { role: 'assistant', content: 'done' } }] };
+		});
+		const oversizedResult = `ACTIVITY SUMMARY\n${'evidence '.repeat(5000)}END OF RESULT`;
+
+		await provider.createCompletion({
+			model: 'glm-5.3-flash-reap50-iq3m',
+			messages: [{
+				role: 'system',
+				content: '<available_skills><skill><name>screenpipe-api</name></skill></available_skills>',
+			}, {
+				role: 'assistant',
+				content: '',
+				tool_calls: [{
+					id: 'call_screenpipe_activity',
+					type: 'function',
+					function: { name: 'read', arguments: '{"path":"screenpipe-api/SKILL.md"}' },
+				}],
+			}, {
+				role: 'tool',
+				tool_call_id: 'call_screenpipe_activity',
+				content: oversizedResult,
+			}],
+			max_completion_tokens: 1,
+		});
+
+		expect(capturedParams).not.toBeNull();
+		const toolMessage = capturedParams!.messages.find((message: { role?: string }) => message.role === 'tool');
+		const compacted = toolMessage.content as string;
+		expect(compacted).toHaveLength(8000);
+		expect(compacted).toStartWith('ACTIVITY SUMMARY');
+		expect(compacted).toContain('tool result compacted for GLM 32K context');
+		expect(compacted).toEndWith('END OF RESULT');
+		expect(toolMessage.tool_call_id).toBe('call_screenpipe_activity');
+	});
+
 	it('normalizes GLM native tagged content into an executable Pi tool call', async () => {
 		const provider = new ScreenpipeGlmProvider('glm-container-secret') as any;
 		provider.client.chat.completions.create = mock(async () => ({


### PR DESCRIPTION
## What changed

- cap oversized tool-result text at 8K characters only for GLM requests where Pi catalog/subagent compaction is active
- retain the beginning and end plus an explicit marker so the model can reread a narrower range when necessary
- preserve tool-call IDs and leave ordinary GLM requests unchanged

## Why

After the initial prompt and one-token output fixes, a real Day Recap successfully made 11 Screenpipe tool calls. The first `screenpipe-api` skill read alone returned 34,786 characters; accumulated tool history made the synthesis request 34,660 tokens and the 32K GLM runtime correctly rejected it. This keeps the evidence loop below the runtime boundary without changing Tinfoil or the enterprise PII/image path.

## Before / after

```text
before: 13.8K initial context + 34.8K-char skill read + evidence loop
        -> 34,660-token synthesis request -> context error

after:  13.8K initial context + bounded 8K-char tool result + evidence loop
        -> newest evidence retained + room for final recap
```

## Verification

- focused GLM provider/streaming tests — 57 pass, 0 fail
- full AI gateway suite — 1,030 pass, 0 fail
- `git diff --check` — pass
