### PR TITLE
fix(ai-gateway): classify current input limits

### DIFF
--- a/packages/ai-gateway/src/handlers/chat.ts
+++ b/packages/ai-gateway/src/handlers/chat.ts
@@ -123,6 +123,8 @@ const USER_INPUT_TOO_LARGE_PATTERNS = [
   /maximum context length/i,
   /context length.*exceeded/i,
   /request payload size exceeds/i,
+  /input tokens exceed the configured limit/i,
+  /exceeds the available context size/i,
   // Vertex MaaS (glm-5 etc): "The input (325052 tokens) is longer than the
   // model's context length (202752 tokens)" — SCREENPIPE-AI-PROXY-C, 28 users.
   /longer than the model'?s context length/i,
@@ -143,6 +145,10 @@ const CLIENT_PAYLOAD_PATTERNS: Array<{ re: RegExp; message: string }> = [
   {
     re: /at least one message is required/i,
     message: 'The request must include at least one user or assistant message.',
+  },
+  {
+    re: /tool_calls.*array too long.*maximum length/i,
+    message: 'A message contains too many tool calls. Start a new chat or compact the conversation and try again.',
   },
 ];
 

--- a/packages/ai-gateway/src/test/chat-fallback.unit.test.ts
+++ b/packages/ai-gateway/src/test/chat-fallback.unit.test.ts
@@ -78,9 +78,35 @@ describe('chat handler — oversized-input classification (SCREENPIPE-AI-PROXY-C
 		expect(isUserInputTooLarge(400, 'prompt is too long: 250000 tokens > 200000 maximum')).toBe(true);
 	});
 
+	it('matches current OpenAI input-limit phrasings', () => {
+		expect(
+			isUserInputTooLarge(
+				400,
+				'Input tokens exceed the configured limit of 272000 tokens. Your messages resulted in 272325 tokens.',
+			),
+		).toBe(true);
+		expect(
+			isUserInputTooLarge(
+				400,
+				'request (64174 tokens) exceeds the available context size (32768 tokens), try increasing it',
+			),
+		).toBe(true);
+	});
+
 	it('ignores unrelated 400s and non-4xx statuses', () => {
 		expect(isUserInputTooLarge(400, 'invalid tool schema')).toBe(false);
 		expect(isUserInputTooLarge(500, 'maximum context length exceeded')).toBe(false);
+	});
+});
+
+describe('chat handler — oversized tool-call payloads', () => {
+	it('returns a clean client message for the current OpenAI tool-call limit', () => {
+		const message = clientPayloadMessage(
+			400,
+			"Invalid 'messages[11].tool_calls': array too long. Expected an array with maximum length 128, but got an array with length 504 instead.",
+		);
+
+		expect(message).toContain('too many tool calls');
 	});
 });
 


### PR DESCRIPTION
## Summary
- recognize the current OpenAI oversized-input error phrasings as client 413s
- classify the 128-tool-call limit as a clean client payload error
- keep both paths out of Sentry while preserving the existing cascade behavior

Fixes SCREENPIPE-AI-PROXY-2N
Fixes SCREENPIPE-AI-PROXY-4A
Fixes SCREENPIPE-AI-PROXY-49

## Verification
- `bun test src/test/chat-fallback.unit.test.ts` — 31 passed, 0 failed
- `git diff --check`
- semantic diff limited to the two existing classifiers and regression tests
- background VM validation pending