### PR TITLE
ci(cli): allow npm-only releases

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -19,6 +19,10 @@ on:
         description: "Windows launch-smoke run only: build the Windows CLI package and run the native + Intel SDE (non-AVX2) probes; skip macOS/Linux builds, EV signing, Sentry symbols, npm publish, and the GitHub release (publish-npm/release skip via their skipped needs)"
         type: boolean
         default: false
+      npm_only:
+        description: "Build and publish the npm packages without creating or updating the rolling GitHub CLI release"
+        type: boolean
+        default: false
 
 concurrency:
   # Serialize releases — aborting a release mid-flight is worse than waiting.
@@ -1069,6 +1073,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
+    if: ${{ !inputs.npm_only }}
     permissions:
       contents: write
     # smoke-windows: nothing ships unless the package launches + inits ONNX


### PR DESCRIPTION
## Summary

- add an npm_only manual input to Release CLI
- skip only the rolling GitHub Release job when npm_only is selected
- preserve all build, signing, non-AVX2 smoke, npm publish, and registry verification gates

## Historical intent

The rolling cli-latest release and the smoke_only dispatch mode were introduced to keep CLI artifacts accessible without flooding GitHub Releases, and to retain the non-AVX2 regression gate. Both behaviors remain the default. This adds a narrow manual mode for npm publication when GitHub Release mutation is outside the operator authorization boundary.

## Verification

- git diff --check
- Ruby YAML parser: passed
- actionlint: no findings on changed lines

No workflow was dispatched and no package or GitHub Release was published by this PR.