### PR TITLE
fix(tray): recover quarantined databases before resume

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/db_recovery_notifications.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/db_recovery_notifications.rs
@@ -184,6 +184,16 @@ fn send_recovery_offer() {
     );
 }
 
+/// Re-surface the protected recovery action after an explicit user attempt to
+/// resume recording. This only offers recovery; it never starts repair work.
+pub fn offer_quarantined_database_recovery(data_dir: PathBuf) -> bool {
+    if !screenpipe_db::sqlite_quarantine_exists(data_dir.join("db.sqlite")) {
+        return false;
+    }
+    send_recovery_offer();
+    true
+}
+
 /// Offer recovery only after launch has proven the durable quarantine marker
 /// exists and has skipped every server, pool, watchdog, and capture startup.
 /// The notice persists in `/notify` and its inbox until the user acts.
@@ -194,7 +204,7 @@ pub fn notify_quarantined_database(data_dir: PathBuf) {
     {
         return;
     }
-    send_recovery_offer();
+    offer_quarantined_database_recovery(data_dir);
 }
 
 /// Start the protected recovery requested from the `/notify` action. Returns

--- a/apps/screenpipe-app-tauri/src-tauri/src/db_recovery_notifications.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/db_recovery_notifications.rs
@@ -184,6 +184,24 @@ fn send_recovery_offer() {
     );
 }
 
