### PR TITLE
fix(windows-arm64): add independent screen capture fallback

### DIFF
--- a/crates/screenpipe-screen/Cargo.toml
+++ b/crates/screenpipe-screen/Cargo.toml
@@ -90,8 +90,16 @@ accessibility-sys = { workspace = true }
 core-foundation = { workspace = true }
 core-graphics = { workspace = true }
 
-[target.'cfg(target_os = "windows")'.dependencies]
+[target.'cfg(all(target_os = "windows", not(target_arch = "aarch64")))'.dependencies]
 xcap = { workspace = true, features = ["wgc"] }
+
+# The primary capture path already uses our direct WGC implementation. Keep its
+# ARM64 fallback independent: enabling xcap's `wgc` feature made both rungs use
+# the same backend, so a WGC/driver failure could leave capture with no frames.
+[target.'cfg(all(target_os = "windows", target_arch = "aarch64"))'.dependencies]
+xcap = { workspace = true }
+
+[target.'cfg(target_os = "windows")'.dependencies]
 uiautomation = { workspace = true }
 windows = { workspace = true, features = [
   "Graphics_Imaging",


### PR DESCRIPTION
## Summary

- keep the direct persistent WGC path as the primary Windows ARM64 capture backend
- make the ARM64 fallback use xcap's GDI implementation instead of retrying WGC through xcap
- leave Windows x64 behavior unchanged

Before:

```text
direct WGC fails -> xcap WGC fails -> no screenshots
```

After:

```text
direct WGC fails -> xcap GDI fallback -> capture can recover
```

Fixes #6884.

## Why

The existing failure ladder enabled xcap's `wgc` feature on every Windows architecture. That made both the primary capture implementation and its fallback depend on Windows Graphics Capture. A WGC or driver failure on ARM64 therefore had no independent recovery path.

This change only alters xcap's feature selection on Windows ARM64. The ordinary direct WGC path remains first, and Windows x64 keeps its current xcap/WGC behavior.

## Verification

- `cargo test -p screenpipe-screen --lib`
  - passed: 156
  - failed: 0
  - ignored: 3 live-desktop tests
- `cargo tree -p screenpipe-screen --target aarch64-pc-windows-msvc -e features`
  - confirmed ARM64 resolves xcap without `wgc`
- `cargo tree -p screenpipe-screen --target x86_64-pc-windows-msvc -e features`
  - confirmed x64 still resolves xcap with `wgc`
- `cargo check -p xcap@0.9.4 --target aarch64-pc-windows-msvc`
  - passed; compilation check only, not runtime evidence
- `cargo check -p screenpipe-screen --target aarch64-pc-windows-msvc`
  - blocked before the changed crate by missing ARM64 `clang-cl`/MSVC native tooling on this x64 machine

ARM64 runtime capture was not claimed or performed. The required disposable Azure Windows validation workflow could not be dispatched because Azure CLI/image configuration is unavailable on this machine.

## AI assistance and human ownership

- AI tool: Codex
- autonomy level: agent
- human verification: none recorded
- automated verification: exact commands and results are listed above