### PR TITLE
fix(sqlite): recover readable rows with missing FK parents

### DIFF
--- a/crates/screenpipe-sqlite-recovery/VENDORING.md
+++ b/crates/screenpipe-sqlite-recovery/VENDORING.md
@@ -11,8 +11,14 @@ Source archive:
 Vendored upstream files and SHA-256 digests:
 
 - `dbdata.c`: `0a57eae22b51507c28f6c647fba00ccacd39b5aaf3393dfe9435fb04810a6e0e`
-- `sqlite3recover.c`: `bc56c1131dfdc979fd93a7e013856f4c2a98570c722c069600f6c66d2d47743f`
+- `sqlite3recover.c`: `2b93163ec8af9a3667881b1aa1835a494ff6c6d91ba898790cade67225e203fd`
 - `sqlite3recover.h`: `c088088d15af055304e931842f7c197024d46ff1b7077912ec42149e9fa4f9bb`
+
+`sqlite3recover.c` carries the required Screenpipe source header and one local
+integration patch: the file-output connection disables foreign-key enforcement
+before recovery writes, matching the SQL emitted by the extension's
+callback-output mode. The unpatched upstream digest is
+`bc56c1131dfdc979fd93a7e013856f4c2a98570c722c069600f6c66d2d47743f`.
 
 When the bundled SQLite version changes, replace these files from the matching
 official SQLite tag, update the digests above, and run the recovery tests on

--- a/crates/screenpipe-sqlite-recovery/src/lib.rs
+++ b/crates/screenpipe-sqlite-recovery/src/lib.rs
@@ -278,6 +278,42 @@ mod tests {
     }
 
     #[test]
+    fn recovers_foreign_key_child_when_parent_row_is_unavailable() {
+        // Page-level recovery must salvage every readable row. The higher-level
+        // screenpipe-db verifier still rejects a candidate with unresolved
+        // foreign-key violations before it can replace the quarantined source.
+        let directory = tempfile::tempdir().expect("temporary recovery directory");
+        let source = directory.path().join("source.sqlite");
+        let destination = directory.path().join("destination.sqlite");
+        let connection = Connection::open(&source).expect("open source");
+        connection
+            .execute_batch(
+                "PRAGMA foreign_keys = OFF;\
+                 CREATE TABLE children (\
+                   id INTEGER PRIMARY KEY,\
+                   parent_id INTEGER NOT NULL REFERENCES parents(id)\
+                     DEFERRABLE INITIALLY DEFERRED\
+                 );\
+                 CREATE TABLE parents (id INTEGER PRIMARY KEY);\
+                 INSERT INTO children VALUES (1, 1);",
+            )
+            .expect("seed related rows");
+        drop(connection);
+
+        recover_database(&source, &destination).expect("recover foreign-key relationships");
+
+        let recovered = Connection::open_with_flags(&destination, OpenFlags::SQLITE_OPEN_READ_ONLY)
+            .expect("open recovered database");
+        assert_eq!(
+            recovered
+                .query_row("SELECT COUNT(*) FROM children", [], |row| row
+                    .get::<_, i64>(0))
+                .expect("count recovered children"),
+            1
+        );
+    }
+
+    #[test]
     fn salvages_rows_when_an_index_page_is_corrupt() {
         let directory = tempfile::tempdir().expect("temporary recovery directory");
         let source = directory.path().join("corrupt.sqlite");

--- a/crates/screenpipe-sqlite-recovery/vendor/sqlite-3.51.3-recovery/sqlite3recover.c
+++ b/crates/screenpipe-sqlite-recovery/vendor/sqlite-3.51.3-recovery/sqlite3recover.c
@@ -1,3 +1,6 @@
+// screenpipe — AI that knows everything you've seen, said, or heard
+// https://screenpipe.com
+
 /*
 ** 2022-08-27
 **
@@ -995,6 +998,8 @@ static int recoverOpenOutput(sqlite3_recover *p){
   if( sqlite3_open_v2(p->zUri, &db, flags, 0) ){
     recoverDbError(p, db);
   }
+
+  recoverExec(p, db, "PRAGMA foreign_keys = off");
 
   /* Register the sqlite_dbdata and sqlite_dbptr virtual table modules.
   ** These two are registered with the output database handle - this


### PR DESCRIPTION
## Summary

- Disable foreign-key enforcement on the private SQLite page-recovery output connection, allowing readable orphan child rows to be salvaged instead of aborting recovery at commit.
- Keep the safety boundary fail-closed: `screenpipe-db` still runs `PRAGMA foreign_key_check` before installation, and the CLI verifies again after the installed database identity transition.
- This covers the complete file-output recovery surface because the pragma now applies to the connection that actually receives recovered rows; callback-only SQL output is no longer relied on for connection state.

## Source and review

- Source feedback task: `t_c90b8b77`
- Independent review task: `t_d0b321d1`
- Reviewed head: `a36bef894ced52c225177e980a12fe3d6a6f2f7d`
- Reviewed against `screenpipe/screenpipe:main` at `923294f6848b0aaf5800aee3b33b1f07a9eb9c3f`

## Root cause

SQLite's file-output recovery path emitted `PRAGMA foreign_keys = off` only to SQL-callback consumers, not to the private output connection. A recoverable orphan under a deferred foreign key therefore made `sqlite3_recover_run` abort at commit with SQLite code 19 (`FOREIGN KEY constraint failed`).

## Changed files

- `crates/screenpipe-sqlite-recovery/VENDORING.md`
- `crates/screenpipe-sqlite-recovery/src/lib.rs`
- `crates/screenpipe-sqlite-recovery/vendor/sqlite-3.51.3-recovery/sqlite3recover.c`

## Before / after evidence

```text
Before: page recovery -> deferred FK commit -> SQLite code 19 -> recovery aborts
After:  page recovery -> readable rows salvaged -> foreign_key_check -> unresolved violations rejected before install
```

## Verification

- RED: `cargo test -p screenpipe-sqlite-recovery recovers_foreign_key_child_when_parent_row_is_unavailable -- --nocapture` failed without the fix with exit 101 / SQLite code 19.
- GREEN: the same focused test passed with the fix.
- `cargo test -p screenpipe-sqlite-recovery` — 6 passed, plus doc tests.
- `cargo test -p screenpipe-db recovery::tests --lib` — 5 passed.
- Focused `foreign_key_violation_never_clears_recovery_boundary` check — 1 passed.
- `cargo fmt -p screenpipe-sqlite-recovery -- --check` — passed.
- `git diff --check` — passed.
- Vendored checksums and upstream provenance — matched.

## Platform scope and limitation

The changed SQLite page-recovery path is cross-platform. Focused and broad recovery checks ran on Linux. The `screenpipe-engine` recovery tests could not be compiled on this host because `libpipewire-0.3` development metadata is unavailable; no engine-suite pass is claimed.
