### PR TITLE
fix(chat): enable existing context-pruning extension

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/pi.rs
@@ -2550,6 +2550,13 @@ pub async fn pi_start_inner(
             .map(|agent| agent.id.as_str())
             == Some("pi-acp");
 
+    if !use_acp || is_pi_acp {
+        screenpipe_core::agents::pi::PiExecutor::ensure_context_pruning_extension(
+            std::path::Path::new(&project_dir),
+        )
+        .map_err(|e| format!("Failed to install context guard: {}", e))?;
+    }
+
     // ACP agents receive Screenpipe via MCP during session/new. Pi-only
     // extensions and packages must not be installed or required there — except
     // pi-acp, which is pi and can't consume the MCP servers.


### PR DESCRIPTION
## description

Chat startup did not install the context-pruning extension already used by backend pipes, leaving chat without its existing oversized-message and tool-result guards. Install the same extension when native Pi or pi-acp chat starts, using the existing shared helper.

The change is seven added lines in one file. The extension implementation is unchanged.

## before / after

Source-level flow (not a runtime recording):

```text
Before
  Backend pipes -> install context-pruning.ts -> start Pi
  Chat          ->                               start Pi

After
  Backend pipes -> install context-pruning.ts -> start Pi
  Chat          -> install context-pruning.ts -> start Pi
```

## how to test

Agent-run validation:

- `cd apps/screenpipe-app-tauri && bun x vitest run lib/__tests__/context-pruning.test.ts` — 29 existing tests passed.
- `git diff --check` — passed.
- Inspected chat startup and the shared installer: native Pi and pi-acp install the extension before launch; other ACP agents bypass it.

The reported 32,768-token failure has not been reproduced end to end with this final, narrowed patch. The existing tests validate the extension behavior, not native chat startup.

## Historical intent

Inspected #3854 (`e128ba1a34`), which placed oversized-message handling in Pi's context/compaction layer, and #4516 (`eb9fb72ce4`), which preserved skill-file reads. This change connects chat to that existing implementation and preserves its behavior and test expectations.

## AI assistance and human ownership

- AI tool: Codex.
- Autonomy level: agent, creating this PR at the user's explicit request.
- Verification: the agent-run checks above; no human verification is claimed.

- [ ] Human author has reviewed and can explain every material change.
