### PR TITLE
Bump app to v2.7.23

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.lock
@@ -11143,7 +11143,7 @@ dependencies = [
 
 [[package]]
 name = "screenpipe-app"
-version = "2.7.22"
+version = "2.7.23"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm 0.10.3",

--- a/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
+++ b/apps/screenpipe-app-tauri/src-tauri/Cargo.toml
@@ -7,7 +7,7 @@ members = ["wer-dump-helper", "windows/persistence-supervisor"]
 
 [package]
 name = "screenpipe-app"
-version = "2.7.22"
+version = "2.7.23"
 description = "24/7 memory for your desktop. 100% local."
 authors = ["you"]
 license = ""


### PR DESCRIPTION
## Summary

- bump the desktop app manifest from 2.7.22 to 2.7.23
- keep the app Cargo.lock package entry in sync
- prepare an immutable artifact that includes the no-card Free onboarding repair from #6907

## Verification

- `./scripts/regenerate-locks.sh --check`
- `git diff --check`
- manifest and lock versions both resolve to `2.7.23`

This PR prepares a versioned artifact only. Public updater publication remains a human-only action in the admin releases UI.