### PR TITLE
Fix BYOK connection error handling for stale pi subprocess (#6642)

### DIFF
--- a/apps/screenpipe-app-tauri/lib/chat/provider-errors.ts
+++ b/apps/screenpipe-app-tauri/lib/chat/provider-errors.ts
@@ -114,6 +114,25 @@ function isConnectionLikeError(errorStr: string): boolean {
   );
 }
 
+// A bare "Connection error." (no status code, no other specific network
+// signature) is the OpenAI SDK's APIConnectionError default message -- it is
+// only produced when the underlying fetch itself rejects at the network
+// layer, before any HTTP response; a real HTTP status is formatted by pi-ai
+// as "<status>: <body>" instead. When the long-lived pi subprocess's fetch
+// layer gets wedged, every subsequent turn fails with exactly this bare
+// string, indefinitely, even though the endpoint/key/model are all healthy.
+// Telling the user to check their internet connection here is actively
+// wrong -- restarting screenpipe (which respawns pi) is what actually fixes
+// it. See #6642.
+function isBareConnectionError(errorStr: string): boolean {
+  return errorStr.trim().toLowerCase() === "connection error.";
+}
+
+export function buildStuckAgentProcessMessage(provider?: string | null): string {
+  const named = provider && provider !== "custom" ? ` for ${provider}` : "";
+  return `The AI agent process${named} appears to be stuck and is rejecting every request -- this isn't your internet connection or provider setup. Restart screenpipe to clear it, then try again.`;
+}
+
 export function isHostedScreenpipeProvider(provider?: string | null): boolean {
   // screenpipe's own hosted gateway (default chat preset + the Pi agent both
   // route through api.screenpipe.com). A connection failure here is on us,
@@ -336,6 +355,13 @@ function buildGenericProviderErrorMessage(
       normalized.includes("request was blocked"))
   ) {
     return "The custom AI provider rejected the request. Check the API key and Custom URL in Settings → AI, including any required API path such as /v1, then run Test Connection.";
+  }
+
+  // A bare "Connection error." means the long-lived process's fetch layer is
+  // wedged, not that the network is actually down -- check this before the
+  // broader connection-like bucket below. See #6642.
+  if (isBareConnectionError(errorStr)) {
+    return buildStuckAgentProcessMessage(provider);
   }
 
   // Hosted/remote providers: a connection-like failure means we never reached

--- a/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
@@ -3607,7 +3607,14 @@ pub async fn pi_start_inner(
                         cmd.env("ANTHROPIC_API_KEY", api_key);
                     }
                     "custom" => {
-                        cmd.env("CUSTOM_API_KEY", api_key);
+                        // Trim to match the normalization already applied when
+                        // testing the connection in Settings (see
+                        // `const key = apiKey.trim()` in
+                        // connections-section.tsx). A stray trailing newline
+                        // in a pasted/imported key still passes Test
+                        // Connection but was previously sent verbatim into
+                        // the subprocess env here. See #6642.
+                        cmd.env("CUSTOM_API_KEY", api_key.trim());
                     }
                     _ => {}
                 }


### PR DESCRIPTION
- Surface a clear 'stuck agent process' message when the raw 'Connection error.' string appears, instead of the misleading generic connection-check message (provider-errors.ts)
- Trim the custom API key before passing it into the pi subprocess env, matching the normalization already applied in the Settings Test Connection flow (pi.rs)

Scoped narrowly per discussion in the issue comments: the process-health/respawn question tied to #6649's terminal-failure policy is left as-is for maintainer input, not addressed here.

---
name: pull request
about: submit changes to the project
title: "[pr] "
labels: ''
assignees: ''

---

## description

brief description of the changes in this pr.

related issue: #

> attach screenshots / recordings here — **never commit media into the repo.** drag the file into this box (works for anyone, browser only) and github hosts it. on the cli: attach it as a release asset — `gh release upload <tag> file.png` if you can write here, else `gh release create media file.png --repo <you>/screenpipe` on your fork — and paste the url.

## AI assistance and human ownership

read the [AI-assisted contribution policy](https://github.com/screenpipe/screenpipe/blob/main/CONTRIBUTING.md#ai-assisted-contributions).

- AI tool(s) used (`none` if not used):
- autonomy level (`none`, `autocomplete`, `chat`, or `agent`):
- what I personally verified:

- [ ] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [ ] The problem statement, rationale, and replies to maintainers are my own.

## evidence type

check every category that applies and provide its required evidence below.

- [ ] UI or behavior change — before/after recording
- [ ] Backend change — regression tests and relevant logs/results
- [ ] Performance change — reproducible before/after benchmarks
- [ ] Docs, CI, or pure refactor — relevant checks and an explanation; no video required

## before

for UI or behavior changes, add a recording of the app/CLI before this change. otherwise write `not applicable` and explain why.

## after

for UI or behavior changes, add a recording of the app/CLI after this change. otherwise write `not applicable` and provide the evidence required above.

## how to test

list the exact commands or manual steps you personally ran and their results.

1. 
2. 
3. 

## desktop app checklist (if applicable)

If this PR adds or changes `#[tauri::command]` handlers or Rust types exported to the frontend, from `apps/screenpipe-app-tauri/`:

- [ ] `bun run bindings:generate` (if bindings changed)
- [ ] `bun run bindings:check`
- [ ] `bun run typecheck`

Commands are auto-collected via the vendored `tauri-helper` crate — no manual handler list edits in `main.rs`.
