### PR TITLE
fix(app): suppress native context menu in packaged builds

### DIFF
--- a/apps/screenpipe-app-tauri/app/layout.tsx
+++ b/apps/screenpipe-app-tauri/app/layout.tsx
@@ -103,6 +103,16 @@ export default function RootLayout({
 
     const uninstallBrowserLogBridge = installBrowserLogBridge();
 
+    // Packaged builds should not expose WKWebView's browser context menu.
+    // Listen during bubbling so app-owned context-menu handlers still run;
+    // preventing the default here only suppresses the native webview menu.
+    const preventNativeContextMenu = (event: MouseEvent) => {
+      event.preventDefault();
+    };
+    if (process.env.NODE_ENV === "production") {
+      document.addEventListener("contextmenu", preventNativeContextMenu);
+    }
+
     // A native foreground watchdog requires a heartbeat from WebKit's main
     // event loop. When paint submission wedges in the GPU-process IPC path,
     // the page cannot run this callback; the shell then rebuilds the stale UI
@@ -234,6 +244,7 @@ export default function RootLayout({
 
     return () => {
       uninstallBrowserLogBridge();
+      document.removeEventListener("contextmenu", preventNativeContextMenu);
       window.removeEventListener("focus", handleWindowFocus);
       window.removeEventListener("mousedown", handlePointerRecovery, true);
       window.removeEventListener("keydown", markKeyActivity, true);


### PR DESCRIPTION
## Summary

- suppress WKWebView's native browser context menu in packaged builds
- keep Screenpipe-owned custom context menus working by cancelling only the default action after app handlers run
- retain the normal native inspection workflow in the live development server

## Before / after

```text
BEFORE (reported release behavior)
right-click app background -> native webview menu

AFTER (Orchard observation)
right-click app background -> no native menu

Screenpipe-owned context menus -> unchanged
```

## Historical intent

PR #6593 removed Tauri's release `devtools` feature so release builds would not expose developer controls, while retaining development inspection. That change did not cancel WKWebView's default `contextmenu` action. This patch completes the release behavior at the frontend event boundary while preserving app-owned menus and live-development inspection.

## Verification

- `bunx vitest run components/chat/chat-tab-strip.test.tsx components/__tests__/sidebar-nav-list.test.tsx`
  - 2 files passed, 39 tests passed
- Orchard headless macOS acceptance at exact commit `400183b65f727a92215fc7a210a33a3854a65320`
  - immutable macOS Sequoia base: `sha256:3f4d14a5ffb9efd3bda2ae0184fd4bc2773d924ff8b7565f958761420ec41a0c`
  - guest: macOS 15.7.7, 8 CPU, 16 GiB memory, 80 GB disk, 47 GiB free
  - packaged v2.7.22 app installed and launched in the disposable guest
  - synthetic right-click on the onboarding webview produced no native context menu
  - guest operated through command-line VNC only; no host UI was opened
  - VM and port forward were deleted and teardown verified

### Test deviations

- The repository build compiled successfully but Tauri's bundle signing order stopped on an unsigned `libonnxruntime.dylib`. The disposable artifact was completed by signing that dylib and the app with the available Apple Development identity; `codesign --verify --deep --strict` passed before transfer.
- The expired local AWS session prevented encrypted object-storage handoff. The checksummed artifact was transferred directly over Orchard's encrypted SSH transport instead; SHA-256 matched on host and guest: `fa7435ce42101d046e11e0f38f7996814a24d42261c736b9a199bbc0d37558fe`.
