### PR TITLE
fix(ai-gateway): coerce Anthropic tool input objects

### DIFF
--- a/packages/ai-gateway/src/providers/anthropic.ts
+++ b/packages/ai-gateway/src/providers/anthropic.ts
@@ -31,14 +31,17 @@ function safeJson(value: unknown): string {
 }
 
 function safeToolInput(value: unknown): Record<string, any> {
+	let parsed = value;
 	if (typeof value === 'string') {
 		try {
-			return JSON.parse(value);
+			parsed = JSON.parse(value);
 		} catch {
 			return {};
 		}
 	}
-	return (value && typeof value === 'object') ? value as Record<string, any> : {};
+	return parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
+		? parsed as Record<string, any>
+		: {};
 }
 
 function anthropicStopReasonToOpenAI(reason: unknown): string {

--- a/packages/ai-gateway/src/test/anthropic-proxy.unit.test.ts
+++ b/packages/ai-gateway/src/test/anthropic-proxy.unit.test.ts
@@ -678,6 +678,22 @@ describe('AnthropicProvider.formatMessages', () => {
 		expect(toolResult.content).toBe('Found: result');
 	});
 
+	it('coerces parsed non-object tool arguments to an empty object', () => {
+		for (const argumentsValue of ['null', '[]', '42', '"text"']) {
+			const result = provider.formatMessages([{
+				role: 'assistant',
+				content: '',
+				tool_calls: [{
+					id: 'call_1',
+					type: 'function' as const,
+					function: { name: 'search', arguments: argumentsValue },
+				}],
+			}]);
+			const toolUse = (result[0].content as any[]).find((part: any) => part.type === 'tool_use');
+			expect(toolUse.input).toEqual({});
+		}
+	});
+
 	it('should handle image_url content parts', () => {
 		const result = provider.formatMessages([{
 			role: 'user',


### PR DESCRIPTION
## What

Fixes [SCREENPIPE-AI-PROXY-34](https://mediar.sentry.io/issues/7644837007/): Anthropic rejects an assistant history block with `tool_use.input: Input should be an object`.

## Root cause

The OpenAI-to-Anthropic adapter parsed stringified tool arguments and returned `JSON.parse(...)` directly. Valid JSON can still be `null`, an array, number, or string, so those values escaped the function declared to return an object and reached Anthropic unchanged.

## Fix

After parsing, accept only a non-null, non-array object. Every other value becomes `{}`, preserving the tool call and letting the model continue. Valid object arguments and malformed-JSON behavior are unchanged. This changes the failed operation rather than merely suppressing its Sentry report.

## Test

`bun test src/test/anthropic-proxy.unit.test.ts --timeout=10000`

56 passed, 0 failed at `99f2055467`. The new regression exercises `null`, array, number, and string JSON arguments through `AnthropicProvider.formatMessages`; existing valid tool argument, tool ID, streaming, routing, and provider-error tests all pass.

A disposable Windows VM exact-head run is queued behind the current native VM validation; no foreground desktop session will be used.