### PR TITLE
fix(cli): honor openai-compatible transcription settings headless; VAD-gate retranscribe

### DIFF
--- a/crates/screenpipe-audio/src/vad/mod.rs
+++ b/crates/screenpipe-audio/src/vad/mod.rs
@@ -73,6 +73,49 @@ static MODEL_PATH: Mutex<Option<PathBuf>> = Mutex::const_new(None);
 
 static DOWNLOADING: AtomicBool = AtomicBool::new(false);
 
+/// Fraction of fixed-size frames the VAD classifies as speech.
+///
+/// Mirrors the live capture path in `speaker::prepare_segments` (same frame
+/// size, same RMS normalisation, same relaxed threshold for output devices) so
+/// that a chunk the recorder would have skipped is also skipped when it is
+/// re-transcribed later. Callers compare the result against
+/// [`min_speech_ratio`]. `samples` must be 16 kHz mono.
+///
+/// The lock is held for the whole pass: Silero carries LSTM state between
+/// frames, so interleaving two streams through one engine degrades both.
+pub async fn speech_ratio(
+    samples: &[f32],
+    vad_engine: &Mutex<Box<dyn VadEngine>>,
+    is_output_device: bool,
+) -> f32 {
+    if samples.is_empty() {
+        return 0.0;
+    }
+    let audio = crate::utils::audio::normalize_v2(samples);
+
+    #[cfg(target_os = "windows")]
+    let frame_size = 512;
+    #[cfg(not(target_os = "windows"))]
+    let frame_size = 1600;
+
+    let mut vad = vad_engine.lock().await;
+    if is_output_device {
+        vad.set_speech_threshold(Some(OUTPUT_SPEECH_THRESHOLD));
+    }
+    let mut total_frames = 0usize;
+    let mut speech_frames = 0usize;
+    for frame in audio.chunks(frame_size) {
+        total_frames += 1;
+        if matches!(vad.audio_type(frame), Ok(VadStatus::Speech)) {
+            speech_frames += 1;
+        }
+    }
+    if is_output_device {
+        vad.set_speech_threshold(None);
+    }
+    speech_frames as f32 / total_frames as f32
+}
+
 pub async fn create_vad_engine(engine: VadEngineEnum) -> anyhow::Result<Box<dyn VadEngine>> {
     match engine {
         VadEngineEnum::WebRtc => Ok(Box::new(WebRtcVad::new())),

--- a/crates/screenpipe-engine/src/recording_config.rs
+++ b/crates/screenpipe-engine/src/recording_config.rs
@@ -8,6 +8,9 @@ use screenpipe_audio::core::engine::AudioTranscriptionEngine;
 use screenpipe_audio::meeting_streaming::MeetingStreamingConfig;
 use screenpipe_audio::transcription::deepgram::DeepgramTranscriptionConfig;
 use screenpipe_audio::transcription::VocabularyEntry;
+use screenpipe_audio::{
+    OpenAICompatibleConfig, DEFAULT_OPENAI_COMPATIBLE_ENDPOINT, DEFAULT_OPENAI_COMPATIBLE_MODEL,
+};
 use screenpipe_audio::vad::VadEngineEnum;
 use screenpipe_config::{ChannelConfig, DbConfig, DomainRule, SemanticContextMode, UrlRule};
 use screenpipe_core::Language;
@@ -492,6 +495,45 @@ impl RecordingConfig {
         }
     }
 
+    /// OpenAI-compatible transcription config derived from the settings store.
+    ///
+    /// Returns `None` when neither an endpoint nor a model has been configured,
+    /// so an untouched install keeps today's behaviour. It is deliberately NOT
+    /// gated on `audio_transcription_engine == OpenAICompatible`: the engine can
+    /// be selected per request (`POST /audio/retranscribe` with
+    /// `"engine": "openai-compatible"`) while the live engine is something else
+    /// (or `disabled`), and that path reads this config off the audio manager.
+    pub fn openai_compatible_config(&self) -> Option<OpenAICompatibleConfig> {
+        let endpoint = self
+            .openai_compatible_endpoint
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty());
+        let model = self
+            .openai_compatible_model
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty());
+        if endpoint.is_none() && model.is_none() {
+            return None;
+        }
+        Some(OpenAICompatibleConfig {
+            endpoint: endpoint
+                .map(str::to_string)
+                .unwrap_or_else(|| DEFAULT_OPENAI_COMPATIBLE_ENDPOINT.to_string()),
+            api_key: self
+                .openai_compatible_api_key
+                .clone()
+                .filter(|k| !k.trim().is_empty()),
+            model: model
+                .map(str::to_string)
+                .unwrap_or_else(|| DEFAULT_OPENAI_COMPATIBLE_MODEL.to_string()),
+            client: None,
+            headers: self.openai_compatible_headers.clone(),
+            raw_audio: self.openai_compatible_raw_audio,
+        })
+    }
+
     /// Build an `AudioManagerBuilder` pre-configured from this config.
     /// The caller can chain additional builder methods (e.g. `.realtime()`, `.meeting_detector()`)
     /// before calling `.build(db)`.
