### PR TITLE
fix(app): retain agent deep links in production builds

### DIFF
--- a/apps/screenpipe-app-tauri/components/chat/home-card-agent-actions.test.tsx
+++ b/apps/screenpipe-app-tauri/components/chat/home-card-agent-actions.test.tsx
@@ -6,6 +6,12 @@ import React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import tauriConfig from "../../src-tauri/tauri.conf.json";
+import productionConfig from "../../src-tauri/tauri.prod.conf.json";
+import enterpriseConfig from "../../src-tauri/tauri.enterprise.conf.json";
+import {
+  agentHandoffTargetForPrompt,
+  handoffTargets,
+} from "@/lib/first-run/agent-handoff";
 
 import {
   buildHomeCardAgentPrompt,
@@ -258,13 +264,38 @@ describe("HomeCardAgentActions", () => {
     );
   });
 
-  it("allows every agent deeplink through the cross-platform shell validator", () => {
-    const validator = new RegExp(`^${tauriConfig.plugins.shell.open}$`);
+  it.each([
+    ["development", tauriConfig],
+    ["production", productionConfig],
+    ["enterprise", enterpriseConfig],
+  ])("allows home-card deeplinks in the %s shell config", (_, config) => {
+    // Release workflows replace the base config, so each packaged config
+    // must retain the same narrow shell allowlist.
+    expect(config.plugins).toHaveProperty(
+      "shell.open",
+      tauriConfig.plugins.shell.open,
+    );
+    const validator = new RegExp(`^${config.plugins.shell.open}$`);
 
-    expect(validator.test("claude://claude.ai/new?q=test")).toBe(true);
-    expect(
-      validator.test("cursor://anysphere.cursor-deeplink/prompt?text=test"),
-    ).toBe(true);
-    expect(validator.test("codex://threads/new?prompt=test")).toBe(true);
+    for (const target of handoffTargets()) {
+      if (
+        target.id !== "claude" &&
+        target.id !== "cursor" &&
+        target.id !== "codex"
+      ) continue;
+      const prompt = buildHomeCardAgentPrompt(DAY_RECAP, target.id);
+      const { deeplink } = agentHandoffTargetForPrompt(target, prompt);
+      expect(validator.test(deeplink!)).toBe(true);
+    }
+
+    for (const url of [
+      "file:///tmp/prompt",
+      "claude://unrelated",
+      "cursor://unrelated",
+      "codex://unrelated",
+      "--help",
+    ]) {
+      expect(validator.test(url)).toBe(false);
+    }
   });
 });

--- a/apps/screenpipe-app-tauri/src-tauri/tauri.enterprise.conf.json
+++ b/apps/screenpipe-app-tauri/src-tauri/tauri.enterprise.conf.json
@@ -61,6 +61,9 @@
     }
   },
   "plugins": {
+    "shell": {
+      "open": "(?:https?://.*|mailto:.*|tel:.*|x-apple-reminderkit://.*|claude://claude\\.ai/new\\?q=.*|cursor://anysphere\\.cursor-deeplink/prompt\\?text=.*|codex://threads/new\\?prompt=.*)"
+    },
     "updater": {
       "active": true,
       "dialog": false,

--- a/apps/screenpipe-app-tauri/src-tauri/tauri.prod.conf.json
+++ b/apps/screenpipe-app-tauri/src-tauri/tauri.prod.conf.json
@@ -51,6 +51,9 @@
     }
   },
   "plugins": {
+    "shell": {
+      "open": "(?:https?://.*|mailto:.*|tel:.*|x-apple-reminderkit://.*|claude://claude\\.ai/new\\?q=.*|cursor://anysphere\\.cursor-deeplink/prompt\\?text=.*|codex://threads/new\\?prompt=.*)"
+    },
     "updater": {
       "active": true,
       "dialog": false,


### PR DESCRIPTION
Home-card actions can copy the prompt but fail to open Claude, Cursor, or Codex in packaged builds. Release workflows replace `tauri.conf.json` with the production or enterprise config, discarding the shell URL allowlist added by #6866. The shell plugin then falls back to its default validator, which rejects these schemes.

Add the existing narrow allowlist to both configs used by release packaging. Expand the existing regression to check all three configs against URLs generated by the actual home-card prompt builder, keep their allowlists equal, and reject unrelated routes and command-like inputs.

## Before / after

```text
Before: packaged home-card click -> custom scheme rejected -> prompt copied
After:  packaged home-card click -> allowed route -> OS protocol handler
                                                  -> clipboard fallback on failure
```

## Validation

From `apps/screenpipe-app-tauri`:

- `bun x vitest run --config vitest.config.ts components/chat/home-card-agent-actions.test.tsx lib/first-run/agent-handoff.test.ts` — 34 passed. Before the config fix, the two new production/enterprise cases failed while the other 32 passed.
- `git diff --check` — passed.

These checks prove the configuration regression and existing handoff behavior under mocks. No new packaged binary was built or launched; end-to-end OS/application acceptance remains unverified for this revision. No release or publication is included.

## Historical intent

- #6866 (`d99ebcc660`) switched home-card actions to the cross-platform shell opener and allowed the exact agent prompt routes in the development config.
- `release-app.yml` and `release-enterprise.yml` replace that base config before packaging. Their complete replacement configs omitted the allowlist.
- Preserve the original prompt routes and clipboard recovery. The former test checked development only; extending it to the shipped configs catches the gap without changing the handoff contract.
