### PR TITLE
fix(home): make agent actions easier to click and identify

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat/home-card-agent-actions.test.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/home-card-agent-actions.test.tsx
@@ -9,7 +9,6 @@ import tauriConfig from "../../src-tauri/tauri.conf.json";
 
 import {
   buildHomeCardAgentPrompt,
-  HOME_CARD_AGENT_TOOLTIP,
   HomeCardAgentActions,
 } from "./home-card-agent-actions";
 
@@ -51,7 +50,7 @@ describe("HomeCardAgentActions", () => {
     vi.clearAllMocks();
   });
 
-  it("offers named Claude, Cursor, and Codex actions", () => {
+  it("offers named Claude, Cursor, and Codex actions and tooltips", async () => {
     render(<HomeCardAgentActions pipe={DAY_RECAP} />);
 
     expect(
@@ -68,9 +67,15 @@ describe("HomeCardAgentActions", () => {
         .getByRole("button", { name: "Run in Codex" })
         .querySelector("img"),
     ).toHaveAttribute("src", "/images/openai.svg");
-    expect(HOME_CARD_AGENT_TOOLTIP).toBe(
-      "run this in your favorite agent",
-    );
+    for (const agent of ["Claude", "Cursor", "Codex"]) {
+      const button = screen.getByRole("button", { name: `Run in ${agent}` });
+      fireEvent.focus(button);
+      expect(
+        await screen.findByRole("tooltip", { name: `Run in ${agent}` }),
+      ).toBeInTheDocument();
+      expect(button).toHaveAccessibleDescription(`Run in ${agent}`);
+      fireEvent.blur(button);
+    }
   });
 
   it("centers the action cluster over compact chips", () => {

--- a/apps/screenpipe-app-tauri/components/chat/home-card-agent-actions.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/home-card-agent-actions.tsx
@@ -31,8 +31,6 @@ type LaunchState = "opening" | "opened" | "copied" | "unavailable";
 
 const SCREENPIPE_GITHUB_URL = "https://github.com/screenpipe/screenpipe";
 
-export const HOME_CARD_AGENT_TOOLTIP = "run this in your favorite agent";
-
 const SETUP_TARGETS: Record<HomeCardAgentId, string> = {
   claude: "claude-desktop",
   cursor: "cursor",
@@ -83,7 +81,7 @@ Use Screenpipe's recorded data and only report activity you can verify.`;
 }
 
 function AgentLogo({ id }: { id: HomeCardAgentId }) {
-  const className = "h-3.5 w-3.5";
+  const className = "h-4 w-4";
   if (id === "claude") {
     // eslint-disable-next-line @next/next/no-img-element
     return <img src="/images/claude-ai.svg" alt="" className={className} />;
@@ -91,7 +89,7 @@ function AgentLogo({ id }: { id: HomeCardAgentId }) {
   if (id === "cursor") return <CursorLogo className={className} />;
   return (
     // eslint-disable-next-line @next/next/no-img-element
-    <img src="/images/openai.svg" alt="" className={className} />
+    <img src="/images/openai.svg" alt="" className={`${className} dark:invert`} />
   );
 }
 
@@ -201,7 +199,7 @@ export function HomeCardAgentActions({
       data-placement={placement}
       role="group"
       aria-label={`Run ${pipe.title} in another agent`}
-      className={`absolute top-1/2 z-20 flex -translate-y-1/2 items-center gap-0.5 text-foreground transition-opacity duration-150 motion-reduce:transition-none ${
+      className={`absolute top-1/2 z-20 flex -translate-y-1/2 items-center gap-0.5 rounded-md border border-border bg-background p-0.5 text-foreground transition-opacity duration-150 motion-reduce:transition-none ${
         placement === "chip" ? "left-1/2 -translate-x-1/2" : "right-3"
       } ${
         state
@@ -219,6 +217,7 @@ export function HomeCardAgentActions({
       <TooltipProvider delayDuration={120}>
         {HOME_CARD_AGENT_TARGETS.map((target) => {
           const label = AGENT_LABELS[target.id];
+          const actionLabel = `Run in ${label}`;
           const isOpening = pending && activeAgent === target.id;
           const isResult = !pending && state && activeAgent === target.id;
           return (
@@ -227,23 +226,21 @@ export function HomeCardAgentActions({
                 <button
                   type="button"
                   data-testid={`home-card-agent-${pipe.name}-${target.id}`}
-                  aria-label={`Run in ${label}`}
+                  aria-label={actionLabel}
                   disabled={pending}
                   onPointerEnter={() => trackAgentViewed(target.id, "hover")}
                   onFocus={() => trackAgentViewed(target.id, "keyboard")}
                   onClick={() => void launch(target)}
-                  className={`flex h-5 w-5 items-center justify-center rounded-full opacity-75 transition-[color,background-color,opacity,transform] duration-150 hover:z-10 hover:scale-110 hover:bg-background/10 hover:opacity-100 focus-visible:z-10 focus-visible:bg-background/10 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-background disabled:cursor-wait disabled:opacity-50 motion-reduce:transform-none motion-reduce:transition-none ${
-                    isResult ? "z-10 text-signal opacity-100" : ""
-                  }`}
+                  className="flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded-sm transition-colors duration-150 hover:bg-foreground/10 focus-visible:bg-foreground/10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground disabled:cursor-wait disabled:opacity-50 motion-reduce:transition-none"
                 >
                   {isOpening ? (
-                    <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+                    <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
                   ) : isResult && state === "opened" ? (
-                    <Check className="h-3.5 w-3.5" aria-hidden />
+                    <Check className="h-4 w-4" aria-hidden />
                   ) : isResult && state === "copied" ? (
-                    <Clipboard className="h-3.5 w-3.5" aria-hidden />
+                    <Clipboard className="h-4 w-4" aria-hidden />
                   ) : isResult && state === "unavailable" ? (
-                    <X className="h-3.5 w-3.5" aria-hidden />
+                    <X className="h-4 w-4" aria-hidden />
                   ) : (
                     <AgentLogo id={target.id} />
                   )}
@@ -254,7 +251,7 @@ export function HomeCardAgentActions({
                 sideOffset={6}
                 className="rounded-md px-2.5 py-1.5 text-[11px] font-normal"
               >
-                {HOME_CARD_AGENT_TOOLTIP}
+                {actionLabel}
               </TooltipContent>
             </Tooltip>
           );

--- a/apps/screenpipe-app-tauri/components/chat/summary-cards.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/summary-cards.tsx
@@ -265,11 +265,11 @@ export function SummaryCards({
                 slug={featured[0].name}
                 className="h-5 w-5 shrink-0 text-foreground/70 group-hover/home-card:text-background group-focus-within/home-card:text-background"
               />
-              <div className="flex-1 pr-16">
+              <div className="min-w-0 flex-1 pr-24">
                 <div className="text-sm font-semibold group-hover/home-card:text-background group-focus-within/home-card:text-background leading-tight">
                   {featured[0].title}
                 </div>
-                <div className="text-xs text-muted-foreground group-hover/home-card:text-background/60 group-focus-within/home-card:text-background/60 leading-tight mt-0.5">
+                <div className="text-pretty text-xs text-muted-foreground group-hover/home-card:text-background/60 group-focus-within/home-card:text-background/60 leading-tight mt-0.5">
                   {featured[0].description}
                 </div>
               </div>
@@ -297,11 +297,11 @@ export function SummaryCards({
                 slug={featured[1].name}
                 className="h-4 w-4 shrink-0 text-foreground/65 group-hover/home-card:text-background group-focus-within/home-card:text-background"
               />
-              <div className="flex-1 pr-16">
+              <div className="min-w-0 flex-1 pr-24">
                 <div className="text-xs font-semibold text-foreground/85 group-hover/home-card:text-background group-focus-within/home-card:text-background leading-tight">
                   {featured[1].title}
                 </div>
-                <div className="text-xs text-muted-foreground group-hover/home-card:text-background/70 group-focus-within/home-card:text-background/70 leading-tight mt-0.5">
+                <div className="text-pretty text-xs text-muted-foreground group-hover/home-card:text-background/70 group-focus-within/home-card:text-background/70 leading-tight mt-0.5">
                   {featured[1].description}
                 </div>
               </div>
@@ -323,7 +323,7 @@ export function SummaryCards({
       <div className="w-full max-w-lg mb-4 flex flex-wrap items-center gap-1">
         {/* Template-backed chips (Time Breakdown, Missed To-Dos) */}
         {featured.slice(2).map((pipe) => (
-          <div key={pipe.name} className="group/home-card relative grow">
+          <div key={pipe.name} className="group/home-card relative min-w-[108px] flex-1">
             <button
               type="button"
               data-testid={`summary-card-${pipe.name}`}
@@ -332,7 +332,7 @@ export function SummaryCards({
                 previewPromptForPipe(pipe),
                 onPreviewPrompt,
               )}
-              className="w-full cursor-pointer rounded-md border border-foreground/20 bg-card px-2 py-0.5 text-[11px] text-foreground/75 transition-colors duration-150 group-hover/home-card:border-foreground group-hover/home-card:bg-foreground group-hover/home-card:text-background group-focus-within/home-card:border-foreground group-focus-within/home-card:bg-foreground group-focus-within/home-card:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground focus-visible:ring-offset-1 focus-visible:ring-offset-background motion-reduce:transition-none"
+              className="h-10 w-full cursor-pointer rounded-md border border-foreground/20 bg-card px-0 text-[11px] text-foreground/75 transition-colors duration-150 group-hover/home-card:border-foreground group-hover/home-card:bg-foreground group-hover/home-card:text-background group-focus-within/home-card:border-foreground group-focus-within/home-card:bg-foreground group-focus-within/home-card:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground focus-visible:ring-offset-1 focus-visible:ring-offset-background motion-reduce:transition-none"
             >
               <span className="transition-opacity duration-150 group-hover/home-card:opacity-0 group-focus-within/home-card:opacity-0 motion-reduce:transition-none">
                 {pipe.title}
@@ -343,7 +343,7 @@ export function SummaryCards({
         ))}
         {/* Quick summary chips */}
         {QUICK_SUMMARY_TASKS.map((task) => (
-          <div key={task.name} className="group/home-card relative grow">
+          <div key={task.name} className="group/home-card relative min-w-[108px] flex-1">
             <button
               type="button"
               {...promptPreviewHandlers(
@@ -363,7 +363,7 @@ export function SummaryCards({
                   "other_builtin",
                 );
               }}
-              className="w-full cursor-pointer rounded-md border border-foreground/20 bg-card px-2 py-0.5 text-[11px] text-foreground/75 transition-colors duration-150 group-hover/home-card:border-foreground group-hover/home-card:bg-foreground group-hover/home-card:text-background group-focus-within/home-card:border-foreground group-focus-within/home-card:bg-foreground group-focus-within/home-card:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground focus-visible:ring-offset-1 focus-visible:ring-offset-background motion-reduce:transition-none"
+              className="h-10 w-full cursor-pointer rounded-md border border-foreground/20 bg-card px-0 text-[11px] text-foreground/75 transition-colors duration-150 group-hover/home-card:border-foreground group-hover/home-card:bg-foreground group-hover/home-card:text-background group-focus-within/home-card:border-foreground group-focus-within/home-card:bg-foreground group-focus-within/home-card:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground focus-visible:ring-offset-1 focus-visible:ring-offset-background motion-reduce:transition-none"
             >
               <span className="transition-opacity duration-150 group-hover/home-card:opacity-0 group-focus-within/home-card:opacity-0 motion-reduce:transition-none">
                 {task.title}
@@ -382,7 +382,7 @@ export function SummaryCards({
         {customTemplates.map((ct) => (
           <div
             key={ct.id}
-            className="group/home-card relative inline-flex max-w-[140px] grow"
+            className="group/home-card relative inline-flex min-w-[108px] max-w-[140px] grow"
           >
             <button
               type="button"
@@ -394,7 +394,7 @@ export function SummaryCards({
               )}
               onClick={() => handleCustomTemplateClick(ct)}
               title={ct.description || ct.timeRange}
-              className="inline-flex w-full cursor-pointer items-center justify-center gap-1 rounded-md border border-foreground/20 bg-card px-2 py-0.5 text-[11px] text-foreground/70 transition-colors duration-150 group-hover/home-card:border-foreground group-hover/home-card:bg-foreground group-hover/home-card:text-background group-focus-within/home-card:border-foreground group-focus-within/home-card:bg-foreground group-focus-within/home-card:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground focus-visible:ring-offset-1 focus-visible:ring-offset-background motion-reduce:transition-none"
+              className="inline-flex h-10 w-full cursor-pointer items-center justify-center gap-1 rounded-md border border-foreground/20 bg-card px-2 text-[11px] text-foreground/70 transition-colors duration-150 group-hover/home-card:border-foreground group-hover/home-card:bg-foreground group-hover/home-card:text-background group-focus-within/home-card:border-foreground group-focus-within/home-card:bg-foreground group-focus-within/home-card:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground focus-visible:ring-offset-1 focus-visible:ring-offset-background motion-reduce:transition-none"
             >
               <span className="inline-flex min-w-0 items-center gap-1 transition-opacity duration-150 group-hover/home-card:opacity-0 group-focus-within/home-card:opacity-0 motion-reduce:transition-none">
                 <Pin className="h-3 w-3 shrink-0" strokeWidth={1.5} />
@@ -414,7 +414,7 @@ export function SummaryCards({
             posthog.capture("home_card_clicked", { kind: "custom_summary_open" });
             setShowBuilder(true);
           }}
-          className="cursor-pointer rounded-md border border-dashed border-foreground/25 px-2 py-0.5 text-[11px] text-muted-foreground transition-colors duration-150 hover:border-foreground hover:bg-foreground hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground focus-visible:ring-offset-1 focus-visible:ring-offset-background motion-reduce:transition-none"
+          className="h-10 cursor-pointer rounded-md border border-dashed border-foreground/25 px-1 text-[11px] text-muted-foreground transition-colors duration-150 hover:border-foreground hover:bg-foreground hover:text-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground focus-visible:ring-offset-1 focus-visible:ring-offset-background motion-reduce:transition-none"
         >
           + custom
         </button>


### PR DESCRIPTION
## Description

Home-card agent buttons were hard to click, and the black Codex logo disappeared against the black hover background. The actions now have 32×32px targets, 16px icons on a contrasting surface, and tooltips naming the hovered or focused agent: “Run in Claude”, “Run in Cursor”, or “Run in Codex”.

The small quick-action chips are also resized from about 22px to 40px tall, with a 108px minimum width, to accommodate the larger controls. Card text reserves space for the actions, and the chips wrap at narrower window widths.

## Before

User-provided screenshot showing the small controls and generic tooltip:

![Before](https://github.com/user-attachments/assets/dc0495da-8916-47c2-9d03-6523f1eabbdd)

## After

Actual Home components rendered in the browser-mock app, with agent-specific keyboard-focus tooltips:

![Light theme](https://github.com/user-attachments/assets/bb2810fe-d4f2-414c-a086-b4871666a4eb)

![Dark theme](https://github.com/user-attachments/assets/2ccbf485-5a11-4048-ba8f-68376324dddb)

## How to test

```sh
cd apps/screenpipe-app-tauri
bun x vitest run components/chat/home-card-agent-actions.test.tsx components/chat/summary-cards.test.tsx
```

Result: **23 tests passed across 2 files**. The existing named-actions test now checks rendered tooltips and accessible descriptions for all three agents.

Browser verification with `bun run dev:web`: inspected light and dark themes, card and chip actions, keyboard focus, and layouts at 1280px and 760px wide. Measured 32×32px targets and verified a click near the button edge triggers the mock handoff without running the primary card. No horizontal overflow at 760px. The temporary light-theme fixture was removed; native IPC and external-app launching were mocked.

`git diff --check` passed. No Tauri commands or bindings changed.

## Historical intent

- #6822 (`fb6a4b77`) introduced inline actions and the generic tooltip. This request supersedes the tiny targets and generic wording.
- #6859 (`ee69ac2a`) restored inline actions after a popover obscured the cards. The inline interaction is preserved.
- #6866 (`d99ebcc6`) fixed deep-link routing. Copy-first handoff, fallback behavior, and telemetry remain unchanged.

## AI assistance and human ownership

- AI tool: Codex; autonomy level: `agent`.
- Implementation, tests, and browser verification above were performed by Codex at the maintainer’s request. No human native-runtime verification is claimed.
- [ ] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [ ] The problem statement, rationale, and replies to maintainers are my own.
