### PR TITLE
fix(cli): align recording defaults and preserve explicit overrides

### DIFF
--- a/crates/screenpipe-engine/src/cli/mod.rs
+++ b/crates/screenpipe-engine/src/cli/mod.rs
@@ -81,17 +81,13 @@ pub enum CliAudioTranscriptionEngine {
     Disabled,
 }
 
-/// Default audio engine based on hardware tier.
-///
-/// - Low tier (≤8GB): WhisperTiny (parakeet-mlx would OOM)
-/// - Mid/High tier: Parakeet (auto-upgrades to MLX GPU when compiled in)
+/// Use the same hardware, OS, and CPU defaults as the recording engine.
 fn default_audio_engine() -> CliAudioTranscriptionEngine {
-    let tier = screenpipe_config::detect_tier();
-    if matches!(tier, screenpipe_config::DeviceTier::Low) {
-        CliAudioTranscriptionEngine::WhisperTiny
-    } else {
-        CliAudioTranscriptionEngine::Parakeet
-    }
+    CliAudioTranscriptionEngine::from_str(
+        screenpipe_config::best_engine_for_platform(screenpipe_config::detect_tier()),
+        false,
+    )
+    .expect("the shared default audio engine must be supported by the CLI")
 }
 
 fn cli_engine_to_str(engine: &CliAudioTranscriptionEngine) -> &'static str {
