### PR TITLE
fix(chat): recover from silent Pi extension crashes

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
@@ -20,6 +20,9 @@ use std::io::{BufRead, BufReader, Write};
 use tauri::Manager;
 use tokio::sync::oneshot;
 
+#[path = "pi_extension_recovery.rs"]
+mod pi_extension_recovery;
+
 #[derive(Clone, Debug)]
 pub(crate) struct InternalAgentEvent {
     pub session_id: String,
@@ -897,6 +900,10 @@ pub struct PiManager {
     last_activity: std::time::Instant,
     /// Guard: ensures only one `pi_terminated` event is emitted per session.
     terminated_emitted: Arc<AtomicBool>,
+    /// Set before Screenpipe intentionally stops this exact child. The stdout
+    /// reader uses its own Arc generation so stale readers cannot classify a
+    /// deliberate replacement as an extension crash.
+    termination_expected: Arc<AtomicBool>,
     /// Channels waiting for RPC responses, keyed by request ID.
     pending_responses: PendingResponses,
     /// Command queue handle — all commands go through here for serialization.
@@ -959,6 +966,7 @@ impl PiManager {
             app_handle,
             last_activity: std::time::Instant::now(),
             terminated_emitted: Arc::new(AtomicBool::new(false)),
+            termination_expected: Arc::new(AtomicBool::new(true)),
             pending_responses: Arc::new(std::sync::Mutex::new(HashMap::new())),
             queue_handle: None,
             queue_state: None,
@@ -1013,6 +1021,7 @@ impl PiManager {
     }
 
     pub async fn stop(&mut self) {
+        self.termination_expected.store(true, Ordering::Release);
         // Signal queue to stop accepting commands
         if let Some(state) = self.queue_state.take() {
             state.signal_terminated();
@@ -3657,6 +3666,7 @@ pub async fn pi_start_inner(
 
     // Update manager for this session
     let terminated_emitted = Arc::new(AtomicBool::new(false));
+    let termination_expected = Arc::new(AtomicBool::new(false));
     let pending_responses: PendingResponses;
     if let Some(m) = pool.sessions.get_mut(&sid) {
         // Spawn the command queue for this session
@@ -3678,6 +3688,7 @@ pub async fn pi_start_inner(
         m.last_activity = std::time::Instant::now();
         // Fresh flag for this session — old reader threads keep their own Arc
         m.terminated_emitted = terminated_emitted.clone();
+        m.termination_expected = termination_expected.clone();
         pending_responses = m.pending_responses.clone();
     } else {
         pending_responses = Arc::new(std::sync::Mutex::new(HashMap::new()));
@@ -3740,7 +3751,10 @@ pub async fn pi_start_inner(
     // Spawn stdout reader thread — this is the SOLE emitter of `pi_terminated`.
     let app_handle = app.clone();
     let terminated_guard = terminated_emitted.clone();
+    let termination_expected_reader = termination_expected.clone();
     let sid_clone = sid.clone();
+    let project_dir_stdout = project_dir.clone();
+    let extension_safe_mode_at_start = extension_safe_mode;
     let pending_for_reader = pending_responses.clone();
     std::thread::spawn(move || {
         let mut reader = BufReader::new(stdout);
@@ -3932,6 +3946,17 @@ pub async fn pi_start_inner(
             "Pi stdout reader ended (pid: {}, session: {}), processed {} lines",
             pid, sid_clone, line_count
         );
+        if pi_extension_recovery::should_enable_pi_extension_safe_mode_on_exit(
+            use_acp,
+            termination_expected_reader.load(Ordering::Acquire),
+            extension_safe_mode_at_start,
+        ) && enable_pi_extension_safe_mode(&project_dir_stdout)
+        {
+            warn!(
+                "Pi exited unexpectedly for '{}'; the next automatic restart will load only Screenpipe-managed extensions",
+                project_dir_stdout
+            );
+        }
         if !ready_signalled {
             if let Ok(mut startup) = startup_result_reader.lock() {
                 *startup = Some(Err(

--- a/apps/screenpipe-app-tauri/src-tauri/src/pi_extension_recovery.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/pi_extension_recovery.rs
@@ -1,0 +1,45 @@
+// screenpipe — AI that knows everything you've seen, said, or heard
+// https://screenpipe.com
+
+/// Decide whether an exited native Pi process should make its next automatic
+/// restart ignore third-party extensions.
+pub(crate) fn should_enable_pi_extension_safe_mode_on_exit(
+    use_acp: bool,
+    termination_expected: bool,
+    already_in_safe_mode: bool,
+) -> bool {
+    !use_acp && !termination_expected && !already_in_safe_mode
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_enable_pi_extension_safe_mode_on_exit;
+
+    #[test]
+    fn silent_unexpected_native_exit_enables_safe_mode() {
+        assert!(should_enable_pi_extension_safe_mode_on_exit(
+            false, false, false
+        ));
+    }
+
+    #[test]
+    fn intentional_stop_does_not_enable_safe_mode() {
+        assert!(!should_enable_pi_extension_safe_mode_on_exit(
+            false, true, false
+        ));
+    }
+
+    #[test]
+    fn acp_exit_does_not_enable_pi_extension_safe_mode() {
+        assert!(!should_enable_pi_extension_safe_mode_on_exit(
+            true, false, false
+        ));
+    }
+
+    #[test]
+    fn safe_mode_exit_does_not_rearm_safe_mode() {
+        assert!(!should_enable_pi_extension_safe_mode_on_exit(
+            false, false, true
+        ));
+    }
+}


### PR DESCRIPTION
## Source

- Sanitized Discord feedback identity: message `1545901000601243781`
- Source task: `t_e01e58c1` (implementation run 972)
- Independent review: `t_36aa926c` (run 973), unconditional approval for exact commit `15d018f2921fd6e8ba7a0a7f7862223bc982dd70`

## Root cause

The native Pi process only armed managed-extension safe mode for two recognized stderr messages. When a third-party extension crashed Pi without either message, stdout reached EOF, the existing lifecycle emitted `agent_terminated`, and automatic restart loaded the same extension again. That left the reported Windows 10 installation in a crash loop and surfaced `Pi process died during prompt`.

## Fix

- Give each spawned Pi child its own atomic intentional-termination marker.
- Set that marker before every managed stop or replacement path.
- On unexpected native stdout EOF, arm the existing per-project managed-extension safe mode before queue and frontend termination signals trigger restart.
- Keep ACP, intentional stops, already-safe-mode processes, provider/readiness behavior, and stale readers from replaced generations excluded.

This covers the lifecycle surface rather than matching another crash string: all deliberate native termination paths mark their exact child generation, while any otherwise-unclassified native EOF uses the existing safe restart path.

## Scope

- `apps/screenpipe-app-tauri/src-tauri/src/pi.rs`
- `apps/screenpipe-app-tauri/src-tauri/src/pi_extension_recovery.rs`

Reported platform: Windows 10, app 2.7.21, native Pi. The recovery classification is in the native Pi path; ACP is intentionally unchanged.

## Before / after evidence

```text
Before: extension crash -> silent EOF -> agent_terminated -> restart same extensions -> repeat
After:  extension crash -> unexpected native EOF -> arm project safe mode
       -> agent_terminated -> restart without third-party extensions

Intentional stop / ACP / already-safe-mode exit -> no reclassification
```

This is process-lifecycle behavior with no new visible UI, so the control-flow trace is the relevant visual evidence.

## Verification

- RED: dependency-minimal Rust test produced the expected single failure in `silent_unexpected_native_exit_enables_safe_mode` (3 passed, 1 failed).
- GREEN: `rustc --edition 2021 --test apps/screenpipe-app-tauri/src-tauri/src/pi_extension_recovery.rs -o <temporary binary> && <temporary binary>` -> 4 passed, 0 failed.
- `rustfmt --edition 2021 --check apps/screenpipe-app-tauri/src-tauri/src/pi_extension_recovery.rs` -> passed.
- `git diff --check` -> passed.
- `git show --check HEAD` -> passed.
- Independent lifecycle and history audit verified exact clean SHA, sole parent, two-file scope, per-generation stop safety, and unchanged provider/readiness and restart-loop controls.

## Native test limitation

The canonical Tauri native wrapper could not be run on this Linux host because the repository-required system native build queue is unavailable there. Per repository policy, no raw Cargo fallback, direct local compilation, or dependency installation was used.