@@ -515,6 +557,7 @@ impl RecordingConfig {
             .macos_input_vpio_enabled(self.macos_input_vpio_enabled)
             .screenpipe_aec_enabled(self.screenpipe_aec_enabled)
             .deepgram_config(self.deepgram_config.clone())
+            .openai_compatible_config(self.openai_compatible_config())
             .output_path(output_path)
             .use_pii_removal(self.use_pii_removal)
             .filter_music(self.filter_music)

--- a/crates/screenpipe-engine/src/routes/retranscribe.rs
+++ b/crates/screenpipe-engine/src/routes/retranscribe.rs
@@ -12,15 +12,97 @@ use oasgen::{oasgen, OaSchema};
 use screenpipe_audio::core::engine::AudioTranscriptionEngine;
 use screenpipe_audio::transcription::engine::TranscriptionEngine;
 use screenpipe_audio::transcription::VocabularyEntry;
+use screenpipe_audio::vad::{
+    create_vad_engine, min_speech_ratio, speech_ratio, VadEngine, VadEngineEnum,
+};
 use screenpipe_db::{AudioChunkInfo, NewMeetingTranscriptSegment};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::HashSet;
 use std::path::Path as StdPath;
 use std::sync::Arc;
-use tracing::{error, info};
+use tokio::sync::Mutex;
+use tracing::{debug, error, info, warn};
 
 use crate::server::AppState;
+
+/// Minimum-speech gate for re-transcription.
+///
+/// The live capture path only sends audio to the STT engine when Silero VAD
+/// finds more than `min_speech_ratio()` speech (see `stt.rs`), but the
+/// retranscribe routes fed every stored chunk file straight into the engine.
+/// Devices write a chunk every `audio_chunk_duration` seconds whether or not
+/// anyone spoke, so a day's backlog is mostly silence — which is also exactly
+/// the input STT models hallucinate on. Reusing the recorder's threshold keeps
+/// both paths in agreement about what counts as speech.
+///
+/// A dedicated engine per request rather than the AudioManager's: Silero keeps
+/// LSTM state between frames, and sharing it with live capture would interleave
+/// two unrelated streams. Falls back to WebRTC like AudioManager does, and to
+/// no gating at all if neither loads — a VAD failure must never silently drop
+/// transcription.
+struct SilenceGate {
+    vad: Option<Mutex<Box<dyn VadEngine>>>,
+}
+
+impl SilenceGate {
+    async fn new() -> Self {
+        let vad = match create_vad_engine(VadEngineEnum::Silero).await {
+            Ok(v) => Some(v),
+            Err(e) => {
+                warn!("retranscribe: silero vad unavailable ({}), trying webrtc", e);
+                match create_vad_engine(VadEngineEnum::WebRtc).await {
+                    Ok(v) => Some(v),
+                    Err(e) => {
+                        warn!("retranscribe: no vad available ({}), transcribing everything", e);
+                        None
+                    }
+                }
+            }
+        };
+        Self {
+            vad: vad.map(Mutex::new),
+        }
+    }
+
+    /// `true` when the audio should be skipped as silent.
+    async fn is_silent(
+        &self,
+        samples: &[f32],
+        sample_rate: u32,
+        is_output_device: bool,
+        label: &str,
+    ) -> bool {
+        let Some(vad) = &self.vad else {
+            return false;
+        };
+        let resampled;
+        let samples_16k: &[f32] = if sample_rate == 16000 {
+            samples
+        } else {
+            match screenpipe_audio::resample(samples, sample_rate, 16000) {
+                Ok(r) => {
+                    resampled = r;
+                    &resampled
+                }
+                Err(e) => {
+                    warn!(
+                        "retranscribe: resample for vad failed on {} ({}), not gating",
+                        label, e
+                    );
+                    return false;
+                }
+            }
+        };
+        let ratio = speech_ratio(samples_16k, vad, is_output_device).await;
+        let min_ratio = min_speech_ratio();
+        debug!(
+            "retranscribe: {} speech ratio {:.3} (min {:.3})",
+            label, ratio, min_ratio
+        );
+        ratio <= min_ratio
+    }
+}
 
 #[derive(Debug, Deserialize)]
 pub struct RetranscribeRequest {
@@ -55,6 +137,8 @@ pub struct RetranscribeChunkResult {
 #[derive(Debug, Serialize)]
 pub struct RetranscribeResponse {
     pub chunks_processed: usize,
+    /// Chunks left untouched because VAD found no speech in them.
+    pub chunks_skipped_silent: usize,
     pub transcriptions: Vec<RetranscribeChunkResult>,
 }
 
@@ -80,6 +164,8 @@ pub struct MeetingRetranscribeResponse {
     pub engine: String,
     pub chunks_found: usize,
     pub chunks_processed: usize,
+    /// Chunks in batches skipped because VAD found no speech in them.
+    pub chunks_skipped_silent: usize,
     pub batches_processed: usize,
     pub seconds_processed: f64,
     pub replaced_segments: u64,
@@ -304,6 +390,7 @@ pub async fn retranscribe_handler(
         info!("retranscribe: no audio chunks found");
         return JsonResponse(json!({
             "chunks_processed": 0,
+            "chunks_skipped_silent": 0,
             "transcriptions": []
         }))
         .into_response();
@@ -313,6 +400,8 @@ pub async fn retranscribe_handler(
         "retranscribe: found {} raw rows (may include dupes)",
         chunks.len()
     );
+
+    let silence_gate = SilenceGate::new().await;
 
     // 2. Get transcription config from audio manager
     let audio_manager = &state.audio_manager;
@@ -373,6 +462,7 @@ pub async fn retranscribe_handler(
     // 4. Process each chunk
     let mut results = Vec::new();
     let mut processed = 0;
+    let mut skipped_silent = 0;
 
     // Deduplicate chunks by ID (multiple transcription rows per chunk)
     let mut seen_ids = std::collections::HashSet::new();
@@ -402,6 +492,20 @@ pub async fn retranscribe_handler(
             };
 
         if samples.is_empty() {
+            continue;
+        }
+
+        let is_output_device = !chunk.is_input_device.unwrap_or(false);
+        if silence_gate
+            .is_silent(
+                &samples,
+                sample_rate,
+                is_output_device,
+                &format!("chunk {}", chunk.id),
+            )
+            .await
+        {
+            skipped_silent += 1;
             continue;
         }
 
@@ -459,13 +563,15 @@ pub async fn retranscribe_handler(
     }
 
     info!(
-        "retranscribe complete: {} chunks processed, {} transcription results",
+        "retranscribe complete: {} chunks processed, {} skipped as silent, {} transcription results",
         processed,
+        skipped_silent,
         results.len()
     );
 
     let response = RetranscribeResponse {
         chunks_processed: processed,
+        chunks_skipped_silent: skipped_silent,
         transcriptions: results,
     };
     JsonResponse(json!(response)).into_response()
@@ -533,6 +639,7 @@ pub async fn retranscribe_meeting_handler(
             engine: "none".to_string(),
             chunks_found: 0,
             chunks_processed: 0,
+            chunks_skipped_silent: 0,
             batches_processed: 0,
             seconds_processed: 0.0,
             replaced_segments: 0,
@@ -578,8 +685,10 @@ pub async fn retranscribe_meeting_handler(
     };
 
     let batches = group_meeting_chunks(&chunks, max_batch_duration);
+    let silence_gate = SilenceGate::new().await;
     let mut pending = Vec::new();
     let mut chunks_processed = 0usize;
+    let mut chunks_skipped_silent = 0usize;
     let mut seconds_processed = 0.0f64;
     let mut sequence = 0u64;
 
@@ -633,6 +742,19 @@ pub async fn retranscribe_meeting_handler(
             continue;
         }
 
+        if silence_gate
+            .is_silent(
+                &combined_samples,
+                sample_rate,
+                !device.is_input,
+                &format!("meeting batch from chunk {}", first_chunk_id),
+            )
+            .await
+        {
+            chunks_skipped_silent += valid_chunks;
+            continue;
+        }
+
         let mut session = match transcription_engine.create_session() {
             Ok(session) => session,
             Err(e) => {
@@ -677,6 +799,7 @@ pub async fn retranscribe_meeting_handler(
             engine: engine_name,
             chunks_found: chunks.len(),
             chunks_processed,
+            chunks_skipped_silent,
             batches_processed: 0,
             seconds_processed,
             replaced_segments: 0,
@@ -757,6 +880,7 @@ pub async fn retranscribe_meeting_handler(
         engine: engine_name,
         chunks_found: chunks.len(),
         chunks_processed,
+        chunks_skipped_silent,
         batches_processed: inserted,
         seconds_processed,
         replaced_segments,


### PR DESCRIPTION
## Summary

Two small, independent fixes for the headless CLI's transcription path.

**1. The CLI never used the OpenAI-compatible settings.** `RecordingConfig` parses `openaiCompatibleEndpoint/ApiKey/Model/Headers/RawAudio` from the settings store, but `to_audio_manager_builder()` chained `.deepgram_config(...)` and not `.openai_compatible_config(...)`. Only the Tauri app built an `OpenAICompatibleConfig` (`server_core.rs`, `capture_session.rs`). Under `screenpipe record` the audio manager's config stayed `None`, so both live STT and `POST /audio/retranscribe` with `"engine": "openai-compatible"` fell back to the hardcoded `http://127.0.0.1:8080` / `whisper-1`:

```
ERROR screenpipe_audio::transcription::engine: device: unknown, openai compatible transcription failed:
  error sending request for url (http://127.0.0.1:8080/v1/audio/transcriptions) ... Connection refused
```

The fix adds `RecordingConfig::openai_compatible_config()` and chains it from the builder. It returns `None` unless an endpoint or model is set, so unconfigured installs are unchanged. It is deliberately not gated on the live engine being `OpenAICompatible`: retranscribe selects the engine per request while the live engine may be anything (including `disabled`), and it reads this config off the audio manager. The Tauri app's own `.openai_compatible_config(...)` call still runs afterwards and overrides it, so desktop behaviour is unchanged.

**2. Retranscribe transcribed silence.** Live capture only hands audio to STT when Silero finds more than `min_speech_ratio()` speech (`stt.rs` via `prepare_segments`), but both retranscribe routes fed every stored chunk file straight into the engine. Devices write a chunk every `audio_chunk_duration` seconds whether or not anyone spoke, so re-transcribing a day is mostly silence — which STT models hallucinate on, and which a remote engine bills per request.

This adds `vad::speech_ratio()` (the frame loop from `prepare_segments`: same frame size, RMS normalisation, and relaxed threshold for output devices) and gates each chunk / meeting batch on it before `create_session()`. Skipped chunks leave their DB rows untouched and are reported in a new `chunks_skipped_silent` field. The gate uses a dedicated VAD instance per request (Silero keeps LSTM state between frames; sharing the AudioManager's would interleave two streams), falls back to WebRTC like AudioManager does, and to no gating at all if neither loads.

## Before / after

Measured on macOS 26, Apple Silicon, `screenpipe record` with the live engine `disabled` and `openaiCompatibleEndpoint` pointed at a local OpenAI-compatible server (omlx, Qwen3-ASR-1.7B):

```
POST /audio/retranscribe {"start":..., "end":..., "engine":"openai-compatible"}

before   chunks_processed: 0      every chunk: Connection refused (127.0.0.1:8080)
after    chunks_processed: 53     chunks_skipped_silent: 6     59 chunks in 50 s

quiet 20-minute window (3 AM):
before   81 chunks sent to the engine
after    5 processed, 76 skipped as silent, 4 with text
```

## Test plan

- [x] `cargo check -p screenpipe-engine --bin screenpipe --features metal,redact-onnx-coreml` on main
- [x] Built `release-dev` and ran `screenpipe record` headless; retranscribe hits the configured endpoint (verified in server logs), transcripts are correct
- [x] Retranscribe of a silent window skips chunks without touching their rows
- [x] No change with the settings unset (config stays `None`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YZupQA9crbWZJb23QtWg9S