@@ -467,9 +463,10 @@ pub struct RecordArgs {
     #[arg(long, default_value_t = false)]
     pub experimental_coreaudio_system_audio: bool,
 
-    /// Beta: meeting-driven per-process audio capture (piggyback; "Smart
-    /// recording" in the app). Engages during meetings in any capture mode.
-    #[arg(long, default_value_t = false)]
+    /// Meeting-driven per-process audio capture ("Smart recording" in the app).
+    /// Enabled by default; the backend checks platform support. Pass false to
+    /// use the configured capture devices throughout meetings.
+    #[arg(long, action = ArgAction::Set, num_args = 0..=1, default_value_t = screenpipe_config::default_experimental_meeting_piggyback(), default_missing_value = "true")]
     pub experimental_meeting_piggyback: bool,
 
     /// [experimental, Windows] Request WASAPI microphone AEC when supported.
@@ -504,7 +501,9 @@ pub struct RecordArgs {
     #[arg(short = 'm', long)]
     pub monitor_id: Vec<u32>,
 
-    /// Automatically record all monitors. Ignored when `--monitor-id` is passed.
+    /// Automatically record all monitors. Fresh low/mid-tier installs use the
+    /// primary monitor unless this flag is explicitly set. Ignored when
+    /// `--monitor-id` is passed.
     #[arg(long, action = ArgAction::Set, num_args = 0..=1, default_value_t = true, default_missing_value = "true")]
     pub use_all_monitors: bool,
 
@@ -607,20 +606,23 @@ pub struct RecordArgs {
 
     /// Select structured app context: off, memory, automation, or both.
     /// Memory builds compact context for retrieval and pipes; automation keeps
-    /// action controls, state, and bounds for computer-use agents. Off by default.
+    /// action controls, state, and bounds for computer-use agents. New CLI
+    /// configurations default to memory; saved choices are preserved.
     #[arg(long, value_enum)]
     pub app_context: Option<CliAppContext>,
 
-    /// Enable experimental normalized semantic context parsing. Parsing runs
-    /// after durable frame capture in a bounded background worker. Off by
-    /// default, preserving the historical capture and retrieval behavior.
-    /// Kept for compatibility; equivalent to `--app-context memory` on a
-    /// fresh CLI configuration. `--app-context` takes precedence when
-    /// both are supplied.
+    /// Enable normalized semantic context parsing. Parsing runs after durable
+    /// frame capture in a bounded background worker. On for new CLI configurations.
+    /// Kept for compatibility; prefer `--app-context memory` or `--app-context off`.
+    /// Explicit `--app-context` takes precedence over this flag and its environment
+    /// variable. Environment values override saved settings, but not CLI flags.
     #[arg(
         long,
         env = "SCREENPIPE_ENABLE_SEMANTIC_CONTEXT",
-        default_value_t = false
+        action = ArgAction::Set,
+        num_args = 0..=1,
+        default_value_t = true,
+        default_missing_value = "true"
     )]
     pub enable_semantic_context: bool,
 
@@ -800,18 +802,16 @@ pub struct RecordArgs {
     #[arg(long, default_value_t = false)]
     pub pause_on_drm_content: bool,
 
-    /// Disable clipboard capture entirely. The UI recorder will not record
-    /// clipboard copy/paste events or contents — useful when piping
-    /// ~/.screenpipe data into a remote LLM (passwords, keys, secrets often
-    /// pass through the clipboard).
-    #[arg(long, default_value_t = false)]
+    /// Disable storing clipboard events and contents (default). Clipboard
+    /// operations can still trigger a screen capture. Pass false to store them.
+    #[arg(long, action = ArgAction::Set, num_args = 0..=1, default_value_t = true, default_missing_value = "true")]
     pub disable_clipboard_capture: bool,
 
-    /// Disable persisting keyboard / typed-text rows. Keyboard events still
+    /// Disable persisting keyboard / typed-text rows (default). Keyboard events still
     /// wake event-driven capture, and the accessibility tree + OCR still
     /// capture on-screen text. Useful when piping ~/.screenpipe data into a
-    /// remote LLM (secrets get typed).
-    #[arg(long, default_value_t = false)]
+    /// remote LLM (secrets get typed). Pass false to store keyboard / typed-text rows.
+    #[arg(long, action = ArgAction::Set, num_args = 0..=1, default_value_t = true, default_missing_value = "true")]
     pub disable_keyboard_capture: bool,
 
     /// Disable persisting mouse-click rows. Clicks still wake event-driven
@@ -977,7 +977,10 @@ impl RecordArgSources {
             disable_vision: from_command_line(record, "disable_vision"),
             disable_screenshots: from_command_line(record, "disable_screenshots"),
             app_context: from_command_line(record, "app_context"),
-            enable_semantic_context: from_command_line(record, "enable_semantic_context"),
+            enable_semantic_context: matches!(
+                record.value_source("enable_semantic_context"),
+                Some(ValueSource::CommandLine | ValueSource::EnvVariable)
+            ),
             ignored_windows: from_command_line(record, "ignored_windows"),
             included_windows: from_command_line(record, "included_windows"),
             ignored_urls: from_command_line(record, "ignored_urls"),
@@ -1291,16 +1294,10 @@ impl RecordArgs {
             false
         };
 
-        // Preserve explicit CLI monitor flags so tier defaults don't clobber them.
-        let cli_monitor_ids = self.monitor_id.clone();
-        let cli_use_all_monitors = self.use_all_monitors;
-
         let persisted_settings = load_recording_settings_from_store(&data_dir)?;
         let loaded_from_store = persisted_settings.is_some();
         let mut settings = persisted_settings.unwrap_or_else(|| self.to_recording_settings());
-        if loaded_from_store {
-            self.apply_explicit_overrides(&mut settings, sources);
-        }
+        let mut fresh_tier = None;
 
         // #3943: the desktop app migrates the cloud token out of plaintext
         // store.bin into the shared encrypted SecretStore. A standalone CLI
@@ -1334,29 +1331,12 @@ impl RecordArgs {
                 // Existing config without tier = upgrade — just set the tier for DB/channel tuning.
                 let is_fresh = !config_path.exists() && !loaded_from_store;
                 if is_fresh {
-                    screenpipe_config::apply_tier_defaults(&mut settings, tier);
-
-                    // Restore CLI audio engine — user's explicit -a/--audio-transcription-engine
-                    // must win over tier defaults
-                    settings.audio_transcription_engine =
-                        cli_engine_to_str(&self.audio_transcription_engine).to_string();
-
-                    // Restore CLI monitor flags — user's explicit --use-all-monitors or -m
-                    // must win over tier defaults (fixes #2897).
-                    // Explicit `--monitor-id` implies `use_all_monitors=false`
-                    // so privacy-motivated filtering actually takes effect.
-                    if !cli_monitor_ids.is_empty() {
-                        settings.use_all_monitors = false;
-                        settings.monitor_ids =
-                            cli_monitor_ids.iter().map(|id| id.to_string()).collect();
-                    } else if cli_use_all_monitors {
-                        settings.use_all_monitors = true;
-                        settings.monitor_ids = vec![];
-                    }
+                    fresh_tier = Some(tier);
                 }
                 settings.device_tier = Some(tier.as_str().to_string());
             }
         }
+        self.apply_defaults_and_overrides(&mut settings, fresh_tier, sources);
 
         // Safety guard: downgrade engine if unsafe for this platform
         // (Low tier = OOM, macOS < 26 = parakeet-mlx segfault)
@@ -1409,6 +1389,20 @@ impl RecordArgs {
         }
 
         Ok(config)
+    }
+
+    /// Apply hardware defaults only for fresh installs, then let explicit input
+    /// win. Clap defaults must not overwrite saved choices or hardware policy.
+    fn apply_defaults_and_overrides(
+        &self,
+        settings: &mut screenpipe_config::RecordingSettings,
+        fresh_tier: Option<screenpipe_config::DeviceTier>,
+        sources: &RecordArgSources,
+    ) {
+        if let Some(tier) = fresh_tier {
+            screenpipe_config::apply_tier_defaults(settings, tier);
+        }
+        self.apply_explicit_overrides(settings, sources);
     }
 
     fn apply_explicit_overrides(
@@ -2629,20 +2623,236 @@ mod tests {
         match cli.command {
             Command::Record(args) => {
                 assert!(!args.pause_on_drm_content, "default should be false");
-                assert!(args.app_context.is_none());
-                assert!(
-                    !args.enable_semantic_context,
-                    "semantic parsing must remain opt-in"
-                );
-                let settings = args.to_recording_settings();
-                assert!(!settings.enable_semantic_context);
-                assert_eq!(
-                    settings.semantic_context_mode,
-                    screenpipe_config::SemanticContextMode::Memory
-                );
             }
             _ => panic!("expected Record command"),
         }
+    }
+
+    #[test]
+    fn test_fresh_cli_defaults_enable_memory_without_sensitive_input_storage() {
+        let args = record_args(["screenpipe", "record"]);
+        let settings = args.to_recording_settings();
+        assert!(settings.enable_semantic_context);
+        assert_eq!(
+            settings.semantic_context_mode,
+            screenpipe_config::SemanticContextMode::Memory
+        );
+        assert_eq!(
+            settings.experimental_meeting_piggyback,
+            screenpipe_config::default_experimental_meeting_piggyback()
+        );
+        assert!(settings.disable_clipboard_capture);
+        assert!(settings.disable_keyboard_capture);
+        assert_eq!(
+            settings.audio_transcription_engine,
+            screenpipe_config::best_engine_for_platform(screenpipe_config::detect_tier())
+        );
+
+        let ui = args.to_ui_recorder_config();
+        assert!(!ui.capture_clipboard_content);
+        assert!(!ui.capture_text);
+        assert!(!ui.record_clipboard_events);
+        assert!(!ui.record_keyboard_events);
+        assert!(ui.capture_on_keystroke);
+        assert!(ui.record_click_events);
+    }
+
+    #[test]
+    fn test_new_default_flags_accept_explicit_false_and_bare_true() {
+        for flag in [
+            "--enable-semantic-context",
+            "--experimental-meeting-piggyback",
+            "--disable-clipboard-capture",
+            "--disable-keyboard-capture",
+        ] {
+            let with_value = format!("{flag}=false");
+            for (argv, enabled) in [
+                (vec!["screenpipe", "record", with_value.as_str()], false),
+                (vec!["screenpipe", "record", flag, "false"], false),
+                (vec!["screenpipe", "record", flag], true),
+            ] {
+                let matches = Cli::command().try_get_matches_from(argv).unwrap();
+                let sources = RecordArgSources::from_cli_matches(&matches);
+                let cli = <Cli as clap::FromArgMatches>::from_arg_matches(&matches).unwrap();
+                let Command::Record(args) = cli.command else {
+                    panic!("expected record");
+                };
+                // Start with opposite saved values to prove false is an explicit override.
+                let mut settings = screenpipe_config::RecordingSettings {
+                    enable_semantic_context: !enabled,
+                    experimental_meeting_piggyback: !enabled,
+                    disable_clipboard_capture: !enabled,
+                    disable_keyboard_capture: !enabled,
+                    ..Default::default()
+                };
+                args.apply_defaults_and_overrides(&mut settings, None, &sources);
+                let actual = match flag {
+                    "--enable-semantic-context" => settings.enable_semantic_context,
+                    "--experimental-meeting-piggyback" => settings.experimental_meeting_piggyback,
+                    "--disable-clipboard-capture" => settings.disable_clipboard_capture,
+                    _ => settings.disable_keyboard_capture,
+                };
+                assert_eq!(actual, enabled, "{flag}");
+                assert!(sources.has_recording_override());
+            }
+        }
+    }
+
+    #[test]
+    fn test_new_defaults_preserve_saved_choices() {
+        let args = record_args(["screenpipe", "record"]);
+        let sources = record_sources(["screenpipe", "record"]);
+        let mut settings = screenpipe_config::RecordingSettings {
+            enable_semantic_context: false,
+            semantic_context_mode: screenpipe_config::SemanticContextMode::ComputerUse,
+            experimental_meeting_piggyback: false,
+            disable_clipboard_capture: false,
+            disable_keyboard_capture: false,
+            video_quality: "max".to_string(),
+            use_all_monitors: false,
+            monitor_ids: vec!["42".to_string()],
+            ..Default::default()
+        };
+        let before = serde_json::to_value(&settings).unwrap();
+        args.apply_defaults_and_overrides(&mut settings, None, &sources);
+        assert_eq!(serde_json::to_value(&settings).unwrap(), before);
+        assert!(!sources.has_recording_override());
+    }
+
+    #[test]
+    fn test_fresh_hardware_defaults_survive_absent_cli_flags() {
+        use screenpipe_config::DeviceTier;
+        let args = record_args(["screenpipe", "record"]);
+        let sources = record_sources(["screenpipe", "record"]);
+        for tier in [DeviceTier::Low, DeviceTier::Mid, DeviceTier::High] {
+            let mut settings = args.to_recording_settings();
+            args.apply_defaults_and_overrides(&mut settings, Some(tier), &sources);
+            assert_eq!(
+                settings.audio_transcription_engine,
+                screenpipe_config::best_engine_for_platform(tier)
+            );
+            assert_eq!(
+                settings.video_quality,
+                if tier == DeviceTier::Low {
+                    "low"
+                } else {
+                    "balanced"
+                }
+            );
+            assert_eq!(settings.use_all_monitors, tier == DeviceTier::High);
+            if tier != DeviceTier::High {
+                assert_eq!(settings.monitor_ids, ["default"]);
+            }
+        }
+    }
+
+    #[test]
+    fn test_explicit_capture_choices_win_after_fresh_hardware_defaults() {
+        use screenpipe_config::DeviceTier;
+        let argv = [
+            "screenpipe",
+            "record",
+            "--video-quality",
+            "max",
+            "--monitor-id",
+            "42",
+            "--audio-transcription-engine",
+            "deepgram",
+            "--app-context",
+            "off",
+        ];
+        let args = record_args(argv);
+        let sources = record_sources(argv);
+        for tier in [DeviceTier::Low, DeviceTier::Mid, DeviceTier::High] {
+            let mut settings = args.to_recording_settings();
+            args.apply_defaults_and_overrides(&mut settings, Some(tier), &sources);
+            assert_eq!(settings.video_quality, "max");
+            assert_eq!(settings.audio_transcription_engine, "deepgram");
+            assert!(!settings.use_all_monitors);
+            assert_eq!(settings.monitor_ids, ["42"]);
+            assert!(!settings.enable_semantic_context);
+        }
+
+        for (flag, enabled) in [
+            ("--use-all-monitors", true),
+            ("--use-all-monitors=false", false),
+        ] {
+            let argv = ["screenpipe", "record", flag];
+            let args = record_args(argv);
+            let sources = record_sources(argv);
+            for tier in [DeviceTier::Low, DeviceTier::High] {
+                let mut settings = args.to_recording_settings();
+                args.apply_defaults_and_overrides(&mut settings, Some(tier), &sources);
+                assert_eq!(settings.use_all_monitors, enabled);
+                if enabled {
+                    assert!(settings.monitor_ids.is_empty());
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_semantic_context_environment_precedence() {
+        // Exercise real clap environment parsing in child processes, without
+        // mutating the process-wide environment of parallel tests.
+        const CHILD: &str = "SCREENPIPE_TEST_SEMANTIC_DEFAULTS_CHILD";
+        let Ok(value) = std::env::var(CHILD) else {
+            for value in ["true", "false"] {
+                let output = std::process::Command::new(std::env::current_exe().unwrap())
+                    .args([
+                        "--exact",
+                        "cli::tests::test_semantic_context_environment_precedence",
+                        "--nocapture",
+                    ])
+                    .env(CHILD, value)
+                    .env("SCREENPIPE_ENABLE_SEMANTIC_CONTEXT", value)
+                    .output()
+                    .unwrap();
+                assert!(
+                    output.status.success(),
+                    "environment={value}\n{}\n{}",
+                    String::from_utf8_lossy(&output.stdout),
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            }
+            return;
+        };
+        let enabled: bool = value.parse().unwrap();
+        let argv = ["screenpipe", "record"];
+        let args = record_args(argv);
+        let sources = record_sources(argv);
+        assert!(sources.enable_semantic_context);
+        assert!(sources.has_recording_override());
+        assert_eq!(
+            args.to_recording_settings().enable_semantic_context,
+            enabled
+        );
+        let mut settings = screenpipe_config::RecordingSettings {
+            enable_semantic_context: !enabled,
+            ..Default::default()
+        };
+        args.apply_defaults_and_overrides(&mut settings, None, &sources);
+        assert_eq!(settings.enable_semantic_context, enabled);
+
+        let flag = format!("--enable-semantic-context={}", !enabled);
+        let argv = ["screenpipe", "record", flag.as_str()];
+        let args = record_args(argv);
+        assert_eq!(
+            args.to_recording_settings().enable_semantic_context,
+            !enabled
+        );
+        args.apply_defaults_and_overrides(&mut settings, None, &record_sources(argv));
+        assert_eq!(settings.enable_semantic_context, !enabled);
+
+        let mode = if enabled { "off" } else { "memory" };
+        let argv = ["screenpipe", "record", "--app-context", mode];
+        let args = record_args(argv);
+        assert_eq!(
+            args.to_recording_settings().enable_semantic_context,
+            !enabled
+        );
+        args.apply_defaults_and_overrides(&mut settings, None, &record_sources(argv));
+        assert_eq!(settings.enable_semantic_context, !enabled);
     }
 
     #[test]


### PR DESCRIPTION
Fresh `screenpipe record` runs leave structured app context disabled and persist clipboard/typed-text rows, while the desktop defaults skip that input storage. Hardware tuning also overwrites an explicit `--video-quality`, default monitor arguments undo hardware limits, and parser environment overrides are ignored when a settings store exists.

Enable memory-mode app context and the shared smart-recording default for new CLI settings stores, make clipboard/typed-text storage opt-in, and apply explicit input after hardware defaults. Use the shared platform/CPU-aware audio-engine picker. Saved settings remain unchanged unless explicitly overridden; the engine's existing safety checks still apply.

```text
Fresh CLI configuration         Before              After
App-context parsing             off                 memory
Clipboard / typed-text rows     stored              skipped
Smart meeting recording         off                 shared default (on)
Low/mid-tier monitor selection  all monitors        primary monitor
Explicit --video-quality max    overwritten         max
Parser env with saved settings  ignored             applied
```

`--app-context off` disables parsing. The legacy parser flag, smart recording, and both input-storage flags accept bare flags, `=false`, or a space-separated boolean. Parser precedence is explicit `--app-context`, then an explicit legacy flag, then its environment value, then saved settings/defaults. Environment handling is limited to the parser flag; this does not change how secret-bearing environment variables are persisted.

Validation on macOS arm64:

- `cargo test -p screenpipe-semantic --tests` — 141 passed.
- `cargo run -p screenpipe-semantic --example context_eval -- --report` — 10 fixture cases, 1,000 iterations each; per-case p95 adaptation + parsing + rendering 0.037–0.185 ms. All 30 expected facts retained, with 68.0% fewer prompt tokens than raw accessibility JSON. This is a fixture benchmark in the dev profile, not a measurement of the full capture pipeline.
- `cargo test -j 1 -p screenpipe-engine --lib cli::tests` — 48 passed, including the new defaults, saved choices, explicit booleans, low/mid/high hardware policy, and environment precedence in isolated child processes.
- `cargo test -j 1 -p screenpipe-engine --lib semantic_worker::tests` — 12 passed, including bounded queues/cache, deduplication, redaction, and persistence.
- `cargo test -j 1 -p screenpipe-engine --lib recording_config::tests` — 15 passed, including input-storage toggles and capture-trigger preservation.
- Scoped rustfmt check and `git diff --check` passed.

The first default-parallel engine build stalled in Whisper's native macOS `make`; the engine tests were retried with `-j 1`. No build-system changes are included.