+fn effective_recovery_data_dir_with<F>(settings_lookup: F) -> Result<PathBuf, String>
+where
+    F: FnOnce() -> Result<Option<SettingsStore>, String>,
+{
+    let settings = settings_lookup()
+        .map_err(|_| "could not read settings for database recovery".to_string())?
+        .unwrap_or_default();
+    crate::config::resolve_data_dir(&settings.data_dir)
+        .map(|(data_dir, _fell_back)| data_dir)
+        .map_err(|_| "could not resolve the database recovery data directory".to_string())
+}
+
+/// Resolve the one effective data directory used by both recovery offers and
+/// the explicit user-approved repair action.
+pub(crate) fn effective_recovery_data_dir(app: &AppHandle) -> Result<PathBuf, String> {
+    effective_recovery_data_dir_with(|| SettingsStore::get(app))
+}
+
 /// Re-surface the protected recovery action after an explicit user attempt to
 /// resume recording. This only offers recovery; it never starts repair work.
 pub fn offer_quarantined_database_recovery(data_dir: PathBuf) -> bool {
@@ -210,7 +228,7 @@ pub fn notify_quarantined_database(data_dir: PathBuf) {
 /// Start the protected recovery requested from the `/notify` action. Returns
 /// immediately so the notification panel can close while work continues.
 pub fn start_quarantined_database_recovery(app: AppHandle) -> Result<(), String> {
-    let data_dir = screenpipe_core::paths::default_screenpipe_data_dir();
+    let data_dir = effective_recovery_data_dir(&app)?;
     start_quarantined_database_recovery_inner(app, data_dir, RecoveryInitiation::UserAction)
 }
 
@@ -339,6 +357,47 @@ mod tests {
         assert_eq!(action["url"], RECOVERY_DEEPLINK);
         assert_eq!(action["primary"], true);
         assert!(!action.to_string().contains("fingerprint"));
+    }
+
+    #[test]
+    fn recovery_offer_and_action_resolve_the_same_custom_data_dir() {
+        let custom_dir = tempfile::tempdir().expect("custom recovery tempdir");
+        let mut settings = SettingsStore::default();
+        settings.data_dir = custom_dir.path().to_string_lossy().into_owned();
+
+        let offer_target = effective_recovery_data_dir_with(|| Ok(Some(settings.clone())))
+            .expect("resolve offer target");
+        let action_target =
+            effective_recovery_data_dir_with(|| Ok(Some(settings))).expect("resolve action target");
+
+        assert_eq!(offer_target, custom_dir.path());
+        assert_eq!(action_target, offer_target);
+    }
+
+    #[test]
+    fn recovery_data_dir_preserves_default_and_fallback_semantics() {
+        let default_target = effective_recovery_data_dir_with(|| Ok(None))
+            .expect("resolve missing-settings default");
+
+        let mut fallback_settings = SettingsStore::default();
+        fallback_settings.data_dir = "relative/recovery-data".to_string();
+        let fallback_target = effective_recovery_data_dir_with(|| Ok(Some(fallback_settings)))
+            .expect("resolve invalid custom-path fallback");
+
+        assert_eq!(
+            default_target,
+            screenpipe_core::paths::default_screenpipe_data_dir()
+        );
+        assert_eq!(fallback_target, default_target);
+    }
+
+    #[test]
+    fn recovery_data_dir_lookup_errors_fail_closed() {
+        let error = effective_recovery_data_dir_with(|| Err("sensitive details".to_string()))
+            .expect_err("settings lookup must fail closed");
+
+        assert_eq!(error, "could not read settings for database recovery");
+        assert!(!error.contains("sensitive details"));
     }
 
     #[test]

--- a/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
@@ -300,6 +300,44 @@ enum TrayRecordingAction {
     Stop,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TrayStartRoute {
+    StartCapture,
+    OfferDatabaseRecovery,
+}
+
+fn tray_start_route_with<F>(quarantine_lookup: F) -> Result<TrayStartRoute, String>
+where
+    F: FnOnce() -> Result<bool, String>,
+{
+    if quarantine_lookup()? {
+        Ok(TrayStartRoute::OfferDatabaseRecovery)
+    } else {
+        Ok(TrayStartRoute::StartCapture)
+    }
+}
+
+fn database_is_quarantined(database_path: &std::path::Path) -> Result<bool, String> {
+    let marker_path = screenpipe_db::sqlite_quarantine_marker_path(database_path)
+        .ok_or_else(|| "the database path cannot be quarantined".to_string())?;
+    match std::fs::symlink_metadata(marker_path) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(format!(
+            "could not check whether the database needs recovery: {error}"
+        )),
+    }
+}
+
+fn tray_start_data_dir(app: &AppHandle) -> Result<std::path::PathBuf, String> {
+    let settings = SettingsStore::get(app)
+        .map_err(|error| format!("could not read settings for recording start: {error}"))?
+        .unwrap_or_default();
+    let (data_dir, _fell_back) = crate::config::resolve_data_dir(&settings.data_dir)
+        .map_err(|error| format!("could not resolve the recording data directory: {error}"))?;
+    Ok(data_dir)
+}
+
 impl TrayRecordingAction {
     fn optimistic_status(self) -> RecordingStatus {
         match self {
@@ -337,7 +375,27 @@ async fn run_tray_recording_action(
     info!(?action, "handling recording action from native tray");
     let state = app.state::<RecordingState>();
     match action {
-        TrayRecordingAction::Start => crate::recording::start_capture(state, app.clone()).await?,
+        TrayRecordingAction::Start => {
+            let data_dir = tray_start_data_dir(app)?;
+            let database_path = data_dir.join("db.sqlite");
+            match tray_start_route_with(|| database_is_quarantined(&database_path))? {
+                TrayStartRoute::StartCapture => {
+                    crate::recording::start_capture(state, app.clone()).await?
+                }
+                TrayStartRoute::OfferDatabaseRecovery => {
+                    info!("native tray start routed to protected database recovery offer");
+                    if !crate::db_recovery_notifications::offer_quarantined_database_recovery(
+                        data_dir,
+                    ) {
+                        return Err(
+                            "the database recovery marker disappeared during recording start"
+                                .to_string(),
+                        );
+                    }
+                    return Ok(());
+                }
+            }
+        }
         TrayRecordingAction::Stop => crate::recording::stop_capture(state, app.clone()).await?,
     }
 
@@ -2257,6 +2315,34 @@ mod tests {
             next_tray_recording_action(true),
             TrayRecordingAction::Stop
         ));
+    }
+
+    #[test]
+    fn tray_start_routes_quarantined_database_to_recovery_offer() {
+        let data_dir = tempfile::tempdir().expect("tray quarantine tempdir");
+        let database_path = data_dir.path().join("db.sqlite");
+        std::fs::write(&database_path, b"quarantined generation").expect("write database");
+        screenpipe_db::persist_sqlite_quarantine(&database_path, Some(11), "database corrupt")
+            .expect("persist quarantine");
+
+        assert_eq!(
+            tray_start_route_with(|| database_is_quarantined(&database_path)),
+            Ok(TrayStartRoute::OfferDatabaseRecovery)
+        );
+    }
+
+    #[test]
+    fn tray_start_allows_healthy_database_and_fails_closed_on_unknown_state() {
+        let data_dir = tempfile::tempdir().expect("healthy tray tempdir");
+        let database_path = data_dir.path().join("db.sqlite");
+        assert_eq!(
+            tray_start_route_with(|| database_is_quarantined(&database_path)),
+            Ok(TrayStartRoute::StartCapture)
+        );
+        assert_eq!(
+            tray_start_route_with(|| Err("lookup failed".to_string())),
+            Err("lookup failed".to_string())
+        );
     }
 
     #[test]

--- a/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
@@ -306,6 +306,22 @@ enum TrayStartRoute {
     OfferDatabaseRecovery,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TrayRecordingActionOutcome {
+    CaptureStateChanged,
+    RecoveryOffered,
+}
+
+fn success_notification_for_outcome(
+    outcome: TrayRecordingActionOutcome,
+    success_notification: Option<(&'static str, &'static str)>,
+) -> Option<(&'static str, &'static str)> {
+    match outcome {
+        TrayRecordingActionOutcome::CaptureStateChanged => success_notification,
+        TrayRecordingActionOutcome::RecoveryOffered => None,
+    }
+}
+
 fn tray_start_route_with<F>(quarantine_lookup: F) -> Result<TrayStartRoute, String>
 where
     F: FnOnce() -> Result<bool, String>,
@@ -362,7 +378,7 @@ fn clear_optimistic_status() {
 async fn run_tray_recording_action(
     app: &AppHandle,
     action: TrayRecordingAction,
-) -> Result<(), String> {
+) -> Result<TrayRecordingActionOutcome, String> {
     info!(?action, "handling recording action from native tray");
     let state = app.state::<RecordingState>();
     match action {
@@ -383,7 +399,7 @@ async fn run_tray_recording_action(
                                 .to_string(),
                         );
                     }
-                    return Ok(());
+                    return Ok(TrayRecordingActionOutcome::RecoveryOffered);
                 }
             }
         }
@@ -393,7 +409,7 @@ async fn run_tray_recording_action(
     // This event is UI-only. The native action above is authoritative so tray
     // controls continue working when every webview is closed or still loading.
     let _ = app.emit("tray-recording-state-changed", action.event_payload());
-    Ok(())
+    Ok(TrayRecordingActionOutcome::CaptureStateChanged)
 }
 
 fn rebuild_tray_after_recording_action(app: &AppHandle) {
@@ -418,8 +434,10 @@ fn dispatch_tray_recording_action(
         clear_optimistic_status();
 
         match result {
-            Ok(()) => {
-                if let Some((title, body)) = success_notification {
+            Ok(outcome) => {
+                if let Some((title, body)) =
+                    success_notification_for_outcome(outcome, success_notification)
+                {
                     send_notify(title, body);
                 }
             }
@@ -467,7 +485,7 @@ pub(crate) async fn toggle_recording_from_harness(app: AppHandle) -> Result<(), 
     set_optimistic_status(action.optimistic_status());
     let result = run_tray_recording_action(&app, action).await;
     clear_optimistic_status();
-    result
+    result.map(|_| ())
 }
 
 /// Immediately rebuild the tray menu (called from main thread after optimistic status set).
@@ -2333,6 +2351,32 @@ mod tests {
         assert_eq!(
             tray_start_route_with(|| Err("lookup failed".to_string())),
             Err("lookup failed".to_string())
+        );
+    }
+
+    #[test]
+    fn quarantined_auto_resume_does_not_emit_recording_resumed_success() {
+        let notification = Some(("Recording resumed", "screenpipe is recording again."));
+
+        assert_eq!(
+            success_notification_for_outcome(
+                TrayRecordingActionOutcome::RecoveryOffered,
+                notification,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn healthy_auto_resume_emits_recording_resumed_success() {
+        let notification = Some(("Recording resumed", "screenpipe is recording again."));
+
+        assert_eq!(
+            success_notification_for_outcome(
+                TrayRecordingActionOutcome::CaptureStateChanged,
+                notification,
+            ),
+            notification
         );
     }
 

--- a/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
@@ -329,15 +329,6 @@ fn database_is_quarantined(database_path: &std::path::Path) -> Result<bool, Stri
     }
 }
 
-fn tray_start_data_dir(app: &AppHandle) -> Result<std::path::PathBuf, String> {
-    let settings = SettingsStore::get(app)
-        .map_err(|error| format!("could not read settings for recording start: {error}"))?
-        .unwrap_or_default();
-    let (data_dir, _fell_back) = crate::config::resolve_data_dir(&settings.data_dir)
-        .map_err(|error| format!("could not resolve the recording data directory: {error}"))?;
-    Ok(data_dir)
-}
-
 impl TrayRecordingAction {
     fn optimistic_status(self) -> RecordingStatus {
         match self {
@@ -376,7 +367,7 @@ async fn run_tray_recording_action(
     let state = app.state::<RecordingState>();
     match action {
         TrayRecordingAction::Start => {
-            let data_dir = tray_start_data_dir(app)?;
+            let data_dir = crate::db_recovery_notifications::effective_recovery_data_dir(app)?;
             let database_path = data_dir.join("db.sqlite");
             match tray_start_route_with(|| database_is_quarantined(&database_path))? {
                 TrayStartRoute::StartCapture => {
@@ -2318,7 +2309,7 @@ mod tests {
     }
 
     #[test]
-    fn tray_start_routes_quarantined_database_to_recovery_offer() {
+    fn tray_start_offers_quarantined_database_recovery_without_starting_repair() {
         let data_dir = tempfile::tempdir().expect("tray quarantine tempdir");
         let database_path = data_dir.path().join("db.sqlite");
         std::fs::write(&database_path, b"quarantined generation").expect("write database");


### PR DESCRIPTION
## Source feedback

- Discord feedback message `1545688113152524298` (ingest task `t_b7b335c0`)
- Reported environment: Windows 10.0.26200, screenpipe 2.7.21
- Reported symptom: recording could not resume because capture/server startup failed and requested a full restart

## Root cause

Native tray `Start` did not route a durable SQLite primary-code-11 quarantine through the existing protected recovery flow before retrying capture/server startup. The first correction also exposed two related surface-wide contract gaps: the explicit recovery action could target the default directory instead of the same settings-resolved custom/fallback directory used by the offer, and a recovery-only outcome could be reported as a successful timed auto-resume.

## Fix

- Resolve the effective recovery directory once for both the tray offer and the explicit recovery action, preserving custom, default, and fallback behavior.
- Fail closed with sanitized errors when settings, path, or quarantine-marker lookup fails.
- Return `RecoveryOffered` when quarantined `Start` shows the protected recovery offer without changing capture state.
- Suppress the optional `Recording resumed` success notification for that outcome.
- Keep repair/restart behind explicit user consent; healthy `Start` and successful `Stop` behavior are unchanged.

This covers the full affected surface because both entry points now share the same target resolver, while the dispatcher distinguishes an offered recovery from a real capture-state change.

## RED / GREEN evidence

RED / reproduced failure evidence:
- The Windows report showed native tray resume falling through to capture/server restart despite the durable quarantine.
- Pre-fix control-flow inspection confirmed tray `Start` skipped the quarantine route. Independent reviews of the intermediate commits also reproduced the custom-directory target mismatch and the false-success notification in the exact call paths.
- No native RED binary was executed on this Linux host; see the limitation below.

GREEN:
- Exact committed auto-resume outcome/helper tests: 2 passed, 0 failed (`quarantined_auto_resume_does_not_emit_recording_resumed_success`, `healthy_auto_resume_emits_recording_resumed_success`).
- `cargo test -p screenpipe-sqlite-coordinator quarantine -- --nocapture`: 11 passed, 0 failed.
- `rustfmt --edition 2021 --check apps/screenpipe-app-tauri/src-tauri/src/db_recovery_notifications.rs`: passed.
- `git diff --check origin/main...HEAD`: passed.
- Independent review approved exact commit `c7ee3dc065d5d84c8230d462e8c38c554fcdd27c`.

## Platform scope and native limitation

This changes the native desktop tray recovery path; the originating report is Windows. It does not add platform-specific OS calls. The supported Tauri test wrapper could not compile the native app on the Linux verification host because `libpipewire-0.3` was unavailable, so this PR does not claim a native Tauri test pass.

## Visual evidence (behavior flow)

```text
Before
Tray Start -> quarantined DB -> capture retry/restart -> failure
                                      \-> timed path could say "Recording resumed"

After
Tray Start -> quarantine marker -> protected recovery offer -> wait for consent
                                      \-> no capture-state success notification
Explicit recovery action -> same resolved custom/default/fallback directory -> repair/restart
```
