### PR TITLE
fix(app): explain trial activation recording gate

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/recording.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/recording.rs
@@ -198,7 +198,23 @@ pub(crate) fn server_access_allowed(app: &tauri::AppHandle, store: &SettingsStor
 /// Consumer builds allow signed-in accounts to record on the free plan.
 /// Enterprise builds keep their native entitlement guard, and consumer builds
 /// still reject accounts that are required to use an enterprise binary.
-pub(crate) fn recording_access_allowed(app: &tauri::AppHandle, store: &SettingsStore) -> bool {
+fn recording_access_denial_message(
+    trial_activation_paywall: bool,
+    authentication_status: crate::startup_auth::AuthenticationStatus,
+) -> &'static str {
+    if authentication_status != crate::startup_auth::AuthenticationStatus::LoggedOut
+        && trial_activation_paywall
+    {
+        "trial_activation_required: finish setup to start screenpipe recording"
+    } else {
+        "account_required: sign in to start screenpipe recording"
+    }
+}
+
+fn recording_access_decision(
+    app: &tauri::AppHandle,
+    store: &SettingsStore,
+) -> Result<(), &'static str> {
     let trial_activation_paywall = !crate::should_skip_onboarding()
         && OnboardingStore::get(app)
             .ok()
@@ -219,13 +235,12 @@ pub(crate) fn recording_access_allowed(app: &tauri::AppHandle, store: &SettingsS
             crate::enterprise_policy::recording_authorized()
         } else {
             store.has_cloud_authentication()
-        }
-    {
+        } {
         crate::startup_auth::AuthenticationStatus::Authenticated
     } else {
         resolved_authentication
     };
-    recording_access_policy(
+    if recording_access_policy(
         cfg!(feature = "enterprise-build"),
         cfg!(debug_assertions),
         store.local_plan_policy() != LocalPlanPolicy::Unknown,
@@ -233,16 +248,25 @@ pub(crate) fn recording_access_allowed(app: &tauri::AppHandle, store: &SettingsS
         !cfg!(debug_assertions) && store.requires_enterprise_app_for_consumer(),
         trial_activation_paywall,
         authentication_status,
-    )
+    ) {
+        Ok(())
+    } else {
+        Err(recording_access_denial_message(
+            trial_activation_paywall,
+            authentication_status,
+        ))
+    }
+}
+
+pub(crate) fn recording_access_allowed(app: &tauri::AppHandle, store: &SettingsStore) -> bool {
+    recording_access_decision(app, store).is_ok()
 }
 
 fn require_recording_access(app: &tauri::AppHandle, store: &SettingsStore) -> Result<(), String> {
-    if recording_access_allowed(app, store) {
-        return Ok(());
-    }
-
-    crate::health::set_recording_status(crate::health::RecordingStatus::Paused);
-    Err("account_required: sign in to start screenpipe recording".to_string())
+    recording_access_decision(app, store).map_err(|error| {
+        crate::health::set_recording_status(crate::health::RecordingStatus::Paused);
+        error.to_string()
+    })
 }
 
 fn require_server_access(app: &tauri::AppHandle, store: &SettingsStore) -> Result<(), String> {
@@ -1725,7 +1749,7 @@ mod local_api_auth_tests {
 
 #[cfg(test)]
 mod recording_access_tests {
-    use super::{recording_access_policy, server_access_policy};
+    use super::{recording_access_denial_message, recording_access_policy, server_access_policy};
     use crate::startup_auth::AuthenticationStatus;
 
     #[test]
@@ -1813,6 +1837,25 @@ mod recording_access_tests {
             true,
             AuthenticationStatus::Authenticated,
         ));
+    }
+
+    #[test]
+    fn authenticated_trial_activation_denial_does_not_request_sign_in() {
+        let error = recording_access_denial_message(true, AuthenticationStatus::Authenticated);
+
+        assert_eq!(
+            error,
+            "trial_activation_required: finish setup to start screenpipe recording"
+        );
+        assert!(!error.contains("sign in"));
+    }
+
+    #[test]
+    fn signed_out_trial_activation_denial_still_requests_sign_in_first() {
+        assert_eq!(
+            recording_access_denial_message(true, AuthenticationStatus::LoggedOut),
+            "account_required: sign in to start screenpipe recording"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Authenticated users blocked by the trial-activation gate were told to sign in even though authentication had already succeeded. This change makes that denial actionable by returning `trial_activation_required: finish setup to start screenpipe recording` while preserving the existing sign-in message for signed-out users.

## Source feedback

- Discord feedback message: `1547267878036963389`
- Internal feedback task: `screenpipe-feedback/t_832d4197`
- Reported environment: Windows 10, Screenpipe 2.7.27
- Reported symptom: starting recording claimed sign-in was required although the user was already signed in

## Root cause

`recording_access_policy` correctly denied capture for both signed-out users and authenticated users blocked by trial activation, but `require_recording_access` collapsed every denial into the same `account_required` error. The policy decision was correct; the returned reason was not.

## Fix and coverage

- Centralize the recording decision so boolean callers and error-returning callers use the same policy result.
- Return the setup-required denial only when trial activation blocks a user who is not logged out.
- Keep signed-out precedence as `account_required`.
- Preserve verified-plan, trial, Enterprise authorization, mandatory-Enterprise consumer, signup-free, debug, server-access, and recording-health behavior.
- Native tray and frontend shortcut start paths already surface the returned error, so the correction covers the reported recording-start surface without bypassing any gate.

## Before / after visual evidence

```text
Authenticated + trial activation incomplete

BEFORE
Start recording
  -> account_required: sign in to start screenpipe recording
                         ^ misleading: already signed in

AFTER
Start recording
  -> trial_activation_required: finish setup to start screenpipe recording
                                 ^ actionable next step

Signed out + trial activation incomplete
  -> account_required: sign in to start screenpipe recording  (unchanged)
```

## Current-main reconciliation

- Merged current `origin/main` (`5b1a3cbb56a01dfb383645266faf4d071a8e9c45`) into the previously reviewed tip (`9ad446ddcfc07aa7ddcb92181510315e311edd5c`) as merge commit `4be88f27a8e55111b1704e3b338cd25847270af7`; the fork branch was updated without force-push.
- The conflict was limited to `apps/screenpipe-app-tauri/src-tauri/src/recording.rs`. The resolution preserves main's delayed-account-startup behavior and five tests byte-for-byte while retaining the authenticated trial-activation setup guidance and signed-out precedence.
- Independent review unconditionally approved exact clean SHA `4be88f27a8e55111b1704e3b338cd25847270af7` after parent/topology, one-file diff, `git diff --check`, `git show --check`, `git fsck`, caller/security, and exact-source behavior checks (4/4).

## Verification

RED:
- On reviewed `origin/main` (`1941f86e2a8149eb97dd82f97ba1d9d2b3278ce2`), the expected trial-activation denial string was absent (`git grep`, exit 1).

GREEN:
- Exact-source denial harness passed 2/2 in implementation and independent review.
- Added focused tests for authenticated trial activation and signed-out precedence.

Broader evidence:
- `git diff --check 5b1a3cbb56a01dfb383645266faf4d071a8e9c45...HEAD` passed for the reconciled commit.
- Independent one-file caller/security audit confirmed auth, verified-plan, trial, Enterprise, mandatory-Enterprise consumer, signup-free, health side effects, and signed-out precedence remain intact.
- The supported native command was attempted: `PATH=/home/ezra/.bun/bin:$PATH bun run test:tauri recording_access_tests -- --nocapture`.

## Test limitations

The supported native wrapper could not reach the app tests on this Linux host because the native build queue and host `libpipewire` prerequisites were unavailable. No unsupported local-compilation bypass was used for the reconciled commit. The exact-source behavior harness passed 4/4, and independent review verified main's deferred-account implementation and five tests remained byte-identical.

## Platform scope and risk

The report came from Windows, while the corrected native Rust policy and returned error are shared across desktop platforms. Risk is low and limited to selecting the denial string after the existing policy rejects recording; the gates themselves are unchanged.
