### PR TITLE
fix(onboarding): revert no-card Free bypass

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -277,7 +277,7 @@ jobs:
       working-directory: ./apps/screenpipe-app-tauri
       run: bun run test:e2e:onboarding-background-ai-tools
 
-    - name: Verify clean Free onboarding without card capture
+    - name: Verify first-run onboarding and existing-owner checkout bypass
       shell: pwsh
       working-directory: ./apps/screenpipe-app-tauri
       run: bun run test:e2e:onboarding-first-run
@@ -929,7 +929,7 @@ jobs:
       working-directory: ./apps/screenpipe-app-tauri
       run: bun run test:e2e:onboarding-background-ai-tools
 
-    - name: Verify clean Free onboarding without card capture
+    - name: Verify first-run onboarding and existing-owner checkout bypass
       shell: bash
       working-directory: ./apps/screenpipe-app-tauri
       run: bun run test:e2e:onboarding-first-run

--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -23,14 +23,14 @@ results and `cargo llvm-cov` data on top when judging release confidence.
 ### Tauri E2E
 
 - Mapped specs: 140
-- Declared test blocks: 405
-- Weighted coverage points: 326.1
+- Declared test blocks: 404
+- Weighted coverage points: 325.1
 
 | Platform | Specs | Declared tests | Weighted points | Layers | Features | Critical score |
 | --- | --- | --- | --- | --- | --- | --- |
-| windows | 107 | 343 | 286.1 | 15 | 122 | 85% |
-| macos | 136 | 367 | 295.9 | 17 | 132 | 88% |
-| linux | 95 | 301 | 255.5 | 14 | 119 | 80% |
+| windows | 107 | 342 | 285.1 | 15 | 122 | 85% |
+| macos | 136 | 366 | 294.9 | 17 | 132 | 88% |
+| linux | 95 | 300 | 254.5 | 14 | 119 | 80% |
 
 ### Core Engine
 

