### PR TITLE
fix(live-views): support ACP editor tools

### DIFF
--- a/apps/screenpipe-app-tauri/lib/live-views/__tests__/generate-live-view-with-pi.test.ts
+++ b/apps/screenpipe-app-tauri/lib/live-views/__tests__/generate-live-view-with-pi.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildLiveViewGenerationPrompt,
+  matchesLiveViewToolName,
   parseGeneratedLiveView,
 } from "../generate-live-view-with-pi";
 
@@ -395,6 +396,33 @@ describe("parseGeneratedLiveView", () => {
 });
 
 describe("buildLiveViewGenerationPrompt", () => {
+  it("uses the ACP MCP tool names and accepts their adapter-prefixed events", () => {
+    const prompt = buildLiveViewGenerationPrompt({
+      prompt: "track how I spend my time",
+      scope: "dashboard",
+      preset: { provider: "acp" } as any,
+      userToken: null,
+      pipes: [],
+    });
+
+    expect(prompt).toContain("live_view action=pipes");
+    expect(prompt).toContain("live_view_propose");
+    expect(prompt).not.toContain("screenpipe_live_view");
+    expect(
+      matchesLiveViewToolName(
+        "mcp__screenpipe_tools__live_view",
+        "live_view",
+      ),
+    ).toBe(true);
+    expect(
+      matchesLiveViewToolName(
+        "mcp__screenpipe_tools__live_view_propose",
+        "live_view_propose",
+      ),
+    ).toBe(true);
+    expect(matchesLiveViewToolName("exec", "live_view")).toBe(false);
+  });
+
   it("references an existing Live View lazily and looks at what it renders first", () => {
     const prompt = buildLiveViewGenerationPrompt({
       prompt: "show more detail",

--- a/apps/screenpipe-app-tauri/lib/live-views/generate-live-view-with-pi.ts
+++ b/apps/screenpipe-app-tauri/lib/live-views/generate-live-view-with-pi.ts
@@ -19,7 +19,10 @@ import { applyResolvedModelLimits } from "@/lib/model-metadata";
 
 const GENERATION_TIMEOUT_MS = 90_000;
 const PROJECT_DIR = "pi-live-views";
+const LIVE_VIEW_TOOL = "screenpipe_live_view";
 const PROPOSE_TOOL = "screenpipe_live_view_propose";
+const ACP_LIVE_VIEW_TOOL = "live_view";
+const ACP_PROPOSE_TOOL = "live_view_propose";
 const READ_ACTIONS = new Set(["get", "list", "pipes", "values"]);
 const COMPONENTS = new Set<BrainViewComponent>([
   "metric.v1",
@@ -83,6 +86,21 @@ type GenerateLiveViewOptions = {
   signal?: AbortSignal;
   onPhase?: (phase: "starting" | "working" | "reviewing") => void;
 };
+
+function liveViewTools(preset: AIPreset) {
+  return preset.provider === "acp"
+    ? { read: ACP_LIVE_VIEW_TOOL, propose: ACP_PROPOSE_TOOL }
+    : { read: LIVE_VIEW_TOOL, propose: PROPOSE_TOOL };
+}
+
+export function matchesLiveViewToolName(
+  reportedName: string | undefined,
+  expectedName: string,
+): boolean {
+  if (!reportedName) return false;
+  const normalized = reportedName.toLowerCase().replaceAll("-", "_");
+  return normalized === expectedName || normalized.endsWith(`__${expectedName}`);
+}
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   return typeof value === "object" && value !== null && !Array.isArray(value)
@@ -305,6 +323,7 @@ screenpipe_live_view_propose({"operations":[{"op":"add","block":{"id":"meeting-f
 export function buildLiveViewGenerationPrompt(
   options: GenerateLiveViewOptions,
 ): string {
+  const tools = liveViewTools(options.preset);
   const editing = Boolean(options.currentViewRef);
   const replacing = editing && options.replaceExisting === true;
   const scopeInstruction =
@@ -332,21 +351,26 @@ ${JSON.stringify(
   })),
 )}`
       : `
-Find scheduled tasks with screenpipe_live_view action=pipes and a short query. Bind pipeName only to a name that search returned; use null when nothing fits.`;
+Find scheduled tasks with ${tools.read} action=pipes and a short query. Bind pipeName only to a name that search returned; use null when nothing fits.`;
 
-  return `Design a Screenpipe Live View change for the user to review, then submit it with screenpipe_live_view_propose. The app applies nothing until the user accepts, so never call action=save.
+  const editExamples = EDIT_EXAMPLES.replaceAll(PROPOSE_TOOL, tools.propose).replaceAll(
+    LIVE_VIEW_TOOL,
+    tools.read,
+  );
+
+  return `Design a Screenpipe Live View change for the user to review, then submit it with ${tools.propose}. The app applies nothing until the user accepts, so never call action=save.
 
 ${scopeInstruction}
 
 Work in this order:
-1. ${editing && !replacing ? `Call screenpipe_live_view action=values for ${JSON.stringify(options.currentViewRef?.id ?? "")} to see what the Blocks currently render. A Block shows its bound task's last payload, so an intent-only edit changes nothing the user can see.` : "Decide the outcomes the user wants to see."}
+1. ${editing && !replacing ? `Call ${tools.read} action=values for ${JSON.stringify(options.currentViewRef?.id ?? "")} to see what the Blocks currently render. A Block shows its bound task's last payload, so an intent-only edit changes nothing the user can see.` : "Decide the outcomes the user wants to see."}
 2. ${options.pipeAvailability === "store" ? "Choose from the installable tasks listed below." : "Look up scheduled tasks only if a section needs one."}
-3. Call screenpipe_live_view_propose once with the finished change. Fix and retry if it reports problems.
+3. Call ${tools.propose} once with the finished change. Fix and retry if it reports problems.
 
 Each Block needs a precise, source-backed intent covering the selected period and how missing evidence is handled. Avoid duplicate Blocks. Reuse the id of every Block you edit.
 ${storeCandidates}
 
-${editing && !replacing ? EDIT_EXAMPLES : ""}
+${editing && !replacing ? editExamples : ""}
 
 User request:
 ${options.prompt.trim()}
@@ -383,7 +407,7 @@ function providerConfig(preset: AIPreset): PiProviderConfig {
     // tasks, and submit a reviewable proposal. Restrict the runtime itself so
     // normal Chat, MCP, web, filesystem, and artifact tools are never
     // advertised on this private editing surface.
-    allowedTools: ["screenpipe_live_view", PROPOSE_TOOL],
+    allowedTools: Object.values(liveViewTools(preset)),
   };
 }
 
@@ -414,6 +438,7 @@ async function runGeneration(
   const sessionId = `${INTERNAL_TITLE_PREFIX}live-view-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   await mountAgentEventBus();
   const projectDir = await liveViewProjectDir();
+  const tools = liveViewTools(options.preset);
 
   // The proposal arrives as tool arguments and is only kept once the tool
   // accepts it, so a retry after a rejection is what reaches the user.
@@ -453,14 +478,14 @@ async function runGeneration(
     const event = envelope.event;
     if (event.type === "agent_start") options.onPhase?.("working");
     if (event.type === "tool_execution_start") {
-      if (event.toolName === PROPOSE_TOOL) {
+      if (matchesLiveViewToolName(event.toolName, tools.propose)) {
         const args = asRecord(event.args);
         if (args && event.toolCallId)
           pendingProposals.set(event.toolCallId, args);
         options.onPhase?.("reviewing");
         return;
       }
-      if (event.toolName !== "screenpipe_live_view") {
+      if (!matchesLiveViewToolName(event.toolName, tools.read)) {
         fail("Live View editor tried to use an unrelated tool");
         void commands.piStop(sessionId);
         return;

--- a/apps/screenpipe-app-tauri/src-tauri/assets/mcp/__tests__/screenpipe-tools.test.ts
+++ b/apps/screenpipe-app-tauri/src-tauri/assets/mcp/__tests__/screenpipe-tools.test.ts
@@ -124,6 +124,7 @@ describe("screenpipe-tools MCP server", () => {
         "query_recordings",
         "list_connections",
         "live_view",
+        "live_view_propose",
         "save_artifact",
         "search_chats",
         "send_to_chat",
@@ -140,12 +141,13 @@ describe("screenpipe-tools MCP server", () => {
     const props = (saveArtifact?.inputSchema as { properties?: Record<string, { enum?: string[] }> })
       ?.properties;
     expect(props?.encoding?.enum).toEqual(["utf8", "base64"]);
-    // live_view advertises the list/get/save action set (Live Views parity).
+    // ACP Live View editing needs the same read actions and review-only handoff as Pi.
     const liveView = tools.find((t) => t.name === "live_view");
     const actionEnum = (liveView?.inputSchema as {
       properties?: Record<string, { enum?: string[] }>;
     })?.properties?.action?.enum;
-    expect(actionEnum).toEqual(["list", "get", "save"]);
+    expect(actionEnum).toEqual(["list", "get", "save", "pipes", "values"]);
+    expect(tools.find((t) => t.name === "live_view_propose")).toBeDefined();
 
     const sendToChat = tools.find((t) => t.name === "send_to_chat");
     const sendProperties = sendToChat?.inputSchema as {
@@ -163,6 +165,35 @@ describe("screenpipe-tools MCP server", () => {
     await server.request(1, "initialize", {});
     const res = await server.request(3, "tools/call", { name: "does_not_exist", arguments: {} });
     expect(res.error).toMatchObject({ code: -32602 });
+  });
+
+  it("accepts a review-only Live View proposal without calling the engine", async () => {
+    server = new Server({ SCREENPIPE_API_URL: "http://127.0.0.1:1" });
+    const res = await server.request(1, "tools/call", {
+      name: "live_view_propose",
+      arguments: {
+        note: "Adds a focus summary.",
+        blocks: [
+          {
+            title: "Focus",
+            intent: "Summarize focused work in the selected period.",
+            component: "metric.v1",
+            width: 6,
+            pipeName: null,
+          },
+        ],
+      },
+    });
+
+    const text = (
+      res.result as { content: Array<{ text: string }>; isError?: boolean }
+    ).content[0].text;
+    expect(JSON.parse(text)).toMatchObject({
+      accepted: true,
+      awaitingUserReview: true,
+      blockCount: 1,
+    });
+    expect((res.result as { isError?: boolean }).isError).not.toBe(true);
   });
 
   it("keeps cross-chat sends out of unattended ACP tasks", async () => {

--- a/crates/screenpipe-core/assets/acp/screenpipe-tools.mjs
+++ b/crates/screenpipe-core/assets/acp/screenpipe-tools.mjs
@@ -360,6 +360,152 @@ function liveViewSaveRequest(view) {
   };
 }
 
+const LIVE_VIEW_COMPONENTS = [
+  "metric.v1",
+  "list.v1",
+  "bar-chart.v1",
+  "line-chart.v1",
+  "table.v1",
+  "timeline.v1",
+  "markdown.v1",
+];
+const LIVE_VIEW_TIME_RANGES = ["today", "24h", "7d", "30d"];
+const LIVE_VIEW_WIDTHS = [3, 6, 12];
+const LIVE_VIEW_BLOCK_SCHEMA = {
+  type: "object",
+  properties: {
+    id: { type: "string" },
+    title: { type: "string" },
+    intent: { type: "string" },
+    component: { type: "string", enum: LIVE_VIEW_COMPONENTS },
+    width: { type: "integer", enum: LIVE_VIEW_WIDTHS },
+    pipeName: { type: ["string", "null"] },
+  },
+  required: ["title", "intent", "component", "width"],
+  additionalProperties: false,
+};
+const LIVE_VIEW_PROPOSAL_SCHEMA = {
+  type: "object",
+  properties: {
+    note: { type: "string" },
+    title: { type: "string" },
+    timeRange: { type: "string", enum: LIVE_VIEW_TIME_RANGES },
+    timeRangeBehavior: { type: "string", enum: ["selectable", "fixed"] },
+    blocks: { type: "array", items: LIVE_VIEW_BLOCK_SCHEMA },
+    operations: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          op: { type: "string", enum: ["add", "update", "remove"] },
+          blockId: { type: "string" },
+          block: LIVE_VIEW_BLOCK_SCHEMA,
+        },
+        required: ["op"],
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ["note"],
+  additionalProperties: false,
+};
+
+function validateLiveViewProposal(params) {
+  const hasBlocks = Array.isArray(params?.blocks) && params.blocks.length > 0;
+  const hasOperations = Array.isArray(params?.operations) && params.operations.length > 0;
+  if (hasBlocks === hasOperations) {
+    throw new Error(
+      hasBlocks
+        ? "Send either blocks (new dashboard) or operations (edit), not both."
+        : "Send blocks for a new dashboard, or operations for an edit. Both were empty.",
+    );
+  }
+  if (typeof params.note !== "string" || !params.note.trim()) {
+    throw new Error("note is required and must say what visibly changes");
+  }
+}
+
+function searchWords(value) {
+  return [
+    ...new Set(
+      String(value || "")
+        .toLowerCase()
+        .split(/[^a-z0-9]+/)
+        .filter((word) => word.length >= 3),
+    ),
+  ];
+}
+
+async function searchInstalledPipes(query) {
+  const body = await liveViewJson(
+    await fetch(`${apiBase()}/pipes`, { method: "GET", headers: authHeaders() }),
+  );
+  const raw = Array.isArray(body?.data) ? body.data : Array.isArray(body) ? body : [];
+  const pipes = raw.flatMap((entry) => {
+    const config = entry?.config ?? entry;
+    const name = typeof config?.name === "string" ? config.name : entry?.id;
+    if (typeof name !== "string" || !name.trim()) return [];
+    const description =
+      typeof config?.description === "string"
+        ? config.description
+        : typeof config?.config?.description === "string"
+          ? config.config.description
+          : "";
+    return [{
+      name: name.trim(),
+      description: description.slice(0, 240),
+      enabled: entry?.enabled === true || config?.enabled === true,
+    }];
+  });
+  const words = searchWords(query);
+  if (words.length === 0) return pipes.slice(0, 24);
+  const matched = pipes.filter((pipe) => {
+    const haystack = `${pipe.name} ${pipe.description}`.toLowerCase();
+    return words.some((word) => haystack.includes(word));
+  });
+  return (matched.length > 0 ? matched : pipes).slice(0, 24);
+}
+
+function liveViewValuePreview(value) {
+  const payload = value && typeof value === "object" ? value.payload ?? value : null;
+  if (payload == null) return { hasValue: false, renders: null };
+  const text = JSON.stringify(payload);
+  if (typeof text !== "string") return { hasValue: false, renders: null };
+  return {
+    hasValue: true,
+    renders: text.length > 600 ? `${text.slice(0, 600)}...` : text,
+  };
+}
+
+async function liveViewValues(viewId, blockId) {
+  const views = await liveViewJson(
+    await fetch(`${apiBase()}/live-views`, { method: "GET", headers: authHeaders() }),
+  );
+  const view = (Array.isArray(views) ? views : []).find((entry) => entry?.id === viewId);
+  if (!view) throw new Error(`Live View "${viewId}" was not found`);
+  const blocks = Array.isArray(view.slots)
+    ? view.slots
+    : Array.isArray(view.blocks)
+      ? view.blocks
+      : [];
+  const wanted = typeof blockId === "string" && blockId.trim()
+    ? blocks.filter((block) => block?.id === blockId.trim())
+    : blocks;
+  if (typeof blockId === "string" && blockId.trim() && wanted.length === 0) {
+    throw new Error(`Block "${blockId}" was not found in "${viewId}"`);
+  }
+  return {
+    viewId,
+    blocks: wanted.slice(0, 12).map((block) => ({
+      id: block?.id ?? null,
+      title: block?.title ?? null,
+      component: block?.component ?? block?.kind ?? null,
+      pipeName: block?.binding?.pipeName ?? block?.source?.pipeName ?? null,
+      ...liveViewValuePreview(block?.value),
+    })),
+  };
+}
+
 const IMAGE_EXT_KIND = {
   ".png": "image",
   ".jpg": "image",
@@ -803,19 +949,27 @@ const TOOLS = [
     // lazily by the model — dashboard contents are never preloaded into chat.
     name: "live_view",
     description:
-      "Read or edit the user's saved Screenpipe Live Views (dashboards) on demand. Use only when the user asks about a dashboard or Live View. action=list returns compact summaries; action=get returns one editable definition; action=save persists a complete definition previously returned by get. Before saving, get the latest definition and preserve every block the user did not ask to change; the revision guards against overwriting a newer edit. Only save when the user explicitly asked to create or change a Live View.",
+      "Read or edit the user's saved Screenpipe Live Views (dashboards) on demand. Use only when the user asks about a dashboard or Live View. action=list returns compact summaries; action=get returns one editable definition; action=pipes searches installed scheduled tasks; action=values returns what Blocks currently render; action=save persists a complete definition previously returned by get. Before saving, get the latest definition and preserve every block the user did not ask to change; the revision guards against overwriting a newer edit. Only save when the user explicitly asked to create or change a Live View.",
     inputSchema: {
       type: "object",
       properties: {
         action: {
           type: "string",
-          enum: ["list", "get", "save"],
+          enum: ["list", "get", "save", "pipes", "values"],
           description:
-            "list returns compact dashboard summaries; get returns one editable definition; save persists a complete definition previously returned by get.",
+            "list returns compact dashboard summaries; get returns one editable definition; pipes searches installed scheduled tasks; values returns what Blocks currently render; save persists a complete definition previously returned by get.",
         },
         viewId: {
           type: "string",
-          description: "Live View id for get. Use list first when the target is unknown.",
+          description: "Live View id for get and values. Use list first when the target is unknown.",
+        },
+        blockId: {
+          type: "string",
+          description: "Optional Block id for values. Omit to inspect every Block.",
+        },
+        query: {
+          type: "string",
+          description: "Optional search text for pipes.",
         },
         view: {
           type: "object",
@@ -857,6 +1011,16 @@ const TOOLS = [
         return JSON.stringify({ view });
       }
 
+      if (action === "pipes") {
+        return JSON.stringify({ pipes: await searchInstalledPipes(args?.query) });
+      }
+
+      if (action === "values") {
+        return JSON.stringify(
+          await liveViewValues(requireViewId(args?.viewId), args?.blockId),
+        );
+      }
+
       if (action === "save") {
         const request = liveViewSaveRequest(args?.view);
         const res = await fetch(
@@ -875,6 +1039,21 @@ const TOOLS = [
       }
 
       throw new Error(`unsupported Live View action: ${action || "<missing>"}`);
+    },
+  },
+  {
+    name: "live_view_propose",
+    description:
+      "Submit a finished Live View design for user review. This validates and returns the proposal without writing anything.",
+    inputSchema: LIVE_VIEW_PROPOSAL_SCHEMA,
+    async run(args) {
+      validateLiveViewProposal(args);
+      return JSON.stringify({
+        accepted: true,
+        awaitingUserReview: true,
+        blockCount: Array.isArray(args?.blocks) ? args.blocks.length : undefined,
+        operationCount: Array.isArray(args?.operations) ? args.operations.length : undefined,
+      });
     },
   },
   {


### PR DESCRIPTION
## Summary

- use the ACP MCP tool names in the Live View editor prompt and scoped allowlist
- expose the review-only `live_view_propose` tool plus the missing `pipes` and `values` actions through the bundled ACP MCP server
- recognize adapter-prefixed MCP tool events while keeping unrelated tools blocked

## Root cause

The Live View editor always prompted and allowlisted the native Pi tool names (`screenpipe_live_view` and `screenpipe_live_view_propose`). ACP agents instead receive tools from the bundled `screenpipe-tools` MCP server, which only exposed `live_view` with `list/get/save`.

When an ACP adapter emitted `mcp__screenpipe_tools__live_view`, the foreground editor treated it as unrelated and stopped the session before the proposal could be produced.

## Before / after

```text
before: screenpipe_live_view prompt -> ACP mcp__screenpipe_tools__live_view -> rejected
after:  live_view prompt            -> ACP mcp__screenpipe_tools__live_view -> allowed
                                      -> live_view_propose -> user review
```

The existing `live_view` MCP name and save behavior remain compatible. The new proposal tool only validates and returns arguments; it does not persist a Live View.

## Verification

- `bun x vitest run --config vitest.config.ts lib/live-views/__tests__/generate-live-view-with-pi.test.ts` (17 passed)
- `bun x vitest run --config vitest.config.ts src-tauri/assets/mcp/__tests__/screenpipe-tools.test.ts` (6 passed)
- `bun x tsc --noEmit`
- `bunx --bun @biomejs/biome check` on the three changed TypeScript test/source files
- `bun build crates/screenpipe-core/assets/acp/screenpipe-tools.mjs --target=bun --outfile=/tmp/screenpipe-tools-check.js`