### PR TITLE
Fix visibility and tooltips for Home agent actions

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat/home-card-agent-actions.test.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/home-card-agent-actions.test.tsx
@@ -9,7 +9,6 @@ import tauriConfig from "../../src-tauri/tauri.conf.json";
 
 import {
   buildHomeCardAgentPrompt,
-  HOME_CARD_AGENT_TOOLTIP,
   HomeCardAgentActions,
 } from "./home-card-agent-actions";
 
@@ -68,10 +67,20 @@ describe("HomeCardAgentActions", () => {
         .getByRole("button", { name: "Run in Codex" })
         .querySelector("img"),
     ).toHaveAttribute("src", "/images/openai.svg");
-    expect(HOME_CARD_AGENT_TOOLTIP).toBe(
-      "run this in your favorite agent",
-    );
   });
+
+  it.each(["Claude", "Cursor", "Codex"])(
+    "identifies %s in its keyboard-accessible tooltip",
+    async (label) => {
+      render(<HomeCardAgentActions pipe={DAY_RECAP} />);
+
+      fireEvent.focus(screen.getByRole("button", { name: `Run in ${label}` }));
+
+      expect(await screen.findByRole("tooltip")).toHaveTextContent(
+        `Run in ${label}`,
+      );
+    },
+  );
 
   it("centers the action cluster over compact chips", () => {
     render(<HomeCardAgentActions pipe={DAY_RECAP} placement="chip" />);
@@ -130,7 +139,7 @@ describe("HomeCardAgentActions", () => {
     );
 
     await waitFor(() =>
-      expect(screen.getByRole("status")).toHaveTextContent("opened"),
+      expect(screen.getByRole("status")).toHaveTextContent("Opened in Claude"),
     );
     const prompt = buildHomeCardAgentPrompt(DAY_RECAP, "claude");
     expect(mocks.copyTextToClipboard).toHaveBeenCalledWith(prompt);
@@ -176,7 +185,7 @@ describe("HomeCardAgentActions", () => {
     );
 
     await waitFor(() =>
-      expect(screen.getByRole("status")).toHaveTextContent("opened"),
+      expect(screen.getByRole("status")).toHaveTextContent("Opened in Codex"),
     );
     expect(mocks.capture).toHaveBeenCalledWith(
       "home_card_agent_handoff_clicked",
@@ -210,6 +219,13 @@ describe("HomeCardAgentActions", () => {
     await waitFor(() =>
       expect(screen.getByRole("status")).toHaveTextContent("copied"),
     );
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Codex could not open. Paste the copied prompt there.",
+    );
+    fireEvent.focus(screen.getByRole("button", { name: "Run in Codex" }));
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Codex could not open. Paste the copied prompt there.",
+    );
     expect(mocks.capture).toHaveBeenCalledWith(
       "home_card_agent_handoff_completed",
       expect.objectContaining({
@@ -236,7 +252,9 @@ describe("HomeCardAgentActions", () => {
     );
 
     await waitFor(() =>
-      expect(screen.getByRole("status")).toHaveTextContent("unavailable"),
+      expect(screen.getByRole("status")).toHaveTextContent(
+        "Could not open Cursor or copy the prompt.",
+      ),
     );
     const prompt = buildHomeCardAgentPrompt(DAY_RECAP, "cursor");
     expect(mocks.openUrl).toHaveBeenCalledWith(

--- a/apps/screenpipe-app-tauri/components/chat/home-card-agent-actions.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/home-card-agent-actions.tsx
@@ -31,8 +31,6 @@ type LaunchState = "opening" | "opened" | "copied" | "unavailable";
 
 const SCREENPIPE_GITHUB_URL = "https://github.com/screenpipe/screenpipe";
 
-export const HOME_CARD_AGENT_TOOLTIP = "run this in your favorite agent";
-
 const SETUP_TARGETS: Record<HomeCardAgentId, string> = {
   claude: "claude-desktop",
   cursor: "cursor",
@@ -91,16 +89,8 @@ function AgentLogo({ id }: { id: HomeCardAgentId }) {
   if (id === "cursor") return <CursorLogo className={className} />;
   return (
     // eslint-disable-next-line @next/next/no-img-element
-    <img src="/images/openai.svg" alt="" className={className} />
+    <img src="/images/openai.svg" alt="" className={`${className} dark:invert`} />
   );
-}
-
-function statusLabel(state: LaunchState | null): string {
-  if (state === "opening") return "opening";
-  if (state === "opened") return "opened";
-  if (state === "copied") return "copied";
-  if (state === "unavailable") return "unavailable";
-  return "run in";
 }
 
 function resultDescription(state: LaunchState, label: string): string {
@@ -201,7 +191,7 @@ export function HomeCardAgentActions({
       data-placement={placement}
       role="group"
       aria-label={`Run ${pipe.title} in another agent`}
-      className={`absolute top-1/2 z-20 flex -translate-y-1/2 items-center gap-0.5 text-foreground transition-opacity duration-150 motion-reduce:transition-none ${
+      className={`absolute top-1/2 z-20 flex -translate-y-1/2 items-center gap-0.5 rounded-md border border-border bg-background px-0.5 text-foreground transition-opacity duration-150 motion-reduce:transition-none ${
         placement === "chip" ? "left-1/2 -translate-x-1/2" : "right-3"
       } ${
         state
@@ -214,9 +204,11 @@ export function HomeCardAgentActions({
         role="status"
         className="sr-only"
       >
-        {statusLabel(state)}
+        {state && activeAgent
+          ? resultDescription(state, AGENT_LABELS[activeAgent])
+          : ""}
       </span>
-      <TooltipProvider delayDuration={120}>
+      <TooltipProvider delayDuration={120} disableHoverableContent>
         {HOME_CARD_AGENT_TARGETS.map((target) => {
           const label = AGENT_LABELS[target.id];
           const isOpening = pending && activeAgent === target.id;
@@ -232,8 +224,8 @@ export function HomeCardAgentActions({
                   onPointerEnter={() => trackAgentViewed(target.id, "hover")}
                   onFocus={() => trackAgentViewed(target.id, "keyboard")}
                   onClick={() => void launch(target)}
-                  className={`flex h-5 w-5 items-center justify-center rounded-full opacity-75 transition-[color,background-color,opacity,transform] duration-150 hover:z-10 hover:scale-110 hover:bg-background/10 hover:opacity-100 focus-visible:z-10 focus-visible:bg-background/10 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-background disabled:cursor-wait disabled:opacity-50 motion-reduce:transform-none motion-reduce:transition-none ${
-                    isResult ? "z-10 text-signal opacity-100" : ""
+                  className={`flex h-5 w-5 items-center justify-center rounded-sm opacity-75 transition-[color,background-color,opacity,transform] duration-150 hover:z-10 hover:scale-110 hover:bg-foreground/10 hover:opacity-100 focus-visible:z-10 focus-visible:bg-foreground/10 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground disabled:cursor-wait disabled:opacity-50 motion-reduce:transform-none motion-reduce:transition-none ${
+                    isResult ? "z-10 opacity-100" : ""
                   }`}
                 >
                   {isOpening ? (
@@ -250,11 +242,13 @@ export function HomeCardAgentActions({
                 </button>
               </TooltipTrigger>
               <TooltipContent
-                side={placement === "chip" ? "bottom" : "right"}
+                side="bottom"
                 sideOffset={6}
                 className="rounded-md px-2.5 py-1.5 text-[11px] font-normal"
               >
-                {HOME_CARD_AGENT_TOOLTIP}
+                {state && activeAgent === target.id
+                  ? resultDescription(state, label)
+                  : `Run in ${label}`}
               </TooltipContent>
             </Tooltip>
           );


### PR DESCRIPTION
## Description

Hovering over Claude’s tooltip blocked neighboring agent buttons. Separately, poor background contrast made the icons difficult to see, and every tooltip used the same vague label.

I changed the controls to have their own contrasting background, positioned tooltips below the buttons, and made each tooltip identify its agent. Clipboard feedback now also explains the fallback.

This addresses the remaining UI problems in #6864. The deep-link launch issue was already fixed in #6866.

Related issue: #6864

## AI assistance and human ownership

- AI tool(s) used: Codex
- autonomy level: agent
- what I personally verified: I independently ran the 49 focused tests covering Home agent actions, summary cards, and agent handoff; TypeScript type checking; all 242 Bun-native tests; and Biome across 1,246 files. All these checks passed.

- [x] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [x] The problem statement, rationale, and replies to maintainers are my own.

## evidence type

- [x] UI or behavior change - before/after recording
- [ ] Backend change - regression tests and relevant logs/results
- [ ] Performance change - reproducible before/after benchmarks
- [ ] Docs, CI, or pure refactor - relevant checks and an explanation; no video required

## before

[before.webm](https://github.com/user-attachments/assets/e29fb8f5-0f1a-4e8d-a8e6-a7ca806cec59)

Recorded by Codex in browser-mock mode using synthetic data.

## after

[after.webm](https://github.com/user-attachments/assets/86ba4dab-86a4-4742-bfb7-c00bb7306111)

Recorded by Codex in browser-mock mode using synthetic data.

## how to test

### Personally run checks

On Windows, using Bun 1.3.10:

From `apps/screenpipe-app-tauri`:

- `bun x vitest run components/chat/home-card-agent-actions.test.tsx components/chat/summary-cards.test.tsx lib/first-run/agent-handoff.test.ts --maxWorkers=2 --minWorkers=1`
  - 49 tests passed across 3 files.
- `bun run typecheck`
  - completed without errors.
- `bun run test:bun`
  - 242 passed, 0 failed across 21 files.

From the repository root:

- `bun x --bun @biomejs/biome@2.4.13 check`
  - 1,246 files checked with no diagnostics or fixes.

### Additional agent-run validation

Codex recorded browser-mock checks covering light/dark themes, cards and compact chips, adjacent-button hovering, keyboard navigation, reduced motion, and clipboard fallback feedback.

Codex also ran the full Vitest suite: 4,997 passed, 1 failed. The remaining failure concerns Windows CRLF/LF differences in generated skill content; those files are unchanged by this patch. Local regeneration failed with EEXIST, leaving that check unresolved.

Native Tauri and actual external-agent launches were not tested.


## desktop app checklist (if applicable)

Not applicable: no Tauri commands or exported Rust types changed.