### PR TITLE
fix(auth): refresh account access before blocking engine startup

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/commands.rs
@@ -1164,6 +1164,7 @@ pub async fn set_cloud_token(
     // fallible secret-store write so the on-disk copies never outlive the
     // session even if persistence below fails.
     if should_clear_pi_auth {
+        state.deferred_account_start.cancel();
         if let Err(e) = crate::pi::clear_screenpipe_auth_token_files() {
             warn!("failed to clear pi screenpipe auth token: {}", e);
         }
@@ -1205,10 +1206,16 @@ pub async fn set_cloud_token(
     // Err so the frontend won't strip the last plaintext copy of a token it
     // couldn't durably save (the caller ignores the Result for session purposes;
     // only the save-and-strip path checks it).
-    crate::auth_token::store_cloud_token(normalized.as_deref())
+    let persistence_result = crate::auth_token::store_cloud_token(normalized.as_deref())
         .await
-        .map_err(|e| format!("failed to persist cloud token to secret store: {e}"))?;
-    Ok(())
+        .map_err(|e| format!("failed to persist cloud token to secret store: {e}"));
+    if !should_clear_pi_auth {
+        // `loadUser` calls this after saving verified account data. Both
+        // in-process token caches are now updated, even if persistence failed.
+        // Resume native startup without relying on a frontend gate transition.
+        crate::recording::resume_deferred_account_start(app.clone());
+    }
+    persistence_result
 }
 
 /// Persist the user's enterprise admin status, team API token, and the org's

--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -945,6 +945,7 @@ async fn main() {
         is_starting_capture: Arc::new(AtomicBool::new(false)),
         last_spawn_epoch: Arc::new(AtomicU64::new(0)),
         wants_recording: Arc::new(AtomicBool::new(false)),
+        deferred_account_start: Default::default(),
         interrupted_meeting: Arc::new(tokio::sync::Mutex::new(None)),
         cloud_token: Arc::new(arc_swap::ArcSwap::new(Arc::new(initial_cloud_token))),
         history_access: screenpipe_engine::history_access::HistoryAccessPolicy::unrestricted(),
@@ -1866,9 +1867,15 @@ async fn main() {
                 let store_clone = store.clone();
                 let data_dir_clone = data_dir.clone();
                 if !crate::recording::server_access_allowed(&app_handle, &store_clone) {
+                    app_handle
+                        .state::<RecordingState>()
+                        .deferred_account_start
+                        .defer();
                     info!("Skipping server auto-start: screenpipe account access required");
                     crate::health::set_recording_status(crate::health::RecordingStatus::Paused);
                     let _ = app_handle.emit("app-entitlement-required", ());
+                    // A webview may already have refreshed the startup snapshot.
+                    crate::recording::resume_deferred_account_start(app_handle.clone());
                     break 'start_server;
                 }
                 let recording_state = app_handle.state::<RecordingState>();

--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -1418,7 +1418,6 @@ async fn main() {
             // an empty plugin handle and save defaults over the ciphertext.
             // Note: StoreBuilder handles file creation internally — pre-creating
             // store.bin here caused TOCTOU race conditions ("File exists" os error 17).
-            #[allow(unused_mut)] // E2E seeds mutate the store in feature builds.
             let mut store = store::init_store(&app.handle()).map_err(|e| {
                 error!("Failed to init settings store; aborting startup: {}", e);
                 // A log line is invisible to the user: without this the app just
@@ -1434,15 +1433,14 @@ async fn main() {
             #[cfg(feature = "e2e")]
             e2e::seeds::apply_settings(app.handle(), &mut store);
 
-            app.manage(store.clone());
-
             // Resolve authentication at the first point its settings
             // prerequisite is available, before beginning any application
             // runtime. Consumer and Enterprise builds deliberately share these
             // two sequential steps; only the credential check inside the
             // resolver varies by build. `SCREENPIPE_SKIP_ONBOARDING` returns
             // `NotRequired` without invoking either checker.
-            startup_auth::bootstrap(&app_handle, &store);
+            startup_auth::bootstrap(&app_handle, &mut store);
+            app.manage(store.clone());
 
             crate::recording::refresh_history_access_policy(
                 &app.state::<RecordingState>().history_access,

--- a/apps/screenpipe-app-tauri/src-tauri/src/recording.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/recording.rs
@@ -344,6 +344,7 @@ pub struct RecordingState {
     /// recording" that keeps the server up. `last_spawn_epoch` can't carry this
     /// — it's reset to 0 on a failed spawn too, and never sees the tray toggle.
     pub wants_recording: Arc<AtomicBool>,
+    pub(crate) deferred_account_start: crate::startup_auth::DeferredAccountStart,
     /// Recently active meeting to revive when capture is immediately restarted.
     pub(crate) interrupted_meeting: Arc<Mutex<Option<InterruptedMeeting>>>,
     /// App-scoped cloud-auth token (Clerk JWT). Outlives the Server (which
@@ -382,6 +383,9 @@ impl RecordingState {
     /// `stop_screenpipe` clear it. (Capture has two on-paths and two off-paths;
     /// missing any one is how a tray-stopped capture got resurrected.)
     pub fn set_capture_intent(&self, on: bool) {
+        // An explicit start owns the lifecycle now; an explicit stop must not
+        // be undone by a later background account refresh.
+        self.deferred_account_start.cancel();
         self.wants_recording.store(on, Ordering::SeqCst);
     }
 
@@ -981,6 +985,39 @@ pub async fn spawn_screenpipe(
         return Ok(());
     };
     spawn_screenpipe_inner(&state, app).await
+}
+
+/// Account verification can complete on either side of the native startup
+/// check, without the frontend ever rendering an access gate. Reconcile both
+/// events against current settings and the same native access policy.
+pub(crate) fn resume_deferred_account_start(app: tauri::AppHandle) {
+    tauri::async_runtime::spawn(async move {
+        let state = app.state::<RecordingState>();
+        // Wait before claiming the deferred start so a busy lifecycle cannot
+        // discard recovery. An explicit start/stop or sign-out cancels it.
+        let _lifecycle_guard = state.server_lifecycle.lock().await;
+        if crate::process_exit::QUIT_REQUESTED.load(Ordering::SeqCst) {
+            return;
+        }
+        let Some(settings) = SettingsStore::get(&app).ok().flatten() else {
+            return;
+        };
+        let access_allowed = state.cloud_token.load().as_ref().is_some()
+            && server_access_allowed(&app, &settings);
+        let capture_allowed = recording_access_allowed(&app, &settings);
+        if !state
+            .deferred_account_start
+            .take_if_allowed(access_allowed, || {
+                state.wants_recording.store(capture_allowed, Ordering::SeqCst);
+            })
+        {
+            return;
+        }
+        info!("Account access verified; resuming deferred server auto-start");
+        if let Err(error) = spawn_screenpipe_inner(&state, app.clone()).await {
+            error!("Failed to resume server after account verification: {}", error);
+        }
+    });
 }
 
 /// Automatic retry preserves capture intent; unlike the user command it must
@@ -1726,7 +1763,103 @@ mod local_api_auth_tests {
 #[cfg(test)]
 mod recording_access_tests {
     use super::{recording_access_policy, server_access_policy};
-    use crate::startup_auth::AuthenticationStatus;
+    use crate::startup_auth::{AuthenticationStatus, DeferredAccountStart};
+    use crate::store::{LocalPlanPolicy, SettingsStore};
+
+    #[test]
+    fn account_refresh_recovers_deferred_start_without_a_frontend_gate() {
+        let pending = DeferredAccountStart::default();
+        let mut settings = SettingsStore::default();
+        settings.user.id = Some("subscribed-user".into());
+        settings.user.subscription_plan = Some("pro".into());
+        settings.user.app_entitled = Some(true);
+        let access = |settings: &SettingsStore| {
+            server_access_policy(
+                false,
+                false,
+                settings.local_plan_policy() != LocalPlanPolicy::Unknown,
+                false,
+                false,
+            )
+        };
+
+        // Boot has a signed-in paid account but no verified cached evidence.
+        assert!(!access(&settings));
+        pending.defer();
+        assert!(!pending.take_if_allowed(access(&settings), || {}));
+
+        // /api/user refresh supplies verified evidence before any UI gate
+        // mounts. Recovery must not require a frontend stop or gate transition.
+        settings.user.entitlement = Some(serde_json::json!({
+            "plan": "pro",
+            "active": true,
+            "source": "subscription",
+            "checked_at": chrono::Utc::now().to_rfc3339(),
+            "features": { "app": true }
+        }));
+        assert!(access(&settings));
+        assert!(pending.take_if_allowed(access(&settings), || {}));
+        assert!(!pending.take_if_allowed(access(&settings), || {}));
+    }
+
+    #[test]
+    fn account_refresh_does_not_start_an_unrequested_or_cancelled_engine() {
+        let pending = DeferredAccountStart::default();
+        assert!(!pending.take_if_allowed(true, || {}));
+        pending.defer();
+        pending.cancel(); // explicit capture stop or sign-out
+        assert!(!pending.take_if_allowed(true, || {}));
+    }
+
+    #[test]
+    fn account_refresh_before_native_deferral_is_reconciled_at_deferral() {
+        let pending = DeferredAccountStart::default();
+        // A refresh before the native gate has nothing to resume yet.
+        assert!(!pending.take_if_allowed(true, || {}));
+        pending.defer();
+        // Native deferral also checks current access, not its old snapshot.
+        assert!(pending.take_if_allowed(true, || {}));
+        assert!(!pending.take_if_allowed(true, || {}));
+    }
+
+    #[test]
+    fn concurrent_account_refreshes_claim_only_one_deferred_start() {
+        let pending = std::sync::Arc::new(DeferredAccountStart::default());
+        pending.defer();
+        let workers: Vec<_> = (0..8)
+            .map(|_| {
+                let pending = pending.clone();
+                std::thread::spawn(move || pending.take_if_allowed(true, || {}))
+            })
+            .collect();
+        let starts = workers
+            .into_iter()
+            .map(|worker| usize::from(worker.join().unwrap()))
+            .sum::<usize>();
+        assert_eq!(starts, 1);
+    }
+
+    #[test]
+    fn explicit_stop_wins_over_an_in_flight_account_resume() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        let pending = DeferredAccountStart::default();
+        let wants_recording = AtomicBool::new(false);
+        pending.defer();
+        let (stop_requested, stop_request) = std::sync::mpsc::channel();
+        std::thread::scope(|scope| {
+            pending.take_if_allowed(true, || {
+                scope.spawn(|| {
+                    stop_requested.send(()).unwrap();
+                    pending.cancel();
+                    wants_recording.store(false, Ordering::SeqCst);
+                });
+                stop_request.recv().unwrap();
+                wants_recording.store(true, Ordering::SeqCst);
+            });
+        });
+        assert!(!wants_recording.load(Ordering::SeqCst));
+        assert!(!pending.take_if_allowed(true, || panic!("stop was lost")));
+    }
 
     #[test]
     fn verified_free_consumer_can_record_without_a_paid_entitlement() {

--- a/apps/screenpipe-app-tauri/src-tauri/src/startup_auth.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/startup_auth.rs
@@ -4,10 +4,38 @@
 
 use serde::Serialize;
 use specta::Type;
+use std::sync::Mutex;
 use tauri::Manager;
 use tracing::info;
 
 use crate::store::SettingsStore;
+
+/// Native startup may wait for account data that a webview refreshes before
+/// rendering its gate. Remember that start independently of the gate's UI.
+#[derive(Default)]
+pub(crate) struct DeferredAccountStart(Mutex<bool>);
+
+impl DeferredAccountStart {
+    pub(crate) fn defer(&self) {
+        *self.0.lock().expect("deferred account start lock poisoned") = true;
+    }
+
+    pub(crate) fn cancel(&self) {
+        *self.0.lock().expect("deferred account start lock poisoned") = false;
+    }
+
+    pub(crate) fn take_if_allowed(&self, access_allowed: bool, start: impl FnOnce()) -> bool {
+        let mut pending = self.0.lock().expect("deferred account start lock poisoned");
+        if !access_allowed || !*pending {
+            return false;
+        }
+        *pending = false;
+        // Publish capture intent while cancellation is excluded. A concurrent
+        // explicit stop must clear intent after this, never be overwritten.
+        start();
+        true
+    }
+}
 
 /// Authentication is resolved exactly once before the application runtime is
 /// initialized. Keep this separate from entitlement: an authenticated account

--- a/apps/screenpipe-app-tauri/src-tauri/src/startup_auth.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/startup_auth.rs
@@ -5,10 +5,194 @@
 use serde::Serialize;
 use specta::Type;
 use std::sync::Mutex;
+use std::time::Duration;
 use tauri::Manager;
-use tracing::info;
+use tracing::{info, warn};
 
-use crate::store::SettingsStore;
+use crate::store::{LocalPlanPolicy, SettingsStore, User};
+
+const ACCOUNT_REFRESH_TIMEOUT: Duration = Duration::from_secs(10);
+
+enum AccountRefresh {
+    Updated(serde_json::Value),
+    Rejected,
+}
+
+fn cached_account_needs_refresh(settings: &SettingsStore) -> bool {
+    settings.local_plan_policy() == LocalPlanPolicy::Unknown
+        || settings.requires_enterprise_app_for_consumer()
+}
+
+fn refresh_account_before_gate(
+    settings: &mut SettingsStore,
+    refresh: impl FnOnce() -> Result<AccountRefresh, String>,
+) -> Result<Option<AccountRefresh>, String> {
+    if !cached_account_needs_refresh(settings) {
+        return Ok(None);
+    }
+    let result = refresh()?;
+    // Replace the entire account, including explicit unknown/rejected results.
+    // Merging could retain the very entitlement fields we needed to refresh.
+    settings.user = match &result {
+        AccountRefresh::Updated(user) => serde_json::from_value(user.clone())
+            .map_err(|_| "invalid account refresh fields".to_string())?,
+        AccountRefresh::Rejected => User::default(),
+    };
+    Ok(Some(result))
+}
+
+/// Called on a worker thread, never inside Tauri's Tokio setup runtime.
+fn fetch_account(url: &str, token: &str, timeout: Duration) -> Result<AccountRefresh, String> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(timeout)
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|_| "could not create account refresh client".to_string())?;
+    let response = client
+        .post(url)
+        .json(&serde_json::json!({ "token": token, "verify": true }))
+        .send()
+        .map_err(|error| {
+            if error.is_timeout() {
+                "account refresh timed out".to_string()
+            } else {
+                "account refresh request failed".to_string()
+            }
+        })?;
+    if matches!(response.status().as_u16(), 401 | 403) {
+        return Ok(AccountRefresh::Rejected);
+    }
+    if !response.status().is_success() {
+        return Err(format!(
+            "account refresh returned HTTP {}",
+            response.status()
+        ));
+    }
+    let mut response: serde_json::Value = response
+        .json()
+        .map_err(|_| "invalid account refresh response".to_string())?;
+    if response.get("success") == Some(&serde_json::Value::Bool(false))
+        || response.get("user").is_none_or(serde_json::Value::is_null)
+    {
+        return Ok(AccountRefresh::Rejected);
+    }
+    let mut user = response["user"].take();
+    let object = user.as_object_mut().ok_or("invalid account refresh user")?;
+    // The request credential stays in the encrypted secret store. Never write
+    // the token echoed by /api/user back into plaintext settings.
+    object.remove("token");
+    // Match the frontend's canonical-plan fallback without inventing paid
+    // evidence from a subscription label or boolean alone.
+    if object
+        .get("subscription_plan")
+        .is_none_or(serde_json::Value::is_null)
+    {
+        if let Some(plan) = object
+            .get("entitlement")
+            .and_then(|e| e.get("plan"))
+            .cloned()
+        {
+            object.insert("subscription_plan".into(), plan);
+        }
+    }
+    if let Some(entitlement) = object
+        .get_mut("entitlement")
+        .and_then(|e| e.as_object_mut())
+    {
+        if entitlement
+            .get("checked_at")
+            .is_none_or(serde_json::Value::is_null)
+        {
+            entitlement.insert(
+                "checked_at".into(),
+                serde_json::Value::String(chrono::Utc::now().to_rfc3339()),
+            );
+        }
+    }
+    serde_json::from_value::<User>(user.clone())
+        .map_err(|_| "invalid account refresh fields".to_string())?;
+    Ok(AccountRefresh::Updated(user))
+}
+
+fn refresh_consumer_account(app: &tauri::AppHandle, settings: &mut SettingsStore) {
+    if !cached_account_needs_refresh(settings) {
+        return;
+    }
+    let token = crate::auth_token::cached_cloud_token()
+        .or_else(|| settings.user.token.clone())
+        .filter(|token| !token.is_empty());
+    let Some(token) = token else { return };
+    // Seeded accounts describe exact scenarios and must never be sent to the
+    // production service. Real accounts in E2E builds still use this refresh.
+    #[cfg(feature = "e2e")]
+    if token.starts_with("e2e-fake-token-")
+        || crate::store::get_store(app, None)
+            .ok()
+            .and_then(|store| store.get("settings"))
+            .is_some_and(|value| value["user"]["__e2eSkipAccountRefresh"] == true)
+    {
+        return;
+    }
+    info!("Refreshing account access before applying startup gate");
+    let result = refresh_account_before_gate(settings, || {
+        let worker = std::thread::Builder::new()
+            .name("consumer-startup-auth".into())
+            .spawn(move || {
+                let result = fetch_account(
+                    &crate::web_base::screenpipe_web_url("/api/user"),
+                    &token,
+                    ACCOUNT_REFRESH_TIMEOUT,
+                )?;
+                if matches!(result, AccountRefresh::Rejected) {
+                    // Finish durable sign-out before webviews can begin a new
+                    // login. A detached clear could erase that newer session.
+                    crate::auth_token::seed_cloud_token(None);
+                    match tokio::runtime::Builder::new_current_thread()
+                        .enable_all()
+                        .build()
+                    {
+                        Ok(runtime) => {
+                            if let Err(error) =
+                                runtime.block_on(crate::auth_token::store_cloud_token(None))
+                            {
+                                warn!("Failed to persist rejected startup session: {error}");
+                            }
+                        }
+                        Err(error) => warn!("Failed to initialize startup sign-out: {error}"),
+                    }
+                }
+                Ok(result)
+            });
+        match worker {
+            Ok(worker) => worker
+                .join()
+                .unwrap_or_else(|_| Err("account refresh worker failed".into())),
+            Err(_) => Err("could not start account refresh worker".into()),
+        }
+    });
+    let user = match result {
+        Ok(Some(AccountRefresh::Updated(user))) => {
+            info!("Startup account refresh completed; replacing cached account access");
+            user
+        }
+        Ok(Some(AccountRefresh::Rejected)) => {
+            warn!("Startup account refresh rejected the saved session");
+            crate::auth_token::seed_cloud_token(None);
+            app.state::<crate::recording::RecordingState>()
+                .cloud_token
+                .store(std::sync::Arc::new(None));
+            serde_json::json!({})
+        }
+        Ok(None) => return,
+        Err(error) => {
+            warn!("Startup account refresh unavailable: {error}; cached access remains unverified");
+            return;
+        }
+    };
+    if let Err(error) = settings.replace_startup_user(app, user) {
+        warn!("Failed to persist refreshed startup account: {error}");
+    }
+}
 
 /// Native startup may wait for account data that a webview refreshes before
 /// rendering its gate. Remember that start independently of the gate's UI.
@@ -75,11 +259,12 @@ fn classify_authentication(
 
 /// Shared Consumer/Enterprise bootstrap resolver. Signup-free builds take the
 /// immediate branch; otherwise only the build-specific credential check varies.
-fn resolve(app: &tauri::AppHandle, settings: &SettingsStore) -> AuthenticationStatus {
+fn resolve(app: &tauri::AppHandle, settings: &mut SettingsStore) -> AuthenticationStatus {
     let status = classify_authentication(!crate::should_skip_onboarding(), || {
         if cfg!(feature = "enterprise-build") {
             crate::enterprise_sync::authorize_startup(app)
         } else {
+            refresh_consumer_account(app, settings);
             settings.has_cloud_authentication()
         }
     });
@@ -108,14 +293,203 @@ fn resolve_then_initialize(
 /// The only application bootstrap entry point. Resolution and initialization
 /// are intentionally expressed as adjacent, synchronous steps so neither build
 /// can start the app while its authentication check is still running.
-pub(crate) fn bootstrap(app: &tauri::AppHandle, settings: &SettingsStore) -> AuthenticationStatus {
+pub(crate) fn bootstrap(
+    app: &tauri::AppHandle,
+    settings: &mut SettingsStore,
+) -> AuthenticationStatus {
     resolve_then_initialize(|| resolve(app, settings), |status| initialize(app, status))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{classify_authentication, resolve_then_initialize, AuthenticationStatus};
+    use super::*;
+    use serde_json::json;
     use std::cell::Cell;
+    use wiremock::{
+        matchers::{body_json, method, path},
+        Mock, MockServer, ResponseTemplate,
+    };
+
+    fn stale_account() -> SettingsStore {
+        let mut settings = SettingsStore::default();
+        settings.user.id = Some("account".into());
+        settings.user.subscription_plan = Some("standard".into());
+        settings.user.app_entitled = Some(true);
+        settings.user.entitlement = Some(json!({
+            "plan": "standard", "active": true, "source": "subscription",
+            "checked_at": "2020-01-01T00:00:00Z", "features": { "app": true }
+        }));
+        assert!(cached_account_needs_refresh(&settings));
+        settings
+    }
+
+    fn paid_response() -> serde_json::Value {
+        json!({ "success": true, "user": {
+            "id": "account", "token": "must-not-persist", "app_entitled": true,
+            "subscription_plan": "pro", "has_payment_method": true,
+            "entitlement": { "plan": "pro", "active": true, "source": "subscription",
+                "checked_at": chrono::Utc::now().to_rfc3339(), "features": { "app": true } }
+        }})
+    }
+
+    async fn refresh_at(
+        mut settings: SettingsStore,
+        server: &MockServer,
+        timeout: Duration,
+    ) -> (SettingsStore, Result<Option<AccountRefresh>, String>) {
+        let url = format!("{}/api/user", server.uri());
+        tokio::task::spawn_blocking(move || {
+            let result = refresh_account_before_gate(&mut settings, || {
+                fetch_account(&url, "test-session", timeout)
+            });
+            (settings, result)
+        })
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn startup_refreshes_stale_paid_evidence_before_gate_evaluation() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/user"))
+            .and(body_json(
+                json!({ "token": "test-session", "verify": true }),
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(paid_response()))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let (settings, result) = refresh_at(stale_account(), &server, Duration::from_secs(2)).await;
+        let Some(AccountRefresh::Updated(user)) = result.unwrap() else {
+            panic!("startup did not refresh the account");
+        };
+        assert_eq!(settings.local_plan_policy(), LocalPlanPolicy::VerifiedPaid);
+        assert_eq!(settings.user.subscription_plan.as_deref(), Some("pro"));
+        assert!(settings.user.token.is_none());
+        assert!(user.get("token").is_none());
+        assert_eq!(user["has_payment_method"], true);
+    }
+
+    #[tokio::test]
+    async fn refreshed_entitlement_supplies_missing_plan_and_check_time() {
+        let server = MockServer::start().await;
+        let mut response = paid_response();
+        response["user"]
+            .as_object_mut()
+            .unwrap()
+            .remove("subscription_plan");
+        response["user"]["entitlement"]
+            .as_object_mut()
+            .unwrap()
+            .remove("checked_at");
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(response))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let (settings, result) = refresh_at(stale_account(), &server, Duration::from_secs(2)).await;
+        assert!(result.is_ok());
+        assert_eq!(settings.local_plan_policy(), LocalPlanPolicy::VerifiedPaid);
+    }
+
+    #[tokio::test]
+    async fn refresh_replaces_cached_fields_even_when_new_account_is_unknown() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "success": true, "user": { "id": "account" }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let (settings, result) = refresh_at(stale_account(), &server, Duration::from_secs(2)).await;
+        assert!(result.is_ok());
+        assert_eq!(settings.local_plan_policy(), LocalPlanPolicy::Unknown);
+        assert!(settings.user.entitlement.is_none());
+        assert!(settings.user.subscription_plan.is_none());
+    }
+
+    #[tokio::test]
+    async fn refreshed_free_account_can_start_without_retaining_stale_paid_evidence() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "success": true, "user": {
+                    "id": "account", "cloud_subscribed": false, "app_entitled": false,
+                    "subscription_plan": "none", "entitlement": {
+                        "plan": "none", "active": false, "source": "none",
+                        "checked_at": chrono::Utc::now().to_rfc3339(),
+                        "features": { "app": false, "cloud": false }
+                    }
+                }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let (settings, result) = refresh_at(stale_account(), &server, Duration::from_secs(2)).await;
+        assert!(result.is_ok());
+        assert_eq!(settings.local_plan_policy(), LocalPlanPolicy::VerifiedFree);
+        assert_eq!(settings.user.subscription_plan.as_deref(), Some("none"));
+    }
+
+    #[tokio::test]
+    async fn rejected_startup_session_clears_cached_account() {
+        for response in [
+            ResponseTemplate::new(401),
+            ResponseTemplate::new(403),
+            ResponseTemplate::new(200).set_body_json(json!({ "success": false })),
+            ResponseTemplate::new(200).set_body_json(json!({ "success": true, "user": null })),
+        ] {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .respond_with(response)
+                .expect(1)
+                .mount(&server)
+                .await;
+            let (settings, result) =
+                refresh_at(stale_account(), &server, Duration::from_secs(2)).await;
+            assert!(matches!(result, Ok(Some(AccountRefresh::Rejected))));
+            assert!(!settings.has_account_identity());
+            assert!(settings.user.entitlement.is_none());
+            assert_eq!(settings.local_plan_policy(), LocalPlanPolicy::Unknown);
+        }
+    }
+
+    #[tokio::test]
+    async fn unavailable_refresh_is_bounded_and_does_not_grant_stale_paid_access() {
+        for response in [
+            ResponseTemplate::new(500),
+            ResponseTemplate::new(200).set_body_string("not json"),
+            ResponseTemplate::new(200)
+                .set_body_json(paid_response())
+                .set_delay(Duration::from_secs(1)),
+        ] {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .respond_with(response)
+                .expect(1)
+                .mount(&server)
+                .await;
+            let started = std::time::Instant::now();
+            let (settings, result) =
+                refresh_at(stale_account(), &server, Duration::from_millis(100)).await;
+            assert!(result.is_err());
+            assert!(started.elapsed() < Duration::from_secs(2));
+            assert_eq!(settings.local_plan_policy(), LocalPlanPolicy::Unknown);
+        }
+    }
+
+    #[test]
+    fn already_verified_access_keeps_its_offline_startup_path() {
+        let mut settings = stale_account();
+        settings.user = serde_json::from_value(paid_response()["user"].clone()).unwrap();
+        let result = refresh_account_before_gate(&mut settings, || {
+            panic!("an allowed cached account must not wait for a network refresh")
+        });
+        assert!(matches!(result, Ok(None)));
+        assert_eq!(settings.local_plan_policy(), LocalPlanPolicy::VerifiedPaid);
+    }
 
     #[test]
     fn signup_free_build_resolves_immediately() {

--- a/apps/screenpipe-app-tauri/src-tauri/src/store.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/store.rs
@@ -2575,6 +2575,23 @@ impl SettingsStore {
         Ok(())
     }
 
+    /// Startup refresh replaces account evidence before any gate or webview
+    /// consumes it. Preserve other settings and response fields used by the UI.
+    pub(crate) fn replace_startup_user(
+        &mut self,
+        app: &AppHandle,
+        user: Value,
+    ) -> Result<(), String> {
+        self.user = serde_json::from_value(user.clone()).map_err(|e| e.to_string())?;
+        let store = get_store(app, None).map_err(|e| e.to_string())?;
+        let mut settings = store.get("settings").ok_or("settings unavailable")?;
+        settings["user"] = user;
+        store.set("settings", settings);
+        save_store_with_permission_repair(app, store.as_ref())?;
+        reencrypt_store_file(app);
+        Ok(())
+    }
+
     /// Update only identity, preserving the latest settings and rejecting a
     /// concurrent identity change. The server association and cursor must already
     /// be durable before the enterprise uploader calls this.


### PR DESCRIPTION
## description

Consumer startup checks for a stored session token, then decides whether to start the engine using cached account evidence. It never refreshes that evidence before denying access. A subscribed account with stale, incomplete, or inconsistent cached plan fields can therefore be blocked before the frontend refreshes it.

Before applying a cached account-access denial, native startup now sends a bounded `POST /api/user` with `verify: true`. It replaces the cached account in both the startup snapshot and shared settings before initializing the app and evaluating engine access. The response's token is excluded from plaintext settings; other account-response fields used by the UI are preserved.

HTTP 401/403 and explicit session rejection clear the saved session. A successful response with unknown plan evidence replaces the old fields and remains blocked. Network errors and timeouts do not turn stale evidence into authorization. Already verified accounts retain their existing offline startup path, and Enterprise and seeded E2E authentication keep their existing paths.

If the initial request fails and a later account refresh succeeds, the native deferred-start recovery resumes the engine once. Explicit start, Stop, and sign-out cancel that deferred request, including Stop during capture-intent publication.

## before / after

Illustrative control flow, not a Windows runtime recording:

```text
BEFORE
Stored token -> cached account denies access -> engine blocked
               no account refresh before this decision

AFTER
Stored token -> cached account would deny access
            -> POST /api/user (verify=true, 10-second request timeout)
            -> replace native snapshot + shared account settings
            -> evaluate refreshed account -> start if authorized

Initial refresh unavailable -> remain blocked -> later verified refresh can resume
Explicit Stop or sign-out  -> cancel deferred startup
```

## Historical intent

Inspected `27fb5d8470` / #6810 and #6838: authentication must resolve before application initialization, and unknown plan evidence must not authorize engine access. This preserves those boundaries while replacing the cache-only consumer decision with a refresh before a cached denial. Existing valid-cache offline behavior, the summary-trial server/capture split, and Enterprise authorization are retained.

## evidence type

- [x] Backend change — native HTTP and recovery regression tests.

The startup HTTP tests use a local mock server and synthetic credentials. They exercise the actual request body and fresh account replacement, paid/free results, missing canonical plan/check time, explicit rejection, unknown evidence, malformed responses, and a bounded timeout. Recovery tests cover both refresh orderings, duplicate refreshes, cancellation, and Stop during recovery.

## how to test

From `apps/screenpipe-app-tauri`:

- `bun run test:tauri startup_auth::tests -- --nocapture` — **10 passed**.
- `bun run test:tauri -- -- --nocapture startup_auth::tests recording_access_tests tauri_bindings_are_current` — **24 passed** (10 startup, 13 access/recovery, 1 binding consistency).
- `bun x vitest run components/app-entitlement-gate.test.tsx lib/app-entitlement.test.ts` — **98 passed**.
- `bun run typecheck` — **passed**.

Native tests use the required machine-wide build queue and `debug-dev` profile. From repository root, `git diff --check` passes.

Windows runtime and live-account recovery have not been verified. These checks do not prove resolution of a particular customer incident. No confidential diagnostics or customer identifiers are included.

## desktop app checklist

- [x] Command signatures and exported types are unchanged; binding generation is not needed.
- [x] Binding consistency test.
- [x] `bun run typecheck`.

## AI assistance and human ownership

- AI tool: OpenAI Codex.
- Autonomy level: `agent`; implemented and submitted at the user's explicit request.
- Verification: Codex ran the commands above. No human manual-testing claim is made.
- [ ] Human contributor has reviewed every material change and can explain it independently.
