### PR TITLE
fix(app): recover null persisted AI presets

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/store.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/store.rs
@@ -2028,6 +2028,7 @@ impl SettingsStore {
             ];
             if let Some(presets) = obj.get_mut("aiPresets") {
                 if let Some(arr) = presets.as_array_mut() {
+                    arr.retain(|preset| !preset.is_null());
                     for preset in arr.iter_mut() {
                         Self::repair_orphaned_acp_preset(preset);
                         if let Some(provider) = preset.get("provider").and_then(|p| p.as_str()) {
@@ -4948,6 +4949,24 @@ mod tests {
         let preset = &sanitized_acp["aiPresets"][0];
         assert_eq!(preset["provider"].as_str(), Some("acp"));
         assert_eq!(preset["acpAgent"]["id"].as_str(), Some("codex-acp"));
+    }
+
+    #[test]
+    fn persisted_ai_presets_skip_null_but_reject_other_malformed_entries() {
+        let mut persisted = serde_json::to_value(SettingsStore::default()).unwrap();
+        persisted["aiPresets"] = json!([
+            {"id": "working", "provider": "screenpipe-cloud"},
+            null
+        ]);
+
+        let sanitized = SettingsStore::sanitize_legacy_fields(persisted.clone());
+        let settings: SettingsStore = serde_json::from_value(sanitized).unwrap();
+        assert_eq!(settings.ai_presets.len(), 1);
+        assert_eq!(settings.ai_presets[0].id, "working");
+
+        persisted["aiPresets"][1] = json!("malformed");
+        let malformed = SettingsStore::sanitize_legacy_fields(persisted);
+        assert!(serde_json::from_value::<SettingsStore>(malformed).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## What

Fixes production Sentry issues [SCREENPIPE-APP-N3](https://mediar.sentry.io/issues/7701975360/) and [SCREENPIPE-APP-N4](https://mediar.sentry.io/issues/7701975399/): persisted settings failed to load with `invalid type: null, expected a map`.

The latest event breadcrumb identifies the failing field: `unknown AI provider pi-agent in preset`, immediately before deserialization failed. Old persisted `aiPresets` arrays can contain a null entry.\n\n## Fix\n\nThe existing persisted-settings compatibility sanitizer drops only null entries from `aiPresets` before applying the existing preset repairs. Other malformed entries still fail closed instead of being silently discarded. Valid presets are preserved.\n\n## Test\n\n`bun run test:tauri persisted_ai_presets_skip_null_but_reject_other_malformed_entries -- --nocapture`\n\nResult at `8d76f12112`: 1 passed, 0 failed. The test serializes the real `SettingsStore::default()` persisted shape, proves null recovery, and proves a non-null malformed entry still fails. Generated Tauri schemas were restored after the supported pre-build step.\n\nA disposable Windows VM exact-head run is queued behind the current native VM validation; no foreground desktop session will be used.