### PR TITLE
chore(deps): switch Dependabot ecosystem from npm to bun

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -83,10 +83,10 @@ updates:
     commit-message:
       prefix: "chore(deps)"
 
-  # ------------------------------------------------------------------ npm ----
-  # Desktop app frontend. Highest-value npm target: a single stale `next` pin
+  # ------------------------------------------------------------------ bun ----
+  # Desktop app frontend. Highest-value bun target: a single stale `next` pin
   # accounted for 32 of the 144 open alerts, including both runtime criticals.
-  - package-ecosystem: npm
+  - package-ecosystem: bun
     directory: "/apps/screenpipe-app-tauri"
     schedule:
       interval: weekly
@@ -105,8 +105,8 @@ updates:
     commit-message:
       prefix: "chore(deps)"
 
-  # Published to npm — users install these directly, so keep them current.
-  - package-ecosystem: npm
+  # Published to bun — users install these directly, so keep them current.
+  - package-ecosystem: bun
     directory: "/packages/screenpipe-mcp"
     schedule:
       interval: weekly
@@ -118,7 +118,7 @@ updates:
     commit-message:
       prefix: "chore(deps)"
 
-  - package-ecosystem: npm
+  - package-ecosystem: bun
     directory: "/packages/sdk"
     schedule:
       interval: weekly
@@ -133,7 +133,7 @@ updates:
   # Example apps. Dev-scope only and never shipped, so they get a low limit and
   # a single grouped PR — the electron example alone carries 31 open alerts
   # (all one package, `electron`, 7 majors behind) and would otherwise dominate.
-  - package-ecosystem: npm
+  - package-ecosystem: bun
     directory: "/packages/sdk/examples/electron-app"
     schedule:
       interval: monthly
@@ -144,7 +144,7 @@ updates:
     commit-message:
       prefix: "chore(deps)"
 
-  - package-ecosystem: npm
+  - package-ecosystem: bun
     directory: "/packages/sdk/examples/tauri-app"
     schedule:
       interval: monthly
@@ -155,7 +155,7 @@ updates:
     commit-message:
       prefix: "chore(deps)"
 
-  - package-ecosystem: npm
+  - package-ecosystem: bun
     directory: "/crates/screenpipe-gateway/e2e/conformance"
     schedule:
       interval: monthly


### PR DESCRIPTION
---
name: pull request
about: submit changes to the project
title: switch Dependabot ecosystem from npm to bun
labels: ''
assignees: ''

---

## description

### Problem

Every open npm Dependabot PR fails CI. Dependabot's `npm` ecosystem bumps only
`package.json` and never touches `bun.lock`. CI runs `bun install --frozen-lockfile`,
which fails:

error: lockfile had changes, but lockfile is frozen

That single failure cascades into Vitest, Knip, build, and E2E jobs.
Seven PRs were closed in a cleanup sweep because rebasing cannot fix them.

### Fix

Replace all 6 `package-ecosystem: npm` entries with `package-ecosystem: bun`
in `.github/dependabot.yml`. GitHub's Bun ecosystem natively understands
`bun.lock` and will commit both the manifest and lockfile together.

- `/apps/screenpipe-app-tauri`
- `/packages/screenpipe-mcp`
- `/packages/sdk`
- `/packages/sdk/examples/electron-app`
- `/packages/sdk/examples/tauri-app`
- `/crates/screenpipe-gateway/e2e/conformance`

Cargo and github-actions entries are unchanged.

related issue: #6211 

## AI assistance and human ownership

read the [AI-assisted contribution policy](https://github.com/screenpipe/screenpipe/blob/main/CONTRIBUTING.md#ai-assisted-contributions).

- AI tool(s) used (`none` if not used): OpenCode
- autonomy level (`none`, `autocomplete`, `chat`, or `agent`): chat
- what I personally verified: the yml file

- [X] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [X] The problem statement, rationale, and replies to maintainers are my own.

## evidence type

check every category that applies and provide its required evidence below.

- [ ] UI or behavior change — before/after recording
- [ ] Backend change — regression tests and relevant logs/results
- [ ] Performance change — reproducible before/after benchmarks
- [X] Docs, CI, or pure refactor — relevant checks and an explanation; no video required

## before

not applicable; this is a CI config change, no UI or behavior change.

## after

not applicable; this is a CI config change, no UI or behavior change. Evidence is the CI passing on the next Dependabot PR.

## how to test

1. `gh pr list -S 'is:open label:dependencies ecosystem:np'` — confirm no open npm dependabot PRs remain
2. Push the change, wait for Dependabot's next schedule run on a `bun` ecosystem directory
3. Verify the new PR contains both `package.json` and `bun.lock` changes
4. CI on that PR should pass `bun install --frozen-lockfile` green

## desktop app checklist (if applicable)

If this PR adds or changes `#[tauri::command]` handlers or Rust types exported to the frontend, from `apps/screenpipe-app-tauri/`:

- [ ] `bun run bindings:generate` (if bindings changed)
- [ ] `bun run bindings:check`
- [ ] `bun run typecheck`

Commands are auto-collected via the vendored `tauri-helper` crate — no manual handler list edits in `main.rs`.