### PR TITLE
fix(chat): separate outages from usage limits

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -23,13 +23,13 @@ results and `cargo llvm-cov` data on top when judging release confidence.
 ### Tauri E2E
 
 - Mapped specs: 140
-- Declared test blocks: 401
-- Weighted coverage points: 322.1
+- Declared test blocks: 402
+- Weighted coverage points: 323.1
 
 | Platform | Specs | Declared tests | Weighted points | Layers | Features | Critical score |
 | --- | --- | --- | --- | --- | --- | --- |
 | windows | 107 | 340 | 283.1 | 15 | 122 | 85% |
-| macos | 136 | 363 | 291.9 | 17 | 132 | 88% |
+| macos | 136 | 364 | 292.9 | 17 | 132 | 88% |
 | linux | 95 | 298 | 252.5 | 14 | 119 | 80% |
 
 ### Core Engine

--- a/apps/screenpipe-app-tauri/lib/chat/__tests__/provider-errors.test.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/__tests__/provider-errors.test.ts
@@ -171,6 +171,30 @@ describe("provider error copy", () => {
     expect(msg).toContain("Codex");
   });
 
+  it("reserves upgrade guidance for explicit hosted rate limits", () => {
+    for (const raw of ["rate-limited", "rate limit exceeded", "too many requests"]) {
+      const msg = buildProviderErrorMessage(raw, {
+        provider: "screenpipe-cloud",
+        model: "auto",
+      });
+
+      expect(msg).toContain("rate-limited");
+      expect(msg).toContain("upgrade");
+    }
+  });
+
+  it("maps hosted unavailability to outage copy without upgrade guidance", () => {
+    const msg = buildProviderErrorMessage("service temporarily unavailable", {
+      provider: "screenpipe-cloud",
+      model: "auto",
+    });
+
+    expect(msg).toContain("screenpipe cloud");
+    expect(msg).toContain("outage on our end");
+    expect(msg).not.toContain("rate-limited");
+    expect(msg).not.toContain("upgrade");
+  });
+
   it("maps the per-message tool-loop cap separately", () => {
     const msg = buildProviderErrorMessage(
       '{"error":"free_chat_turn_request_limit_exceeded"}',

--- a/apps/screenpipe-app-tauri/lib/chat/provider-errors.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/provider-errors.ts
@@ -306,10 +306,12 @@ function buildGenericProviderErrorMessage(
     if (
       normalized.includes("rate-limited") ||
       normalized.includes("rate limit") ||
-      normalized.includes("too many requests") ||
-      normalized.includes("unavailable")
+      normalized.includes("too many requests")
     ) {
-      return `You are currently rate-limited or the service is temporarily unavailable. Please wait a moment before trying again, or upgrade your plan for higher limits.`;
+      return `You are currently rate-limited. Please wait a moment before trying again, or upgrade your plan for higher limits.`;
+    }
+    if (normalized.includes("unavailable")) {
+      return buildCloudConnectionMessage();
     }
   }
 


### PR DESCRIPTION
## Summary

- reserve rate-limit and upgrade guidance for explicit rate-limit signatures
- map hosted `unavailable` failures to the existing Screenpipe Cloud outage message
- cover both classifications with focused regression tests

## Before / after

```text
before: service unavailable -> "rate-limited ... upgrade your plan"
 after: service unavailable -> "brief outage on our end ... try again"

before: explicit 429/rate limit -> mixed outage/quota copy
 after: explicit 429/rate limit -> rate-limit and upgrade guidance only
```

## Historical intent

The combined classification arrived with `provider-errors.ts` in app version commit `3a6bf7b9a2`. The same module already defines dedicated hosted-cloud outage copy, but `unavailable` bypassed it and shared the quota branch. This patch preserves explicit rate-limit handling and routes only unavailable failures through the existing outage path.

## Verification

- `bun test lib/chat/__tests__/provider-errors.test.ts` — 48 passed
- `git diff --check`

## Scope

This PR corrects the shipped desktop copy. The paired website PR returns 401 for a confirmed missing Clerk subject so the existing desktop auth guard clears that stale credential.