### PR TITLE
fix: preserve symlinked AI tool configs

### DIFF
--- a/apps/screenpipe-app-tauri/lib/__tests__/ai-tools-mcp.test.ts
+++ b/apps/screenpipe-app-tauri/lib/__tests__/ai-tools-mcp.test.ts
@@ -11,6 +11,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const fsMock = vi.hoisted(() => ({
   files: new Map<string, string>(),
+  symlinks: new Map<string, string>(),
   unreadable: new Set<string>(),
 }));
 
@@ -28,16 +29,37 @@ vi.mock("@tauri-apps/api/path", () => ({
   homeDir: vi.fn(async () => "/Users/test"),
   join: vi.fn(async (...parts: string[]) => parts.join("/")),
   dirname: vi.fn(async (p: string) => p.split("/").slice(0, -1).join("/")),
+  isAbsolute: vi.fn(async (p: string) => p.startsWith("/")),
+  resolve: vi.fn(async (...parts: string[]) => {
+    const resolved: string[] = [];
+    for (const part of parts.join("/").split("/")) {
+      if (!part || part === ".") continue;
+      if (part === "..") resolved.pop();
+      else resolved.push(part);
+    }
+    return `/${resolved.join("/")}`;
+  }),
 }));
 
 vi.mock("@tauri-apps/plugin-fs", () => ({
-  exists: vi.fn(async (path: string) => fsMock.files.has(path) || fsMock.unreadable.has(path)),
+  exists: vi.fn(async (path: string) => fsMock.files.has(path) || fsMock.symlinks.has(path) || fsMock.unreadable.has(path)),
   mkdir: vi.fn(async () => undefined),
   readTextFile: vi.fn(async (path: string) => {
+    path = fsMock.symlinks.get(path) ?? path;
     if (fsMock.unreadable.has(path)) throw new Error("EACCES: permission denied");
     const text = fsMock.files.get(path);
     if (text === undefined) throw new Error(`missing ${path}`);
     return text;
+  }),
+  readLink: vi.fn(async (path: string) => {
+    const target = fsMock.symlinks.get(path);
+    if (target === undefined) throw new Error(`not a symlink: ${path}`);
+    return target;
+  }),
+  lstat: vi.fn(async (path: string) => {
+    if (fsMock.symlinks.has(path)) return { isSymlink: true };
+    if (fsMock.files.has(path)) return { isSymlink: false };
+    throw new Error(`missing ${path}`);
   }),
   writeFile: vi.fn(async (path: string, bytes: Uint8Array) => {
     fsMock.files.set(path, new TextDecoder().decode(bytes));
@@ -49,6 +71,7 @@ vi.mock("@tauri-apps/plugin-fs", () => ({
     const text = fsMock.files.get(from);
     if (text === undefined) throw new Error(`missing ${from}`);
     fsMock.files.set(to, text);
+    fsMock.symlinks.delete(to);
     fsMock.files.delete(from);
   }),
   copyFile: vi.fn(async (from: string, to: string) => {
@@ -115,6 +138,7 @@ const tmpsOf = (path: string) =>
 
 beforeEach(() => {
   fsMock.files.clear();
+  fsMock.symlinks.clear();
   fsMock.unreadable.clear();
   skillsMock.installExternalAgentSkills.mockClear();
   skillsMock.removeExternalAgentSkills.mockClear();
@@ -122,6 +146,18 @@ beforeEach(() => {
 });
 
 describe("safe config IO", () => {
+  it("writes through a config symlink instead of replacing it", async () => {
+    const target = "/Users/test/dotfiles/codex-config.toml";
+    fsMock.files.set(target, "model = \"gpt-5\"\n");
+    fsMock.symlinks.set("/Users/test/.codex/config.toml", target);
+
+    await connectAiTool("codex");
+
+    expect(fsMock.symlinks.get("/Users/test/.codex/config.toml")).toBe(target);
+    expect(fsMock.files.get(target)).toContain("[mcp_servers.screenpipe]");
+    expect(backupsOf(target)).toHaveLength(1);
+  });
+
   it("preserves unrelated servers and settings, and takes a backup", async () => {
     const seeded = JSON.stringify({ mcpServers: { other: { command: "x" } }, theme: "dark" });
     fsMock.files.set(CURSOR, seeded);

--- a/apps/screenpipe-app-tauri/lib/ai-tools-mcp.ts
+++ b/apps/screenpipe-app-tauri/lib/ai-tools-mcp.ts
@@ -6,7 +6,7 @@
 // launch reconciliation in crates/screenpipe-engine/src/cli/agent.rs; this
 // module remains the explicit connect/remove surface in Settings.
 
-import { homeDir, join, dirname } from "@tauri-apps/api/path";
+import { homeDir, join, dirname, isAbsolute, resolve } from "@tauri-apps/api/path";
 import {
   readTextFile,
   writeFile,
@@ -16,6 +16,8 @@ import {
   remove,
   copyFile,
   readDir,
+  lstat,
+  readLink,
 } from "@tauri-apps/plugin-fs";
 import { commands } from "@/lib/utils/tauri";
 import {
@@ -252,10 +254,39 @@ async function writeConfigAtomic(configPath: string, text: string): Promise<void
   }
 }
 
+/** Resolve symlinks before an atomic rename so the link itself is preserved. */
+async function resolveConfigWritePath(configPath: string): Promise<string> {
+  let path = configPath;
+  const visited = new Set<string>();
+
+  for (let depth = 0; depth < 40; depth++) {
+    if (visited.has(path)) {
+      throw new Error(`could not write ${configPath}: symlink loop detected`);
+    }
+    visited.add(path);
+
+    let info;
+    try {
+      info = await lstat(path);
+    } catch {
+      return path;
+    }
+    if (!info.isSymlink) return path;
+
+    const target = await readLink(path);
+    path = (await isAbsolute(target))
+      ? target
+      : await resolve(await dirname(path), target);
+  }
+
+  throw new Error(`could not write ${configPath}: too many symlink levels`);
+}
+
 /** Backup (if existing) + atomic write, the standard mutation path. */
 async function replaceConfig(configPath: string, text: string): Promise<void> {
-  await backupConfigIfExists(configPath);
-  await writeConfigAtomic(configPath, text);
+  const writePath = await resolveConfigWritePath(configPath);
+  await backupConfigIfExists(writePath);
+  await writeConfigAtomic(writePath, text);
 }
 
 async function writeJsonConfig(configPath: string, config: Record<string, unknown>): Promise<void> {


### PR DESCRIPTION
## Summary

- resolve AI-tool config symlink chains before backup and atomic replacement
- preserve relative and absolute symlink targets while rejecting loops/excessive depth
- add a Codex regression test proving the link survives and its target is updated/backed up

Closes #6974

## Before / after

```text
before fix:
~/.codex/config.toml -> ~/dotfiles/.codex/config.toml
connect → ~/.codex/config.toml (regular file; link lost)

after fix:
~/.codex/config.toml -> ~/dotfiles/.codex/config.toml
connect → symlink preserved; dotfiles target atomically updated
```

## Test plan

- `cd apps/screenpipe-app-tauri && bun x vitest run --config vitest.config.ts lib/__tests__/ai-tools-mcp.test.ts` — PASS (27 tests)
- `cd apps/screenpipe-app-tauri && bun x tsc --noEmit` — PASS
- `git diff --check` — PASS