--- a/apps/screenpipe-app-tauri/components/first-run/learning-banner.test.tsx
+++ b/apps/screenpipe-app-tauri/components/first-run/learning-banner.test.tsx
@@ -17,8 +17,6 @@ const mocks = vi.hoisted(() => ({
   view: {} as LearningWindowView,
   emit: vi.fn().mockResolvedValue(undefined),
   completeOnboarding: vi.fn().mockResolvedValue(undefined),
-  setOnboardingStep: vi.fn().mockResolvedValue({ status: "ok", data: null }),
-  capture: vi.fn(),
   handoff: {
     targets: [],
     resolved: false,
@@ -50,12 +48,8 @@ vi.mock("@tauri-apps/api/event", () => ({
   emit: mocks.emit,
   listen: vi.fn(async () => () => {}),
 }));
-vi.mock("posthog-js", () => ({ default: { capture: mocks.capture } }));
 vi.mock("@/lib/utils/tauri", () => ({
-  commands: {
-    completeOnboarding: mocks.completeOnboarding,
-    setOnboardingStep: mocks.setOnboardingStep,
-  },
+  commands: { completeOnboarding: mocks.completeOnboarding },
 }));
 
 vi.mock("@/lib/hooks/use-settings", () => ({
@@ -175,26 +169,6 @@ describe("trial activation summary experience", () => {
     expect(
       screen.getByTestId("trial-activation-start-trial").parentElement,
     ).toHaveClass("pointer-events-auto");
-  });
-
-  it("unlocks the full app when the user continues with Free", async () => {
-    render(<TrialActivationUnlockPrompt onStartTrial={vi.fn()} />);
-
-    fireEvent.click(screen.getByTestId("trial-activation-continue-free"));
-
-    await waitFor(() =>
-      expect(mocks.setOnboardingStep).toHaveBeenCalledWith(
-        "trial-activation-v1-unlocked",
-      ),
-    );
-    expect(mocks.capture).toHaveBeenCalledWith(
-      "onboarding_plan_activated",
-      expect.objectContaining({
-        plan: "free",
-        confirmation: "free_no_card",
-        source: "summary_lock",
-      }),
-    );
   });
 
   it("supports an inline CTA beside native product surfaces", () => {

--- a/apps/screenpipe-app-tauri/components/first-run/learning-banner.tsx
+++ b/apps/screenpipe-app-tauri/components/first-run/learning-banner.tsx
@@ -18,11 +18,6 @@ import { appIconUrl } from "@/lib/first-run/recent-activity";
 import { AgentHandoffPicker } from "@/components/first-run/agent-handoff-picker";
 import { useFirstRunLearningWindow } from "@/components/first-run/learning-window-provider";
 import type { AgentHandoffTarget } from "@/lib/first-run/agent-handoff";
-import {
-  TRIAL_ACTIVATION_EXPERIMENT_FLAG,
-  TRIAL_ACTIVATION_TREATMENT,
-  TRIAL_ACTIVATION_UNLOCKED_STEP,
-} from "@/lib/first-run/trial-activation";
 
 function CapturedAppIcon({ app }: { app: FirstRunCapturedApp }) {
   const [failed, setFailed] = React.useState(false);
@@ -398,33 +393,6 @@ export function TrialActivationUnlockPrompt({
   onStartTrial: () => void;
   inline?: boolean;
 }) {
-  const [freeBusy, setFreeBusy] = React.useState(false);
-  const [freeError, setFreeError] = React.useState<string | null>(null);
-
-  const continueWithFree = async () => {
-    if (freeBusy) return;
-    setFreeBusy(true);
-    setFreeError(null);
-    try {
-      const result = await commands.setOnboardingStep(
-        TRIAL_ACTIVATION_UNLOCKED_STEP,
-      );
-      if (result.status === "error") throw new Error(result.error);
-      posthog.capture("onboarding_plan_activated", {
-        experiment: TRIAL_ACTIVATION_EXPERIMENT_FLAG,
-        variant: TRIAL_ACTIVATION_TREATMENT,
-        plan: "free",
-        confirmation: "free_no_card",
-        source: inline ? "timeline_lock" : "summary_lock",
-      });
-    } catch (error) {
-      setFreeBusy(false);
-      setFreeError(
-        error instanceof Error ? error.message : "could not continue with Free",
-      );
-    }
-  };
-
   return (
     <div
       className={
@@ -436,29 +404,13 @@ export function TrialActivationUnlockPrompt({
       data-layout={inline ? "inline" : "overlay"}
     >
       <div className="pointer-events-auto w-full max-w-xl border border-border bg-background p-5 text-center shadow-lg">
-        <div className="pointer-events-auto flex flex-col gap-3">
-          <Button
-            className="h-12 w-full px-8 text-sm"
-            data-testid="trial-activation-start-trial"
-            onClick={onStartTrial}
-          >
-            start your 7-day Business trial
-          </Button>
-          <Button
-            variant="outline"
-            className="h-11 w-full px-8 text-sm"
-            data-testid="trial-activation-continue-free"
-            disabled={freeBusy}
-            onClick={() => void continueWithFree()}
-          >
-            {freeBusy ? "continuing with Free" : "continue with Free — no card"}
-          </Button>
-        </div>
-        {freeError && (
-          <p className="mt-3 text-sm text-destructive" role="alert">
-            {freeError}
-          </p>
-        )}
+        <Button
+          className="h-12 w-full px-8 text-sm"
+          data-testid="trial-activation-start-trial"
+          onClick={onStartTrial}
+        >
+          start your 7-day free trial to unlock full access
+        </Button>
       </div>
     </div>
   );

--- a/apps/screenpipe-app-tauri/components/first-run/trial-activation-paywall.test.tsx
+++ b/apps/screenpipe-app-tauri/components/first-run/trial-activation-paywall.test.tsx
@@ -68,7 +68,6 @@ beforeEach(() => {
   window.sessionStorage.clear();
   mocks.user = null;
   mocks.loadUser.mockResolvedValue(undefined);
-  mocks.setOnboardingStep.mockResolvedValue({ status: "ok", data: null });
   submitSpy = vi
     .spyOn(HTMLFormElement.prototype, "submit")
     .mockImplementation(() => undefined);
@@ -156,44 +155,5 @@ describe("TrialActivationPaywall", () => {
     expect(
       window.sessionStorage.getItem(TRIAL_ACTIVATION_CHECKOUT_STATE_KEY),
     ).toBe("pending");
-  });
-
-  it("lets a user return from checkout and continue with Free", async () => {
-    mocks.user = {
-      token: "in-memory-token",
-      has_payment_method: false,
-      entitlement_source: "none",
-    };
-    window.sessionStorage.setItem(
-      TRIAL_ACTIVATION_CHECKOUT_STATE_KEY,
-      "pending",
-    );
-
-    render(<TrialActivationPaywall open locked />);
-
-    fireEvent.click(
-      await screen.findByRole("button", {
-        name: "continue with Free — no card",
-      }),
-    );
-    await waitFor(() =>
-      expect(mocks.setOnboardingStep).toHaveBeenCalledWith(
-        "trial-activation-v1-unlocked",
-      ),
-    );
-    expect(submitSpy).not.toHaveBeenCalled();
-    await waitFor(() =>
-      expect(
-        window.sessionStorage.getItem(TRIAL_ACTIVATION_CHECKOUT_STATE_KEY),
-      ).toBeNull(),
-    );
-    expect(mocks.capture).toHaveBeenCalledWith(
-      "onboarding_plan_activated",
-      expect.objectContaining({
-        plan: "free",
-        confirmation: "free_no_card",
-        source: "checkout_dialog",
-      }),
-    );
   });
 });

--- a/apps/screenpipe-app-tauri/components/first-run/trial-activation-paywall.tsx
+++ b/apps/screenpipe-app-tauri/components/first-run/trial-activation-paywall.tsx
@@ -45,7 +45,6 @@ export function TrialActivationPaywall({
   );
   const [tokenResolved, setTokenResolved] = React.useState(Boolean(user?.token));
   const [error, setError] = React.useState<string | null>(null);
-  const [freeBusy, setFreeBusy] = React.useState(false);
   const [returnedWithoutStatus, setReturnedWithoutStatus] = React.useState(() =>
     ["pending", "returned"].includes(
       window.sessionStorage.getItem(TRIAL_ACTIVATION_CHECKOUT_STATE_KEY) ?? "",
@@ -138,35 +137,6 @@ export function TrialActivationPaywall({
     }
   }, [checkoutToken]);
 
-  const continueWithFree = React.useCallback(async () => {
-    if (freeBusy) return;
-    submissionStartedRef.current = true;
-    setFreeBusy(true);
-    setError(null);
-    try {
-      const result = await commands.setOnboardingStep(
-        TRIAL_ACTIVATION_UNLOCKED_STEP,
-      );
-      if (result.status === "error") throw new Error(result.error);
-      window.sessionStorage.removeItem(TRIAL_ACTIVATION_CHECKOUT_STATE_KEY);
-      posthog.capture("onboarding_plan_activated", {
-        experiment: "first-summary-card-trial-v1",
-        variant: "summary_first",
-        plan: "free",
-        confirmation: "free_no_card",
-        source: "checkout_dialog",
-      });
-    } catch (freeError) {
-      submissionStartedRef.current = false;
-      setFreeBusy(false);
-      setError(
-        freeError instanceof Error
-          ? freeError.message
-          : "could not continue with Free",
-      );
-    }
-  }, [freeBusy]);
-
   React.useEffect(() => {
     if (!open || !tokenResolved || !checkoutToken || returnedWithoutStatus) {
       return;
@@ -230,13 +200,6 @@ export function TrialActivationPaywall({
             loading screenpipe.com
           </p>
         )}
-        <Button
-          variant="ghost"
-          disabled={freeBusy}
-          onClick={() => void continueWithFree()}
-        >
-          {freeBusy ? "continuing with Free" : "continue with Free — no card"}
-        </Button>
       </DialogContent>
     </Dialog>
   );

--- a/apps/screenpipe-app-tauri/components/onboarding/plan-selection-step.test.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/plan-selection-step.test.tsx
@@ -86,10 +86,6 @@ describe("hosted onboarding checkout", () => {
   it("navigates the existing webview with a hidden POST and keeps secrets out of URLs", async () => {
     render(<PlanSelectionStep handleNextSlide={vi.fn()} />);
 
-    expect(submitSpy).not.toHaveBeenCalled();
-    fireEvent.click(
-      screen.getByRole("button", { name: "start 7-day Business trial" }),
-    );
     await waitFor(() => expect(submitSpy).toHaveBeenCalledOnce());
     const form = checkoutForm();
     expect(form.method).toBe("post");
@@ -110,9 +106,6 @@ describe("hosted onboarding checkout", () => {
 
   it("submits only once when the local controller rerenders", async () => {
     const view = render(<PlanSelectionStep handleNextSlide={vi.fn()} />);
-    fireEvent.click(
-      screen.getByRole("button", { name: "start 7-day Business trial" }),
-    );
     await waitFor(() => expect(submitSpy).toHaveBeenCalledOnce());
 
     view.rerender(<PlanSelectionStep handleNextSlide={vi.fn()} />);
@@ -270,33 +263,14 @@ describe("hosted onboarding checkout", () => {
     ).toBe(buildLocalCheckoutReturnUrl(window.location.href));
   });
 
-  it("offers Free without a card after cancellation", async () => {
+  it("keeps checkout required after cancellation", async () => {
     window.history.replaceState({}, "", "/onboarding?checkout=cancelled");
     const next = vi.fn();
     render(<PlanSelectionStep handleNextSlide={next} />);
 
-    fireEvent.click(screen.getByTestId("onboarding-plan-free"));
-
-    expect(next).toHaveBeenCalledOnce();
-    expect(submitSpy).not.toHaveBeenCalled();
-    expect(mocks.capture).toHaveBeenCalledWith("onboarding_plan_activated", {
-      plan: "free",
-      confirmation: "free_no_card",
-    });
-  });
-
-  it("offers Free without opening checkout on the initial plan screen", () => {
-    const next = vi.fn();
-    render(<PlanSelectionStep handleNextSlide={next} />);
-
-    expect(screen.getByText("choose how to start")).toBeInTheDocument();
-    expect(screen.getByTestId("onboarding-plan-selection")).toBeInTheDocument();
     expect(
-      screen.queryByTestId("onboarding-card-capture"),
+      screen.queryByTestId("onboarding-plan-free"),
     ).not.toBeInTheDocument();
-    fireEvent.click(screen.getByTestId("onboarding-plan-free"));
-
-    expect(next).toHaveBeenCalledOnce();
-    expect(submitSpy).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
   });
 });

--- a/apps/screenpipe-app-tauri/components/onboarding/plan-selection-step.tsx
+++ b/apps/screenpipe-app-tauri/components/onboarding/plan-selection-step.tsx
@@ -35,7 +35,7 @@ export default function PlanSelectionStep({
   const { settings, loadUser } = useSettings();
   const user = settings.user as AppUser | null | undefined;
   const [returnStatus] = useState(checkoutStatus);
-  const [busy, setBusy] = useState(returnStatus === "complete");
+  const [busy, setBusy] = useState(returnStatus !== "cancelled");
   const [error, setError] = useState<string | null>(null);
   const [returnRecoveryFinished, setReturnRecoveryFinished] = useState(
     returnStatus !== "complete",
@@ -81,6 +81,11 @@ export default function PlanSelectionStep({
       );
     }
   }, [userToken]);
+
+  useEffect(() => {
+    if (returnStatus !== null) return;
+    startCheckout();
+  }, [returnStatus, startCheckout]);
 
   useEffect(() => {
     if (returnStatus !== "complete") return;
@@ -199,16 +204,6 @@ export default function PlanSelectionStep({
     setRecoveryAttempt((attempt) => attempt + 1);
   }, [userToken]);
 
-  const continueWithFree = useCallback(() => {
-    if (advancedRef.current) return;
-    advancedRef.current = true;
-    posthog.capture("onboarding_plan_activated", {
-      plan: "free",
-      confirmation: "free_no_card",
-    });
-    void handleNextSlide();
-  }, [handleNextSlide]);
-
   if (returnStatus === "complete") {
     return (
       <div
@@ -257,29 +252,19 @@ export default function PlanSelectionStep({
           checkout was not completed
         </h2>
         <p className="mt-2 font-mono text-[10px] leading-relaxed text-muted-foreground">
-          start the Business trial, or keep using Free without a card.
+          retry when you are ready to start your trial.
         </p>
         {error && (
           <p className="mt-4 font-mono text-[11px] text-destructive">{error}</p>
         )}
-        <div className="mt-5 flex flex-col gap-3">
-          <button
-            type="button"
-            onClick={startCheckout}
-            disabled={busy}
-            className="border bg-foreground px-4 py-2 font-mono text-[10px] uppercase tracking-widest text-background transition-opacity hover:opacity-80 disabled:opacity-50"
-          >
-            {busy ? "opening checkout" : "retry secure checkout"}
-          </button>
-          <button
-            type="button"
-            data-testid="onboarding-plan-free"
-            onClick={continueWithFree}
-            className="border px-4 py-2 font-mono text-[10px] uppercase tracking-widest transition-colors hover:bg-foreground hover:text-background"
-          >
-            continue with Free — no card
-          </button>
-        </div>
+        <button
+          type="button"
+          onClick={startCheckout}
+          disabled={busy}
+          className="mt-5 border bg-foreground px-4 py-2 font-mono text-[10px] uppercase tracking-widest text-background transition-opacity hover:opacity-80 disabled:opacity-50"
+        >
+          {busy ? "opening checkout" : "retry secure checkout"}
+        </button>
       </div>
     );
   }
@@ -287,31 +272,23 @@ export default function PlanSelectionStep({
   return (
     <div
       className="mx-auto w-full max-w-sm text-center"
-      data-testid="onboarding-plan-selection"
+      data-testid="onboarding-card-capture"
     >
-      <h2 className="text-xl font-semibold lowercase">choose how to start</h2>
-      <p className="mt-3 font-mono text-[11px] leading-relaxed text-muted-foreground">
-        Use Screenpipe Free without a card, or start a 7-day Business trial.
+      <h2 className="text-xl font-semibold lowercase">
+        opening secure checkout
+      </h2>
+      <p className="mt-3 font-mono text-[11px] text-muted-foreground">
+        {error || "loading screenpipe.com"}
       </p>
-      {error && <p className="mt-3 font-mono text-[11px] text-destructive">{error}</p>}
-      <div className="mt-5 flex flex-col gap-3">
+      {error && (
         <button
           type="button"
           onClick={startCheckout}
-          disabled={busy}
-          className="border bg-foreground px-4 py-2 font-mono text-[10px] uppercase tracking-widest text-background transition-opacity hover:opacity-80 disabled:opacity-50"
+          className="mt-5 border px-4 py-2 font-mono text-[10px] uppercase tracking-widest transition-colors hover:bg-foreground hover:text-background"
         >
-          {busy ? "opening checkout" : "start 7-day Business trial"}
+          try again
         </button>
-        <button
-          type="button"
-          data-testid="onboarding-plan-free"
-          onClick={continueWithFree}
-          className="border px-4 py-2 font-mono text-[10px] uppercase tracking-widest transition-colors hover:bg-foreground hover:text-background"
-        >
-          continue with Free — no card
-        </button>
-      </div>
+      )}
     </div>
   );
 }

--- a/apps/screenpipe-app-tauri/e2e/COVERAGE.md
+++ b/apps/screenpipe-app-tauri/e2e/COVERAGE.md
@@ -11,8 +11,8 @@ and layer declared in the manifest, weighted by confidence and criticality.
 - Manifest: `e2e/coverage-map.json`
 - Specs directory: `e2e/specs`
 - Mapped specs: 140
-- Declared test blocks: 405
-- Weighted coverage points: 326.1
+- Declared test blocks: 404
+- Weighted coverage points: 325.1
 
 Confidence weights: strong=1.0, partial=0.7, conditional=0.4, smoke=0.3.
 Criticality weights: high=1.0, medium=0.7, low=0.4.
@@ -23,9 +23,9 @@ can execute more runtime cases than this number shows.
 
 | Platform | Specs | Declared tests | Weighted points | Layers | Features | Critical score |
 | --- | --- | --- | --- | --- | --- | --- |
-| windows | 107 | 343 | 286.1 | 15 | 122 | 85% |
-| macos | 136 | 367 | 295.9 | 17 | 132 | 88% |
-| linux | 95 | 301 | 255.5 | 14 | 119 | 80% |
+| windows | 107 | 342 | 285.1 | 15 | 122 | 85% |
+| macos | 136 | 366 | 294.9 | 17 | 132 | 88% |
+| linux | 95 | 300 | 254.5 | 14 | 119 | 80% |
 
 ## Runtime Results
 
@@ -45,14 +45,14 @@ pass/fail/skip counts.
 | entitlement | - | 1 specs / 1 tests / 1.0 pts | - |
 | local-api | 29 specs / 120 tests / 101.0 pts | 39 specs / 117 tests / 100.5 pts | 24 specs / 88 tests / 79.2 pts |
 | notifications | 4 specs / 26 tests / 17.3 pts | 3 specs / 5 tests / 3.4 pts | 2 specs / 4 tests / 3.1 pts |
-| onboarding | 9 specs / 40 tests / 35.8 pts | 11 specs / 44 tests / 39.2 pts | 9 specs / 40 tests / 35.8 pts |
+| onboarding | 9 specs / 39 tests / 34.8 pts | 11 specs / 43 tests / 38.2 pts | 9 specs / 39 tests / 34.8 pts |
 | os-integration | 7 specs / 32 tests / 26.9 pts | 15 specs / 30 tests / 18.4 pts | 2 specs / 15 tests / 10.8 pts |
 | performance | 3 specs / 45 tests / 45.0 pts | 5 specs / 36 tests / 31.8 pts | 2 specs / 30 tests / 30.0 pts |
 | pipes | 6 specs / 20 tests / 20.0 pts | 8 specs / 26 tests / 26.0 pts | 6 specs / 20 tests / 20.0 pts |
-| real-ui-e2e | 80 specs / 241 tests / 204.9 pts | 97 specs / 259 tests / 219.9 pts | 74 specs / 217 tests / 190.9 pts |
+| real-ui-e2e | 80 specs / 240 tests / 203.9 pts | 97 specs / 258 tests / 218.9 pts | 74 specs / 216 tests / 189.9 pts |
 | settings | 15 specs / 42 tests / 39.0 pts | 17 specs / 36 tests / 31.7 pts | 14 specs / 33 tests / 30.0 pts |
 | storage-privacy | 10 specs / 44 tests / 35.3 pts | 10 specs / 29 tests / 28.1 pts | 7 specs / 22 tests / 21.1 pts |
-| tauri-command | 23 specs / 65 tests / 51.9 pts | 35 specs / 88 tests / 70.3 pts | 22 specs / 66 tests / 52.8 pts |
+| tauri-command | 23 specs / 64 tests / 50.9 pts | 35 specs / 87 tests / 69.3 pts | 22 specs / 65 tests / 51.8 pts |
 | window-lifecycle | 22 specs / 71 tests / 59.5 pts | 23 specs / 55 tests / 40.9 pts | 16 specs / 44 tests / 34.4 pts |
 
 ## Critical Feature Matrix
@@ -200,7 +200,7 @@ pass/fail/skip counts.
 | meetings-only-audio-lifecycle.spec.ts | windows, macos | audio-device, local-api, real-ui-e2e | meetings-only-audio-lifecycle, audio-device-health | high | conditional | real-user-flow | 1 | Opt-in real-audio lifecycle lane: configured devices stay closed outside meetings and open only across a manual meeting edge. |
 | notification-viewer-link.spec.ts | windows, macos, linux | notifications, local-api, window-lifecycle | notifications, viewer-deeplink | high | partial | mixed | 3 | Notification local file links rewrite into in-app viewer links. |
 | onboarding-background-ai-tools.spec.ts | windows, macos, linux | onboarding, real-ui-e2e, storage-privacy | onboarding, settings-ai | high | strong | real-user-flow | 2 | Isolated agent-home CI lane verifies private native config writes, the resolved local API credential, a real authenticated MCP tool call, skills setup, and migration from the removed connection slide through engine startup to optional recommended setup and completion. |
-| onboarding-first-run.spec.ts | windows, macos, linux | onboarding, real-ui-e2e, tauri-command | onboarding, first-run-learning, settings-persistence | high | strong | real-user-flow | 10 | Fresh-install setup walk: signed-out users restoring a post-login step return to login; after account creation, the acquisition slide is reachable in the shipped order and counted by the progress bar, offers no free-text field, one tap persists through to store.bin via the real settings command, skip records nothing, verified Free accounts continue without card capture or hosted checkout and land in Home, and existing lifetime owners stay out of mandatory checkout. |
+| onboarding-first-run.spec.ts | windows, macos, linux | onboarding, real-ui-e2e, tauri-command | onboarding, first-run-learning, settings-persistence | high | strong | real-user-flow | 9 | Fresh-install setup walk: signed-out users restoring a post-login step return to login; after account creation, the acquisition slide is reachable in the shipped order and counted by the progress bar, offers no free-text field, one tap persists through to store.bin via the real settings command, skip records nothing, and existing lifetime owners stay out of mandatory checkout. |
 | onboarding-h1-follow-up.spec.ts | windows, macos, linux | onboarding, notifications, pipes, real-ui-e2e | onboarding, notifications, pipes | high | strong | real-user-flow | 1 | A due H1 activation runs its real Pipe, sends one visible prompt through the app-control notification server, and remains exactly-once across repeated scheduler ticks. |
 | onboarding-redirect.spec.ts | windows, macos, linux | onboarding, real-ui-e2e, window-lifecycle | onboarding, app-launch | high | conditional | real-user-flow | 5 | Opt-in no-onboarding seed verifies onboarding redirect. |
 | onboarding-trust-affordances.spec.ts | windows, macos, linux | onboarding, real-ui-e2e, tauri-command | onboarding, settings-privacy-api-auth, storage-retention | high | strong | real-user-flow | 4 | Pre-grant reassurance in setup: the login slide carries the storage-locality line and the pause affordance on one line (the only slide every platform sees, since permissions auto-advances on non-mac); the mac permissions slide keeps that promise collapsed to a single line below the permission wheel and on expand renders the data dir the running app actually resolved rather than a reconstructed ~/.screenpipe, with an open action pointed at that path; collapsed and expanded states are both asserted to fit inside the fixed-size onboarding window; and the timeline slide states the capture bounds (incognito skipped, per-app exclusions) where the capture decision is made. The mac assertions share one visit because the slide auto-advances 600ms after all grants land. |

--- a/apps/screenpipe-app-tauri/e2e/coverage-map.json
+++ b/apps/screenpipe-app-tauri/e2e/coverage-map.json
@@ -2281,8 +2281,8 @@
       "criticality": "high",
       "confidence": "strong",
       "ux": "real-user-flow",
-      "tests": 10,
-      "notes": "Fresh-install setup walk: signed-out users restoring a post-login step return to login; after account creation, the acquisition slide is reachable in the shipped order and counted by the progress bar, offers no free-text field, one tap persists through to store.bin via the real settings command, skip records nothing, verified Free accounts continue without card capture or hosted checkout and land in Home, and existing lifetime owners stay out of mandatory checkout."
+      "tests": 9,
+      "notes": "Fresh-install setup walk: signed-out users restoring a post-login step return to login; after account creation, the acquisition slide is reachable in the shipped order and counted by the progress bar, offers no free-text field, one tap persists through to store.bin via the real settings command, skip records nothing, and existing lifetime owners stay out of mandatory checkout."
     },
     {
       "spec": "onboarding-h1-follow-up.spec.ts",

--- a/apps/screenpipe-app-tauri/e2e/specs/onboarding-first-run.spec.ts
+++ b/apps/screenpipe-app-tauri/e2e/specs/onboarding-first-run.spec.ts
@@ -47,7 +47,6 @@ const seedFlags = E2E_SEED_FLAGS.split(",")
 const canRun = !seedFlags.includes("onboarding");
 
 const LEARNING_STORAGE_KEY = "screenpipe.first-run.learning-window.v1";
-const FORCE_BILLING_GATE_KEY = "screenpipe_e2e_force_billing_gate";
 const E2E_ACCOUNT_USER_KEY = "screenpipe_e2e_account_user";
 const E2E_ACCOUNT_USER_EVENT = "screenpipe-e2e-seed-account-user";
 const E2E_ACCOUNT_FIXTURE_ACTIVE_KEY =
@@ -444,80 +443,8 @@ const seedLearningWindow = async (state: Record<string, unknown>) => {
     }
   });
 
-  it("continues from a verified Free account without asking for a card", async () => {
-    // Tauri's encrypted token store survives the app-data reset used between
-    // local E2E runs. Clear any synthetic token from a previous run before
-    // installing this fixture so the native store and settings stay aligned.
-    await seedFreeOnboardingUser();
-
-    try {
-      await gotoSlide("plan");
-      await waitForTestId("onboarding-plan-selection", 30_000);
-
-      const before = await bodyText();
-      expect(before).not.toContain("opening secure checkout");
-      expect(
-        await browser.execute(
-          () =>
-            !!document.querySelector(
-              '[data-testid="onboarding-card-capture"]',
-            ),
-        ),
-      ).toBe(false);
-
-      const continueFree = await waitForTestId("onboarding-plan-free");
-      await continueFree.waitForExist({ timeout: t(20_000) });
-      await continueFree.click();
-
-      await waitForTestId("onboarding-final-setup", 30_000);
-      const after = await bodyText();
-      expect(after).toContain("connect gmail");
-      expect(after).not.toContain("opening secure checkout");
-      expect(
-        await browser.execute(
-          () =>
-            !!document.querySelector(
-              '[data-testid="onboarding-card-capture"]',
-            ),
-        ),
-      ).toBe(false);
-
-      const filepath = await saveScreenshot("onboarding-free-no-card");
-      expect(existsSync(filepath)).toBe(true);
-
-      const finishSetup = await $("button*=continue");
-      await finishSetup.waitForExist({ timeout: t(20_000) });
-      await finishSetup.click();
-
-      await waitForWindowClosed("onboarding", t(30_000));
-      await waitForWindowHandle("home", t(30_000));
-      await browser.switchToWindow("home");
-
-      // E2E builds normally bypass the post-onboarding entitlement gate so
-      // the broad suite can exercise paid surfaces. Force that real gate back
-      // on and reload the already-mounted Home webview before asserting its
-      // navigation; otherwise Home could remain visible through the bypass.
-      await browser.execute((key: string) => {
-        window.localStorage.setItem(key, "1");
-        window.location.reload();
-      }, FORCE_BILLING_GATE_KEY);
-      await browser.pause(t(2_500));
-      await browser.switchToWindow("home");
-
-      const navHome = await $('[data-testid="nav-home"]');
-      await navHome.waitForExist({ timeout: t(30_000) });
-      expect(await navHome.isExisting()).toBe(true);
-    } finally {
-      await browser
-        .execute((key: string) => {
-          window.localStorage.removeItem(key);
-        }, FORCE_BILLING_GATE_KEY)
-        .catch(() => {});
-    }
-  });
-
   it("keeps lifetime ownership out of mandatory checkout", async () => {
-    // The preceding Free scenario installs a different synthetic token. Clear
+    // The preceding scenarios install a different synthetic token. Clear
     // it first so changing fixtures exercises a clean account transition.
     await clearOnboardingUser();
     await seedOnboardingUser({
@@ -539,8 +466,7 @@ const seedLearningWindow = async (state: Record<string, unknown>) => {
     });
 
     // Simulate an upgrade from a build that had already persisted "plan".
-    // The preceding Free test completed setup and closed this window, so reset
-    // the native completion flag before restoring the older in-progress step.
+    // Reset the native completion flag before restoring the in-progress step.
     await invokeOrThrow("reset_onboarding");
     // The current shipped route must map it back to engine instead of opening
     // a hosted checkout for an account that already has access.


### PR DESCRIPTION
## Description

Reverts the no-card Free onboarding behavior introduced by #6907 at the maintainer's request. New eligible accounts automatically open the existing hosted browser checkout again. Removes the Free bypass from checkout cancellation, the first-result unlock prompt, and its checkout dialog.

The three production components exactly match their versions before #6907. Keeps the later login fixes, existing-entitlement bypass, and authentication race protections. Restores the original component tests and removes the obsolete E2E asserting no-card completion; retains the login and lifetime-owner E2Es and synchronizes their coverage inventory.

## Before / after

ASCII flow illustration; no native recording claimed:

```text
Before: onboarding -> choose Business trial OR continue with Free, no card
After:  onboarding -> hosted browser checkout -> verified account -> continue

Before: first-result unlock -> trial OR continue with Free, no card
After:  first-result unlock -> existing trial checkout
```

## Historical intent

Inspected #6907 (`ea260bdc7f`), its parent, the hosted checkout implementation (#6303), and later login fixes (#6921 and #6942). #6907 made checkout optional to allow Free activation; this PR intentionally reverses that product decision. Card collection remains hosted on screenpipe.com with the existing authenticated handoff and server-authoritative completion. Tests expecting a no-card bypass are obsolete under the requested revert.

## Validation

From `apps/screenpipe-app-tauri`:

- `bun x vitest run --config vitest.config.ts components/onboarding/plan-selection-step.test.tsx components/first-run/learning-banner.test.tsx components/first-run/trial-activation-paywall.test.tsx app/onboarding/page.test.tsx lib/onboarding-checkout.test.ts components/app-entitlement-gate.test.tsx` — 153 passed across six suites.
- `bun run typecheck` — passed.
- `bun x eslint components/onboarding/plan-selection-step.tsx components/onboarding/plan-selection-step.test.tsx components/first-run/learning-banner.tsx components/first-run/learning-banner.test.tsx components/first-run/trial-activation-paywall.tsx components/first-run/trial-activation-paywall.test.tsx e2e/specs/onboarding-first-run.spec.ts` — passed.
- `bun run e2e:coverage:check` — passed.
- `git diff --check` — passed.

No native packaged-app or live Stripe checkout test performed. No Rust commands or bindings changed.

## AI assistance and human ownership

- Tool: Codex; autonomy: `agent`.
- Submitted at the maintainer's explicit request. Codex inspected history, implemented the scoped revert, and ran the checks above. No human manual verification is claimed.
