### PR TITLE
fix(ci): restore npm token fallback for CLI packages

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -986,6 +986,12 @@ jobs:
       # every error — versions 0.3.290..0.3.295 all "succeeded" without ever
       # publishing because the npm token had expired and nobody noticed.
       - name: Publish platform packages
+        # npm prefers the job's OIDC identity when a package has trusted
+        # publishing configured, then falls back to this shared release token.
+        # Keep the fallback until every platform package has its own trusted
+        # publisher configuration on npm.
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           for pkg in screenpipe-darwin-arm64 screenpipe-darwin-x64 screenpipe-linux-x64 screenpipe-win32-x64; do
             cd packages/cli/$pkg
@@ -1045,6 +1051,8 @@ jobs:
           done
 
       - name: Publish main package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           cd packages/cli/screenpipe
           err=$(mktemp)


### PR DESCRIPTION
## Summary

- keep npm trusted publishing as the preferred CLI release authentication path
- supply the existing shared NPM_TOKEN as a fallback for platform packages without matching trusted-publisher configuration
- apply the same fallback to the main package publish step

## Failure and acceptance

The CLI build, package preparation, and payload validation all pass. Release CLI runs then fail on the first platform publish with npm E404 permission errors, leaving all five packages at 0.4.41.

Before:

    GitHub OIDC -> npm platform package -> E404 -> release stops

After:

    GitHub OIDC -> npm platform package
          | missing trusted-publisher match
          v
    shared release token -> publish

Acceptance: the next release can publish all four platform packages and the main package, while unexpected npm errors still fail loudly and already-published versions remain idempotent.

## Historical intent

Inspected commits 77671b591e and 63612d7235 plus failed Release CLI runs 32796182177, 32798880868, and 33017502744. The OIDC change removed reliance on an expired long-lived token; that invariant remains intact because npm prefers OIDC and uses NODE_AUTH_TOKEN only as fallback. The explicit latest tag added after npm rejected 0.4.x beneath historical 2.x versions is also preserved.

The shared token is confirmed current by successful Release MCP run 33215167852, which authenticated as louis030195 and published on 2026-08-29.

## Verification

- git diff --check
- Ruby YAML parser: passed
- actionlint: no warnings on changed steps; existing shellcheck findings elsewhere remain
- no release or npm publish was triggered