### PR TITLE
fix(ci): authenticate Intel launch smoke seed

### DIFF
--- a/.github/workflows/macos-intel-launch-smoke.yml
+++ b/.github/workflows/macos-intel-launch-smoke.yml
@@ -277,9 +277,11 @@ jobs:
           # Whisper/VAD/diarization initialization can consume the entire watch
           # window before VisionManager starts and turn a healthy launch red.
           # `no-audio` is the existing vision-only E2E mode documented by
-          # e2e/helpers/app-launcher.ts.
+          # e2e/helpers/app-launcher.ts. The existing cloud-authenticated seed
+          # satisfies the debug app's account gate so capture actually starts;
+          # without it the process stays healthy but never creates VisionManager.
           SCREENPIPE_DATA_DIR="$DATA_DIR" \
-          SCREENPIPE_E2E_SEED="onboarding,no-audio" \
+          SCREENPIPE_E2E_SEED="onboarding,no-audio,cloud-authenticated" \
           SCREENPIPE_FOCUS_PORT="11436" \
           RUST_BACKTRACE=1 \
             "$APP_BIN" >"$LOG" 2>&1 &


### PR DESCRIPTION
Summary

- Add the existing cloud-authenticated E2E seed to the Intel vision-only launch lane.
- Keep production authentication and entitlement behavior unchanged.
- Preserve the fail-closed requirement that VisionManager must actually start.

Why

Run https://github.com/screenpipe/screenpipe/actions/runs/33960613170 passed both Intel process-churn tests and kept the app alive for the full 60-second launch window with status 0 and no crash report. It still failed correctly because the debug app logged that account access was required, skipped capture startup, and never created VisionManager even though the TCC database reported Screen Recording allowed.

Before

TCC grant -> unauthenticated E2E app -> account gate -> no capture -> inconclusive red

After

TCC grant -> authenticated E2E seed -> capture startup -> VisionManager evidence -> crash assertion

Verification

- git diff --check
- YAML parse passed
- Existing cloud-authenticated seed implementation and package script confirmed on current main
- Hosted macos-15-intel workflow is the authoritative end-to-end verification