### PR TITLE
fix(meetings): match browser names at word boundaries

### DIFF
--- a/crates/screenpipe-engine/src/meeting_watcher/shared/ignore.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/shared/ignore.rs
@@ -49,7 +49,7 @@ pub(crate) fn browser_title_matches_pattern(title_lower: &str, pattern: &str) ->
 pub(crate) fn is_browser_app(app_name: &str) -> bool {
     BROWSER_NAMES
         .iter()
-        .any(|b| contains_case_insensitive(app_name, b))
+        .any(|b| contains_at_word_boundary(app_name, b))
         || ends_with_ascii_case_insensitive(app_name, ".exe")
             && [
                 "chrome.exe",
@@ -329,6 +329,52 @@ pub(crate) fn title_contains_meeting_code(title: &str) -> bool {
             && (start == 0 || !extends_token(bytes[start - 1]))
             && (start + CODE_LEN == bytes.len() || !extends_token(bytes[start + CODE_LEN]))
     })
+}
+
+/// Case-insensitive substring match that must land on word boundaries.
+///
+/// `BROWSER_NAMES` holds entries as short as `"dia"` and `"arc"`, which sit
+/// inside ordinary app names: `"nvidia"` and `"media"` both contain `dia`,
+/// `"search"` contains `arc`. A plain substring test therefore reports those
+/// windows as browsers, and a window classified as a browser has its title and
+/// URL matched against every meeting pattern — so the cost is false meeting
+/// detection on a per-window hot path, not just wasted work.
+///
+/// A match counts only when the characters on both sides are non-alphanumeric
+/// or absent, so `"Dia"` and `"Dia Browser"` match while `"NVIDIA"` does not.
+pub(crate) fn contains_at_word_boundary(haystack: &str, needle: &str) -> bool {
+    if needle.is_empty() {
+        return false;
+    }
+
+    if haystack.is_ascii() && needle.is_ascii() {
+        let needle = needle.as_bytes();
+        let bytes = haystack.as_bytes();
+        if bytes.len() < needle.len() {
+            return false;
+        }
+        return (0..=bytes.len() - needle.len()).any(|start| {
+            let end = start + needle.len();
+            bytes[start..end].eq_ignore_ascii_case(needle)
+                && (start == 0 || !bytes[start - 1].is_ascii_alphanumeric())
+                && (end == bytes.len() || !bytes[end].is_ascii_alphanumeric())
+        });
+    }
+
+    let haystack_lower = haystack.to_lowercase();
+    let needle_lower = needle.to_lowercase();
+    haystack_lower
+        .match_indices(&needle_lower)
+        .any(|(start, matched)| {
+            haystack_lower[..start]
+                .chars()
+                .next_back()
+                .is_none_or(|c| !c.is_alphanumeric())
+                && haystack_lower[start + matched.len()..]
+                    .chars()
+                    .next()
+                    .is_none_or(|c| !c.is_alphanumeric())
+        })
 }
 
 pub(crate) fn contains_case_insensitive(haystack: &str, needle: &str) -> bool {

--- a/crates/screenpipe-engine/src/meeting_watcher/shared/profiles.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/shared/profiles.rs
@@ -94,6 +94,7 @@ pub struct MeetingDetectionProfile {
 pub(crate) const BROWSER_NAMES: &[&str] = &[
     "google chrome",
     "arc",
+    "dia",
     "firefox",
     "safari",
     "microsoft edge",

--- a/crates/screenpipe-engine/src/meeting_watcher/ui_scan/macos.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/ui_scan/macos.rs
@@ -366,7 +366,7 @@ pub fn find_running_meeting_apps(
 
                 // Check browser URL patterns — only if this is a browser
                 if !profile.app_identifiers.browser_url_patterns.is_empty()
-                    && BROWSER_NAMES.iter().any(|b| name_lower.contains(b))
+                    && is_browser_app(&name_lower)
                     && has_browser_meeting_url(pid, profile)
                 {
                     results.push(RunningMeetingApp {
@@ -652,7 +652,7 @@ mod live_tests {
                     let app = &running[i];
                     let name = process_name_for_pid(app.pid()).unwrap_or_default();
                     let name_lower = name.to_lowercase();
-                    if BROWSER_NAMES.iter().any(|b| name_lower.contains(b)) {
+                    if is_browser_app(&name_lower) {
                         println!("\nBROWSER: {} (pid={})", name, app.pid());
                         let ax_app = cidre::ax::UiElement::with_app_pid(app.pid());
                         let _ = ax_app.set_messaging_timeout_secs(2.0);

--- a/crates/screenpipe-engine/src/meeting_watcher/ui_scan/tests.rs
+++ b/crates/screenpipe-engine/src/meeting_watcher/ui_scan/tests.rs
@@ -315,7 +315,25 @@ fn browser_app_detection_is_case_insensitive() {
     assert!(is_browser_app("CHROME.EXE"));
     assert!(is_browser_app("Microsoft Edge Helper"));
     assert!(is_browser_app("brave.exe"));
+    assert!(is_browser_app("Dia"));
     assert!(!is_browser_app("Zoom.exe"));
+}
+
+/// Short `BROWSER_NAMES` entries are substrings of ordinary app names, so an
+/// unanchored match reports NVIDIA and Media Player as browsers. A window
+/// classified as a browser has its title and URL run against every meeting
+/// pattern, so a false positive there becomes a false meeting.
+#[test]
+fn browser_app_detection_requires_word_boundaries() {
+    assert!(!is_browser_app("NVIDIA GeForce Experience"));
+    assert!(!is_browser_app("Windows Media Player"));
+    assert!(!is_browser_app("Search"));
+    assert!(!is_browser_app("Diagnostics"));
+
+    assert!(is_browser_app("Dia"));
+    assert!(is_browser_app("Dia Browser"));
+    assert!(is_browser_app("Arc"));
+    assert!(is_browser_app("Arc Browser"));
 }
 
 #[test]


### PR DESCRIPTION
Meetings taken in Dia were never detected, because the browser gate is an allowlist and Dia is not on it. Adding the name alone is not enough: the list is matched with an unanchored substring test, and "dia" sits inside "nvidia" and "media", so the one-line fix would classify NVIDIA GeForce and Windows Media Player as browsers. "arc" already does this to "Search".

That misclassification is not free. A window treated as a browser has its title and URL matched against every meeting profile on a per-window scan, so a false positive there surfaces as a meeting the user never joined.

Match the allowlist at word boundaries, which fixes "arc" as well, and add Dia. The two macOS scan sites repeated the raw substring test instead of calling is_browser_app, which is how one rule came to be enforced three different ways; route them through the shared helper.

---
name: pull request
about: submit changes to the project
title: "[pr] "
labels: ''
assignees: ''

---

## description

brief description of the changes in this pr.

related issue: #

> attach screenshots / recordings here — **never commit media into the repo.** drag the file into this box (works for anyone, browser only) and github hosts it. on the cli: attach it as a release asset — `gh release upload <tag> file.png` if you can write here, else `gh release create media file.png --repo <you>/screenpipe` on your fork — and paste the url.

## AI assistance and human ownership

read the [AI-assisted contribution policy](https://github.com/screenpipe/screenpipe/blob/main/CONTRIBUTING.md#ai-assisted-contributions).

- AI tool(s) used (`none` if not used):
- autonomy level (`none`, `autocomplete`, `chat`, or `agent`):
- what I personally verified:

- [ ] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [ ] The problem statement, rationale, and replies to maintainers are my own.

## evidence type

check every category that applies and provide its required evidence below.

- [ ] UI or behavior change — before/after recording
- [ ] Backend change — regression tests and relevant logs/results
- [ ] Performance change — reproducible before/after benchmarks
- [ ] Docs, CI, or pure refactor — relevant checks and an explanation; no video required

## before

for UI or behavior changes, add a recording of the app/CLI before this change. otherwise write `not applicable` and explain why.

## after

for UI or behavior changes, add a recording of the app/CLI after this change. otherwise write `not applicable` and provide the evidence required above.

## how to test

list the exact commands or manual steps you personally ran and their results.

1. 
2. 
3. 

## desktop app checklist (if applicable)

If this PR adds or changes `#[tauri::command]` handlers or Rust types exported to the frontend, from `apps/screenpipe-app-tauri/`:

- [ ] `bun run bindings:generate` (if bindings changed)
- [ ] `bun run bindings:check`
- [ ] `bun run typecheck`

Commands are auto-collected via the vendored `tauri-helper` crate — no manual handler list edits in `main.rs`.
