### PR TITLE
fix(app): prevent referral settings from signing users out

### DIFF
--- a/apps/screenpipe-app-tauri/components/settings/referral-card.test.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/referral-card.test.tsx
@@ -32,6 +32,7 @@ vi.mock("@/lib/utils/tauri", () => ({
 vi.mock("@/components/ui/use-toast", () => ({ toast: mocks.toast }));
 
 import { ReferralCard } from "./referral-card";
+import { installAuthInterceptor } from "@/lib/auth-guard";
 
 const referral = {
   code: "REF-A1B2C3D4",
@@ -76,17 +77,23 @@ describe("ReferralCard", () => {
     );
   });
 
-  it("explains paid-plan eligibility instead of showing a broken trial link", async () => {
+  it("keeps a free account signed in when it has no referral code", async () => {
     mocks.user = { email: "trial@screenpipe.com", token: "token-1" };
+    const clearSession = vi.fn(async () => {
+      mocks.user = null;
+    });
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue(
-        new Response(JSON.stringify({ error: "no referral code found" }), {
-          status: 404,
-          headers: { "Content-Type": "application/json" },
-        }),
-      ),
+      vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const authenticated =
+          new Headers(init?.headers).get("Authorization") === "Bearer token-1";
+        return new Response(
+          JSON.stringify({ error: authenticated ? "no referral code found" : "unauthorized" }),
+          { status: authenticated ? 404 : 401 },
+        );
+      }),
     );
+    installAuthInterceptor(() => mocks.user?.token, clearSession);
 
     render(<ReferralCard />);
 
@@ -94,6 +101,8 @@ describe("ReferralCard", () => {
       await screen.findByText(/free Business trial does not create a referral code/i),
     ).toBeInTheDocument();
     expect(screen.queryByDisplayValue(/REF-/i)).not.toBeInTheDocument();
+    expect(clearSession).not.toHaveBeenCalled();
+    expect(mocks.user?.token).toBe("token-1");
   });
 
   it("shows a retry path when referral loading fails", async () => {

--- a/apps/screenpipe-app-tauri/components/settings/referral-card.tsx
+++ b/apps/screenpipe-app-tauri/components/settings/referral-card.tsx
@@ -50,7 +50,10 @@ export function ReferralCard() {
             `/api/referral?email=${encodeURIComponent(userEmail)}`,
             "https://screenpipe.com",
           ),
-          { signal: controller.signal },
+          {
+            headers: { Authorization: `Bearer ${userToken}` },
+            signal: controller.signal,
+          },
         );
         if (res.status === 404) {
           setReferral(null);


### PR DESCRIPTION
## Description

Opening Settings → Get free month sent an unauthenticated referral GET. The backend returned 401, and the global auth interceptor cleared the signed-in account. Reopening the remembered referral section repeated the sign-out.

Send the current bearer token on the GET, matching the invite request. A valid account without a referral code receives 404 and sees the existing eligibility explanation. The session-expiry policy remains unchanged.

Fixes #6943.

## Before / after

```text
Before: signed in → Get free month → GET without token → 401 → signed out
After:  signed in → Get free month → authenticated GET → 404 → eligibility message
        leave and reopen Get free month → eligibility message; still signed in
```

## Validation

- The referral regression test uses the real auth interceptor and a backend fixture returning 401 without the expected bearer token, otherwise 404. It reproduced the sign-out before the fix and passes afterward.
- On current main: `bun x vitest run --config vitest.config.ts components/settings/referral-card.test.tsx lib/auth-guard.test.tsx` — 36 passed.
- Focused ESLint and `git diff --check` — passed.
- Browser check on the Settings page with temporary free-account and API fixtures: the request authenticated, the eligibility message appeared, and navigating away and reopening Get free month preserved that state. Fixtures were removed afterward.
- Windows/native runtime and live-account behavior were not tested. No before/after recording was captured; the flow above is a textual illustration.

## Historical intent

Inspected a09c04d6a2 / #5712, which replaced fabricated referral links with backend-issued records and added explicit eligibility and retry states. This fix preserves those behaviors. The current website GET requires a bearer token and resolves identity from it. The existing eligibility test now also exercises authentication and session preservation; its original eligibility expectation is retained.

## AI assistance and human ownership

- Tool: Codex; autonomy level: `agent`.
- Implementation, automated checks, and browser fixture verification were performed by Codex at the user's request.
- Human verification: not claimed; ownership attestations remain for the maintainer.
