### PR TITLE
fix(app): avoid disabled-trial wait and preserve login completion

### DIFF
--- a/apps/screenpipe-app-tauri/app/onboarding/page.test.tsx
+++ b/apps/screenpipe-app-tauri/app/onboarding/page.test.tsx
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => ({
   completeOnboarding: vi.fn(async () => undefined),
   routerReplace: vi.fn(),
   capture: vi.fn(),
+  useRealLoginGate: false,
   trialActivationVariant: undefined as string | undefined,
   posthogDistinctId: "machine-1",
   featureFlagsReady: true,
@@ -95,14 +96,22 @@ vi.mock("@/lib/hooks/use-settings", () => ({
     isSettingsLoaded: mocks.isSettingsLoaded,
   }),
 }));
-vi.mock("@/components/onboarding/login-gate", () => ({
-  default: ({ handleNextSlide }: { handleNextSlide: () => void }) => (
-    <div>
-      regular sign in
-      <button onClick={handleNextSlide}>complete regular sign in</button>
-    </div>
-  ),
-}));
+vi.mock("@/components/onboarding/login-gate", async (importOriginal) => {
+  const { default: LoginGate } = await importOriginal<
+    typeof import("@/components/onboarding/login-gate")
+  >();
+  return {
+    default: (props: { handleNextSlide: () => void; suppressAutoAdvance?: boolean }) =>
+      mocks.useRealLoginGate ? (
+        <LoginGate {...props} />
+      ) : (
+        <div>
+          regular sign in
+          <button onClick={props.handleNextSlide}>complete regular sign in</button>
+        </div>
+      ),
+  };
+});
 vi.mock("@/components/enterprise-license-prompt", () => ({
   EnterpriseLicensePrompt: ({ onSignIn }: { onSignIn?: () => void }) => (
     <div>
@@ -196,6 +205,7 @@ import {
 describe("enterprise onboarding authentication", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.useRealLoginGate = false;
     mocks.trialActivationVariant = undefined;
     mocks.posthogDistinctId = "machine-1";
     mocks.featureFlagsReady = true;
@@ -547,6 +557,95 @@ describe("enterprise onboarding authentication", () => {
     );
     fireEvent.click(screen.getByRole("button", { name: "finish engine" }));
     expect(await screen.findByText("plan selection")).toBeInTheDocument();
+  });
+
+  it("continues immediately when fresh authenticated flags omit the disabled experiment", async () => {
+    mocks.enterprisePolicy.isManagedDeployment = false;
+    mocks.trialActivationVariant = undefined;
+    onboardingData.trialActivationFreshInstall = true;
+    mocks.settings.user = {
+      has_payment_method: false,
+      entitlement_source: "none",
+      token: "tok",
+    };
+    onboardingData.currentStep = "engine";
+
+    render(<OnboardingPage />);
+
+    // The real SDK returns undefined for a flag absent from a successful
+    // response. A disabled experiment must not cost the five-second timeout.
+    expect(await screen.findByText("engine")).toBeInTheDocument();
+    expect(screen.queryByTestId("trial-activation-assignment-pending"))
+      .not.toBeInTheDocument();
+    expect(mocks.capture).not.toHaveBeenCalledWith(
+      "trial_activation_assignment_failed",
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(window.sessionStorage.getItem(TRIAL_ACTIVATION_ASSIGNMENT_SESSION_KEY))
+      .toBe("control");
+  });
+
+  it("records a fresh login once when assignment temporarily unmounts the real login gate", async () => {
+    HTMLCanvasElement.prototype.getContext = vi.fn(() => null) as any;
+    mocks.useRealLoginGate = true;
+    mocks.enterprisePolicy.isManagedDeployment = false;
+    mocks.featureFlagsReady = false;
+    mocks.posthogDistinctId = "clerk-1";
+    mocks.trialActivationVariant = "control";
+    onboardingData.trialActivationFreshInstall = true;
+    const { rerender } = render(<OnboardingPage />);
+    expect(await screen.findByTestId("login-cta")).toBeInTheDocument();
+
+    mocks.settings.user = {
+      has_payment_method: false,
+      entitlement_source: "none",
+      token: "fresh-token",
+      clerk_id: "clerk-1",
+      email: "fresh@example.com",
+    };
+    rerender(<OnboardingPage />);
+    expect(screen.getByTestId("trial-activation-assignment-pending"))
+      .toBeInTheDocument();
+    expect(mocks.capture.mock.calls.filter(([event]) => event === "onboarding_login_completed"))
+      .toHaveLength(1);
+
+    act(() => {
+      mocks.featureFlagsCallback?.([], {}, {});
+      mocks.featureFlagsCallback?.([], {}, {});
+      mocks.featureFlagsCallback?.([], {}, {});
+    });
+    await waitFor(() => expect(screen.queryByTestId("trial-activation-assignment-pending"))
+      .not.toBeInTheDocument());
+    rerender(<OnboardingPage />);
+    expect(mocks.capture.mock.calls.filter(([event]) => event === "onboarding_login_completed"))
+      .toHaveLength(1);
+  });
+
+  it("does not count an authenticated settings hydration as a fresh login", async () => {
+    mocks.enterprisePolicy.isManagedDeployment = false;
+    mocks.isSettingsLoaded = false;
+    const { rerender } = render(<OnboardingPage />);
+
+    mocks.isSettingsLoaded = true;
+    mocks.settings.user = { token: "persisted-token" };
+    rerender(<OnboardingPage />);
+    expect(await screen.findByText("regular sign in")).toBeInTheDocument();
+    expect(mocks.capture).not.toHaveBeenCalledWith("onboarding_login_completed");
+  });
+
+  it("records one fresh login without an experiment assignment as well", async () => {
+    HTMLCanvasElement.prototype.getContext = vi.fn(() => null) as any;
+    mocks.useRealLoginGate = true;
+    mocks.enterprisePolicy.isManagedDeployment = false;
+    const { rerender } = render(<OnboardingPage />);
+    expect(await screen.findByTestId("login-cta")).toBeInTheDocument();
+
+    mocks.settings.user = { token: "fresh-token" };
+    rerender(<OnboardingPage />);
+    rerender(<OnboardingPage />);
+    expect(mocks.capture.mock.calls.filter(([event]) => event === "onboarding_login_completed"))
+      .toHaveLength(1);
   });
 
   it("restores the pinned route instead of reassigning after checkout navigation", async () => {

--- a/apps/screenpipe-app-tauri/app/onboarding/page.tsx
+++ b/apps/screenpipe-app-tauri/app/onboarding/page.tsx
@@ -180,7 +180,13 @@ function TrialActivationFlagAssignment({
         fresh: true,
         send_event: false,
       });
-      if (value === undefined) return;
+      // A disabled/deleted flag is absent even from a successful fresh
+      // response. The authenticated reload guard above has already resolved
+      // that ambiguity: absence means control, not five more seconds waiting.
+      if (value === undefined) {
+        settle({ variant: "control", source: "posthog" });
+        return;
+      }
 
       // Emit the experiment exposure only after the route is pinned to the
       // final identity. Reading cached values through the React hook here was
@@ -309,6 +315,8 @@ export default function OnboardingPage() {
   const { onboardingData, isLoading, completeOnboarding } = useOnboarding();
   const { settings, isSettingsLoaded } = useSettings();
   const user = settings.user as AppUser | null | undefined;
+  const isLoggedIn = Boolean(user?.token);
+  const previousLoginStateRef = React.useRef<boolean | null>(null);
   const completedForHiddenUiRef = React.useRef(false);
   const transitioningRef = React.useRef(false);
   const funnelStartedRef = React.useRef(false);
@@ -323,6 +331,26 @@ export default function OnboardingPage() {
     policy: managedPolicy,
     isSettingLocked,
   } = useManagedPolicy();
+
+  // The page survives the assignment-pending screen; the login slide does
+  // not. Observe the auth transition here so a new account still records its
+  // completion when that same render unmounts the slide. Wait for hydration
+  // so reopening an already authenticated installation remains a resume.
+  useEffect(() => {
+    if (isLoading || !isSettingsLoaded || !isManagedDeploymentResolved) return;
+    const loginCompleted = previousLoginStateRef.current === false && isLoggedIn;
+    previousLoginStateRef.current = isLoggedIn;
+    if (loginCompleted && currentSlide === "login" && !isManagedDeployment) {
+      posthog.capture("onboarding_login_completed");
+    }
+  }, [
+    currentSlide,
+    isLoading,
+    isLoggedIn,
+    isManagedDeployment,
+    isManagedDeploymentResolved,
+    isSettingsLoaded,
+  ]);
   // This intervention is intentionally narrow: only a canonical "low" tier
   // written by the native hardware detector is enough evidence to show it.
   // Missing, malformed, mid, and high tiers all skip it. We also wait for the
@@ -589,9 +617,8 @@ export default function OnboardingPage() {
       return;
     }
 
-    // The login gate owns this event because only it can distinguish a fresh
-    // logged-out -> logged-in transition from resuming a persisted session.
-    // Capturing it here as well duplicates every fresh-login completion.
+    // The page's auth-transition observer owns login completion. Advancing a
+    // resumed session or rerunning this callback must not emit it again.
     if (currentSlide !== "login") {
       posthog.capture(`onboarding_${currentSlide}_completed`);
     }

--- a/apps/screenpipe-app-tauri/components/onboarding/login-gate.test.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/login-gate.test.tsx
@@ -161,7 +161,7 @@ describe("onboarding login gate", () => {
     expect(mocks.loadUser).not.toHaveBeenCalled();
   });
 
-  it("captures completion only for a logged-out to logged-in transition", () => {
+  it("advances once after a fresh login while the page owns completion telemetry", () => {
     vi.useFakeTimers();
     const next = vi.fn();
     const { rerender } = render(<OnboardingLogin handleNextSlide={next} />);
@@ -171,8 +171,7 @@ describe("onboarding login gate", () => {
     };
     rerender(<OnboardingLogin handleNextSlide={next} />);
 
-    expect(mocks.capture).toHaveBeenCalledTimes(1);
-    expect(mocks.capture).toHaveBeenCalledWith(
+    expect(mocks.capture).not.toHaveBeenCalledWith(
       "onboarding_login_completed",
     );
 
@@ -182,7 +181,9 @@ describe("onboarding login gate", () => {
     rerender(<OnboardingLogin handleNextSlide={next} />);
     act(() => vi.advanceTimersByTime(500));
 
-    expect(mocks.capture).toHaveBeenCalledTimes(1);
+    expect(mocks.capture).not.toHaveBeenCalledWith(
+      "onboarding_login_completed",
+    );
     expect(next).toHaveBeenCalledTimes(1);
     vi.useRealTimers();
   });

--- a/apps/screenpipe-app-tauri/components/onboarding/login-gate.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/login-gate.tsx
@@ -249,10 +249,6 @@ const OnboardingLogin: React.FC<OnboardingLoginProps> = ({
   const canSkipLogin = isDevLoginSkipEnabled();
 
   const isLoggedIn = !!settings.user?.token;
-  // null until settings hydrate — SettingsProvider starts from defaults (no
-  // user) and loads store.bin asynchronously, so a mount-time snapshot would
-  // read an existing session as a fresh login on every relaunch.
-  const wasLoggedIn = useRef<boolean | null>(null);
 
   useBackgroundCanvas(bgRef, 500, 480);
   useButtonCanvas(btnRef, 200, 52, isHovered);
@@ -264,13 +260,9 @@ const OnboardingLogin: React.FC<OnboardingLoginProps> = ({
 
   useEffect(() => {
     if (!isSettingsLoaded) return;
-    const loginCompleted = wasLoggedIn.current === false && isLoggedIn;
-    wasLoggedIn.current = isLoggedIn;
-
     if (!suppressAutoAdvance && isLoggedIn && !hasAdvanced.current) {
-      if (loginCompleted) {
-        posthog.capture("onboarding_login_completed");
-      }
+      // The page owns completion telemetry because experiment assignment can
+      // unmount this slide on the same render that delivers the login token.
       // hasAdvanced flips when the timer fires, not when it is scheduled —
       // a cancelled timer (StrictMode remount, dep change within the window)
       // must stay reschedulable or auto-advance dies with the cleanup.


### PR DESCRIPTION
## Description

Fresh onboarding can remain on **“preparing your setup” for five seconds** when `first-summary-card-trial-v1` is disabled or absent. The same assignment transition can suppress `onboarding_login_completed` even though authentication succeeds and the user continues. This fixes both failures on the shared desktop onboarding path, including Windows and macOS.

The regression traces to b0a774ad1a7b85b2b4bc6fa350e604a63835952b (#6826):

- After the authenticated fresh-response guard completes, an absent flag returns `undefined`. Returning without settling the assignment leaves onboarding waiting for the five-second timeout. A successfully loaded response without this flag now selects control immediately; identity protection and the network-error/timeout fallback remain intact.
- When a fresh token arrives, the parent renders the assignment screen and unmounts the login gate before its effect can observe the authentication transition. Login completion now belongs to the persistent parent page. Hydrating a persisted session does not emit a new completion, and advancing or rerendering does not duplicate it.

This was discovered while investigating a reported Windows trial decline. The initial raw funnel comparison was affected by the mix of accounts; excluding the identified anomalous cohort substantially reduced the apparent checkout-start decline, while observed completions increased. Independent login and downstream events also continued when the completion event disappeared. This PR repairs the reproducible delay and measurement bug; it does not establish an installer failure or explain the full trial-volume decline.

## Before / after

ASCII lifecycle illustration (no native recording claimed):

```text
BEFORE
fresh login -> login gate unmounts -> completion event missed
           -> authenticated flags omit experiment
           -> "preparing your setup" [5 seconds] -> timeout -> control

AFTER
fresh login -> persistent page records completion exactly once
           -> authenticated flags omit experiment -> control immediately
```

“Immediately” means after the existing authenticated fresh-response guard; this change does not bypass the flag fetch or identity checks.

## Validation

The two new reproduction cases were first run against the unmodified source and both failed: the disabled-flag case remained on the wait screen, and the real-login-gate case recorded zero completion events. The latter mounts the actual login gate within the page, reproducing the unmount boundary that isolated child tests missed.

Before-fix reproduction command, from `apps/screenpipe-app-tauri`:

```sh
bun x vitest run --config vitest.config.ts app/onboarding/page.test.tsx \
  -t 'continues immediately when fresh|records a fresh login once'
```

After-fix validation, from `apps/screenpipe-app-tauri`:

```sh
bun x vitest run --config vitest.config.ts \
  app/onboarding/page.test.tsx \
  components/onboarding/login-gate.test.tsx \
  components/onboarding/plan-selection-step.test.tsx \
  lib/onboarding-checkout.test.ts \
  lib/first-run/trial-activation.test.ts
bun run typecheck
```

Results: **106 tests passed across five suites; `bun run typecheck` passed**. From the repository root, the following also passed (Biome checked four files with no fixes):

```sh
bunx --bun @biomejs/biome check \
  apps/screenpipe-app-tauri/app/onboarding/page.tsx \
  apps/screenpipe-app-tauri/app/onboarding/page.test.tsx \
  apps/screenpipe-app-tauri/components/onboarding/login-gate.tsx \
  apps/screenpipe-app-tauri/components/onboarding/login-gate.test.tsx
git diff --check
```

No Rust commands, bindings, or native auth/deep-link behavior changed. A packaged Windows/macOS end-to-end run has not been performed.

## Ezra: focused verification

@EzraEllette please review the auth-transition ownership and check a fresh Windows onboarding session:

1. With the trial experiment disabled/absent, sign in and confirm there is no additional five-second setup wait after flags return.
2. Confirm `onboarding_login_completed` appears once and onboarding advances through acquisition to the applicable plan/checkout path.
3. Restart/resume an already authenticated installation and confirm it does not emit a fresh-login completion.
4. Check an active experiment assignment and a failed/offline flag fetch: the route should remain pinned for the authenticated identity, and a fetch failure should still fall back safely.

## AI assistance and human ownership

- AI tool: Codex; autonomy level: `agent`.
- Submitted at the repository maintainer's explicit request. Codex inspected the history/source and executed the regression tests and checks listed above.
- Human manual verification is not claimed; the focused native check above is requested from Ezra.
