### PR TITLE
fix(audio): recover current device startup failures

### DIFF
--- a/crates/screenpipe-audio/src/audio_manager/device_monitor.rs
+++ b/crates/screenpipe-audio/src/audio_manager/device_monitor.rs
@@ -273,6 +273,13 @@ fn default_switch_retry_backoff_active(
     elapsed < delay
 }
 
+fn default_input_is_enumerated(
+    currently_available_devices: &[AudioDevice],
+    new_default: &AudioDevice,
+) -> bool {
+    currently_available_devices.contains(new_default)
+}
+
 /// Returns true if the error from `default_output_device()` indicates a
 /// permanent condition that won't resolve without hardware changes.
 fn is_permanent_output_error(err: &anyhow::Error) -> bool {
@@ -1162,26 +1169,42 @@ pub async fn start_device_monitor(
                                 );
                                 false
                             } else if let Ok(new_device) = parse_audio_device(&new_default_input) {
-                                match audio_manager.start_device(&new_device).await {
-                                    Ok(()) => {
-                                        failed_devices.remove(&new_default_input);
-                                        info!(
-                                            "switched to new system default input: {}",
-                                            new_default_input
-                                        );
-                                        true
-                                    }
-                                    Err(e) => {
-                                        let count = failed_devices
-                                            .entry(new_default_input.clone())
-                                            .or_insert((0, Instant::now()));
-                                        count.0 += 1;
-                                        count.1 = Instant::now();
-                                        warn!(
+                                if !default_input_is_enumerated(
+                                    &currently_available_devices,
+                                    &new_device,
+                                ) {
+                                    // CoreAudio can publish a new system
+                                    // default before device enumeration catches
+                                    // up. Keep the old mic and retry next tick
+                                    // instead of opening a device that cannot
+                                    // yet be found.
+                                    debug!(
+                                        "[DEVICE_RECOVERY] new default input is not enumerated yet: {}",
+                                        new_default_input
+                                    );
+                                    false
+                                } else {
+                                    match audio_manager.start_device(&new_device).await {
+                                        Ok(()) => {
+                                            failed_devices.remove(&new_default_input);
+                                            info!(
+                                                "switched to new system default input: {}",
+                                                new_default_input
+                                            );
+                                            true
+                                        }
+                                        Err(e) => {
+                                            let count = failed_devices
+                                                .entry(new_default_input.clone())
+                                                .or_insert((0, Instant::now()));
+                                            count.0 += 1;
+                                            count.1 = Instant::now();
+                                            warn!(
                                             "failed to start new default input {}: {} — keeping current input(s) running (will back off)",
                                             new_default_input, e
                                         );
-                                        false
+                                            false
+                                        }
                                     }
                                 }
                             } else {
@@ -2957,6 +2980,22 @@ mod tests {
             "failed default-device switches must stay pending and retry even when the old mic is still running"
         );
         assert_eq!(repro.running_input, krisp);
+    }
+
+    #[test]
+    fn default_input_switch_waits_for_device_enumeration() {
+        let built_in = AudioDevice::new("MacBook Pro Microphone".to_string(), DeviceType::Input);
+        let airpods = AudioDevice::new("yolanda airpod".to_string(), DeviceType::Input);
+
+        assert!(!default_input_is_enumerated(&[], &built_in));
+        assert!(!default_input_is_enumerated(
+            std::slice::from_ref(&airpods),
+            &built_in
+        ));
+        assert!(default_input_is_enumerated(
+            &[airpods, built_in.clone()],
+            &built_in
+        ));
     }
 
     fn build_inputs<'a>(

--- a/crates/screenpipe-audio/src/core/stream.rs
+++ b/crates/screenpipe-audio/src/core/stream.rs
@@ -798,8 +798,9 @@ fn create_error_callback(
     }
 }
 
-/// Detect WASAPI's `AUDCLNT_E_UNSUPPORTED_FORMAT` (HRESULT 0x88890008)
-/// surfaced through cpal as `failed to initialize audio client: OS Error
+/// Detect WASAPI configuration rejections that should retry the device's
+/// current shared-mode mix format. `AUDCLNT_E_UNSUPPORTED_FORMAT` (HRESULT
+/// 0x88890008) is surfaced through cpal as `failed to initialize audio client: OS Error
 /// -2004287480 (FormatMessageW() returned error 317)`. The HRESULT has
 /// no system message string, hence error 317 (`ERROR_MR_MID_NOT_FOUND`)
 /// from `FormatMessageW` — we recognize the numeric form instead. Also
@@ -810,6 +811,10 @@ fn is_wasapi_unsupported_format(err: &anyhow::Error) -> bool {
     let s = err.to_string();
     s.contains("-2004287480")
         || s.contains("0x88890008")
+        // Some Windows spatial/exclusive-mode stacks reject the selected
+        // capture shape with this backend-specific device-read error. The
+        // device's current shared-mode mix format is the safe retry.
+        || s.to_ascii_lowercase().contains("0x887c001e")
         || s.to_lowercase().contains("unsupported format")
         // WASAPI with AEC enabled rejects non-default configs with this message
         // (seen on Logitech C922 and other USB mics). The existing fallback to
@@ -1174,5 +1179,12 @@ mod wasapi_format_tests {
         assert!(!is_wasapi_unsupported_format(&err("device disconnected")));
         assert!(!is_wasapi_unsupported_format(&err("stream timeout")));
         assert!(!is_wasapi_unsupported_format(&err("no audio received")));
+    }
+
+    #[test]
+    fn catches_windows_device_read_rejection() {
+        assert!(is_wasapi_unsupported_format(&err(
+            "A backend-specific error has occurred: 0x887C001E"
+        )));
     }
 }


### PR DESCRIPTION
Fixes the two non-Linux audio errors observed on the current production releases:

- SCREENPIPE-APP-NH on screenpipe-app@2.7.25: retry WASAPI 0x887C001E with the device shared-mode mix format before failing.
- SCREENPIPE-CLI-YS on screenpipe-server@0.3.172 in CLI 0.4.50: wait until a newly published default input is present in device enumeration before opening it.

Before / after

    Before: OS default changes -> enumeration is empty/stale -> open missing mic -> Sentry error
    After:  OS default changes -> wait for enumeration -> open new mic -> atomic swap

    Before: selected WASAPI shape -> 0x887C001E -> stop
    After:  selected WASAPI shape -> 0x887C001E -> retry shared-mode mix shape

Tests

- cargo test -p screenpipe-audio wasapi_format_tests -- --nocapture (6 passed)
- cargo test -p screenpipe-audio default_input_switch_waits_for_device_enumeration -- --nocapture (1 passed)

Background VM acceptance will be attached after exact-head testing.