### PR TITLE
Restore no-card Free onboarding and test it end to end

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -277,6 +277,11 @@ jobs:
       working-directory: ./apps/screenpipe-app-tauri
       run: bun run test:e2e:onboarding-background-ai-tools
 
+    - name: Verify clean Free onboarding without card capture
+      shell: pwsh
+      working-directory: ./apps/screenpipe-app-tauri
+      run: bun run test:e2e:onboarding-first-run
+
     - name: Run E2E Tests
       shell: pwsh
       working-directory: ./apps/screenpipe-app-tauri
@@ -635,6 +640,7 @@ jobs:
         export RECORD_VIDEO=1
 
         bun run test:e2e:onboarding-background-ai-tools
+        bun run test:e2e:onboarding-first-run
         rm -rf ./e2e/results
         bun run test:e2e
 
@@ -922,6 +928,11 @@ jobs:
       shell: bash
       working-directory: ./apps/screenpipe-app-tauri
       run: bun run test:e2e:onboarding-background-ai-tools
+
+    - name: Verify clean Free onboarding without card capture
+      shell: bash
+      working-directory: ./apps/screenpipe-app-tauri
+      run: bun run test:e2e:onboarding-first-run
 
     - name: Run E2E Tests
       # ADVISORY (non-blocking): the full serial suite (maxInstances:1) with

--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -23,14 +23,14 @@ results and `cargo llvm-cov` data on top when judging release confidence.
 ### Tauri E2E
 
 - Mapped specs: 140
-- Declared test blocks: 402
-- Weighted coverage points: 323.1
+- Declared test blocks: 403
+- Weighted coverage points: 324.1
 
 | Platform | Specs | Declared tests | Weighted points | Layers | Features | Critical score |
 | --- | --- | --- | --- | --- | --- | --- |
-| windows | 107 | 340 | 283.1 | 15 | 122 | 85% |
-| macos | 136 | 364 | 292.9 | 17 | 132 | 88% |
-| linux | 95 | 298 | 252.5 | 14 | 119 | 80% |
+| windows | 107 | 341 | 284.1 | 15 | 122 | 85% |
+| macos | 136 | 365 | 293.9 | 17 | 132 | 88% |
+| linux | 95 | 299 | 253.5 | 14 | 119 | 80% |
 
 ### Core Engine
 

--- a/apps/screenpipe-app-tauri/components/first-run/learning-banner.test.tsx
+++ b/apps/screenpipe-app-tauri/components/first-run/learning-banner.test.tsx
@@ -17,6 +17,8 @@ const mocks = vi.hoisted(() => ({
   view: {} as LearningWindowView,
   emit: vi.fn().mockResolvedValue(undefined),
   completeOnboarding: vi.fn().mockResolvedValue(undefined),
+  setOnboardingStep: vi.fn().mockResolvedValue({ status: "ok", data: null }),
+  capture: vi.fn(),
   handoff: {
     targets: [],
     resolved: false,
@@ -48,8 +50,12 @@ vi.mock("@tauri-apps/api/event", () => ({
   emit: mocks.emit,
   listen: vi.fn(async () => () => {}),
 }));
+vi.mock("posthog-js", () => ({ default: { capture: mocks.capture } }));
 vi.mock("@/lib/utils/tauri", () => ({
-  commands: { completeOnboarding: mocks.completeOnboarding },
+  commands: {
+    completeOnboarding: mocks.completeOnboarding,
+    setOnboardingStep: mocks.setOnboardingStep,
+  },
 }));
 
 vi.mock("@/lib/hooks/use-settings", () => ({
@@ -169,6 +175,26 @@ describe("trial activation summary experience", () => {
     expect(
       screen.getByTestId("trial-activation-start-trial").parentElement,
     ).toHaveClass("pointer-events-auto");
+  });
+
+  it("unlocks the full app when the user continues with Free", async () => {
+    render(<TrialActivationUnlockPrompt onStartTrial={vi.fn()} />);
+
+    fireEvent.click(screen.getByTestId("trial-activation-continue-free"));
+
+    await waitFor(() =>
+      expect(mocks.setOnboardingStep).toHaveBeenCalledWith(
+        "trial-activation-v1-unlocked",
+      ),
+    );
+    expect(mocks.capture).toHaveBeenCalledWith(
+      "onboarding_plan_activated",
+      expect.objectContaining({
+        plan: "free",
+        confirmation: "free_no_card",
+        source: "summary_lock",
+      }),
+    );
   });
 
   it("supports an inline CTA beside native product surfaces", () => {

--- a/apps/screenpipe-app-tauri/components/first-run/learning-banner.tsx
+++ b/apps/screenpipe-app-tauri/components/first-run/learning-banner.tsx
@@ -18,6 +18,11 @@ import { appIconUrl } from "@/lib/first-run/recent-activity";
 import { AgentHandoffPicker } from "@/components/first-run/agent-handoff-picker";
 import { useFirstRunLearningWindow } from "@/components/first-run/learning-window-provider";
 import type { AgentHandoffTarget } from "@/lib/first-run/agent-handoff";
+import {
+  TRIAL_ACTIVATION_EXPERIMENT_FLAG,
+  TRIAL_ACTIVATION_TREATMENT,
+  TRIAL_ACTIVATION_UNLOCKED_STEP,
+} from "@/lib/first-run/trial-activation";
 
 function CapturedAppIcon({ app }: { app: FirstRunCapturedApp }) {
   const [failed, setFailed] = React.useState(false);
@@ -393,6 +398,33 @@ export function TrialActivationUnlockPrompt({
   onStartTrial: () => void;
   inline?: boolean;
 }) {
+  const [freeBusy, setFreeBusy] = React.useState(false);
+  const [freeError, setFreeError] = React.useState<string | null>(null);
+
+  const continueWithFree = async () => {
+    if (freeBusy) return;
+    setFreeBusy(true);
+    setFreeError(null);
+    try {
+      const result = await commands.setOnboardingStep(
+        TRIAL_ACTIVATION_UNLOCKED_STEP,
+      );
+      if (result.status === "error") throw new Error(result.error);
+      posthog.capture("onboarding_plan_activated", {
+        experiment: TRIAL_ACTIVATION_EXPERIMENT_FLAG,
+        variant: TRIAL_ACTIVATION_TREATMENT,
+        plan: "free",
+        confirmation: "free_no_card",
+        source: inline ? "timeline_lock" : "summary_lock",
+      });
+    } catch (error) {
+      setFreeBusy(false);
+      setFreeError(
+        error instanceof Error ? error.message : "could not continue with Free",
+      );
+    }
+  };
+
   return (
     <div
       className={
@@ -404,13 +436,29 @@ export function TrialActivationUnlockPrompt({
       data-layout={inline ? "inline" : "overlay"}
     >
       <div className="pointer-events-auto w-full max-w-xl border border-border bg-background p-5 text-center shadow-lg">
-        <Button
-          className="h-12 w-full px-8 text-sm"
-          data-testid="trial-activation-start-trial"
-          onClick={onStartTrial}
-        >
-          start your 7-day free trial to unlock full access
-        </Button>
+        <div className="pointer-events-auto flex flex-col gap-3">
+          <Button
+            className="h-12 w-full px-8 text-sm"
+            data-testid="trial-activation-start-trial"
+            onClick={onStartTrial}
+          >
+            start your 7-day Business trial
+          </Button>
+          <Button
+            variant="outline"
+            className="h-11 w-full px-8 text-sm"
+            data-testid="trial-activation-continue-free"
+            disabled={freeBusy}
+            onClick={() => void continueWithFree()}
+          >
+            {freeBusy ? "continuing with Free" : "continue with Free — no card"}
+          </Button>
+        </div>
+        {freeError && (
+          <p className="mt-3 text-sm text-destructive" role="alert">
+            {freeError}
+          </p>
+        )}
       </div>
     </div>
   );

--- a/apps/screenpipe-app-tauri/components/first-run/trial-activation-paywall.test.tsx
+++ b/apps/screenpipe-app-tauri/components/first-run/trial-activation-paywall.test.tsx
@@ -68,6 +68,7 @@ beforeEach(() => {
   window.sessionStorage.clear();
   mocks.user = null;
   mocks.loadUser.mockResolvedValue(undefined);
+  mocks.setOnboardingStep.mockResolvedValue({ status: "ok", data: null });
   submitSpy = vi
     .spyOn(HTMLFormElement.prototype, "submit")
     .mockImplementation(() => undefined);
@@ -155,5 +156,44 @@ describe("TrialActivationPaywall", () => {
     expect(
       window.sessionStorage.getItem(TRIAL_ACTIVATION_CHECKOUT_STATE_KEY),
     ).toBe("pending");
+  });
+
+  it("lets a user return from checkout and continue with Free", async () => {
+    mocks.user = {
+      token: "in-memory-token",
+      has_payment_method: false,
+      entitlement_source: "none",
+    };
+    window.sessionStorage.setItem(
+      TRIAL_ACTIVATION_CHECKOUT_STATE_KEY,
+      "pending",
+    );
+
+    render(<TrialActivationPaywall open locked />);
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "continue with Free — no card",
+      }),
+    );
+    await waitFor(() =>
+      expect(mocks.setOnboardingStep).toHaveBeenCalledWith(
+        "trial-activation-v1-unlocked",
+      ),
+    );
+    expect(submitSpy).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(
+        window.sessionStorage.getItem(TRIAL_ACTIVATION_CHECKOUT_STATE_KEY),
+      ).toBeNull(),
+    );
+    expect(mocks.capture).toHaveBeenCalledWith(
+      "onboarding_plan_activated",
+      expect.objectContaining({
+        plan: "free",
+        confirmation: "free_no_card",
+        source: "checkout_dialog",
+      }),
+    );
   });
 });

--- a/apps/screenpipe-app-tauri/components/first-run/trial-activation-paywall.tsx
+++ b/apps/screenpipe-app-tauri/components/first-run/trial-activation-paywall.tsx
@@ -45,6 +45,7 @@ export function TrialActivationPaywall({
   );
   const [tokenResolved, setTokenResolved] = React.useState(Boolean(user?.token));
   const [error, setError] = React.useState<string | null>(null);
+  const [freeBusy, setFreeBusy] = React.useState(false);
   const [returnedWithoutStatus, setReturnedWithoutStatus] = React.useState(() =>
     ["pending", "returned"].includes(
       window.sessionStorage.getItem(TRIAL_ACTIVATION_CHECKOUT_STATE_KEY) ?? "",
@@ -137,6 +138,35 @@ export function TrialActivationPaywall({
     }
   }, [checkoutToken]);
 
+  const continueWithFree = React.useCallback(async () => {
+    if (freeBusy) return;
+    submissionStartedRef.current = true;
+    setFreeBusy(true);
+    setError(null);
+    try {
+      const result = await commands.setOnboardingStep(
+        TRIAL_ACTIVATION_UNLOCKED_STEP,
+      );
+      if (result.status === "error") throw new Error(result.error);
+      window.sessionStorage.removeItem(TRIAL_ACTIVATION_CHECKOUT_STATE_KEY);
+      posthog.capture("onboarding_plan_activated", {
+        experiment: "first-summary-card-trial-v1",
+        variant: "summary_first",
+        plan: "free",
+        confirmation: "free_no_card",
+        source: "checkout_dialog",
+      });
+    } catch (freeError) {
+      submissionStartedRef.current = false;
+      setFreeBusy(false);
+      setError(
+        freeError instanceof Error
+          ? freeError.message
+          : "could not continue with Free",
+      );
+    }
+  }, [freeBusy]);
+
   React.useEffect(() => {
     if (!open || !tokenResolved || !checkoutToken || returnedWithoutStatus) {
       return;
@@ -200,6 +230,13 @@ export function TrialActivationPaywall({
             loading screenpipe.com
           </p>
         )}
+        <Button
+          variant="ghost"
+          disabled={freeBusy}
+          onClick={() => void continueWithFree()}
+        >
+          {freeBusy ? "continuing with Free" : "continue with Free — no card"}
+        </Button>
       </DialogContent>
     </Dialog>
   );

--- a/apps/screenpipe-app-tauri/components/onboarding/plan-selection-step.test.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/plan-selection-step.test.tsx
@@ -86,6 +86,10 @@ describe("hosted onboarding checkout", () => {
   it("navigates the existing webview with a hidden POST and keeps secrets out of URLs", async () => {
     render(<PlanSelectionStep handleNextSlide={vi.fn()} />);
 
+    expect(submitSpy).not.toHaveBeenCalled();
+    fireEvent.click(
+      screen.getByRole("button", { name: "start 7-day Business trial" }),
+    );
     await waitFor(() => expect(submitSpy).toHaveBeenCalledOnce());
     const form = checkoutForm();
     expect(form.method).toBe("post");
@@ -106,6 +110,9 @@ describe("hosted onboarding checkout", () => {
 
   it("submits only once when the local controller rerenders", async () => {
     const view = render(<PlanSelectionStep handleNextSlide={vi.fn()} />);
+    fireEvent.click(
+      screen.getByRole("button", { name: "start 7-day Business trial" }),
+    );
     await waitFor(() => expect(submitSpy).toHaveBeenCalledOnce());
 
     view.rerender(<PlanSelectionStep handleNextSlide={vi.fn()} />);
@@ -263,14 +270,29 @@ describe("hosted onboarding checkout", () => {
     ).toBe(buildLocalCheckoutReturnUrl(window.location.href));
   });
 
-  it("keeps checkout required after cancellation", async () => {
+  it("offers Free without a card after cancellation", async () => {
     window.history.replaceState({}, "", "/onboarding?checkout=cancelled");
     const next = vi.fn();
     render(<PlanSelectionStep handleNextSlide={next} />);
 
-    expect(
-      screen.queryByTestId("onboarding-plan-free"),
-    ).not.toBeInTheDocument();
-    expect(next).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId("onboarding-plan-free"));
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(submitSpy).not.toHaveBeenCalled();
+    expect(mocks.capture).toHaveBeenCalledWith("onboarding_plan_activated", {
+      plan: "free",
+      confirmation: "free_no_card",
+    });
+  });
+
+  it("offers Free without opening checkout on the initial plan screen", () => {
+    const next = vi.fn();
+    render(<PlanSelectionStep handleNextSlide={next} />);
+
+    expect(screen.getByText("choose how to start")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("onboarding-plan-free"));
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(submitSpy).not.toHaveBeenCalled();
   });
 });

--- a/apps/screenpipe-app-tauri/components/onboarding/plan-selection-step.test.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/plan-selection-step.test.tsx
@@ -290,6 +290,10 @@ describe("hosted onboarding checkout", () => {
     render(<PlanSelectionStep handleNextSlide={next} />);
 
     expect(screen.getByText("choose how to start")).toBeInTheDocument();
+    expect(screen.getByTestId("onboarding-plan-selection")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("onboarding-card-capture"),
+    ).not.toBeInTheDocument();
     fireEvent.click(screen.getByTestId("onboarding-plan-free"));
 
     expect(next).toHaveBeenCalledOnce();

--- a/apps/screenpipe-app-tauri/components/onboarding/plan-selection-step.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/plan-selection-step.tsx
@@ -35,7 +35,7 @@ export default function PlanSelectionStep({
   const { settings, loadUser } = useSettings();
   const user = settings.user as AppUser | null | undefined;
   const [returnStatus] = useState(checkoutStatus);
-  const [busy, setBusy] = useState(returnStatus !== "cancelled");
+  const [busy, setBusy] = useState(returnStatus === "complete");
   const [error, setError] = useState<string | null>(null);
   const [returnRecoveryFinished, setReturnRecoveryFinished] = useState(
     returnStatus !== "complete",
@@ -81,11 +81,6 @@ export default function PlanSelectionStep({
       );
     }
   }, [userToken]);
-
-  useEffect(() => {
-    if (returnStatus !== null) return;
-    startCheckout();
-  }, [returnStatus, startCheckout]);
 
   useEffect(() => {
     if (returnStatus !== "complete") return;
@@ -204,6 +199,16 @@ export default function PlanSelectionStep({
     setRecoveryAttempt((attempt) => attempt + 1);
   }, [userToken]);
 
+  const continueWithFree = useCallback(() => {
+    if (advancedRef.current) return;
+    advancedRef.current = true;
+    posthog.capture("onboarding_plan_activated", {
+      plan: "free",
+      confirmation: "free_no_card",
+    });
+    void handleNextSlide();
+  }, [handleNextSlide]);
+
   if (returnStatus === "complete") {
     return (
       <div
@@ -252,19 +257,29 @@ export default function PlanSelectionStep({
           checkout was not completed
         </h2>
         <p className="mt-2 font-mono text-[10px] leading-relaxed text-muted-foreground">
-          retry when you are ready to start your trial.
+          start the Business trial, or keep using Free without a card.
         </p>
         {error && (
           <p className="mt-4 font-mono text-[11px] text-destructive">{error}</p>
         )}
-        <button
-          type="button"
-          onClick={startCheckout}
-          disabled={busy}
-          className="mt-5 border bg-foreground px-4 py-2 font-mono text-[10px] uppercase tracking-widest text-background transition-opacity hover:opacity-80 disabled:opacity-50"
-        >
-          {busy ? "opening checkout" : "retry secure checkout"}
-        </button>
+        <div className="mt-5 flex flex-col gap-3">
+          <button
+            type="button"
+            onClick={startCheckout}
+            disabled={busy}
+            className="border bg-foreground px-4 py-2 font-mono text-[10px] uppercase tracking-widest text-background transition-opacity hover:opacity-80 disabled:opacity-50"
+          >
+            {busy ? "opening checkout" : "retry secure checkout"}
+          </button>
+          <button
+            type="button"
+            data-testid="onboarding-plan-free"
+            onClick={continueWithFree}
+            className="border px-4 py-2 font-mono text-[10px] uppercase tracking-widest transition-colors hover:bg-foreground hover:text-background"
+          >
+            continue with Free — no card
+          </button>
+        </div>
       </div>
     );
   }
@@ -274,21 +289,29 @@ export default function PlanSelectionStep({
       className="mx-auto w-full max-w-sm text-center"
       data-testid="onboarding-card-capture"
     >
-      <h2 className="text-xl font-semibold lowercase">
-        opening secure checkout
-      </h2>
-      <p className="mt-3 font-mono text-[11px] text-muted-foreground">
-        {error || "loading screenpipe.com"}
+      <h2 className="text-xl font-semibold lowercase">choose how to start</h2>
+      <p className="mt-3 font-mono text-[11px] leading-relaxed text-muted-foreground">
+        Use Screenpipe Free without a card, or start a 7-day Business trial.
       </p>
-      {error && (
+      {error && <p className="mt-3 font-mono text-[11px] text-destructive">{error}</p>}
+      <div className="mt-5 flex flex-col gap-3">
         <button
           type="button"
           onClick={startCheckout}
-          className="mt-5 border px-4 py-2 font-mono text-[10px] uppercase tracking-widest transition-colors hover:bg-foreground hover:text-background"
+          disabled={busy}
+          className="border bg-foreground px-4 py-2 font-mono text-[10px] uppercase tracking-widest text-background transition-opacity hover:opacity-80 disabled:opacity-50"
         >
-          try again
+          {busy ? "opening checkout" : "start 7-day Business trial"}
         </button>
-      )}
+        <button
+          type="button"
+          data-testid="onboarding-plan-free"
+          onClick={continueWithFree}
+          className="border px-4 py-2 font-mono text-[10px] uppercase tracking-widest transition-colors hover:bg-foreground hover:text-background"
+        >
+          continue with Free — no card
+        </button>
+      </div>
     </div>
   );
 }

--- a/apps/screenpipe-app-tauri/components/onboarding/plan-selection-step.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/plan-selection-step.tsx
@@ -287,7 +287,7 @@ export default function PlanSelectionStep({
   return (
     <div
       className="mx-auto w-full max-w-sm text-center"
-      data-testid="onboarding-card-capture"
+      data-testid="onboarding-plan-selection"
     >
       <h2 className="text-xl font-semibold lowercase">choose how to start</h2>
       <p className="mt-3 font-mono text-[11px] leading-relaxed text-muted-foreground">

--- a/apps/screenpipe-app-tauri/e2e/COVERAGE.md
+++ b/apps/screenpipe-app-tauri/e2e/COVERAGE.md
@@ -11,8 +11,8 @@ and layer declared in the manifest, weighted by confidence and criticality.
 - Manifest: `e2e/coverage-map.json`
 - Specs directory: `e2e/specs`
 - Mapped specs: 140
-- Declared test blocks: 402
-- Weighted coverage points: 323.1
+- Declared test blocks: 403
+- Weighted coverage points: 324.1
 
 Confidence weights: strong=1.0, partial=0.7, conditional=0.4, smoke=0.3.
 Criticality weights: high=1.0, medium=0.7, low=0.4.
@@ -23,9 +23,9 @@ can execute more runtime cases than this number shows.
 
 | Platform | Specs | Declared tests | Weighted points | Layers | Features | Critical score |
 | --- | --- | --- | --- | --- | --- | --- |
-| windows | 107 | 340 | 283.1 | 15 | 122 | 85% |
-| macos | 136 | 364 | 292.9 | 17 | 132 | 88% |
-| linux | 95 | 298 | 252.5 | 14 | 119 | 80% |
+| windows | 107 | 341 | 284.1 | 15 | 122 | 85% |
+| macos | 136 | 365 | 293.9 | 17 | 132 | 88% |
+| linux | 95 | 299 | 253.5 | 14 | 119 | 80% |
 
 ## Runtime Results
 
@@ -45,14 +45,14 @@ pass/fail/skip counts.
 | entitlement | - | 1 specs / 1 tests / 1.0 pts | - |
 | local-api | 29 specs / 119 tests / 100.0 pts | 39 specs / 116 tests / 99.5 pts | 24 specs / 87 tests / 78.2 pts |
 | notifications | 4 specs / 26 tests / 17.3 pts | 3 specs / 5 tests / 3.4 pts | 2 specs / 4 tests / 3.1 pts |
-| onboarding | 9 specs / 38 tests / 33.8 pts | 11 specs / 42 tests / 37.2 pts | 9 specs / 38 tests / 33.8 pts |
+| onboarding | 9 specs / 39 tests / 34.8 pts | 11 specs / 43 tests / 38.2 pts | 9 specs / 39 tests / 34.8 pts |
 | os-integration | 7 specs / 32 tests / 26.9 pts | 15 specs / 30 tests / 18.4 pts | 2 specs / 15 tests / 10.8 pts |
 | performance | 3 specs / 45 tests / 45.0 pts | 5 specs / 36 tests / 31.8 pts | 2 specs / 30 tests / 30.0 pts |
 | pipes | 6 specs / 20 tests / 20.0 pts | 8 specs / 26 tests / 26.0 pts | 6 specs / 20 tests / 20.0 pts |
-| real-ui-e2e | 80 specs / 238 tests / 201.9 pts | 97 specs / 256 tests / 216.9 pts | 74 specs / 214 tests / 187.9 pts |
+| real-ui-e2e | 80 specs / 239 tests / 202.9 pts | 97 specs / 257 tests / 217.9 pts | 74 specs / 215 tests / 188.9 pts |
 | settings | 15 specs / 42 tests / 39.0 pts | 17 specs / 36 tests / 31.7 pts | 14 specs / 33 tests / 30.0 pts |
 | storage-privacy | 10 specs / 44 tests / 35.3 pts | 10 specs / 29 tests / 28.1 pts | 7 specs / 22 tests / 21.1 pts |
-| tauri-command | 23 specs / 62 tests / 48.9 pts | 35 specs / 85 tests / 67.3 pts | 22 specs / 63 tests / 49.8 pts |
+| tauri-command | 23 specs / 63 tests / 49.9 pts | 35 specs / 86 tests / 68.3 pts | 22 specs / 64 tests / 50.8 pts |
 | window-lifecycle | 22 specs / 71 tests / 59.5 pts | 23 specs / 55 tests / 40.9 pts | 16 specs / 44 tests / 34.4 pts |
 
 ## Critical Feature Matrix
@@ -200,7 +200,7 @@ pass/fail/skip counts.
 | meetings-only-audio-lifecycle.spec.ts | windows, macos | audio-device, local-api, real-ui-e2e | meetings-only-audio-lifecycle, audio-device-health | high | conditional | real-user-flow | 1 | Opt-in real-audio lifecycle lane: configured devices stay closed outside meetings and open only across a manual meeting edge. |
 | notification-viewer-link.spec.ts | windows, macos, linux | notifications, local-api, window-lifecycle | notifications, viewer-deeplink | high | partial | mixed | 3 | Notification local file links rewrite into in-app viewer links. |
 | onboarding-background-ai-tools.spec.ts | windows, macos, linux | onboarding, real-ui-e2e, storage-privacy | onboarding, settings-ai | high | strong | real-user-flow | 2 | Isolated agent-home CI lane verifies private native config writes, the resolved local API credential, a real authenticated MCP tool call, skills setup, and migration from the removed connection slide through engine startup to optional recommended setup and completion. |
-| onboarding-first-run.spec.ts | windows, macos, linux | onboarding, real-ui-e2e, tauri-command | onboarding, first-run-learning, settings-persistence | high | strong | real-user-flow | 8 | Fresh-install setup walk: the acquisition slide is reachable in the shipped slide order and counted by the progress bar, offers no free-text field, one tap persists through to store.bin via the real settings command, skip records nothing, and the engine slide is the last one with no goal picker after it. |
+| onboarding-first-run.spec.ts | windows, macos, linux | onboarding, real-ui-e2e, tauri-command | onboarding, first-run-learning, settings-persistence | high | strong | real-user-flow | 9 | Fresh-install setup walk: the acquisition slide is reachable in the shipped slide order and counted by the progress bar, offers no free-text field, one tap persists through to store.bin via the real settings command, skip records nothing, signed-out users reach recommended setup, verified Free accounts continue without card capture or hosted checkout and land in Home, and existing lifetime owners stay out of mandatory checkout. |
 | onboarding-h1-follow-up.spec.ts | windows, macos, linux | onboarding, notifications, pipes, real-ui-e2e | onboarding, notifications, pipes | high | strong | real-user-flow | 1 | A due H1 activation runs its real Pipe, sends one visible prompt through the app-control notification server, and remains exactly-once across repeated scheduler ticks. |
 | onboarding-redirect.spec.ts | windows, macos, linux | onboarding, real-ui-e2e, window-lifecycle | onboarding, app-launch | high | conditional | real-user-flow | 5 | Opt-in no-onboarding seed verifies onboarding redirect. |
 | onboarding-trust-affordances.spec.ts | windows, macos, linux | onboarding, real-ui-e2e, tauri-command | onboarding, settings-privacy-api-auth, storage-retention | high | strong | real-user-flow | 4 | Pre-grant reassurance in setup: the login slide carries the storage-locality line and the pause affordance on one line (the only slide every platform sees, since permissions auto-advances on non-mac); the mac permissions slide keeps that promise collapsed to a single line below the permission wheel and on expand renders the data dir the running app actually resolved rather than a reconstructed ~/.screenpipe, with an open action pointed at that path; collapsed and expanded states are both asserted to fit inside the fixed-size onboarding window; and the timeline slide states the capture bounds (incognito skipped, per-app exclusions) where the capture decision is made. The mac assertions share one visit because the slide auto-advances 600ms after all grants land. |

--- a/apps/screenpipe-app-tauri/e2e/coverage-map.json
+++ b/apps/screenpipe-app-tauri/e2e/coverage-map.json
@@ -2281,8 +2281,8 @@
       "criticality": "high",
       "confidence": "strong",
       "ux": "real-user-flow",
-      "tests": 7,
-      "notes": "Fresh-install setup walk: the acquisition slide is reachable in the shipped slide order and counted by the progress bar, offers no free-text field, one tap persists through to store.bin via the real settings command, skip records nothing, and the engine slide is the last one with no goal picker after it."
+      "tests": 9,
+      "notes": "Fresh-install setup walk: the acquisition slide is reachable in the shipped slide order and counted by the progress bar, offers no free-text field, one tap persists through to store.bin via the real settings command, skip records nothing, signed-out users reach recommended setup, verified Free accounts continue without card capture or hosted checkout and land in Home, and existing lifetime owners stay out of mandatory checkout."
     },
     {
       "spec": "onboarding-h1-follow-up.spec.ts",

--- a/apps/screenpipe-app-tauri/e2e/specs/onboarding-first-run.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/onboarding-first-run.spec.ts
@@ -289,14 +289,6 @@ const seedLearningWindow = async (state: Record<string, unknown>) => {
       },
     });
 
-    // E2E builds normally bypass the post-onboarding entitlement gate so the
-    // broad suite can exercise paid surfaces. Force that real gate back on
-    // before Home mounts; otherwise reaching Home would only prove the
-    // onboarding half of the Free path.
-    await browser.execute((key: string) => {
-      window.localStorage.setItem(key, "1");
-    }, FORCE_BILLING_GATE_KEY);
-
     try {
       await gotoSlide("plan");
       await waitForTestId("onboarding-plan-selection", 30_000);
@@ -339,6 +331,18 @@ const seedLearningWindow = async (state: Record<string, unknown>) => {
       await waitForWindowClosed("onboarding", t(30_000));
       await waitForWindowHandle("home", t(30_000));
       await browser.switchToWindow("home");
+
+      // E2E builds normally bypass the post-onboarding entitlement gate so
+      // the broad suite can exercise paid surfaces. Force that real gate back
+      // on and reload the already-mounted Home webview before asserting its
+      // navigation; otherwise Home could remain visible through the bypass.
+      await browser.execute((key: string) => {
+        window.localStorage.setItem(key, "1");
+        window.location.reload();
+      }, FORCE_BILLING_GATE_KEY);
+      await browser.pause(t(2_500));
+      await browser.switchToWindow("home");
+
       const navHome = await $('[data-testid="nav-home"]');
       await navHome.waitForExist({ timeout: t(30_000) });
       expect(await navHome.isExisting()).toBe(true);

--- a/apps/screenpipe-app-tauri/e2e/specs/onboarding-first-run.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/onboarding-first-run.spec.ts
@@ -267,6 +267,69 @@ const seedLearningWindow = async (state: Record<string, unknown>) => {
     }
   });
 
+  it("continues from a verified Free account without asking for a card", async () => {
+    const checkedAt = new Date().toISOString();
+    await seedOnboardingUser({
+      id: "e2e-free-user",
+      clerk_id: "e2e-free-user",
+      token: "e2e-free-token",
+      email: "free-user@screenpipe.test",
+      cloud_subscribed: false,
+      app_entitled: false,
+      subscription_plan: "none",
+      entitlement_source: "none",
+      has_payment_method: false,
+      entitlement: {
+        active: false,
+        plan: "none",
+        source: "none",
+        checked_at: checkedAt,
+        features: { app: false, cloud: false },
+      },
+    });
+
+    await gotoSlide("plan");
+    await waitForBodyText("plan selection", 30_000);
+
+    const before = await bodyText();
+    expect(before).not.toContain("opening secure checkout");
+    expect(
+      await browser.execute(
+        () =>
+          !!document.querySelector('[data-testid="onboarding-card-capture"]'),
+      ),
+    ).toBe(false);
+
+    const continueFree = await $("button*=continue free plan");
+    await continueFree.waitForExist({ timeout: t(20_000) });
+    await continueFree.click();
+
+    await waitForTestId("onboarding-final-setup", 30_000);
+    const after = await bodyText();
+    expect(after).toContain("connect gmail");
+    expect(after).not.toContain("opening secure checkout");
+    expect(
+      await browser.execute(
+        () =>
+          !!document.querySelector('[data-testid="onboarding-card-capture"]'),
+      ),
+    ).toBe(false);
+
+    const filepath = await saveScreenshot("onboarding-free-no-card");
+    expect(existsSync(filepath)).toBe(true);
+
+    const finishSetup = await $("button*=continue");
+    await finishSetup.waitForExist({ timeout: t(20_000) });
+    await finishSetup.click();
+
+    await waitForWindowClosed("onboarding", t(30_000));
+    await waitForWindowHandle("home", t(30_000));
+    await browser.switchToWindow("home");
+    const navHome = await $('[data-testid="nav-home"]');
+    await navHome.waitForExist({ timeout: t(30_000) });
+    expect(await navHome.isExisting()).toBe(true);
+  });
+
   it("keeps lifetime ownership out of mandatory checkout", async () => {
     await seedOnboardingUser({
       id: "e2e-lifetime-owner",

--- a/apps/screenpipe-app-tauri/e2e/specs/onboarding-first-run.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/onboarding-first-run.spec.ts
@@ -47,6 +47,7 @@ const seedFlags = E2E_SEED_FLAGS.split(",")
 const canRun = !seedFlags.includes("onboarding");
 
 const LEARNING_STORAGE_KEY = "screenpipe.first-run.learning-window.v1";
+const FORCE_BILLING_GATE_KEY = "screenpipe_e2e_force_billing_gate";
 
 const bodyText = async (): Promise<string> =>
   (
@@ -288,46 +289,66 @@ const seedLearningWindow = async (state: Record<string, unknown>) => {
       },
     });
 
-    await gotoSlide("plan");
-    await waitForTestId("onboarding-plan-selection", 30_000);
+    // E2E builds normally bypass the post-onboarding entitlement gate so the
+    // broad suite can exercise paid surfaces. Force that real gate back on
+    // before Home mounts; otherwise reaching Home would only prove the
+    // onboarding half of the Free path.
+    await browser.execute((key: string) => {
+      window.localStorage.setItem(key, "1");
+    }, FORCE_BILLING_GATE_KEY);
 
-    const before = await bodyText();
-    expect(before).not.toContain("opening secure checkout");
-    expect(
-      await browser.execute(
-        () =>
-          !!document.querySelector('[data-testid="onboarding-card-capture"]'),
-      ),
-    ).toBe(false);
+    try {
+      await gotoSlide("plan");
+      await waitForTestId("onboarding-plan-selection", 30_000);
 
-    const continueFree = await waitForTestId("onboarding-plan-free");
-    await continueFree.waitForExist({ timeout: t(20_000) });
-    await continueFree.click();
+      const before = await bodyText();
+      expect(before).not.toContain("opening secure checkout");
+      expect(
+        await browser.execute(
+          () =>
+            !!document.querySelector(
+              '[data-testid="onboarding-card-capture"]',
+            ),
+        ),
+      ).toBe(false);
 
-    await waitForTestId("onboarding-final-setup", 30_000);
-    const after = await bodyText();
-    expect(after).toContain("connect gmail");
-    expect(after).not.toContain("opening secure checkout");
-    expect(
-      await browser.execute(
-        () =>
-          !!document.querySelector('[data-testid="onboarding-card-capture"]'),
-      ),
-    ).toBe(false);
+      const continueFree = await waitForTestId("onboarding-plan-free");
+      await continueFree.waitForExist({ timeout: t(20_000) });
+      await continueFree.click();
 
-    const filepath = await saveScreenshot("onboarding-free-no-card");
-    expect(existsSync(filepath)).toBe(true);
+      await waitForTestId("onboarding-final-setup", 30_000);
+      const after = await bodyText();
+      expect(after).toContain("connect gmail");
+      expect(after).not.toContain("opening secure checkout");
+      expect(
+        await browser.execute(
+          () =>
+            !!document.querySelector(
+              '[data-testid="onboarding-card-capture"]',
+            ),
+        ),
+      ).toBe(false);
 
-    const finishSetup = await $("button*=continue");
-    await finishSetup.waitForExist({ timeout: t(20_000) });
-    await finishSetup.click();
+      const filepath = await saveScreenshot("onboarding-free-no-card");
+      expect(existsSync(filepath)).toBe(true);
 
-    await waitForWindowClosed("onboarding", t(30_000));
-    await waitForWindowHandle("home", t(30_000));
-    await browser.switchToWindow("home");
-    const navHome = await $('[data-testid="nav-home"]');
-    await navHome.waitForExist({ timeout: t(30_000) });
-    expect(await navHome.isExisting()).toBe(true);
+      const finishSetup = await $("button*=continue");
+      await finishSetup.waitForExist({ timeout: t(20_000) });
+      await finishSetup.click();
+
+      await waitForWindowClosed("onboarding", t(30_000));
+      await waitForWindowHandle("home", t(30_000));
+      await browser.switchToWindow("home");
+      const navHome = await $('[data-testid="nav-home"]');
+      await navHome.waitForExist({ timeout: t(30_000) });
+      expect(await navHome.isExisting()).toBe(true);
+    } finally {
+      await browser
+        .execute((key: string) => {
+          window.localStorage.removeItem(key);
+        }, FORCE_BILLING_GATE_KEY)
+        .catch(() => {});
+    }
   });
 
   it("keeps lifetime ownership out of mandatory checkout", async () => {

--- a/apps/screenpipe-app-tauri/e2e/specs/onboarding-first-run.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/onboarding-first-run.spec.ts
@@ -48,6 +48,8 @@ const canRun = !seedFlags.includes("onboarding");
 
 const LEARNING_STORAGE_KEY = "screenpipe.first-run.learning-window.v1";
 const FORCE_BILLING_GATE_KEY = "screenpipe_e2e_force_billing_gate";
+const E2E_ACCOUNT_USER_KEY = "screenpipe_e2e_account_user";
+const E2E_ACCOUNT_USER_EVENT = "screenpipe-e2e-seed-account-user";
 
 const bodyText = async (): Promise<string> =>
   (
@@ -105,8 +107,8 @@ const readSetting = async <T>(key: string): Promise<T | undefined> => {
   return settings[key] as T | undefined;
 };
 
-/** Persist account truth through the same store the onboarding window reads. */
-const seedOnboardingUser = async (user: Record<string, unknown>) => {
+/** Remove one persisted setting so a retried spec still starts from its premise. */
+const clearSetting = async (key: string) => {
   const rid = await invokeOrThrow<number | null>("plugin:store|get_store", {
     path: join(E2E_DATA_DIR, "store.bin"),
   });
@@ -115,12 +117,64 @@ const seedOnboardingUser = async (user: Record<string, unknown>) => {
     [Record<string, unknown>, boolean]
   >("plugin:store|get", { rid, key: "settings" });
   if (!exists || !settings) throw new Error("settings are not loaded");
+  const next = { ...settings };
+  delete next[key];
   await invokeOrThrow("plugin:store|set", {
     rid,
     key: "settings",
-    value: { ...settings, user },
+    value: next,
   });
   await invokeOrThrow("plugin:store|save", { rid });
+};
+
+/**
+ * Seed account truth through the app's E2E-only account hook.
+ *
+ * This uses SettingsProvider.updateSettings instead of editing store.bin: the
+ * token follows the real encrypted-secret path and every webview receives the
+ * settings broadcast. The marker is honored only by E2E bundles and prevents
+ * the synthetic token from being sent to the production account API.
+ */
+const seedOnboardingUser = async (user: Record<string, unknown>) => {
+  const seededUser = { ...user, __e2eSkipAccountRefresh: true };
+  await browser.execute(
+    (key: string, eventName: string, value: string) => {
+      window.localStorage.setItem(key, value);
+      window.dispatchEvent(new Event(eventName));
+    },
+    E2E_ACCOUNT_USER_KEY,
+    E2E_ACCOUNT_USER_EVENT,
+    JSON.stringify(seededUser),
+  );
+  await browser.waitUntil(
+    async () => {
+      const persisted = await readSetting<Record<string, unknown>>("user");
+      return (
+        persisted?.id === user.id &&
+        persisted?.__e2eSkipAccountRefresh === true
+      );
+    },
+    {
+      timeout: t(15_000),
+      timeoutMsg: `synthetic account ${String(user.id)} was not persisted`,
+    },
+  );
+};
+
+const clearOnboardingUser = async () => {
+  await browser.execute(
+    (key: string, eventName: string) => {
+      window.localStorage.setItem(key, "null");
+      window.dispatchEvent(new Event(eventName));
+    },
+    E2E_ACCOUNT_USER_KEY,
+    E2E_ACCOUNT_USER_EVENT,
+  );
+  await browser.waitUntil(async () => (await readSetting("user")) == null, {
+    timeout: t(15_000),
+    timeoutMsg: "synthetic onboarding account was not cleared",
+  });
+  await invokeOrThrow("set_cloud_token", { token: null });
 };
 
 /**
@@ -171,6 +225,10 @@ const seedLearningWindow = async (state: Record<string, unknown>) => {
     await waitForAppReady();
   });
 
+  after(async () => {
+    await clearOnboardingUser().catch(() => {});
+  });
+
   // ─── setup slides ──────────────────────────────────────────────────────
 
   it("opens setup on a fresh install", async () => {
@@ -218,6 +276,8 @@ const seedLearningWindow = async (state: Record<string, unknown>) => {
   // Skip runs before the answer case on purpose: it asserts that nothing was
   // written, which is only meaningful while the setting is still unset.
   it("lets the user skip without recording an answer", async () => {
+    await clearSetting("acquisitionSource");
+    await gotoSlide("acquisition");
     const skip = await waitForTestId("acquisition-skip");
     await skip.click();
 
@@ -269,6 +329,10 @@ const seedLearningWindow = async (state: Record<string, unknown>) => {
   });
 
   it("continues from a verified Free account without asking for a card", async () => {
+    // Tauri's encrypted token store survives the app-data reset used between
+    // local E2E runs. Clear any synthetic token from a previous run before
+    // installing this fixture so the native store and settings stay aligned.
+    await clearOnboardingUser();
     const checkedAt = new Date().toISOString();
     await seedOnboardingUser({
       id: "e2e-free-user",
@@ -356,9 +420,15 @@ const seedLearningWindow = async (state: Record<string, unknown>) => {
   });
 
   it("keeps lifetime ownership out of mandatory checkout", async () => {
+    // The preceding Free scenario installs a different synthetic token. Clear
+    // it first so changing fixtures exercises a clean account transition.
+    await clearOnboardingUser();
     await seedOnboardingUser({
       id: "e2e-lifetime-owner",
+      clerk_id: "e2e-lifetime-owner",
+      token: "e2e-lifetime-token",
       email: "lifetime-owner@screenpipe.test",
+      cloud_subscribed: false,
       app_entitled: true,
       subscription_plan: "lifetime",
       entitlement_source: "lifetime",
@@ -372,11 +442,27 @@ const seedLearningWindow = async (state: Record<string, unknown>) => {
     });
 
     // Simulate an upgrade from a build that had already persisted "plan".
+    // The preceding Free test completed setup and closed this window, so reset
+    // the native completion flag before restoring the older in-progress step.
+    await invokeOrThrow("reset_onboarding");
     // The current shipped route must map it back to engine instead of opening
     // a hosted checkout for an account that already has access.
     await gotoSlide("plan");
     await waitForTestId("onboarding-engine-startup", 30_000);
 
+    const engineText = await bodyText();
+    expect(engineText).not.toContain("opening secure checkout");
+    expect(
+      await browser.execute(
+        () =>
+          !!document.querySelector('[data-testid="onboarding-card-capture"]'),
+      ),
+    ).toBe(false);
+
+    // Engine is the compatibility landing point, not the end of setup. Once
+    // it verifies readiness, an existing owner must still receive the final
+    // connection step without ever passing through plan selection.
+    await waitForTestId("onboarding-final-setup", 30_000);
     const text = await bodyText();
     expect(text).not.toContain("opening secure checkout");
     expect(

--- a/apps/screenpipe-app-tauri/e2e/specs/onboarding-first-run.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/onboarding-first-run.spec.ts
@@ -50,6 +50,8 @@ const LEARNING_STORAGE_KEY = "screenpipe.first-run.learning-window.v1";
 const FORCE_BILLING_GATE_KEY = "screenpipe_e2e_force_billing_gate";
 const E2E_ACCOUNT_USER_KEY = "screenpipe_e2e_account_user";
 const E2E_ACCOUNT_USER_EVENT = "screenpipe-e2e-seed-account-user";
+const E2E_ACCOUNT_FIXTURE_ACTIVE_KEY =
+  "screenpipe_e2e_account_fixture_active";
 
 const bodyText = async (): Promise<string> =>
   (
@@ -127,6 +129,55 @@ const clearSetting = async (key: string) => {
   await invokeOrThrow("plugin:store|save", { rid });
 };
 
+/** Rebuild the native onboarding record as a genuinely fresh install. */
+const seedFreshOnboardingPremise = async () => {
+  const rid = await invokeOrThrow<number | null>("plugin:store|get_store", {
+    path: join(E2E_DATA_DIR, "store.bin"),
+  });
+  if (rid == null) throw new Error("settings store is not loaded");
+  const [value, exists] = await invokeOrThrow<
+    [Record<string, unknown>, boolean]
+  >("plugin:store|get", { rid, key: "onboarding" });
+  const onboarding = exists && value ? value : {};
+  await invokeOrThrow("plugin:store|set", {
+    rid,
+    key: "onboarding",
+    value: {
+      ...onboarding,
+      isCompleted: false,
+      completedAt: null,
+      currentStep: null,
+      trialActivationFreshInstall: true,
+      firstRunSummaryPhase: "idle",
+      firstRunSummaryStartedAt: null,
+      firstRunSummaryChatId: null,
+      firstRunSummaryNotificationSentAt: null,
+      firstRunSummaryNotificationId: null,
+      firstRunSummaryError: null,
+      firstRunSummaryTelemetryVersion: 0,
+    },
+  });
+  await invokeOrThrow("plugin:store|save", { rid });
+  await browser.waitUntil(
+    async () => {
+      const status = await invokeOrThrow<{
+        isCompleted: boolean;
+        currentStep: string | null;
+        trialActivationFreshInstall: boolean;
+      }>("get_onboarding_status");
+      return (
+        status.isCompleted === false &&
+        status.currentStep == null &&
+        status.trialActivationFreshInstall === true
+      );
+    },
+    {
+      timeout: t(10_000),
+      timeoutMsg: "fresh onboarding premise was not persisted",
+    },
+  );
+};
+
 /**
  * Seed account truth through the app's E2E-only account hook.
  *
@@ -138,13 +189,15 @@ const clearSetting = async (key: string) => {
 const seedOnboardingUser = async (user: Record<string, unknown>) => {
   const seededUser = { ...user, __e2eSkipAccountRefresh: true };
   await browser.execute(
-    (key: string, eventName: string, value: string) => {
+    (key: string, eventName: string, value: string, activeKey: string) => {
+      window.localStorage.setItem(activeKey, "1");
       window.localStorage.setItem(key, value);
       window.dispatchEvent(new Event(eventName));
     },
     E2E_ACCOUNT_USER_KEY,
     E2E_ACCOUNT_USER_EVENT,
     JSON.stringify(seededUser),
+    E2E_ACCOUNT_FIXTURE_ACTIVE_KEY,
   );
   await browser.waitUntil(
     async () => {
@@ -163,12 +216,14 @@ const seedOnboardingUser = async (user: Record<string, unknown>) => {
 
 const clearOnboardingUser = async () => {
   await browser.execute(
-    (key: string, eventName: string) => {
+    (key: string, eventName: string, activeKey: string) => {
+      window.localStorage.removeItem(activeKey);
       window.localStorage.setItem(key, "null");
       window.dispatchEvent(new Event(eventName));
     },
     E2E_ACCOUNT_USER_KEY,
     E2E_ACCOUNT_USER_EVENT,
+    E2E_ACCOUNT_FIXTURE_ACTIVE_KEY,
   );
   await browser.waitUntil(async () => (await readSetting("user")) == null, {
     timeout: t(15_000),
@@ -223,6 +278,25 @@ const seedLearningWindow = async (state: Record<string, unknown>) => {
 
   before(async () => {
     await waitForAppReady();
+
+    // CI runs this after two other onboarding canaries and retries the whole
+    // file in the same app/profile. Re-establish the fresh-install premise on
+    // every attempt so a prior synthetic account or completed retry cannot
+    // strand these assertions on Home or a later setup slide.
+    await showWindow({ Home: { page: null } });
+    await waitForWindowHandle("home", t(20_000));
+    await browser.switchToWindow("home");
+    await waitForAppReady();
+    await clearOnboardingUser();
+    await seedFreshOnboardingPremise();
+    await clearSetting("acquisitionSource");
+
+    await closeWindow("Onboarding").catch(() => {});
+    await waitForWindowClosed("onboarding", t(15_000)).catch(() => {});
+    await showWindow("Onboarding");
+    await waitForWindowHandle("onboarding", t(20_000));
+    await browser.switchToWindow("onboarding");
+    await waitForWindowUrl("/onboarding", undefined, t(20_000));
   });
 
   after(async () => {

--- a/apps/screenpipe-app-tauri/e2e/specs/onboarding-first-run.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/onboarding-first-run.spec.ts
@@ -289,7 +289,7 @@ const seedLearningWindow = async (state: Record<string, unknown>) => {
     });
 
     await gotoSlide("plan");
-    await waitForBodyText("plan selection", 30_000);
+    await waitForTestId("onboarding-plan-selection", 30_000);
 
     const before = await bodyText();
     expect(before).not.toContain("opening secure checkout");
@@ -300,7 +300,7 @@ const seedLearningWindow = async (state: Record<string, unknown>) => {
       ),
     ).toBe(false);
 
-    const continueFree = await $("button*=continue free plan");
+    const continueFree = await waitForTestId("onboarding-plan-free");
     await continueFree.waitForExist({ timeout: t(20_000) });
     await continueFree.click();
 

--- a/apps/screenpipe-app-tauri/lib/auth-guard.test.tsx
+++ b/apps/screenpipe-app-tauri/lib/auth-guard.test.tsx
@@ -296,6 +296,32 @@ describe("AuthGuard session-expiry handling", () => {
     expect(mocks.updateSettings).not.toHaveBeenCalled();
     expect(mocks.setCloudToken).not.toHaveBeenCalled();
   });
+
+  it("does not let an old token's delayed 401 clear a newly selected account", async () => {
+    let rejectOldRequest!: (error: Error) => void;
+    mocks.loadUser.mockImplementationOnce(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectOldRequest = reject;
+        }),
+    );
+    const view = renderGuard();
+    fireEvent(window, new Event("focus"));
+    await waitFor(() => expect(mocks.loadUser).toHaveBeenCalledWith("tok-123"));
+
+    mocks.state.user = { token: "tok-new-account", cloud_subscribed: false };
+    view.rerender(
+      <AuthGuard>
+        <div>child</div>
+      </AuthGuard>,
+    );
+    rejectOldRequest(new Error("failed to verify token: 401 Unauthorized"));
+
+    await waitFor(() => expect(mocks.loadUser).toHaveBeenCalledTimes(1));
+    expect(mocks.updateSettings).not.toHaveBeenCalled();
+    expect(mocks.setCloudToken).not.toHaveBeenCalled();
+    expect(mocks.capture).not.toHaveBeenCalled();
+  });
 });
 
 describe("installAuthInterceptor sign-out scoping", () => {

--- a/apps/screenpipe-app-tauri/lib/auth-guard.tsx
+++ b/apps/screenpipe-app-tauri/lib/auth-guard.tsx
@@ -213,6 +213,11 @@ export function AuthGuard({ children }: { children: React.ReactNode }) {
       // must never clear the account. Anything else
       // (network blip, 5xx) is silent — retry on the next interval.
       if (msg.includes(" 401 ")) {
+        // The request may have started for account A and completed after a
+        // login/account switch installed account B. loadUser already refuses
+        // to clear a changed token; preserve that guarantee here instead of
+        // turning A's stale 401 into a logout of B.
+        if (tokenRef.current !== token) return;
         await handleSessionExpired({
           source: "verify_token",
           status: 401,

--- a/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -1491,6 +1491,21 @@ function createSettingsStore() {
 
 const settingsStore = createSettingsStore();
 
+/**
+ * E2E account fixtures carry complete user and plan truth in the shared store.
+ * Read that authoritative state instead of a particular webview's React copy:
+ * Home and Onboarding can mount at different times, while either may initiate
+ * a background account verification.
+ */
+const hasPersistedE2EAccountFixture = async (): Promise<boolean> => {
+	if (process.env.NEXT_PUBLIC_SCREENPIPE_E2E !== "true") return false;
+	const persisted = await settingsStore.get();
+	return (
+		(persisted.user as User & { __e2eSkipAccountRefresh?: boolean })
+			?.__e2eSkipAccountRefresh === true
+	);
+};
+
 // Context for React
 interface SettingsContextType {
 	settings: Settings;
@@ -1581,8 +1596,28 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
 
 	useEffect(() => {
 		installAuthInterceptor(
-			() => settingsRef.current.user?.token ?? undefined,
+			() => {
+				const user = settingsRef.current.user as
+					| (User & { __e2eSkipAccountRefresh?: boolean })
+					| null
+					| undefined;
+				// Synthetic E2E sessions intentionally use tokens the production web
+				// service cannot verify. A background cloud request may still return
+				// 401 while the native onboarding flow is under test; do not let that
+				// unrelated response erase the fixture from every app window.
+				if (
+					process.env.NEXT_PUBLIC_SCREENPIPE_E2E === "true" &&
+					user?.__e2eSkipAccountRefresh === true
+				) {
+					return undefined;
+				}
+				return user?.token ?? undefined;
+			},
 			async () => {
+				// Any webview can observe a 401 from an unrelated cloud request. An
+				// E2E fixture is intentionally synthetic, so consult the shared store
+				// before allowing that response to erase the account across windows.
+				if (await hasPersistedE2EAccountFixture()) return;
 				// A response from the website auth surface definitively rejected the
 				// credential. Clear the account so it cannot be confused with a
 				// transient secret-store hydration miss.
@@ -1621,6 +1656,18 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
 		if (!isSettingsLoaded) return;
 		const token = settings.user?.token;
 		if (!token) return;
+		// E2E account seeds already contain the exact server response that their
+		// scenario is exercising. Sending their synthetic token to the production
+		// account API immediately converts a deterministic native-app test into a
+		// real-network 401. This branch is compiled into E2E bundles only; normal
+		// app authentication and refresh behavior are unchanged.
+		if (
+			process.env.NEXT_PUBLIC_SCREENPIPE_E2E === "true" &&
+			(settings.user as User & { __e2eSkipAccountRefresh?: boolean })
+				.__e2eSkipAccountRefresh === true
+		) {
+			return;
+		}
 
 		let cancelled = false;
 		const MAX_RETRIES = 3;
@@ -1883,6 +1930,17 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
 	};
 
 	const loadUser = async (token: string, verify = false) => {
+		// Every background verifier funnels through loadUser. E2E account fixtures
+		// already contain their scenario's exact server response, and their tokens
+		// must never be sent to the production account API.
+		// Keep the environment check outside the await: production loadUser must
+		// snapshot authGeneration synchronously so a same-tick logout cannot race it.
+		if (
+			process.env.NEXT_PUBLIC_SCREENPIPE_E2E === "true" &&
+			(await hasPersistedE2EAccountFixture())
+		) {
+			return;
+		}
 		// Snapshot the auth generation at the start of the request. If the user
 		// signs out while this fetch is in flight, the generation changes and we
 		// abort the write below instead of resurrecting the cleared session.

--- a/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
+++ b/apps/screenpipe-app-tauri/lib/hooks/use-settings.tsx
@@ -1490,6 +1490,20 @@ function createSettingsStore() {
 }
 
 const settingsStore = createSettingsStore();
+const E2E_ACCOUNT_FIXTURE_ACTIVE_KEY =
+	"screenpipe_e2e_account_fixture_active";
+
+const hasActiveE2EAccountFixture = (): boolean => {
+	if (process.env.NEXT_PUBLIC_SCREENPIPE_E2E !== "true") return false;
+	try {
+		return (
+			typeof window !== "undefined" &&
+			window.localStorage?.getItem(E2E_ACCOUNT_FIXTURE_ACTIVE_KEY) === "1"
+		);
+	} catch {
+		return false;
+	}
+};
 
 /**
  * E2E account fixtures carry complete user and plan truth in the shared store.
@@ -1499,6 +1513,11 @@ const settingsStore = createSettingsStore();
  */
 const hasPersistedE2EAccountFixture = async (): Promise<boolean> => {
 	if (process.env.NEXT_PUBLIC_SCREENPIPE_E2E !== "true") return false;
+	// The fixture owner writes this sentinel before its asynchronous store
+	// update. localStorage is shared by the app's same-origin webviews, so stale
+	// Home/Onboarding copies can reject an old 401 without waiting for a store
+	// broadcast or racing the queued write.
+	if (hasActiveE2EAccountFixture()) return true;
 	const persisted = await settingsStore.get();
 	return (
 		(persisted.user as User & { __e2eSkipAccountRefresh?: boolean })
@@ -1607,7 +1626,8 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
 				// unrelated response erase the fixture from every app window.
 				if (
 					process.env.NEXT_PUBLIC_SCREENPIPE_E2E === "true" &&
-					user?.__e2eSkipAccountRefresh === true
+					(hasActiveE2EAccountFixture() ||
+						user?.__e2eSkipAccountRefresh === true)
 				) {
 					return undefined;
 				}
@@ -1932,12 +1952,18 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
 	const loadUser = async (token: string, verify = false) => {
 		// Every background verifier funnels through loadUser. E2E account fixtures
 		// already contain their scenario's exact server response, and their tokens
-		// must never be sent to the production account API.
+		// must never be sent to the production account API. Check this webview's
+		// optimistic React state first: updateSettings publishes it before the
+		// queued durable write, so consulting only the store leaves a brief window
+		// where the auto-refresh effect can race the fixture persistence.
 		// Keep the environment check outside the await: production loadUser must
 		// snapshot authGeneration synchronously so a same-tick logout cannot race it.
 		if (
 			process.env.NEXT_PUBLIC_SCREENPIPE_E2E === "true" &&
-			(await hasPersistedE2EAccountFixture())
+			((settingsRef.current.user as User & {
+				__e2eSkipAccountRefresh?: boolean;
+			})?.__e2eSkipAccountRefresh === true ||
+				(await hasPersistedE2EAccountFixture()))
 		) {
 			return;
 		}
@@ -1979,6 +2005,16 @@ export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ chil
 			if (!response.ok) {
 				const body = await response.text().catch(() => "<no body>");
 				if (response.status === 401 || response.status === 403) {
+					// A peer webview can finish a request for the preceding CI seed
+					// after the shared store has installed a new E2E account. Its
+					// React ref may still name the old token, so recheck the durable
+					// fixture before clearing or surfacing a stale auth failure.
+					if (
+						process.env.NEXT_PUBLIC_SCREENPIPE_E2E === "true" &&
+						(await hasPersistedE2EAccountFixture())
+					) {
+						return;
+					}
 					await clearRejectedSession();
 				}
 				throw new Error(


### PR DESCRIPTION
/opt/homebrew/etc/bash_completion.d/himalaya: line 1: syntax error near unexpected token `('
/opt/homebrew/etc/bash_completion.d/himalaya: line 1: `1 completion script(s) successfully generated in /private/tmp/himalaya-20260726-5297-fd0iv3/himalaya-2.0.0:'
## Why

Screenpipe has a Free tier, but current onboarding auto-opens hosted checkout for an authenticated Free account with no card. The same mandatory gate can appear again after the first-result learning window. That blocks clean activation and makes creator/affiliate trials harder to trust.

## What changed

- restore an explicit **continue with Free — no card** choice in onboarding
- preserve the optional 7-day Business trial checkout
- add the same Free escape at the first-result unlock prompt and checkout dialog
- track Free activation distinctly from Business-trial activation
- add a real desktop E2E for an authenticated Free account with `has_payment_method: false`
- run that focused E2E before the general suite on Windows, Linux, and macOS
- refresh E2E and unified coverage dashboards

## User flow

```text
verified Free account
        |
        v
choose how to start
   |                 |
   v                 v
Free, no card    Business trial
   |
   v
recommended setup
   |
   v
Home
```

The E2E uses the real settings store, onboarding window, native commands, final window transition, and Home navigation. It explicitly re-enables the production entitlement gate that E2E builds normally bypass, proves that neither card capture nor hosted checkout opens on the Free path, verifies that the server-shaped Free account still reaches Home through the real gate, and saves the hosted screenshot artifact `onboarding-free-no-card`.

## Validation

- `bunx vitest run components/first-run/learning-banner.test.tsx components/first-run/trial-activation-paywall.test.tsx components/onboarding/plan-selection-step.test.tsx app/onboarding/page.test.tsx components/app-entitlement-gate.test.tsx` — 141 passed
- ESLint passed for all changed TS/TSX files
- `bun run coverage:all:check`
- `git diff --check`
- hosted Windows/Linux/macOS desktop E2E pending
